### PR TITLE
Ab#11640

### DIFF
--- a/projects/safe/src/lib/components/form-modal/form-modal.component.html
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.html
@@ -1,4 +1,7 @@
 <safe-button mat-dialog-close (click)="onClose()" [isIcon]="true" icon="close" variant="danger" class="modal-close"></safe-button>
+<mat-tab-group animationDuration="0ms" (selectedIndexChange)="onShowPage($event)" *ngIf="formPages.length > 1">
+    <mat-tab *ngFor="let page of formPages" [label]="page.title ? page.title : page.name"></mat-tab>
+</mat-tab-group>
 <span mat-dialog-title *ngIf="modifiedAt" class="record-date">Last edit: {{ modifiedAt | date:'dd/MM/yy, h:mm a' }}</span>
 <mat-dialog-content [id]="containerId"></mat-dialog-content>
 <div mat-dialog-actions align="end" *ngIf="survey">

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.html
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.html
@@ -5,5 +5,5 @@
     <button mat-button color="warn" (click)="onClose()">Cancel</button>
     <button *ngIf="!survey.isFirstPage" mat-button color="primary" (click)="survey.prevPage()">Previous</button>
     <button *ngIf="!survey.isLastPage" mat-button color="primary" (click)="survey.nextPage()">Next</button>
-    <button mat-flat-button color="primary" (click)="survey.completeLastPage()">Complete</button>
+    <button *ngIf="!survey.hasErrors()" mat-flat-button color="primary" (click)="survey.completeLastPage()">Save and close</button>
 </div>

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.html
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.html
@@ -1,5 +1,5 @@
 <safe-button mat-dialog-close (click)="onClose()" [isIcon]="true" icon="close" variant="danger" class="modal-close"></safe-button>
-<mat-tab-group animationDuration="0ms" (selectedIndexChange)="onShowPage($event)" *ngIf="formPages.length > 1">
+<mat-tab-group animationDuration="0ms" [selectedIndex]="selectedTabIndex" (selectedIndexChange)="onShowPage($event)" *ngIf="formPages.length > 1">
     <mat-tab *ngFor="let page of formPages" [label]="page.title ? page.title : page.name"></mat-tab>
 </mat-tab-group>
 <span mat-dialog-title *ngIf="modifiedAt" class="record-date">Last edit: {{ modifiedAt | date:'dd/MM/yy, h:mm a' }}</span>

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.html
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.html
@@ -1,12 +1,17 @@
 <safe-button mat-dialog-close (click)="onClose()" [isIcon]="true" icon="close" variant="danger" class="modal-close"></safe-button>
-<mat-tab-group animationDuration="0ms" [selectedIndex]="selectedTabIndex" (selectedIndexChange)="onShowPage($event)" *ngIf="formPages.length > 1">
-    <mat-tab *ngFor="let page of formPages" [label]="page.title ? page.title : page.name"></mat-tab>
+<mat-tab-group animationDuration="0ms" [selectedIndex]="selectedTabIndex" (selectedIndexChange)="onShowPage($event)">
+    <mat-tab *ngFor="let page of pages$ | async" [label]="page.title ? page.title : page.name">
+        <ng-template mat-tab-label>
+            {{ page.title ? page.title : page.name }}
+            <safe-icon *ngIf="page.containsErrors" icon="error" variant="danger" [inline]="true"></safe-icon>
+        </ng-template>
+    </mat-tab>
 </mat-tab-group>
 <span mat-dialog-title *ngIf="modifiedAt" class="record-date">Last edit: {{ modifiedAt | date:'dd/MM/yy, h:mm a' }}</span>
 <mat-dialog-content [id]="containerId"></mat-dialog-content>
 <div mat-dialog-actions align="end" *ngIf="survey">
     <button mat-button color="warn" (click)="onClose()">Cancel</button>
-    <button *ngIf="!survey.isFirstPage" mat-button color="primary" (click)="survey.prevPage()">Previous</button>
-    <button *ngIf="!survey.isLastPage" mat-button color="primary" (click)="survey.nextPage()">Next</button>
-    <button *ngIf="!survey.hasErrors()" mat-flat-button color="primary" (click)="survey.completeLastPage()">Save and close</button>
+    <button [disabled]="survey.isFirstPage" mat-button color="primary" (click)="survey.prevPage()">Previous</button>
+    <button [disabled]="survey.isLastPage" mat-button color="primary" (click)="survey.nextPage()">Next</button>
+    <button mat-flat-button color="primary" (click)="submit()">Save and close</button>
 </div>

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -45,6 +45,7 @@ export class SafeFormModalComponent implements OnInit {
   private isMultiEdition = false;
 
   public survey?: Survey.Model;
+  public formPages: any[] = [];
   private temporaryFilesStorage: any = {};
 
   // === SURVEY COLORS
@@ -113,6 +114,11 @@ export class SafeFormModalComponent implements OnInit {
     this.survey.onDownloadFile.add((survey, options) => this.onDownloadFile(survey, options));
     this.survey.onUpdateQuestionCssClasses.add((_, options) => this.onSetCustomCss(options));
     this.survey.locale = this.data.locale ? this.data.locale : 'en';
+    for (const page of this.survey.pages) {
+      if (page.isVisible) {
+        this.formPages.push(page);
+      }
+    }
     if (this.data.recordId && this.record) {
       addCustomFunctions(Survey, this.authService, this.record);
       this.survey.data = this.isMultiEdition ? null : this.record.data;
@@ -278,6 +284,10 @@ export class SafeFormModalComponent implements OnInit {
       });
   }
 
+  public onShowPage(i: number): void {
+    if (this.survey) this.survey.currentPageNo = i;
+  }
+  
   private onDownloadFile(survey: Survey.SurveyModel, options: any): void {
     if (options.content.indexOf('base64') !== -1 || options.content.indexOf('http') !== -1) {
       options.callback('success', options.content);

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -45,6 +45,7 @@ export class SafeFormModalComponent implements OnInit {
   private isMultiEdition = false;
 
   public survey?: Survey.Model;
+  public selectedTabIndex = 0;
   public formPages: any[] = [];
   private temporaryFilesStorage: any = {};
 
@@ -113,6 +114,9 @@ export class SafeFormModalComponent implements OnInit {
     this.survey.onUploadFiles.add((survey, options) => this.onUploadFiles(survey, options));
     this.survey.onDownloadFile.add((survey, options) => this.onDownloadFile(survey, options));
     this.survey.onUpdateQuestionCssClasses.add((_, options) => this.onSetCustomCss(options));
+    this.survey.onCurrentPageChanged.add((surveyModel, options) => {
+      this.selectedTabIndex = surveyModel.currentPageNo;
+    });
     this.survey.locale = this.data.locale ? this.data.locale : 'en';
     for (const page of this.survey.pages) {
       if (page.isVisible) {
@@ -285,9 +289,10 @@ export class SafeFormModalComponent implements OnInit {
   }
 
   public onShowPage(i: number): void {
-    if (this.survey) this.survey.currentPageNo = i;
+    if (this.survey) { this.survey.currentPageNo = i; }
+    this.selectedTabIndex = i;
   }
-  
+
   private onDownloadFile(survey: Survey.SurveyModel, options: any): void {
     if (options.content.indexOf('base64') !== -1 || options.content.indexOf('http') !== -1) {
       options.callback('success', options.content);

--- a/projects/safe/src/lib/components/form-modal/form-modal.module.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.module.ts
@@ -5,6 +5,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { SafeButtonModule } from '../ui/button/button.module';
+import { MatTabsModule } from '@angular/material/tabs';
 
 @NgModule({
   declarations: [SafeFormModalComponent],
@@ -13,6 +14,7 @@ import { SafeButtonModule } from '../ui/button/button.module';
     MatDialogModule,
     MatIconModule,
     MatButtonModule,
+    MatTabsModule,
     SafeButtonModule
   ],
   exports: [SafeFormModalComponent]

--- a/projects/safe/src/lib/components/form-modal/form-modal.module.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.module.ts
@@ -6,6 +6,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { SafeButtonModule } from '../ui/button/button.module';
 import { MatTabsModule } from '@angular/material/tabs';
+import { SafeIconModule } from '../ui/icon/icon.module';
 
 @NgModule({
   declarations: [SafeFormModalComponent],
@@ -15,7 +16,8 @@ import { MatTabsModule } from '@angular/material/tabs';
     MatIconModule,
     MatButtonModule,
     MatTabsModule,
-    SafeButtonModule
+    SafeButtonModule,
+    SafeIconModule
   ],
   exports: [SafeFormModalComponent]
 })

--- a/projects/safe/src/lib/components/form/form.component.html
+++ b/projects/safe/src/lib/components/form/form.component.html
@@ -22,3 +22,8 @@
   </kendo-dropdownlist>
 </div>
 <div [id]="containerId"></div>
+<div mat-dialog-actions align="end">
+    <button *ngIf="!survey.isFirstPage" mat-button color="primary" (click)="survey.prevPage()">Previous</button>
+    <button *ngIf="!survey.isLastPage" mat-button color="primary" (click)="survey.nextPage()">Next</button>
+    <button *ngIf="survey.isLastPage" mat-flat-button color="primary" (click)="survey.completeLastPage()">Save</button>
+</div>

--- a/projects/safe/src/lib/components/form/form.component.html
+++ b/projects/safe/src/lib/components/form/form.component.html
@@ -4,13 +4,6 @@
   </safe-button>
 </div>
 
-<div *ngIf="form.uniqueRecord || record">
-  <mat-tab-group animationDuration="0ms" [selectedIndex]="selectedTabIndex" (selectedIndexChange)="onShowPage($event)"
-    *ngIf="survey.pages.length > 1">
-    <mat-tab *ngFor="let page of survey.pages" [label]="page.title"></mat-tab>
-  </mat-tab-group>
-</div>
-
 <span *ngIf="modifiedAt && !isFromCacheData" class="record-date">Last edit: {{ modifiedAt | date:'dd/MM/yy, h:mm a'}}</span>
 <span *ngIf="isFromCacheData" class="record-date">From cache: {{ storageDate | date:'dd/MM/yy, h:mm a'}}</span>
 <div class="survey-float" *ngIf="surveyActive">
@@ -21,9 +14,17 @@
     </ng-template>
   </kendo-dropdownlist>
 </div>
+<mat-tab-group animationDuration="0ms" [selectedIndex]="selectedTabIndex" (selectedIndexChange)="onShowPage($event)">
+  <mat-tab *ngFor="let page of pages$ | async" [label]="page.title ? page.title : page.name">
+      <ng-template mat-tab-label>
+          {{ page.title ? page.title : page.name }}
+          <safe-icon *ngIf="page.containsErrors" icon="error" variant="danger" [inline]="true"></safe-icon>
+      </ng-template>
+  </mat-tab>
+</mat-tab-group>
 <div [id]="containerId"></div>
-<div mat-dialog-actions align="end">
-    <button *ngIf="!survey.isFirstPage" mat-button color="primary" (click)="survey.prevPage()">Previous</button>
-    <button *ngIf="!survey.isLastPage" mat-button color="primary" (click)="survey.nextPage()">Next</button>
-    <button *ngIf="survey.isLastPage" mat-flat-button color="primary" (click)="survey.completeLastPage()">Save</button>
+<div *ngIf="surveyActive" class="survey-navigation">
+  <safe-button [disabled]="survey.isFirstPage" variant="primary" (click)="survey.prevPage()">Previous</safe-button>
+  <safe-button [disabled]="survey.isLastPage" variant="primary" (click)="survey.nextPage()">Next</safe-button>
+  <safe-button variant="primary" category="secondary" (click)="submit()">Save</safe-button>
 </div>

--- a/projects/safe/src/lib/components/form/form.component.scss
+++ b/projects/safe/src/lib/components/form/form.component.scss
@@ -44,3 +44,11 @@ mat-tab-group {
   text-align: end;
   margin-left: auto;
 }
+
+.survey-navigation {
+  display: flex;
+  justify-content: flex-end;
+  safe-button {
+    margin-left: 8px
+  }
+}

--- a/projects/safe/src/lib/components/form/form.component.ts
+++ b/projects/safe/src/lib/components/form/form.component.ts
@@ -9,9 +9,9 @@ import { Record } from '../../models/record.model';
 import { SafeSnackBarService } from '../../services/snackbar.service';
 import { LANGUAGES } from '../../utils/languages';
 import { Router } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { SafeWorkflowService } from '../../services/workflow.service';
-import { SafeDownloadService } from '../../services/download.service';
+import { SafeDownloadService } from '../../services/download.service';
 import addCustomFunctions from '../../utils/custom-functions';
 import { NOTIFICATIONS } from '../../const/notifications';
 import { SafeAuthService } from '../../services/auth.service';
@@ -25,7 +25,7 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @Input() form!: Form;
   @Input() record?: Record;
-  @Output() save: EventEmitter<{completed: boolean, hideNewRecord?: boolean}> = new EventEmitter();
+  @Output() save: EventEmitter<{ completed: boolean, hideNewRecord?: boolean }> = new EventEmitter();
 
   // === SURVEYJS ===
   public survey!: Survey.Model;
@@ -37,6 +37,7 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
   public dropdownLocales: any[] = [];
   public surveyActive = true;
   public selectedTabIndex = 0;
+  private pages = new BehaviorSubject<any[]>([]);
   private temporaryFilesStorage: any = {};
   public containerId: string;
 
@@ -54,6 +55,10 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
   private storageId = '';
   public storageDate: Date = new Date();
   public isFromCacheData = false;
+
+  public get pages$(): Observable<any[]> {
+    return this.pages.asObservable();
+  }
 
   constructor(
     private apollo: Apollo,
@@ -138,7 +143,7 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
     if (this.survey.getUsedLocales().length > 1) {
       this.survey.getUsedLocales().forEach(lang => {
         const nativeName = (LANGUAGES as any)[lang].nativeName.split(',')[0];
-        this.usedLocales.push({value: lang, text: nativeName});
+        this.usedLocales.push({ value: lang, text: nativeName });
         this.dropdownLocales.push(nativeName);
       });
     }
@@ -154,13 +159,21 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     this.survey.showNavigationButtons = false;
+    this.setPages();
     this.survey.onComplete.add(this.complete);
     this.survey.showCompletedPage = false;
     if (!this.record && !this.form.canCreateRecords) {
       this.survey.mode = 'display';
     }
-    this.survey.onCurrentPageChanged.add((surveyModel, options) => {
-      this.selectedTabIndex = surveyModel.currentPageNo;
+    this.survey.onCurrentPageChanged.add((survey, options) => {
+      survey.checkErrorsMode = survey.isLastPage ? 'onComplete' : 'onNextPage';
+      this.selectedTabIndex = survey.currentPageNo;
+    });
+    this.survey.onPageVisibleChanged.add(() => {
+      this.setPages();
+    });
+    this.survey.onSettingQuestionErrors.add((survey, options) => {
+      this.setPages();
     });
     this.survey.onValueChanged.add(this.valueChange.bind(this));
   }
@@ -182,8 +195,21 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
     localStorage.setItem(this.storageId, JSON.stringify({ data: this.survey.data, date: new Date() }));
   }
 
-  /*  Custom SurveyJS method, save a new record or edit existing one.
-  */
+  /**
+   * Calls the complete method of the survey if no error.
+   */
+  public submit(): void {
+    if (!this.survey?.hasErrors()) {
+      this.survey?.completeLastPage();
+    } else {
+      this.snackBar.openSnackBar('Saving failed, some fields require your attention.', { error: true });
+    }
+  }
+
+  /**
+   * Creates the record, or update it if provided.
+   * @param survey Survey instance.
+   */
   public complete = async () => {
     let mutation: any;
     this.surveyActive = false;
@@ -345,12 +371,22 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
     classes.content += 'safe-qst-content';
   }
 
-  public onShowPage(i: number): void {
-    this.survey.currentPageNo = i;
-    this.selectedTabIndex = i;
-    if (this.survey.compareTo) {
-      this.survey.currentPageNo = i;
+  private setPages(): void {
+    const pages = [];
+    if (this.survey) {
+      for (const page of this.survey.pages) {
+        if (page.isVisible) {
+          pages.push(page);
+        }
+      }
     }
+    this.pages.next(pages);
+  }
+
+  public onShowPage(i: number): void {
+    if (this.survey) { this.survey.currentPageNo = i; }
+    if (this.survey.compareTo) { this.survey.currentPageNo = i; }
+    this.selectedTabIndex = i;
   }
 
   public onClear(): void {

--- a/projects/safe/src/lib/components/form/form.component.ts
+++ b/projects/safe/src/lib/components/form/form.component.ts
@@ -153,6 +153,7 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
       this.survey.locale = 'en';
     }
 
+    this.survey.showNavigationButtons = false;
     this.survey.onComplete.add(this.complete);
     this.survey.showCompletedPage = false;
     if (!this.record && !this.form.canCreateRecords) {

--- a/projects/safe/src/lib/components/form/form.module.ts
+++ b/projects/safe/src/lib/components/form/form.module.ts
@@ -1,23 +1,21 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SafeFormComponent } from './form.component';
-import { MatDialogModule } from '@angular/material/dialog';
 import { SafeFormModalModule } from '../form-modal/form-modal.module';
 import { DropDownListModule } from '@progress/kendo-angular-dropdowns';
 import { MatTabsModule } from '@angular/material/tabs';
 import { SafeButtonModule } from '../ui/button/button.module';
-import { MatButtonModule } from '@angular/material/button';
+import { SafeIconModule } from '../ui/icon/icon.module';
 
 @NgModule({
   declarations: [SafeFormComponent],
   imports: [
     CommonModule,
     SafeFormModalModule,
-    MatDialogModule,
     DropDownListModule,
     MatTabsModule,
     SafeButtonModule,
-    MatButtonModule
+    SafeIconModule
   ],
   exports: [SafeFormComponent]
 })

--- a/projects/safe/src/lib/components/form/form.module.ts
+++ b/projects/safe/src/lib/components/form/form.module.ts
@@ -6,6 +6,7 @@ import { SafeFormModalModule } from '../form-modal/form-modal.module';
 import { DropDownListModule } from '@progress/kendo-angular-dropdowns';
 import { MatTabsModule } from '@angular/material/tabs';
 import { SafeButtonModule } from '../ui/button/button.module';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   declarations: [SafeFormComponent],
@@ -15,7 +16,8 @@ import { SafeButtonModule } from '../ui/button/button.module';
     MatDialogModule,
     DropDownListModule,
     MatTabsModule,
-    SafeButtonModule
+    SafeButtonModule,
+    MatButtonModule
   ],
   exports: [SafeFormComponent]
 })

--- a/projects/safe/src/lib/components/record-modal/record-modal.component.html
+++ b/projects/safe/src/lib/components/record-modal/record-modal.component.html
@@ -1,7 +1,7 @@
 <safe-button mat-dialog-close (click)="onClose()" [isIcon]="true" icon="close" variant="danger" class="modal-close"></safe-button>
 <ng-container *ngIf="!loading">
     <div mat-dialog-title>
-        <mat-tab-group animationDuration="0ms" (selectedIndexChange)="onShowPage($event)" *ngIf="formPages.length > 1">
+        <mat-tab-group animationDuration="0ms" [selectedIndex]="selectedTabIndex" (selectedIndexChange)="onShowPage($event)" *ngIf="formPages.length > 1">
             <mat-tab *ngFor="let page of formPages" [label]="page.title ? page.title : page.name"></mat-tab>
         </mat-tab-group>
         <div class="versions-info" *ngIf="data.compareTo">

--- a/projects/safe/src/lib/components/record-modal/record-modal.component.html
+++ b/projects/safe/src/lib/components/record-modal/record-modal.component.html
@@ -36,5 +36,7 @@
 </mat-dialog-actions>
 <mat-dialog-actions align="end" *ngIf="!loading && !data.compareTo && canEdit">
     <button mat-button color="warn" (click)="onClose()">Close</button>
+    <button *ngIf="!survey.isFirstPage" mat-button color="primary" (click)="survey.prevPage()">Previous</button>
+    <button *ngIf="!survey.isLastPage" mat-button color="primary" (click)="survey.nextPage()">Next</button>
     <button mat-flat-button color="primary" (click)="onEdit()">Edit record</button>
 </mat-dialog-actions>

--- a/projects/safe/src/lib/components/record-modal/record-modal.component.html
+++ b/projects/safe/src/lib/components/record-modal/record-modal.component.html
@@ -1,8 +1,8 @@
 <safe-button mat-dialog-close (click)="onClose()" [isIcon]="true" icon="close" variant="danger" class="modal-close"></safe-button>
 <ng-container *ngIf="!loading">
     <div mat-dialog-title>
-        <mat-tab-group animationDuration="0ms" [selectedIndex]="selectedTabIndex" (selectedIndexChange)="onShowPage($event)" *ngIf="formPages.length > 1">
-            <mat-tab *ngFor="let page of formPages" [label]="page.title ? page.title : page.name"></mat-tab>
+        <mat-tab-group animationDuration="0ms" [selectedIndex]="selectedTabIndex" (selectedIndexChange)="onShowPage($event)">
+            <mat-tab *ngFor="let page of pages$ | async" [label]="page.title ? page.title : page.name"></mat-tab>
         </mat-tab-group>
         <div class="versions-info" *ngIf="data.compareTo">
             <div class="version-info">

--- a/projects/safe/src/lib/components/record-modal/record-modal.component.ts
+++ b/projects/safe/src/lib/components/record-modal/record-modal.component.ts
@@ -30,6 +30,7 @@ export class SafeRecordModalComponent implements OnInit {
   public form?: Form;
   public record: Record = {};
   public modifiedAt: Date | null = null;
+  public selectedTabIndex = 0;
   public survey!: Survey.Model;
   public surveyNext: Survey.Model | null = null;
   public formPages: any[] = [];
@@ -101,6 +102,9 @@ export class SafeRecordModalComponent implements OnInit {
       }
     }
     this.survey.onDownloadFile.add((survey, options) => this.onDownloadFile(survey, options));
+    this.survey.onCurrentPageChanged.add((surveyModel, options) => {
+      this.selectedTabIndex = surveyModel.currentPageNo;
+    });
     this.survey.data = this.record.data;
     this.survey.locale = this.data.locale ? this.data.locale : 'en';
     this.survey.mode = 'display';
@@ -146,6 +150,7 @@ export class SafeRecordModalComponent implements OnInit {
 
   public onShowPage(i: number): void {
     this.survey.currentPageNo = i;
+    this.selectedTabIndex = i;
     if (this.data.compareTo && this.surveyNext) {
       this.surveyNext.currentPageNo = i;
     }


### PR DESCRIPTION
# Description

- Add navigations buttons to forms in single pages
- Add pages tabs in the form edition modal
- Show "Save and close" button in a form modal even if not on the last form page
- Prevent form completion unless all required questions are populated.


## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] I tested all form (modal or not) to test for all changes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
