### PR TITLE
Ab#16102

### DIFF
--- a/projects/safe/ng-package.json
+++ b/projects/safe/ng-package.json
@@ -29,7 +29,8 @@
       "lodash/isEqual": "lodash/isEqual",
       "lodash/isNil": "lodash/isNil",
       "lodash/omitBy": "lodash/omitBy",
-      "@progress/kendo-angular-common": "@progress/kendo-angular-common"
+      "@progress/kendo-angular-common": "@progress/kendo-angular-common",
+      "@progress/kendo-angular-layout": "@progress/kendo-angular-layout"
     }
   }
 }

--- a/projects/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -239,29 +239,21 @@ export class SafeGridWidgetComponent implements OnInit {
    */
   private promisedRowsModifications(modifications: any[], items: any[]): Promise<any>[] {
     const promises: Promise<any>[] = [];
-    const modificationFields: any[] = [];
     for (const item of items) {
-      const data = Object.assign({}, item);
+      const update: any = {};
       for (const modification of modifications) {
-        modificationFields.push(modification.field.name);
+        // modificationFields.push(modification.field.name);
         if (['Date', 'DateTime'].includes(modification.field.type.name)) {
-          data[modification.field.name] = this.getDateForFilter(modification.value);
+          update[modification.field.name] = this.getDateForFilter(modification.value);
         } else {
-          data[modification.field.name] = modification.value;
+          update[modification.field.name] = modification.value;
         }
       }
-      modificationFields.push('canDelete', 'canUpdate');
-      // remove all field except the modified one
-      Object.keys(data).forEach(key => {
-        if (!modificationFields.includes(key)) {
-          delete data[key];
-        }
-      });
       promises.push(this.apollo.mutate<EditRecordMutationResponse>({
         mutation: EDIT_RECORD,
         variables: {
           id: item.id,
-          data,
+          data: update,
           template: this.settings.query.template
         }
       }).toPromise());

--- a/projects/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -239,18 +239,24 @@ export class SafeGridWidgetComponent implements OnInit {
    */
   private promisedRowsModifications(modifications: any[], items: any[]): Promise<any>[] {
     const promises: Promise<any>[] = [];
+    const modificationFields: any[] = [];
     for (const item of items) {
       const data = Object.assign({}, item);
       for (const modification of modifications) {
+        modificationFields.push(modification.field.name)
         if (['Date', 'DateTime'].includes(modification.field.type.name)) {
           data[modification.field.name] = this.getDateForFilter(modification.value);
         } else {
           data[modification.field.name] = modification.value;
         }
       }
-      delete data.id;
-      // eslint-disable-next-line no-underscore-dangle
-      delete data.__typename;
+      modificationFields.push('canDelete', 'canUpdate')
+      // remove all field except the modified one
+      Object.keys(data).forEach(key => {
+        if (!modificationFields.includes(key)) {
+          delete data[key]
+        }
+      })
       promises.push(this.apollo.mutate<EditRecordMutationResponse>({
         mutation: EDIT_RECORD,
         variables: {

--- a/projects/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -243,20 +243,20 @@ export class SafeGridWidgetComponent implements OnInit {
     for (const item of items) {
       const data = Object.assign({}, item);
       for (const modification of modifications) {
-        modificationFields.push(modification.field.name)
+        modificationFields.push(modification.field.name);
         if (['Date', 'DateTime'].includes(modification.field.type.name)) {
           data[modification.field.name] = this.getDateForFilter(modification.value);
         } else {
           data[modification.field.name] = modification.value;
         }
       }
-      modificationFields.push('canDelete', 'canUpdate')
+      modificationFields.push('canDelete', 'canUpdate');
       // remove all field except the modified one
       Object.keys(data).forEach(key => {
         if (!modificationFields.includes(key)) {
-          delete data[key]
+          delete data[key];
         }
-      })
+      });
       promises.push(this.apollo.mutate<EditRecordMutationResponse>({
         mutation: EDIT_RECORD,
         variables: {


### PR DESCRIPTION
# Description

Added a loop to remove all keys from the data object that won't be needed for the update.
It won't changes the value of a resource question when using the auto-modify rows from a nested object.

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] I reproduced the steps from the ticket after my changes and its now working well.

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
