### PR TITLE
[SAFE-438] add red indicator next to button form if error

### DIFF
--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -8,7 +8,7 @@
       </mat-form-field>
     </div>
     <div class="form-group">
-      
+
       <safe-query-builder [form]="$any(tileForm.controls.query)"></safe-query-builder>
     </div>
     <div formGroupName="actions" class="form-group">
@@ -28,18 +28,23 @@
     </div>
     <div class="form-group">
       <div class="form-group-title">Quick action buttons</div>
-      <div class="info-text">Quick action buttons will appear on the widget and allow you to complete any of the actions below.</div>
+      <div class="info-text">Quick action buttons will appear on the widget and allow you to complete any of the actions
+        below.</div>
       <button mat-button color="primary" class="add-button" (click)="addFloatingButton()">
         <mat-icon>add</mat-icon>
         Add a button
       </button>
-      <mat-tab-group mat-align-tabs="start" animationDuration="0ms" dynamicHeight style="min-height: 500px" [(selectedIndex)]="tabIndex"
-      *ngIf="floatingButtons.length > 0">
+      <mat-tab-group mat-align-tabs="start" animationDuration="0ms" dynamicHeight style="min-height: 500px"
+        [(selectedIndex)]="tabIndex" *ngIf="floatingButtons.length > 0">
         <ng-container *ngFor="let floatingButton of floatingButtons.controls">
-          <mat-tab [label]="floatingButton.value.name">
+          <mat-tab>
+            <ng-template mat-tab-label>
+              <mat-icon class="form-error" *ngIf="floatingButton.invalid">error</mat-icon>
+              {{ floatingButton.value.name }}
+            </ng-template>
             <ng-template matTabContent>
-              <safe-floating-button-settings [buttonForm]="$any(floatingButton)" [fields]="fields" [channels]="channels" [relatedForms]="relatedForms"
-                                             (deleteButton)="deleteFloatingButton()"></safe-floating-button-settings>
+              <safe-floating-button-settings [buttonForm]="$any(floatingButton)" [fields]="fields" [channels]="channels"
+                [relatedForms]="relatedForms" (deleteButton)="deleteFloatingButton()"></safe-floating-button-settings>
             </ng-template>
           </mat-tab>
         </ng-container>

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.scss
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.scss
@@ -9,3 +9,7 @@
     width: min-content;
     align-self: flex-end;
 }
+
+.form-error {
+    color: red;
+}


### PR DESCRIPTION
# Description

Add red indicator next to button form if there is an error

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Create a button form. Make any change that would lead to an error

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
