### PR TITLE
OORT-113

### DIFF
--- a/projects/back-office/src/app/application/pages/add-page/add-page.component.ts
+++ b/projects/back-office/src/app/application/pages/add-page/add-page.component.ts
@@ -81,7 +81,7 @@ export class AddPageComponent implements OnInit, OnDestroy {
       this.onNext();
     });
     this.authSubscription = this.authService.user.subscribe(() => {
-      this.canCreateForm = this.authService.userHasClaim(Permissions.canManageForms);
+      this.canCreateForm = this.authService.userHasClaim(Permissions.canCreateForms);
     });
   }
 

--- a/projects/safe/src/lib/models/user.model.ts
+++ b/projects/safe/src/lib/models/user.model.ts
@@ -66,11 +66,11 @@ export enum PermissionType {
 export class PermissionsManagement {
     public static mappedPermissions = {
         resources: {
-            access: Permissions.canSeeResources,
+            access: [Permissions.canSeeResources, Permissions.canCreateResources],
             create: [Permissions.canCreateResources, Permissions.canManageResources]
         },
         forms: {
-            access: Permissions.canSeeForms,
+            access: [Permissions.canSeeForms, Permissions.canCreateForms],
             create: [Permissions.canCreateForms, Permissions.canManageForms]
         },
         settings: {


### PR DESCRIPTION

# Description

Change the permissions to allow user with canCreateForm to actually create a form, and user with canCreateForm & canCreateResource to see the form & resources tab on the global layout.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] I created a role with these two permissions and it worked fine.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
