### PR TITLE
feat: set initial order for grid available field list

### DIFF
--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
@@ -26,7 +26,6 @@ export class SafeTabFieldsComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     const selectedFields: string[] = this.form.getRawValue().map(x => x.name);
     this.availableFields = this.fields.slice().filter(x => !selectedFields.includes(x.name));
-    this.availableFields.sort((a, b) => (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0));
     this.selectedFields = selectedFields.map(x => this.fields.find(f => f.name === x) || { name: x });
     this.selectedFields.forEach((x, index) => {
       if (!x.type) {

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
@@ -26,6 +26,7 @@ export class SafeTabFieldsComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     const selectedFields: string[] = this.form.getRawValue().map(x => x.name);
     this.availableFields = this.fields.slice().filter(x => !selectedFields.includes(x.name));
+    this.availableFields.sort((a, b) => (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0));
     this.selectedFields = selectedFields.map(x => this.fields.find(f => f.name === x) || { name: x });
     this.selectedFields.forEach((x, index) => {
       if (!x.type) {

--- a/projects/safe/src/lib/services/query-builder.service.ts
+++ b/projects/safe/src/lib/services/query-builder.service.ts
@@ -37,7 +37,8 @@ export class QueryBuilderService {
 
   public getFields(queryName: string): any[] {
     const query = this.__availableQueries.getValue().find(x => x.name === queryName);
-    return query ? query.type.ofType.fields.filter((x: any) => !DISABLED_FIELDS.includes(x.name)) : [];
+    return query ? query.type.ofType.fields.filter((x: any) => !DISABLED_FIELDS.includes(x.name))
+      .sort((a: any, b: any) => a.name.localeCompare(b.name)) : [];
   }
 
   public getFieldsFromType(typeName: string): any[] {
@@ -45,22 +46,26 @@ export class QueryBuilderService {
       return this.userFields;
     }
     const query = this.__availableQueries.getValue().find(x => x.type.ofType.name === typeName);
-    return query ? query.type.ofType.fields.filter((x: any) => !DISABLED_FIELDS.includes(x.name)) : [];
+    return query ? query.type.ofType.fields.filter((x: any) => !DISABLED_FIELDS.includes(x.name))
+      .sort((a: any, b: any) => a.name.localeCompare(b.name)) : [];
   }
 
   public getListFields(queryName: string): any[] {
     const query = this.__availableQueries.getValue().find(x => x.name === queryName);
-    return query ? query.type.ofType.fields.filter((x: any) => x.type.kind === 'LIST') : [];
+    return query ? query.type.ofType.fields.filter((x: any) => x.type.kind === 'LIST')
+      .sort((a: any, b: any) => a.name.localeCompare(b.name)) : [];
   }
 
   public getFilter(queryName: string): any[] {
     const query = this.__availableQueries.getValue().find(x => x.name === queryName);
-    return query ? query.args.find((x: any) => x.name === 'filter').type.inputFields : [];
+    return query ? [...query.args.find((x: any) => x.name === 'filter').type.inputFields]
+      .sort((a: any, b: any) => a.name.localeCompare(b.name)) : [];
   }
 
   public getFilterFromType(typeName: string): any[] {
     const query = this.__availableQueries.getValue().find(x => x.type.ofType.name === typeName);
-    return query ? query.args.find((x: any) => x.name === 'filter').type.inputFields : [];
+    return query ? [...query.args.find((x: any) => x.name === 'filter').type.inputFields]
+      .sort((a: any, b: any) => a.name.localeCompare(b.name)) : [];
   }
 
   private buildFilter(filter: any): any {


### PR DESCRIPTION
# Description

Set an initial order (sort by name) for available fields of a grid

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A

 - Go to the settings of a grid widget
 - If it works well, the available fields are classed by name

- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
