### PR TITLE
[SAFE-446] added vertical scroll on tab field in grid settings

### DIFF
--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
@@ -3,32 +3,38 @@
     <div class="field-container" *ngIf="!fieldForm">
         <h2>Available fields</h2>
 
-        <div cdkDropList [cdkDropListData]="availableFields" class="field-list" cdkDropListSortingDisabled
-            (cdkDropListDropped)="drop($event)">
-            <div class="field-box" *ngFor="let field of availableFields" cdkDrag>{{ field.name }}<span
-                    class="field-type" *ngIf="field.type.kind !== 'SCALAR'">{{ field.type.kind }}</span></div>
+        <div class="field-list-wrapper">
+            <div cdkDropList [cdkDropListData]="availableFields" class="field-list" cdkDropListSortingDisabled
+                (cdkDropListDropped)="drop($event)">
+                <div class="field-box" *ngFor="let field of availableFields" cdkDrag>{{ field.name }}<span
+                        class="field-type" *ngIf="field.type.kind !== 'SCALAR'">{{ field.type.kind }}</span></div>
+            </div>
         </div>
     </div>
 
     <div class="field-container" *ngIf="!fieldForm">
         <h2>Selected fields</h2>
 
-        <div cdkDropList [cdkDropListData]="selectedFields" class="field-list" (cdkDropListDropped)="drop($event)">
-            <div class="field-box" *ngFor="let field of selectedFields; let index = index" cdkDrag>
-                <div>
-                    <span>{{ field.name }}</span>
-                    <button class="field-error" mat-icon-button (click)="onEdit(index)" *ngIf="form.at(index).invalid && field.type">
-                        <mat-icon>error</mat-icon>
-                    </button>
-                    <button class="field-error" mat-icon-button *ngIf="!field.type" (click)="onDelete(index)" matTooltip="Invalid field. Please click to remove.">
-                        <mat-icon>close</mat-icon>
-                    </button>
-                </div>
-                <div *ngIf="field.type">
-                    <span class="field-type" *ngIf="field.type.kind !== 'SCALAR'">{{ field.type.kind }}</span>
-                    <button mat-icon-button (click)="onEdit(index)">
-                        <mat-icon>edit</mat-icon>
-                    </button>
+        <div class="field-list-wrapper">
+            <div cdkDropList [cdkDropListData]="selectedFields" class="field-list" (cdkDropListDropped)="drop($event)">
+                <div class="field-box" *ngFor="let field of selectedFields; let index = index" cdkDrag>
+                    <div>
+                        <span>{{ field.name }}</span>
+                        <button class="field-error" mat-icon-button (click)="onEdit(index)"
+                            *ngIf="form.at(index).invalid && field.type">
+                            <mat-icon>error</mat-icon>
+                        </button>
+                        <button class="field-error" mat-icon-button *ngIf="!field.type" (click)="onDelete(index)"
+                            matTooltip="Invalid field. Please click to remove.">
+                            <mat-icon>close</mat-icon>
+                        </button>
+                    </div>
+                    <div *ngIf="field.type">
+                        <span class="field-type" *ngIf="field.type.kind !== 'SCALAR'">{{ field.type.kind }}</span>
+                        <button mat-icon-button (click)="onEdit(index)">
+                            <mat-icon>edit</mat-icon>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -42,11 +48,11 @@
                 </button>
                 <mat-form-field appearance="outline">
                     <mat-label>Field name</mat-label>
-                    <input matInput formControlName="name" type="text" [disabled]="true"/>
+                    <input matInput formControlName="name" type="text" [disabled]="true" />
                 </mat-form-field>
                 <mat-form-field appearance="outline">
                     <mat-label>Label</mat-label>
-                    <input matInput formControlName="label" type="text"/>
+                    <input matInput formControlName="label" type="text" />
                 </mat-form-field>
             </form>
         </ng-container>

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.scss
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.scss
@@ -1,15 +1,15 @@
 .field-wrapper {
   display: flex;
   margin-top: 16px;
+  height: 500px;
+  overflow: auto;
 }
 
 .field-container {
+  width: 50%;
   min-width: 400px;
   margin-right: 25px;
-  display: flex;
-  flex-direction: column;
-  vertical-align: top;
-  flex: 1;
+  float: left;
 
   &:last-child {
     margin-right: 0;
@@ -18,17 +18,17 @@
     width: 100%;
   }
 }
-  
+
 .field-list {
   border: solid 1px #ccc;
-  min-height: 60px;
+  min-height: 400px;
   background: #ccc;
   border-radius: 4px;
   overflow: hidden;
   display: block;
   flex: 1;
 }
-  
+
 .field-box {
   padding: 20px 10px;
   border-bottom: solid 1px #ccc;
@@ -42,7 +42,7 @@
   background: white;
   font-size: 14px;
 }
-  
+
 .cdk-drag-preview {
   box-sizing: border-box;
   border-radius: 4px;
@@ -50,7 +50,7 @@
               0 8px 10px 1px rgba(0, 0, 0, 0.14),
               0 3px 14px 2px rgba(0, 0, 0, 0.12);
 }
-  
+
 .cdk-drag-placeholder {
   opacity: 0;
 }

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.scss
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.scss
@@ -19,6 +19,12 @@
   }
 }
 
+.field-list-wrapper {
+  flex: 1;
+  max-height: 400px;
+  overflow: auto;
+}
+
 .field-list {
   border: solid 1px #ccc;
   min-height: 400px;
@@ -26,6 +32,7 @@
   border-radius: 4px;
   overflow: hidden;
   display: block;
+  box-sizing: border-box;
   flex: 1;
 }
 


### PR DESCRIPTION
# Description

Set both tab fields column with max height, and independently scrollable


## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Open grid settings
- [x] If you have more than 8 fields you should see the horizontal scroll bar

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
