### PR TITLE
Ab#25521

### DIFF
--- a/projects/safe/src/lib/components/form/form.component.html
+++ b/projects/safe/src/lib/components/form/form.component.html
@@ -1,6 +1,6 @@
 <safe-record-summary [record]="record" [cacheDate]="storageDate" (clear)="onClear()"
   (showHistory)="onShowHistory()"></safe-record-summary>
-<div class="survey-float" *ngIf="surveyActive">
+<div class="survey-actions" *ngIf="surveyActive">
   <kendo-dropdownlist *ngIf="!!survey && survey.getUsedLocales().length > 1" id="langSelect" [data]="dropdownLocales"
     [value]="surveyLanguage.nativeName.split(',')[0]" (selectionChange)="setLanguage($event)">
     <ng-template kendoDropDownListValueTemplate let-dataItem style="text-transform: capitalize">

--- a/projects/safe/src/lib/components/form/form.component.scss
+++ b/projects/safe/src/lib/components/form/form.component.scss
@@ -4,12 +4,13 @@
   position: relative;
 }
 
-.survey-float {
+.survey-actions {
   position: relative;
   width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
+  margin-bottom: 16px;
 }
 
 #langSelect {
@@ -29,6 +30,9 @@ mat-tab-group {
 .survey-navigation {
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+
   safe-button {
     margin-left: 8px
   }

--- a/projects/safe/src/lib/components/form/form.component.scss
+++ b/projects/safe/src/lib/components/form/form.component.scss
@@ -13,10 +13,7 @@
 }
 
 #langSelect {
-  position: absolute;
   z-index: 99;
-  top: 8px;
-  right: 1em;
   border: 1px solid #777777;
   border-radius: 3px;
 }


### PR DESCRIPTION
# Description

Removed the position:absolute style from the language selector.
The language selector is now above the page selector and not over it.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] I tested it on a form and it doesn't hide the page selector anymore.

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
