### PR TITLE
[SAFE-364] hide menu button when no permissions for actions

### DIFF
--- a/projects/safe/src/lib/components/widgets/grid-settings/floating-button-settings/floating-button-settings.component.scss
+++ b/projects/safe/src/lib/components/widgets/grid-settings/floating-button-settings/floating-button-settings.component.scss
@@ -26,6 +26,7 @@
 
 .form-group {
     flex: 50%;
+    max-width: 100%;
     
     &:not(:first-child) {
         margin-top: 0px;

--- a/projects/safe/src/lib/components/widgets/grid/grid.component.html
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.html
@@ -137,7 +137,8 @@
                 <kendo-grid-column *ngIf="field.type === 'JSON' && multiSelectTypes.includes(field.meta.type)"
                     [field]="field.name" [filterable]="true" [title]="field.title" [editor]="field.editor"
                     [editable]="!field.disabled" [width]="field.title.length * 7 + 50" [minResizableWidth]="50">
-                    <ng-template kendoGridFilterMenuTemplate let-filter let-column="column" let-filterService="filterService">
+                    <ng-template kendoGridFilterMenuTemplate let-filter let-column="column"
+                        let-filterService="filterService">
                         <safe-array-filter-menu [filter]="filter" [filterService]="filterService"
                             [data]="field.meta.choices" [field]="field.name"
                             [textField]="field.meta.choicesByUrl ? field.meta.choicesByUrl.text : 'text'"
@@ -303,13 +304,16 @@
             <!-- ROW ACTIONS -->
             <kendo-grid-column *ngIf="hasEnabledActions" [columnMenu]="false" [width]="56">
                 <ng-template kendoGridCellTemplate let-idx="rowIndex">
-                    <button *ngIf="gridData.data[idx].canUpdate || gridData.data[idx].canDelete || settings.actions.history"
-                    style="text-align: center" kendoButton [icon]="'more-vertical'" [look]="'flat'" [matMenuTriggerFor]="menu">
+                    <button
+                        *ngIf="settings.actions && ((settings.actions.update && gridData.data[idx].canUpdate) || settings.actions.history ||
+                        (settings.actions.convert && gridData.data[idx].canUpdate) || (settings.actions.delete && gridData.data[idx].canDelete))"
+                        style="text-align: center" kendoButton [icon]="'more-vertical'" [look]="'flat'"
+                        [matMenuTriggerFor]="menu">
                     </button>
                     <mat-menu #menu="matMenu">
-                        <button *ngIf="(!settings.actions || settings.actions.delete) && gridData.data[idx].canDelete"
-                            mat-menu-item (click)="onDeleteRow([idx])">
-                            Delete
+                        <button *ngIf="(!settings.actions || settings.actions.update) && gridData.data[idx].canUpdate"
+                            mat-menu-item color="warn" (click)="onUpdateRow(gridData.data[idx].id)">
+                            Update
                         </button>
                         <button *ngIf="!settings.actions || settings.actions.history" mat-menu-item color="warn"
                             (click)="onViewHistory(gridData.data[idx].id)">
@@ -319,9 +323,10 @@
                             mat-menu-item color="warn" (click)="onConvertRecord([idx])">
                             Convert
                         </button>
-                        <button *ngIf="(!settings.actions || settings.actions.update) && gridData.data[idx].canUpdate"
-                            mat-menu-item color="warn" (click)="onUpdateRow(gridData.data[idx].id)">
-                            Update
+                        <mat-divider></mat-divider>
+                        <button *ngIf="(!settings.actions || settings.actions.delete) && gridData.data[idx].canDelete"
+                            mat-menu-item (click)="onDeleteRow([idx])">
+                            Delete
                         </button>
                     </mat-menu>
                 </ng-template>

--- a/projects/safe/src/lib/components/widgets/grid/grid.component.html
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.html
@@ -291,10 +291,9 @@
             <!-- ROW ACTIONS -->
             <kendo-grid-column *ngIf="hasEnabledActions" [columnMenu]="false" [width]="56">
                 <ng-template kendoGridCellTemplate let-idx="rowIndex">
-                    <button style="text-align: center" kendoButton [icon]="'more-vertical'" [look]="'flat'"
-                        [matMenuTriggerFor]="menu">
+                    <button *ngIf="gridData.data[idx].canUpdate || gridData.data[idx].canDelete || settings.actions.history"
+                    style="text-align: center" kendoButton [icon]="'more-vertical'" [look]="'flat'" [matMenuTriggerFor]="menu">
                     </button>
-
                     <mat-menu #menu="matMenu">
                         <button *ngIf="(!settings.actions || settings.actions.delete) && gridData.data[idx].canDelete"
                             mat-menu-item (click)="onDeleteRow([idx])">

--- a/projects/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -9,7 +9,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import {
   CONVERT_RECORD,
-  ConvertRecordMutationResponse, DELETE_RECORD, DeleteRecordMutationResponse, EDIT_RECORD, EditRecordMutationResponse,
+  ConvertRecordMutationResponse, EDIT_RECORD, EditRecordMutationResponse,
   PUBLISH, PUBLISH_NOTIFICATION, PublishMutationResponse, PublishNotificationMutationResponse, DELETE_RECORDS
 } from '../../../graphql/mutations';
 import { SafeFormModalComponent } from '../../form-modal/form-modal.component';

--- a/projects/safe/src/lib/components/widgets/grid/grid.module.ts
+++ b/projects/safe/src/lib/components/widgets/grid/grid.module.ts
@@ -20,6 +20,7 @@ import { SafeExpandedCommentModule } from './expanded-comment/expanded-comment.m
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { SafeArrayFilterModule } from './array-filter/array-filter.module';
 import { SafeArrayFilterMenuModule } from './array-filter-menu/array-filter-menu.module';
+import { MatDividerModule } from '@angular/material/divider';
 
 @NgModule({
   declarations: [
@@ -49,7 +50,8 @@ import { SafeArrayFilterMenuModule } from './array-filter-menu/array-filter-menu
     MatTooltipModule,
     ButtonsModule,
     SafeArrayFilterModule,
-    SafeArrayFilterMenuModule
+    SafeArrayFilterMenuModule,
+    MatDividerModule
   ],
   exports: [SafeGridComponent]
 })


### PR DESCRIPTION
# Description

Hide action button in grid widget if no permission on the record

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Take an user with no update / delete permissions on certain record, but an access to a grid that displays it, with history active and conversion
- [x] Take an user with no update / delete permissions on certain record, but an access to a grid that displays it, without history active but conversion
- [x] Take an user with no update / delete permissions on certain record, but an access to a grid that displays it, without history active and conversion
- [x] Take an user with no update / delete permissions on certain record, but an access to a grid that displays it, with history active but no conversion
- [x] Take an user with all permissions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules