### PR TITLE
AB#11063

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/components/pull-job-modal/pull-job-modal.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/components/pull-job-modal/pull-job-modal.component.ts
@@ -6,13 +6,15 @@ import { ApiConfiguration, Application, Channel, Form, PullJob, status } from '@
 import { Apollo, QueryRef } from 'apollo-angular';
 import {
   GetApiConfigurationsQueryResponse, GET_API_CONFIGURATIONS,
-  GetFormByIdQueryResponse, GET_FORM_BY_ID,
+  GetFormByIdQueryResponse, GET_SHORT_FORM_BY_ID,
   GetFormsQueryResponse, GET_FORM_NAMES, GetRoutingKeysQueryResponse, GET_ROUTING_KEYS
 } from 'projects/back-office/src/app/graphql/queries';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { SubscriptionModalComponent } from '../../../../../application/pages/subscriptions/components/subscription-modal/subscription-modal.component';
 
 const ITEMS_PER_PAGE = 10;
+
+const DEFAULT_FIELDS = ['createdBy'];
 
 @Component({
   selector: 'app-pull-job-modal',
@@ -190,13 +192,14 @@ export class PullJobModalComponent implements OnInit {
       this.fieldsSubscription.unsubscribe();
     }
     this.fieldsSubscription = this.apollo.watchQuery<GetFormByIdQueryResponse>({
-      query: GET_FORM_BY_ID,
+      query: GET_SHORT_FORM_BY_ID,
       variables: {
         id
       }
     }).valueChanges.subscribe(resForm => {
       if (resForm.data.form) {
         this.fields = resForm.data.form.fields || [];
+        this.fields = this.fields.concat(DEFAULT_FIELDS.map(x => ({ name: x })));
       }
     });
   }


### PR DESCRIPTION
# Description

Add the possibility to use 'createdBy' field in pullJobs mapping.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added a line of code to replace an EIOS email with mine so the user would exist in my local instance. Then I hard deleted an Information imported with this EIOS email and it was imported back with the createdBy field working correctly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
