### PR TITLE
notifications are not duplicated anymore

### DIFF
--- a/projects/safe/src/lib/services/notification.service.ts
+++ b/projects/safe/src/lib/services/notification.service.ts
@@ -33,8 +33,8 @@ export class SafeNotificationService {
         } else {
           this._notifications.next([]);
         }
-        this.firstLoad = false;
       });
+      this.firstLoad = false;
       this.apollo.subscribe<NotificationSubscriptionResponse>({
         query: NOTIFICATION_SUBSCRIPTION
       }).subscribe(res => {


### PR DESCRIPTION
# Description

I changed the "initNotifications" function in the notification.service.ts to make sure that the graphQL subscription for the notification won't be triggered more than once.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] I tested my branch by creating and deleting applications to check that it created only one notification.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
