### PR TITLE
add possibility to use today() in the date questions

### DIFF
--- a/projects/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -928,7 +928,11 @@ export class SafeGridComponent implements OnInit, OnChanges, OnDestroy {
       const record = this.gridData.data[index];
       const data = Object.assign({}, record);
       for (const modification of modifications) {
-        data[modification.field.name] = modification.value;
+        if (modification.value === 'today()' && modification.field.type.name === 'Date') {
+          data[modification.field.name] = new Date();
+        } else {
+          data[modification.field.name] = modification.value;
+        }
       }
       delete data.id;
       delete data.__typename;


### PR DESCRIPTION
# Description

Add today() to the automodify rows, so the users can set current date when editing the rows in the grid


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Add automodify to a grid, and set a date field with today() value

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
