### PR TITLE
OORT-89

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/applications/applications.component.html
+++ b/projects/back-office/src/app/dashboard/pages/applications/applications.component.html
@@ -1,12 +1,12 @@
-<mat-spinner diameter="45" class="page-loader" *ngIf="loading"></mat-spinner>
-<ng-container *ngIf="!loading">
+<ng-container *ngIf="!loading; else skeleton_template">
   <!-- FILTERING -->
   <app-filter (filter)="onFilter($event)"></app-filter>
 
   <!-- NEW APPLICATIONS -->
   <h2>{{'apps.recent' | translate}}</h2>
   <safe-applications-summary [canCreate]="canAdd" (add)="onAdd()" [applications]="newApplications"
-    (openApplication)="onOpenApplication($event)" (delete)="onDelete($event)" (preview)="onPreview($event)" (clone)="onClone($event)"></safe-applications-summary>
+    (openApplication)="onOpenApplication($event)" (delete)="onDelete($event)" (preview)="onPreview($event)"
+    (clone)="onClone($event)"></safe-applications-summary>
 
   <!-- APPLICATIONS TABLE -->
   <ng-container>
@@ -91,8 +91,44 @@
       <tr class="clickable" mat-row *matRowDef="let row; columns: displayedColumns"
         [routerLink]="['/applications', row.id]"></tr>
     </table>
-    <mat-paginator [pageSize]="pageInfo.pageSize" [pageSizeOptions]="[10, 25, 50]" [length]="pageInfo.length" aria-label="Select page of applications"
-      (page)="onPage($event)">
+    <mat-paginator [pageSize]="pageInfo.pageSize" [pageSizeOptions]="[10, 25, 50]" [length]="pageInfo.length"
+      aria-label="Select page of applications" (page)="onPage($event)">
     </mat-paginator>
   </ng-container>
 </ng-container>
+
+
+<!-- SKELETON TEMPLATE -->
+<ng-template #skeleton_template>
+  <div style="display: flex;">
+    <kendo-skeleton shape="rectangle" height="36px" width="220px"></kendo-skeleton>
+    <kendo-skeleton style="margin-left: 16px;" shape="rectangle" height="36px" width="120px"></kendo-skeleton>
+  </div>
+
+  <h2 style="margin-top: 16px;">
+    <kendo-skeleton shape="text" width="240px"></kendo-skeleton>
+  </h2>
+
+  <div style="display: flex; gap: 32px;">
+    <kendo-skeleton *ngFor="let item of [1,2,3,4]" shape="rectangle" animation="wave" width="192px" height="192px">
+    </kendo-skeleton>
+  </div>
+
+  <h2 style="margin-top: 64px;">
+    <kendo-skeleton shape="text" width="240px"></kendo-skeleton>
+  </h2>
+
+  <table *ngIf="loading" mat-table [dataSource]="skeletonDataSource">
+    <ng-container *ngFor="let key of skeletonDisplayedColumns" matColumnDef="{{key}}">
+      <th mat-header-cell *matHeaderCellDef>
+        <kendo-skeleton shape="text" width="25%"></kendo-skeleton>
+      </th>
+      <td mat-cell *matCellDef="let element">
+        <kendo-skeleton shape="text" width="25%"></kendo-skeleton>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="skeletonDisplayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: skeletonDisplayedColumns;"></tr>
+  </table>
+</ng-template>

--- a/projects/back-office/src/app/dashboard/pages/applications/applications.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/applications/applications.component.ts
@@ -60,6 +60,20 @@ export class ApplicationsComponent implements OnInit, AfterViewInit, OnDestroy {
   public newApplications: Application[] = [];
   public filter: any;
 
+  // === SKELETON DATA ===
+  public skeletonDataSource: any[] = [
+    { sk1: 'sk1', sk2: 'sk2', sk3: 'sk3', sk4: 'sk4' },
+    { sk1: 'sk1', sk2: 'sk2', sk3: 'sk3', sk4: 'sk4' },
+    { sk1: 'sk1', sk2: 'sk2', sk3: 'sk3', sk4: 'sk4' },
+    { sk1: 'sk1', sk2: 'sk2', sk3: 'sk3', sk4: 'sk4' },
+    { sk1: 'sk1', sk2: 'sk2', sk3: 'sk3', sk4: 'sk4' },
+    { sk1: 'sk1', sk2: 'sk2', sk3: 'sk3', sk4: 'sk4' },
+    { sk1: 'sk1', sk2: 'sk2', sk3: 'sk3', sk4: 'sk4' },
+    { sk1: 'sk1', sk2: 'sk2', sk3: 'sk3', sk4: 'sk4' },
+  ];
+  public skeletonDisplayedColumns: string[] = Object.keys(this.skeletonDataSource[0]);
+
+
   // === SORTING ===
   @ViewChild(MatSort) sort?: MatSort;
 
@@ -85,7 +99,7 @@ export class ApplicationsComponent implements OnInit, AfterViewInit, OnDestroy {
     private snackBar: SafeSnackBarService,
     private authService: SafeAuthService,
     private previewService: PreviewService
-  ) {}
+  ) { }
 
   /**
    * Creates the application query and subscribes to the query changes.

--- a/projects/back-office/src/app/dashboard/pages/applications/applications.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/applications/applications.component.ts
@@ -71,8 +71,9 @@ export class ApplicationsComponent implements OnInit, AfterViewInit, OnDestroy {
     { sk1: 'sk1', sk2: 'sk2', sk3: 'sk3', sk4: 'sk4' },
     { sk1: 'sk1', sk2: 'sk2', sk3: 'sk3', sk4: 'sk4' },
   ];
-  public skeletonDisplayedColumns: string[] = Object.keys(this.skeletonDataSource[0]);
-
+  public skeletonDisplayedColumns: string[] = Object.keys(
+    this.skeletonDataSource[0]
+  );
 
   // === SORTING ===
   @ViewChild(MatSort) sort?: MatSort;
@@ -99,7 +100,7 @@ export class ApplicationsComponent implements OnInit, AfterViewInit, OnDestroy {
     private snackBar: SafeSnackBarService,
     private authService: SafeAuthService,
     private previewService: PreviewService
-  ) { }
+  ) {}
 
   /**
    * Creates the application query and subscribes to the query changes.

--- a/projects/back-office/src/app/dashboard/pages/applications/applications.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/applications/applications.module.ts
@@ -28,6 +28,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { FilterComponent } from './components/filter/filter.component';
 import { TranslateModule } from '@ngx-translate/core';
+import { IndicatorsModule } from "@progress/kendo-angular-indicators";
 
 @NgModule({
   declarations: [ApplicationsComponent, ChoseRoleComponent, FilterComponent],
@@ -57,6 +58,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MatPaginatorModule,
     SafeApplicationsSummaryModule,
     TranslateModule,
+    IndicatorsModule,
   ],
   exports: [ApplicationsComponent],
 })

--- a/projects/back-office/src/app/dashboard/pages/applications/applications.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/applications/applications.module.ts
@@ -28,7 +28,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { FilterComponent } from './components/filter/filter.component';
 import { TranslateModule } from '@ngx-translate/core';
-import { IndicatorsModule } from "@progress/kendo-angular-indicators";
+import { IndicatorsModule } from '@progress/kendo-angular-indicators';
 
 @NgModule({
   declarations: [ApplicationsComponent, ChoseRoleComponent, FilterComponent],

--- a/projects/back-office/src/app/dashboard/pages/forms/forms.component.html
+++ b/projects/back-office/src/app/dashboard/pages/forms/forms.component.html
@@ -1,5 +1,4 @@
-<mat-spinner diameter="45" class="page-loader" *ngIf="loading"></mat-spinner>
-<ng-container *ngIf="!loading">
+<ng-container *ngIf="!loading; else skeleton_template" >
   <div class="forms-header">
     <!-- FILTERING -->
     <app-filter (filter)="onFilter($event)"></app-filter>
@@ -133,3 +132,27 @@
     (page)="onPage($event)">
   </mat-paginator>
 </ng-container>
+
+
+<!-- SKELETON TEMPLATE -->
+<ng-template #skeleton_template>
+  <div style="display: flex; margin-bottom: 18px">
+    <kendo-skeleton shape="rectangle" height="36px" width="230px"></kendo-skeleton>
+    <kendo-skeleton style="margin-left: 16px;" shape="rectangle" height="36px" width="125px"></kendo-skeleton>
+    <kendo-skeleton style="margin-left: auto;" shape="rectangle" height="36px" width="150px"></kendo-skeleton>
+  </div>
+
+  <table *ngIf="loading" mat-table [dataSource]="skeletonDataSource">
+    <ng-container *ngFor="let key of skeletonDisplayedColumns" matColumnDef="{{key}}">
+      <th mat-header-cell *matHeaderCellDef>
+        <kendo-skeleton shape="text" width="25%"></kendo-skeleton>
+      </th>
+      <td mat-cell *matCellDef="let element">
+        <kendo-skeleton shape="text" width="25%"></kendo-skeleton>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="skeletonDisplayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: skeletonDisplayedColumns;"></tr>
+  </table>
+</ng-template>

--- a/projects/back-office/src/app/dashboard/pages/forms/forms.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/forms/forms.component.ts
@@ -77,16 +77,18 @@ export class FormsComponent implements OnInit, OnDestroy, AfterViewInit {
 
   // === SKELETON DATA ===
   public skeletonDataSource: any[] = [
-    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
-    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
-    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
-    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
-    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
-    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
-    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
-    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk' },
   ];
-  public skeletonDisplayedColumns: string[] = Object.keys(this.skeletonDataSource[0]);
+  public skeletonDisplayedColumns: string[] = Object.keys(
+    this.skeletonDataSource[0]
+  );
 
   constructor(
     private apollo: Apollo,

--- a/projects/back-office/src/app/dashboard/pages/forms/forms.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/forms/forms.component.ts
@@ -75,6 +75,19 @@ export class FormsComponent implements OnInit, OnDestroy, AfterViewInit {
     endCursor: '',
   };
 
+  // === SKELETON DATA ===
+  public skeletonDataSource: any[] = [
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
+    { sk1: 'sk', sk2: 'sk', sk3: 'sk', sk4: 'sk', sk5: 'sk', sk6: 'sk', sk7: 'sk', sk8: 'sk' },
+  ];
+  public skeletonDisplayedColumns: string[] = Object.keys(this.skeletonDataSource[0]);
+
   constructor(
     private apollo: Apollo,
     public dialog: MatDialog,

--- a/projects/back-office/src/app/dashboard/pages/forms/forms.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/forms/forms.module.ts
@@ -24,6 +24,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { FilterComponent } from './components/filter/filter.component';
 import { TranslateModule } from '@ngx-translate/core';
+import { IndicatorsModule } from '@progress/kendo-angular-indicators';
 
 @NgModule({
   declarations: [FormsComponent, FilterComponent],
@@ -50,6 +51,7 @@ import { TranslateModule } from '@ngx-translate/core';
     SafeButtonModule,
     MatPaginatorModule,
     TranslateModule,
+    IndicatorsModule,
   ],
   exports: [FormsComponent],
 })


### PR DESCRIPTION
# Description

This MR aims to demonstrate as a PoC the use of skeletons during a page loading instead of a spinner icon.

:warning: Only a PoC: do not merge :warning: 

As an improvement, we could consider creating an angular pipe which would automatically generate the dataSources for mat-table skeletons, to avoid putting empty skeleton data in the component.ts files.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Load the applications page in Back-Office
- [x] Load the forms page in Back-Office

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
