### PR TITLE
[SAFE-524] fix: remove app name setting modal + create a default name…

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/applications/applications.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/applications/applications.component.ts
@@ -123,28 +123,36 @@ export class ApplicationsComponent implements OnInit, AfterViewInit, OnDestroy {
     Add a new application once closed, if result exists.
   */
   onAdd(): void {
-    const dialogRef = this.dialog.open(AddApplicationComponent);
-    dialogRef.afterClosed().subscribe(value => {
-      if (value) {
-        this.apollo.mutate<AddApplicationMutationResponse>({
-          mutation: ADD_APPLICATION,
-          variables: {
-            name: value.name
-          }
-        }).subscribe(res => {
-          if (res.errors) {
-            if (res.errors[0].message.includes('duplicate key error')) {
-              this.snackBar.openSnackBar(NOTIFICATIONS.objectAlreadyExists('app', value.name), { error: true });
+    let appName = '';
+    let num = 0;
+    let continueLoop = true;
+    while (continueLoop){
+      continueLoop = false;
+      num ++;
+      this.applications.data.forEach((v, i, a) => {
+        appName = 'application ' + num;
+        if (v.name === appName){
+          continueLoop = true;
+        }
+      });
+    }
+    this.apollo.mutate<AddApplicationMutationResponse>({
+      mutation: ADD_APPLICATION,
+      variables: {
+        name: appName
+      }
+    }).subscribe(res => {
+      if (res.errors) {
+        if (res.errors[0].message.includes('duplicate key error')) {
+          this.snackBar.openSnackBar(NOTIFICATIONS.objectAlreadyExists('app', name), { error: true });
 
-            } else {
-              this.snackBar.openSnackBar(NOTIFICATIONS.objectNotCreated('App', res.errors[0].message));
-            }
-          } else {
-            this.snackBar.openSnackBar(NOTIFICATIONS.objectCreated(value.name, 'application'));
-            const id = res.data?.addApplication.id;
-            this.router.navigate(['/applications', id]);
-          }
-        });
+        } else {
+          this.snackBar.openSnackBar(NOTIFICATIONS.objectNotCreated('App', res.errors[0].message));
+        }
+      } else {
+        this.snackBar.openSnackBar(NOTIFICATIONS.objectCreated(name, 'application'));
+        const id = res.data?.addApplication.id;
+        this.router.navigate(['/applications', id]);
       }
     });
   }


### PR DESCRIPTION
… of the form of "application {number}"

# Description

Remove app name setting modal
Define the default form by "application {number}"

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A

- Go to the application page and click on the "Create an application" button
- If it works well, the application has been created (without asking a name to you) and the name is the form of 'application (number)

- [x] Test B

- In order to prove the program won't use the same name as one which already exist, try to create 3 application, so you have application 1 2 and 3.
- Delete "application 2"
- Now click on the "Create an application" button
- If it works well, the program must have created an application with the name "application 2"

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
