### PR TITLE
fix: disable the focus of the first input of the add user modal

### DIFF
--- a/projects/safe/src/lib/components/users/components/invite-users/invite-users.component.ts
+++ b/projects/safe/src/lib/components/users/components/invite-users/invite-users.component.ts
@@ -69,7 +69,8 @@ export class SafeInviteUsersComponent implements OnInit {
         roles: this.data.roles,
         users: this.data.users.filter(x => !invitedUsers.includes(x.username)),
         ...this.data.positionAttributeCategories && { positionAttributeCategories: this.data.positionAttributeCategories }
-      }
+      },
+      autoFocus: false
     });
     dialogRef.afterClosed().subscribe(value => {
       if (value) {


### PR DESCRIPTION
# Description

Disable the focus of the first input of the add user modal

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A

 - go to the users tab
 - click on invite
 - click on "invite new" button in the table
 - none of the field is focus by default

- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
