### PR TITLE
AB#23094

### DIFF
--- a/projects/safe/src/lib/components/form-modal/form-modal.component.html
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.html
@@ -1,4 +1,4 @@
-<safe-button mat-dialog-close (click)="onClose()" [isIcon]="true" icon="close" variant="danger" class="modal-close"></safe-button>
+<safe-button (click)="onClose()" [isIcon]="true" icon="close" variant="danger" class="modal-close"></safe-button>
 <safe-record-summary *ngIf="record" [record]="record" (showHistory)="onShowHistory()"></safe-record-summary>
 <mat-tab-group animationDuration="0ms" [selectedIndex]="selectedTabIndex" (selectedIndexChange)="onShowPage($event)">
     <mat-tab *ngFor="let page of pages$ | async" [label]="page.title ? page.title : page.name">

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -28,7 +28,6 @@ import { NOTIFICATIONS } from '../../const/notifications';
 import { RecordHistoryModalComponent } from '../record-history-modal/record-history-modal.component';
 import isNil from 'lodash/isNil';
 import omitBy from 'lodash/omitBy';
-import isEqual from 'lodash/isEqual';
 
 /**
  * Interface of Dialog data.

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -467,8 +467,6 @@ export class SafeFormModalComponent implements OnInit {
    * Closes the modal without sending any data.
    */
   onClose(): void {
-    console.log('onClose()');
-    // close the modal even if we put nothing in this metthode (weird)
     const confirmationDialog = this.confirmationDialog.open(SafeConfirmModalComponent, {
       data: {
         title: 'Close without saving changes?',
@@ -478,14 +476,10 @@ export class SafeFormModalComponent implements OnInit {
       }
     });
     confirmationDialog.afterClosed().subscribe((value) => {
-      console.log('DIALOG CLOSE');
-      console.log(value);
       if(value){
-        console.log('TRUE');
         this.dialogRef.close();
       }
     });
-    // this.dialogRef.close();
   }
 
   /**

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -469,18 +469,22 @@ export class SafeFormModalComponent implements OnInit {
   onClose(): void {
     console.log('onClose()');
     // close the modal even if we put nothing in this metthode (weird)
-    // const confirmationDialog = this.confirmationDialog.open(SafeConfirmModalComponent, {
-    //   data: {
-    //     title: 'Close without saving changes?',
-    //     content: 'Do you confirm that you want to exit the record adding and loose your changes',
-    //     confirmText: 'Confirm',
-    //     confirmColor: 'primary'
-    //   }
-    // });
-    // confirmationDialog.afterClosed().subscribe((value) => {
-    //   console.log('DIALOG CLOSE');
-    //   this.dialogRef.close();
-    // })
+    const confirmationDialog = this.confirmationDialog.open(SafeConfirmModalComponent, {
+      data: {
+        title: 'Close without saving changes?',
+        content: 'Do you confirm that you want to exit the record adding and loose your changes',
+        confirmText: 'Confirm',
+        confirmColor: 'primary'
+      }
+    });
+    confirmationDialog.afterClosed().subscribe((value) => {
+      console.log('DIALOG CLOSE');
+      console.log(value);
+      if(value){
+        console.log('TRUE');
+        this.dialogRef.close();
+      }
+    });
     // this.dialogRef.close();
   }
 

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -28,6 +28,7 @@ import { NOTIFICATIONS } from '../../const/notifications';
 import { RecordHistoryModalComponent } from '../record-history-modal/record-history-modal.component';
 import isNil from 'lodash/isNil';
 import omitBy from 'lodash/omitBy';
+import isEqual from 'lodash/isEqual';
 
 /**
  * Interface of Dialog data.
@@ -77,7 +78,6 @@ export class SafeFormModalComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public data: DialogData,
     public dialog: MatDialog,
     public dialogRef: MatDialogRef<SafeFormModalComponent>,
-    public confirmationDialog: MatDialog,
     private apollo: Apollo,
     private snackBar: SafeSnackBarService,
     private downloadService: SafeDownloadService,
@@ -467,19 +467,25 @@ export class SafeFormModalComponent implements OnInit {
    * Closes the modal without sending any data.
    */
   onClose(): void {
-    const confirmationDialog = this.confirmationDialog.open(SafeConfirmModalComponent, {
-      data: {
-        title: 'Close without saving changes',
-        content: 'Do you confirm that you want to exit and loose your changes?',
-        confirmText: 'Confirm',
-        confirmColor: 'primary'
-      }
-    });
-    confirmationDialog.afterClosed().subscribe((value) => {
-      if(value){
-        this.dialogRef.close();
-      }
-    });
+    // TODO: we should compare the data with init data to display a confirm modal
+    // if (!isEqual(this.survey?.data, this.initData)) {
+    //   const closeDialogRef = this.dialog.open(SafeConfirmModalComponent, {
+    //     data: {
+    //       title: 'Confirm',
+    //       content: 'Record has been modified. You can cancel to continue editing, or discard you changes.',
+    //       confirmText: 'Discard changes',
+    //       confirmColor: 'primary'
+    //     }
+    //   });
+    //   closeDialogRef.afterClosed().subscribe((value) => {
+    //     if(value){
+    //       this.dialogRef.close();
+    //     }
+    //   });
+    // } else {
+    //   this.dialogRef.close();
+    // }
+    this.dialogRef.close();
   }
 
   /**

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -469,8 +469,8 @@ export class SafeFormModalComponent implements OnInit {
   onClose(): void {
     const confirmationDialog = this.confirmationDialog.open(SafeConfirmModalComponent, {
       data: {
-        title: 'Close without saving changes?',
-        content: 'Do you confirm that you want to exit the record adding and loose your changes',
+        title: 'Close without saving changes',
+        content: 'Do you confirm that you want to exit and loose your changes?',
         confirmText: 'Confirm',
         confirmColor: 'primary'
       }

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -77,6 +77,7 @@ export class SafeFormModalComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public data: DialogData,
     public dialog: MatDialog,
     public dialogRef: MatDialogRef<SafeFormModalComponent>,
+    public confirmationDialog: MatDialog,
     private apollo: Apollo,
     private snackBar: SafeSnackBarService,
     private downloadService: SafeDownloadService,
@@ -466,7 +467,21 @@ export class SafeFormModalComponent implements OnInit {
    * Closes the modal without sending any data.
    */
   onClose(): void {
-    this.dialogRef.close();
+    console.log('onClose()');
+    // close the modal even if we put nothing in this metthode (weird)
+    // const confirmationDialog = this.confirmationDialog.open(SafeConfirmModalComponent, {
+    //   data: {
+    //     title: 'Close without saving changes?',
+    //     content: 'Do you confirm that you want to exit the record adding and loose your changes',
+    //     confirmText: 'Confirm',
+    //     confirmColor: 'primary'
+    //   }
+    // });
+    // confirmationDialog.afterClosed().subscribe((value) => {
+    //   console.log('DIALOG CLOSE');
+    //   this.dialogRef.close();
+    // })
+    // this.dialogRef.close();
   }
 
   /**

--- a/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -25,6 +25,7 @@ import { GetRecordDetailsQueryResponse, GET_RECORD_DETAILS } from '../../../grap
 import { SafeFormModalComponent } from '../../form-modal/form-modal.component';
 import { SafeRecordModalComponent } from '../../record-modal/record-modal.component';
 import { SafeConfirmModalComponent } from '../../confirm-modal/confirm-modal.component';
+import { SafeStatusModalComponent } from '../../status-modal/status-modal.component';
 import { SafeConvertModalComponent } from '../../convert-modal/convert-modal.component';
 import { Form } from '../../../models/form.model';
 import { NOTIFICATIONS } from '../../../const/notifications';
@@ -34,6 +35,7 @@ import isEqual from 'lodash/isEqual';
 import { SafeGridService } from '../../../services/grid.service';
 import { SafeResourceGridModalComponent } from '../../search-resource-grid-modal/search-resource-grid-modal.component';
 import { SafeGridComponent } from './grid/grid.component';
+import { values } from 'lodash';
 
 const DEFAULT_FILE_NAME = 'grid.xlsx';
 
@@ -188,6 +190,7 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
     @Inject('environment') environment: any,
     private apollo: Apollo,
     public dialog: MatDialog,
+    public confirmationDialog: MatDialog,
     private resolver: ComponentFactoryResolver,
     private queryBuilder: QueryBuilderService,
     private layoutService: SafeLayoutService,
@@ -523,6 +526,7 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
   private onAdd(): void {
     if (this.settings.query.template) {
       const dialogRef = this.dialog.open(SafeFormModalComponent, {
+        disableClose: true,
         data: {
           template: this.settings.query.template,
           locale: 'en',
@@ -530,7 +534,22 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
         },
         autoFocus: false
       });
+      
+      dialogRef.beforeClosed().subscribe(value => {
+        console.log('beforeClosed()');
+        console.log(value);
+        // const confirmationDialog = this.confirmationDialog.open(SafeConfirmModalComponent, {
+        //   data: {
+        //     title: 'Close without saving changes?',
+        //     content: 'Do you confirm that you want to exit the record adding and loose your changes',
+        //     confirmText: 'Confirm',
+        //     confirmColor: 'primary'
+        //   }
+        // });
+      });
       dialogRef.afterClosed().subscribe(value => {
+        console.log('afterClosed()');
+        console.log(value);
         if (value) {
           this.reloadData();
         }

--- a/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -25,7 +25,6 @@ import { GetRecordDetailsQueryResponse, GET_RECORD_DETAILS } from '../../../grap
 import { SafeFormModalComponent } from '../../form-modal/form-modal.component';
 import { SafeRecordModalComponent } from '../../record-modal/record-modal.component';
 import { SafeConfirmModalComponent } from '../../confirm-modal/confirm-modal.component';
-import { SafeStatusModalComponent } from '../../status-modal/status-modal.component';
 import { SafeConvertModalComponent } from '../../convert-modal/convert-modal.component';
 import { Form } from '../../../models/form.model';
 import { NOTIFICATIONS } from '../../../const/notifications';
@@ -35,7 +34,6 @@ import isEqual from 'lodash/isEqual';
 import { SafeGridService } from '../../../services/grid.service';
 import { SafeResourceGridModalComponent } from '../../search-resource-grid-modal/search-resource-grid-modal.component';
 import { SafeGridComponent } from './grid/grid.component';
-import { values } from 'lodash';
 
 const DEFAULT_FILE_NAME = 'grid.xlsx';
 

--- a/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -534,22 +534,7 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
         },
         autoFocus: false
       });
-      
-      dialogRef.beforeClosed().subscribe(value => {
-        console.log('beforeClosed()');
-        console.log(value);
-        // const confirmationDialog = this.confirmationDialog.open(SafeConfirmModalComponent, {
-        //   data: {
-        //     title: 'Close without saving changes?',
-        //     content: 'Do you confirm that you want to exit the record adding and loose your changes',
-        //     confirmText: 'Confirm',
-        //     confirmColor: 'primary'
-        //   }
-        // });
-      });
       dialogRef.afterClosed().subscribe(value => {
-        console.log('afterClosed()');
-        console.log(value);
         if (value) {
           this.reloadData();
         }

--- a/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -188,7 +188,6 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
     @Inject('environment') environment: any,
     private apollo: Apollo,
     public dialog: MatDialog,
-    public confirmationDialog: MatDialog,
     private resolver: ComponentFactoryResolver,
     private queryBuilder: QueryBuilderService,
     private layoutService: SafeLayoutService,

--- a/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -608,6 +608,7 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
   public onUpdate(items: any[]): void {
     const ids: string[] = items.map(x => x.id ? x.id : x);
     const dialogRef = this.dialog.open(SafeFormModalComponent, {
+      disableClose: true,
       data: {
         recordId: ids.length > 1 ? ids : ids[0],
         locale: 'en',

--- a/projects/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -192,6 +192,7 @@ export class SafeGridWidgetComponent implements OnInit {
 
       // Opens a modal containing the prefilled form.
       this.dialog.open(SafeFormModalComponent, {
+        disableClose: true,
         data: {
           template: options.prefillTargetForm,
           locale: 'en',
@@ -330,6 +331,7 @@ export class SafeGridWidgetComponent implements OnInit {
             if (record) {
               this.snackBar.openSnackBar(NOTIFICATIONS.addRowsToRecord(selectedRecords.length, key, record.data[targetFormField]));
               this.dialog.open(SafeFormModalComponent, {
+                disableClose: true,
                 data: {
                   recordId: record.id,
                   locale: 'en'

--- a/projects/safe/src/lib/survey/widget.ts
+++ b/projects/safe/src/lib/survey/widget.ts
@@ -301,6 +301,7 @@ export function init(Survey: any, domService: DomService, dialog: MatDialog, env
     if (question.addRecord && question.addTemplate) {
       addButton.onclick = () => {
         const dialogRef = dialog.open(SafeFormModalComponent, {
+          disableClose: true,
           data: {
             template: question.addTemplate,
             locale: question.resource.value,


### PR DESCRIPTION
# Description

- Disable clicking outside the SafeFormModal to exit it
- When clicking on red cross to exit, add a SafeConfirmModalComponent before exiting to make sure it's not an error from the user and he really wants to exit the modal.

Affected elements:

- Grid buttons:
 - add record
 - update record

- Quick action buttons:
 - pre fill form
 - attach to records

- add new records button (in resource question)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A

Click on on of the button quoted in the description of the ticket:
- try to click outside of the form modal displayed => if it works well, it will do nothing
- try to close the modal by clicking on the red cross => a confirmation modal will be displayed to confirm the exit or to stay on the form modal.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
