### PR TITLE
OORT-133

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -146,7 +146,7 @@
   "forms": {
     "create": "Create a form",
     "delete": "Delete form",
-    "deleteDesc": "Do you confirm the deletion of the form {{value}}?",
+    "deleteDesc": "Do you confirm the deletion of the form {{name}}?",
     "exit": "Exit without saving changes",
     "exitDesc": "There are unsaved changes on your form. Are you sure you want to exit?",
     "title": "Available forms",


### PR DESCRIPTION
# Description

This PR fixes the string interpolation when deleting forms in the table view. This was done by changing the lang string so it matches the interpolation paramater.

## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Opened the delete form modal on table view, the form name is now displayed as intended


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
