### PR TITLE
AB#11271 - form enhancement

### DIFF
--- a/projects/safe/src/lib/services/form.service.ts
+++ b/projects/safe/src/lib/services/form.service.ts
@@ -8,6 +8,8 @@ import { MatDialog } from '@angular/material/dialog';
 import { Apollo } from 'apollo-angular';
 import { FormBuilder } from '@angular/forms';
 import { SafeAuthService } from './auth.service';
+import { SafeDownloadService } from './download.service';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -20,7 +22,8 @@ export class SafeFormService {
     public dialog: MatDialog,
     public apollo: Apollo,
     public formBuilder: FormBuilder,
-    public authService: SafeAuthService
+    public authService: SafeAuthService,
+    private downloadService: SafeDownloadService
   ) {
     // === CUSTOM WIDGETS / COMPONENTS ===
     initCustomWidgets(SurveyKo, domService, dialog, apollo, formBuilder, authService, environment);
@@ -32,14 +35,112 @@ export class SafeFormService {
     initCustomWidgets(Survey, domService, dialog, apollo, formBuilder, authService, environment);
   }
 
-  createSurvey(structure: string): Survey.Survey {
+  createSurvey(
+    structure: string,
+    readOnly: boolean,
+    pages: BehaviorSubject<any[]>,
+    language: string,
+    temporaryFilesStorage?: any): Survey.Survey {
     const survey = new Survey.Model(structure);
+    if (!readOnly) {
+      survey.onClearFiles.add((_, options) => options.callback('success'));
+      survey.onUploadFiles.add((sender, options) => this.onUploadFiles(sender, options, temporaryFilesStorage));
+      survey.onUpdateQuestionCssClasses.add((_, options) => this.onSetCustomCss(options));
+      survey.onSettingQuestionErrors.add(() => {
+        this.setPages(survey, pages);
+      });
+    } else {
+      survey.mode = 'display';
+    }
+    survey.onDownloadFile.add((sender, options) => this.onDownloadFile(sender, options));
+    survey.onPageVisibleChanged.add(() => {
+      this.setPages(survey, pages);
+    });
+    survey.locale = language ? language : 'en';
+    survey.showNavigationButtons = 'none';
+    survey.showProgressBar = 'off';
     const onCompleteExpression = survey.toJSON().onCompleteExpression;
     if (onCompleteExpression) {
       survey.onCompleting.add(() => {
         survey.runExpression(onCompleteExpression);
       });
     }
+    this.setPages(survey, pages);
     return survey;
+  }
+
+  private onUploadFiles(survey: Survey.SurveyModel, options: any, temporaryFilesStorage: any): void {
+    if (temporaryFilesStorage[options.name] !== undefined) {
+      temporaryFilesStorage[options.name].concat(options.files);
+    } else {
+      temporaryFilesStorage[options.name] = options.files;
+    }
+    let content: any[] = [];
+    options
+      .files
+      .forEach((file: any) => {
+        const fileReader = new FileReader();
+        fileReader.onload = (e) => {
+          content = content.concat([
+            {
+              name: file.name,
+              type: file.type,
+              content: fileReader.result,
+              file
+            }
+          ]);
+          if (content.length === options.files.length) {
+            options.callback('success', content.map((fileContent) => {
+              return { file: fileContent.file, content: fileContent.content };
+            }));
+          }
+        };
+        fileReader.readAsDataURL(file);
+      });
+  }
+
+  private onDownloadFile(survey: Survey.SurveyModel, options: any): void {
+    if (options.content.indexOf('base64') !== -1 || options.content.indexOf('http') !== -1) {
+      options.callback('success', options.content);
+      return;
+    } else {
+      const xhr = new XMLHttpRequest();
+      xhr.open('GET', `${this.downloadService.baseUrl}/download/file/${options.content}`);
+      xhr.setRequestHeader('Authorization', `Bearer ${localStorage.getItem('msal.idtoken')}`);
+      xhr.onloadstart = () => {
+        xhr.responseType = 'blob';
+      };
+      xhr.onload = () => {
+        const file = new File([xhr.response], options.fileValue.name, { type: options.fileValue.type });
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          options.callback('success', e.target?.result);
+        };
+        reader.readAsDataURL(file);
+      };
+      xhr.send();
+    }
+  }
+
+  /**
+   * Add custom CSS classes to the survey elements.
+   * @param survey current survey.
+   * @param options survey options.
+   */
+  private onSetCustomCss(options: any): void {
+    const classes = options.cssClasses;
+    classes.content += 'safe-qst-content';
+  }
+
+  private setPages(survey: Survey.Survey, pages: BehaviorSubject<any[]>): void {
+    const pageList = [];
+    if (survey) {
+      for (const page of survey.pages) {
+        if (page.isVisible) {
+          pageList.push(page);
+        }
+      }
+    }
+    pages.next(pageList);
   }
 }

--- a/projects/safe/src/lib/utils/custom-functions.ts
+++ b/projects/safe/src/lib/utils/custom-functions.ts
@@ -31,6 +31,5 @@ export default function addCustomFunctions(Survey: any, authService: SafeAuthSer
         data: { [fieldName]: value },
       }
     }).subscribe();
-});
-
+  });
 }


### PR DESCRIPTION
# Description

Add a property at the highest level of surveys: `OnCompleteExpression`. It allows to configure an expression which will be run on form completing.
Using the new custom function `editSelected` we can configure a job to update selected records in a resource question (e. g. set them as 'Processed').
Refactor survey initialization.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Created a form with a resource question referring to a resource with a `status` field. Using this expression: `editSelected({sources}, 'status', 'Processed')` I was able to solve the WHO's use case.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
