### PR TITLE
[SAFE-496] refresh charts when changing type

### DIFF
--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
@@ -14,7 +14,7 @@
                             <mat-icon inline="true" class="chart-icon">{{type.icon}}</mat-icon>{{type.name | uppercase
                             }}
                         </mat-select-trigger>
-                        <mat-option *ngFor="let type of types" [value]="type.name" (click)="refreshPipeline()">
+                        <mat-option *ngFor="let type of types" [value]="type.name">
                             <mat-icon>{{type.icon}}</mat-icon> {{type.name | uppercase }}
                         </mat-option>
                     </mat-select>

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
@@ -14,7 +14,7 @@
                             <mat-icon inline="true" class="chart-icon">{{type.icon}}</mat-icon>{{type.name | uppercase
                             }}
                         </mat-select-trigger>
-                        <mat-option *ngFor="let type of types" [value]="type.name">
+                        <mat-option *ngFor="let type of types" [value]="type.name" (click)="refreshPipeline()">
                             <mat-icon>{{type.icon}}</mat-icon> {{type.name | uppercase }}
                         </mat-option>
                     </mat-select>

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.ts
@@ -41,13 +41,8 @@ export class SafeChartSettingsComponent implements OnInit {
     return this.tileForm?.controls.chart as FormGroup || null;
   }
 
-  // public get type(): object {
-  //   return this.types.find(x => x.name === this.tileForm.value.chart.type);
-  // }
-
   constructor(
-    private formBuilder: FormBuilder,
-    private queryBuilder: QueryBuilderService
+    private formBuilder: FormBuilder
   ) { }
 
   /*  Build the settings form, using the widget saved parameters.
@@ -78,52 +73,24 @@ export class SafeChartSettingsComponent implements OnInit {
       this.change.emit(this.tileForm);
     });
 
-    // if (this.tileForm.value.query.name) {
-    //   this.selectedFields = this.getFields(this.tileForm.value.query.fields);
-    // }
-
     const chartForm = this.tileForm?.get('chart') as FormGroup;
     chartForm.controls.type.valueChanges.subscribe((value) => {
       this.type = this.types.find(x => x.name === value);
     });
-
-    // queryForm.controls.name.valueChanges.subscribe(() => {
-    //   this.tileForm.controls.xAxis.setValue('');
-    //   this.tileForm.controls.yAxis.setValue('');
-    // });
-    // queryForm.valueChanges.subscribe((res) => {
-    //   this.selectedFields = this.getFields(queryForm.getRawValue().fields);
-    // });
 
     this.pipeline = chartSettings.pipeline;
     this.settings = this.tileForm?.value;
     chartForm.controls.pipeline.valueChanges.subscribe((value) => {
       this.pipelineChanged = value !== this.pipeline;
     });
+    chartForm.valueChanges.subscribe((value) => {
+      this.settings = { chart: { ...value, ...{ pipeline: this.pipeline } } };
+    });
   }
 
-  private flatDeep(arr: any[]): any[] {
-    return arr.reduce((acc, val) => acc.concat(Array.isArray(val) ? this.flatDeep(val) : val), []);
-  }
-
-  private getFields(fields: any[], prefix?: string): any[] {
-    return this.flatDeep(fields.filter(x => x.kind !== 'LIST').map(f => {
-      switch (f.kind) {
-        case 'OBJECT': {
-          return this.getFields(f.fields, f.name);
-        }
-        default: {
-          return prefix ? `${prefix}.${f.name}` : f.name;
-        }
-      }
-    }));
-  }
-
-  refreshPipeline(): void {
+  public refreshPipeline(): void {
     this.pipeline = this.tileForm?.get('chart.pipeline')?.value;
     this.settings = this.tileForm?.value;
     this.pipelineChanged = false;
   }
-
-
 }

--- a/projects/safe/src/lib/components/widgets/chart/chart.component.html
+++ b/projects/safe/src/lib/components/widgets/chart/chart.component.html
@@ -12,37 +12,3 @@
         [legend]="settings.chart.legend" [series]="series"></safe-donut-chart>
     <mat-spinner [diameter]="30" *ngIf="loading"></mat-spinner>
 </div>
-<!-- <kendo-chart #chart class="widget-content" [categoryAxis]="settings.chart.type === 'line' ? categoryAxis : ''"
-        *ngIf="settings.chart">
-        <kendo-chart-title *ngIf="settings.chart.title" [visible]='settings.chart.title.visible'
-            [text]='settings.chart.title.text' [position]='settings.chart.title.position'></kendo-chart-title>
-        <kendo-chart-legend *ngIf="settings.chart.legend" [visible]='settings.chart.legend.visible'
-            [position]='settings.chart.legend.position' [orientation]='settings.chart.legend.orientation'>
-        </kendo-chart-legend>
-        <kendo-chart-tooltip format='{0}'></kendo-chart-tooltip>
-        <kendo-chart-series>
-            <ng-container *ngIf="['bar'].includes(settings.chart.type)">
-                <kendo-chart-series-item *ngFor='let item of series' [type]='settings.chart.type' [style]='item.style'
-                    [stack]="{ type: '100%' }" [data]='item.data' [name]="item.name" field="field"
-                    categoryField="category">
-                </kendo-chart-series-item>
-            </ng-container>
-            <ng-container *ngIf="['line'].includes(settings.chart.type)">
-                <kendo-chart-series-item *ngFor='let item of series' [type]='settings.chart.type' [style]='item.style'
-                    [data]='item.data' field="field" categoryField="category">
-                </kendo-chart-series-item>
-            </ng-container>
-            <ng-container *ngIf="['pie', 'donut'].includes(settings.chart.type)">
-                <kendo-chart-series-item *ngFor='let item of series' [type]="settings.chart.type" [data]="item.data"
-                    field="field" categoryField="category"></kendo-chart-series-item>
-            </ng-container>
-        </kendo-chart-series>
-    </kendo-chart> -->
-<!-- <ng-container *ngIf="['scatter', 'scatterLine'].includes(settings.chart.type)">
-    <kendo-chart-series-item *ngFor='let item of series'
-        [name]="item.name"
-        [type]="settings.chart.type"
-        [data]="item.data"
-        xField="xField" yField="yField">
-    </kendo-chart-series-item>
-</ng-container> -->

--- a/projects/safe/src/lib/components/widgets/chart/chart.component.ts
+++ b/projects/safe/src/lib/components/widgets/chart/chart.component.ts
@@ -1,6 +1,5 @@
-import { Component, Input, OnChanges, OnDestroy, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild } from '@angular/core';
 import { saveAs } from '@progress/kendo-file-saver';
-import { ChartComponent } from '@progress/kendo-angular-charts';
 import { Subscription } from 'rxjs';
 import { AggregationBuilderService } from '../../../services/aggregation-builder.service';
 import { SafeLineChartComponent } from '../../ui/line-chart/line-chart.component';
@@ -33,24 +32,21 @@ export class SafeChartComponent implements OnChanges, OnDestroy {
   @ViewChild('chartWrapper')
   private chartWrapper?: SafeLineChartComponent | SafePieChartComponent | SafeDonutChartComponent;
 
-  public categoryAxis: any = {
-    type: 'date',
-    maxDivisions: 10
-  };
-
   constructor(
     private aggregationBuilder: AggregationBuilderService
   ) { }
 
   /*  Detect changes of the settings to reload the data.
   */
-  ngOnChanges(): void {
-    this.loading = false;
-    this.dataQuery = this.aggregationBuilder.buildAggregation(this.settings.chart.pipeline);
-    if (this.dataQuery) {
-      this.getData();
-    } else {
-      this.loading = false;
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.settings?.firstChange || changes.settings.currentValue.chart.pipeline !== changes.settings.previousValue.chart.pipeline) {
+      this.loading = true;
+      this.dataQuery = this.aggregationBuilder.buildAggregation(this.settings.chart.pipeline);
+      if (this.dataQuery) {
+        this.getData();
+      } else {
+        this.loading = false;
+      }
     }
   }
 


### PR DESCRIPTION
# Description

When an user select another chart type, the aggregation will reload to update the visual chart.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] In the chart settings, I switched multiples times from Donuts to Pie chart and it worked fine.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
