### PR TITLE
[SAFE-429] add logic to remove history if record deleted in form view

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.ts
@@ -23,6 +23,7 @@ export class FormRecordsComponent implements OnInit {
   displayedColumns: string[] = [];
   dataSource: any[] = [];
   public showSidenav = true;
+  private historyId = '';
 
   // === HISTORY COMPONENT TO BE INJECTED IN LAYOUT SERVICE ===
   public factory?: ComponentFactory<any>;
@@ -85,6 +86,9 @@ export class FormRecordsComponent implements OnInit {
       this.dataSource = this.dataSource.filter( x => {
         return x.id !== id;
       });
+      if (id === this.historyId) {
+        this.layoutService.setRightSidenav(null);
+      }
     });
   }
 
@@ -125,6 +129,7 @@ export class FormRecordsComponent implements OnInit {
         id
       }
     }).subscribe(res => {
+      this.historyId = id;
       this.layoutService.setRightSidenav({
         factory: this.factory,
         inputs: {


### PR DESCRIPTION
# Description

Hide the history if deleted record in form records view corresponds to the currently displayed record history


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Create a record, go to forms / records, show its history, delete another record -> must remain
- [x] Create a record, go to forms / records, show its history, delete  record -> must hide

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules