### PR TITLE
Add a distinction for core form and prevent their edition

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/form-builder/form-builder.component.html
+++ b/projects/back-office/src/app/dashboard/pages/form-builder/form-builder.component.html
@@ -27,5 +27,5 @@
         </mat-button-toggle-group>
     </div>
     <app-history *ngIf="activeVersions" [dataSource]="form.versions || []" (open)="onOpenVersion($event)"></app-history>
-    <safe-form-builder [structure]="structure" [fields]="form.core ? [] : form.fields || []" (save)="onSave($event)" (formChange)="formStructureChange($event)"></safe-form-builder>
+    <safe-form-builder [form]="form" (save)="onSave($event)" (formChange)="formStructureChange($event)"></safe-form-builder>
 </ng-container>

--- a/projects/back-office/src/app/dashboard/pages/form-builder/form-builder.component.html
+++ b/projects/back-office/src/app/dashboard/pages/form-builder/form-builder.component.html
@@ -27,5 +27,5 @@
         </mat-button-toggle-group>
     </div>
     <app-history *ngIf="activeVersions" [dataSource]="form.versions || []" (open)="onOpenVersion($event)"></app-history>
-    <safe-form-builder [structure]="structure" (save)="onSave($event)" (formChange)="formStructureChange($event)"></safe-form-builder>
+    <safe-form-builder [structure]="structure" [fields]="form.core ? [] : form.fields || []" (save)="onSave($event)" (formChange)="formStructureChange($event)"></safe-form-builder>
 </ng-container>

--- a/projects/back-office/src/app/dashboard/pages/form-builder/form-builder.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/form-builder/form-builder.component.ts
@@ -2,7 +2,6 @@ import { Apollo } from 'apollo-angular';
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-
 import { EditFormMutationResponse, EDIT_FORM_NAME, EDIT_FORM_PERMISSIONS, EDIT_FORM_STATUS, EDIT_FORM_STRUCTURE } from '../../../graphql/mutations';
 import { GetFormByIdQueryResponse, GET_SHORT_FORM_BY_ID } from '../../../graphql/queries';
 import { MatDialog } from '@angular/material/dialog';
@@ -152,7 +151,7 @@ export class FormBuilderComponent implements OnInit {
           this.snackBar.openSnackBar(res.errors[0].message, { error: true });
         } else {
           this.snackBar.openSnackBar(NOTIFICATIONS.objectEdited('form', this.form?.name));
-          this.form = res.data?.editForm;
+          this.form = { ...res.data?.editForm, structure };
           this.structure = structure;
           localStorage.removeItem(`form:${this.id}`);
           this.hasChanges = false;
@@ -278,7 +277,7 @@ export class FormBuilderComponent implements OnInit {
         statusModal.close();
       } else {
         this.snackBar.openSnackBar(NOTIFICATIONS.objectEdited('access', ''));
-        this.form = res.data?.editForm;
+        this.form = { ...res.data?.editForm, structure: this.structure };
         statusModal.close();
       }
     });

--- a/projects/back-office/src/app/graphql/mutations.ts
+++ b/projects/back-office/src/app/graphql/mutations.ts
@@ -220,6 +220,8 @@ mutation editForm($id: ID!, $structure: JSON!) {
     name
     createdAt
     status
+    core
+    fields
     versions {
       id
       createdAt

--- a/projects/back-office/src/app/graphql/queries.ts
+++ b/projects/back-office/src/app/graphql/queries.ts
@@ -126,6 +126,7 @@ query GetShortFormById($id: ID!) {
   form(id: $id) {
     id
     name
+    core
     structure
     fields
     status

--- a/projects/back-office/src/app/graphql/queries.ts
+++ b/projects/back-office/src/app/graphql/queries.ts
@@ -136,6 +136,24 @@ query GetShortFormById($id: ID!) {
       modifiedAt
       data
     }
+    permissions {
+      canSee {
+        id
+        title
+      }
+      canCreate {
+        id
+        title
+      }
+      canUpdate {
+        id
+        title
+      }
+      canDelete {
+        id
+        title
+      }
+    }
     canUpdate
   }
 }`;

--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -130,13 +130,8 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
           options.allowDragging = true;
         }
       });
-      let ii = 0
       // Block core fields edition
       this.surveyCreator.onShowingProperty.add((sender, options) => {
-        ii ++;
-        console.log(ii);
-        console.log('name', options.property.name);
-        console.log('category', options.property.category);
         const obj = options.obj;
         if (!obj || !obj.page) return;
         // If it is a core field

--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -89,9 +89,6 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
         };
       }));
 
-    // Remove adorners to set choices directly from survey view
-    SurveyCreator.removeAdorners(["choices-label", "choices-draggable", "select-choices"]);
-
     // Notify parent that form structure has changed
     this.surveyCreator.onModified.add((survey, option) => {
       this.formChange.emit(survey.text);

--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -141,12 +141,7 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
       });
   
       // Highlight core fields
-      this.surveyCreator.survey.onAfterRenderQuestion.add((sender: any, options: any) => {
-        // If it is a core field
-        if (coreFields.some(x => x.name === options.question.valueName)) {
-          options.htmlElement.children[0].className += " core-question";
-        }
-      });
+      this.addCustomClassToCoreFields(coreFields);
     }
   }
 
@@ -157,7 +152,21 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
         this.surveyCreator.survey.showQuestionNumbers = 'off';
         this.surveyCreator.survey.completedHtml = '<h3>The form has successfully been submitted.</h3>';
       }
+      const coreFields = this.fields.filter(x => x.isCore);
+      if (coreFields.length > 0) {
+        // Highlight core fields
+        this.addCustomClassToCoreFields(coreFields);
+      }
     }
+  }
+
+  private addCustomClassToCoreFields(coreFields: any[], className = " core-question"): void {
+    this.surveyCreator.survey.onAfterRenderQuestion.add((sender: any, options: any) => {
+      // If it is a core field
+      if (coreFields.some(x => x.name === options.question.valueName)) {
+        options.htmlElement.children[0].className += className;
+      }
+    });
   }
 
   setCustomTheme(): void {

--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -30,6 +30,20 @@ const QUESTION_TYPES = [
   'tagbox'
 ];
 
+/* Allowed properties for a core question in a child form.
+*/
+const CORE_QUESTION_ALLOWED_PROPERTIES = [
+  'width',
+  'maxWidth',
+  'minWidth',
+  'startWithNewLine',
+  'indent',
+  'page',
+  'titleLocation',
+  'descriptionLocation',
+  'state'
+];
+
 @Component({
   selector: 'safe-form-builder',
   templateUrl: './form-builder.component.html',
@@ -116,13 +130,17 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
           options.allowDragging = true;
         }
       });
-  
+      let ii = 0
       // Block core fields edition
       this.surveyCreator.onShowingProperty.add((sender, options) => {
+        ii ++;
+        console.log(ii);
+        console.log('name', options.property.name);
+        console.log('category', options.property.category);
         const obj = options.obj;
         if (!obj || !obj.page) return;
         // If it is a core field
-        if (coreFields.some(x => x.name === obj.valueName)) {
+        if (coreFields.some(x => x.name === obj.valueName) && !CORE_QUESTION_ALLOWED_PROPERTIES.includes(options.property.name)) {
           options.canShow = false;
         }
       });

--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -113,33 +113,32 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
     if (coreFields.length > 0) {
 
       // Remove core fields adorners
-      this.surveyCreator.onElementAllowOperations.add((sender, options) => {
-        const obj = options.obj;
-        if (!obj || !obj.page) return;
+      this.surveyCreator.onElementAllowOperations.add((sender, opt) => {
+        const obj = opt.obj;
+        if (!obj || !obj.page) { return; }
         // If it is a core field
         if (coreFields.some(x => x.name === obj.valueName)) {
           // Disable deleting, editing, changing type and changing if required or not
-          options.allowDelete = false;
-          options.allowChangeType = false;
-          options.allowChangeRequired = false;
-          options.allowAddToToolbox = false;
-          options.allowCopy = false;
-          options.allowShowEditor = false;
-          options.allowShowHideTitle = false;
+          opt.allowDelete = false;
+          opt.allowChangeType = false;
+          opt.allowChangeRequired = false;
+          opt.allowAddToToolbox = false;
+          opt.allowCopy = false;
+          opt.allowShowEditor = false;
+          opt.allowShowHideTitle = false;
           // options.allowEdit = false;
-          options.allowDragging = true;
+          opt.allowDragging = true;
         }
       });
       // Block core fields edition
-      this.surveyCreator.onShowingProperty.add((sender, options) => {
-        const obj = options.obj;
-        if (!obj || !obj.page) return;
+      this.surveyCreator.onShowingProperty.add((sender, opt) => {
+        const obj = opt.obj;
+        if (!obj || !obj.page) { return; }
         // If it is a core field
-        if (coreFields.some(x => x.name === obj.valueName) && !CORE_QUESTION_ALLOWED_PROPERTIES.includes(options.property.name)) {
-          options.canShow = false;
+        if (coreFields.some(x => x.name === obj.valueName) && !CORE_QUESTION_ALLOWED_PROPERTIES.includes(opt.property.name)) {
+          opt.canShow = false;
         }
       });
-  
       // Highlight core fields
       this.addCustomClassToCoreFields(coreFields);
     }
@@ -160,7 +159,7 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
     }
   }
 
-  private addCustomClassToCoreFields(coreFields: any[], className = " core-question"): void {
+  private addCustomClassToCoreFields(coreFields: any[], className = 'core-question'): void {
     this.surveyCreator.survey.onAfterRenderQuestion.add((sender: any, options: any) => {
       // If it is a core field
       if (coreFields.some(x => x.name === options.question.valueName)) {

--- a/projects/safe/src/lib/graphql/mutations.ts
+++ b/projects/safe/src/lib/graphql/mutations.ts
@@ -101,46 +101,6 @@ export interface UploadFileMutationResponse {
   uploadFile: string;
 }
 
-// === EDIT FORM ===
-export const EDIT_FORM_STRUCTURE = gql`
-mutation editForm($id: ID!, $structure: JSON!) {
-  editForm(id: $id, structure: $structure) {
-    id
-    name
-    createdAt
-    status
-    versions {
-      id
-      createdAt
-      data
-    }
-    permissions {
-      canSee {
-        id
-        title
-      }
-      canCreate {
-        id
-        title
-      }
-      canUpdate {
-        id
-        title
-      }
-      canDelete {
-        id
-        title
-      }
-    }
-    canUpdate
-  }
-}`;
-
-export interface EditFormMutationResponse {
-  loading: boolean;
-  editForm: Form;
-}
-
 // === EDIT USER ===
 export const EDIT_USER = gql`
 mutation editUser($id: ID!, $roles: [ID]!, $application: ID) {

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -423,4 +423,9 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
   }
 }
 
+// === SURVEY BUILDER ===
+.core-question {
+  color: mat-color($safe-warn) !important;
+}
+
 @import "theme.scss";


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Created one parent form and two children with one additional field each. Core fields were correctly set up with red title and no access to properties. Couldn't prevent the edition of the title without removing the drag and drop functionality for the moment (surveyJS does not allow it).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
