### PR TITLE
[SAFE-512] fix query builder to keep selected field in quick actions …

### DIFF
--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -75,11 +75,13 @@ export class SafeGridSettingsComponent implements OnInit, AfterViewInit {
       floatingButtons: this.formBuilder.array(tileSettings.floatingButtons && tileSettings.floatingButtons.length ?
         tileSettings.floatingButtons.map((x: any) => this.createFloatingButtonForm(x)) : [this.createFloatingButtonForm(null)])
     });
+    this.queryName = this.tileForm.get('query')?.value.name;
 
     this.tileForm.get('query')?.valueChanges.subscribe(res => {
       if (res.name) {
-        // Check if the query changed to clean modifications and fields for email in floating button if any
-        if (this.fields && (res.name !== this.queryName)) {
+        // Check if the query changed to clean modifications and fields for email in floating button
+        if (res.name !== this.queryName) {
+          this.queryName = res.name;
           const floatingButtons = this.tileForm?.get('floatingButtons') as FormArray;
           for (const floatingButton of floatingButtons.controls) {
             const modifications = floatingButton.get('modifications') as FormArray;
@@ -90,7 +92,6 @@ export class SafeGridSettingsComponent implements OnInit, AfterViewInit {
           }
         }
         this.fields = this.queryBuilder.getFields(res.name);
-        this.queryName = res.name;
         const query = this.queryBuilder.sourceQuery(this.queryName);
         if (query) {
           query.subscribe((res1: { data: any }) => {
@@ -144,8 +145,6 @@ export class SafeGridSettingsComponent implements OnInit, AfterViewInit {
           });
         }
       });
-
-      this.queryName = this.tileForm.get('query')?.value.name;
     }
   }
 


### PR DESCRIPTION
…button

# Description

I fixed the querybuilder in the grid-settings to keep the selected field in the quick actions buttons.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] I tested it by changing a quick action button and reloading the settings.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
