### PR TITLE
OORT-145 - scheduler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1141,6 +1141,7 @@
     },
     "node_modules/@angular/compiler-cli": {
       "version": "12.2.14",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.8.6",
@@ -1174,6 +1175,7 @@
     },
     "node_modules/@angular/compiler-cli/node_modules/source-map": {
       "version": "0.6.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3861,7 +3863,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -3880,7 +3882,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
       "version": "6.12.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3895,7 +3897,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.12.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3909,7 +3911,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "4.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3917,7 +3919,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@foliojs-fork/fontkit": {
@@ -3977,7 +3979,7 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.0",
@@ -3990,7 +3992,7 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@hutson/parse-repository-url": {
@@ -13564,15 +13566,9 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/ace-builds": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.14.tgz",
-      "integrity": "sha512-NBOQlm9+7RBqRqZwimpgquaLeTJFayqb9UEPtTkpC3TkkwDnlsT/TwsCC0svjt9kEZ6G9mH5AEOHSz6Q/HrzQQ==",
-      "peer": true
-    },
     "node_modules/acorn": {
       "version": "7.4.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -13583,7 +13579,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -13711,6 +13707,7 @@
     },
     "node_modules/ajv": {
       "version": "8.8.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -13793,7 +13790,7 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13996,7 +13993,7 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -14004,7 +14001,7 @@
     },
     "node_modules/argparse/node_modules/sprintf-js": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/aria-query": {
@@ -14290,7 +14287,7 @@
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14934,15 +14931,6 @@
       "version": "1.0.0",
       "license": "ISC"
     },
-    "node_modules/bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/bootstrap-slider": {
       "version": "10.6.2",
       "license": "MIT"
@@ -15472,6 +15460,7 @@
     },
     "node_modules/canonical-path": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/capture-exit": {
@@ -17604,7 +17593,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -18246,7 +18235,7 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-object-diff": {
@@ -18516,6 +18505,7 @@
     },
     "node_modules/dependency-graph": {
       "version": "0.11.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -18670,7 +18660,7 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -19172,7 +19162,7 @@
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1"
@@ -19503,7 +19493,7 @@
     },
     "node_modules/eslint": {
       "version": "7.32.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -19885,7 +19875,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
@@ -19893,7 +19883,7 @@
     },
     "node_modules/eslint/node_modules/@babel/code-frame": {
       "version": "7.12.11",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
@@ -19901,7 +19891,7 @@
     },
     "node_modules/eslint/node_modules/ajv": {
       "version": "6.12.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -19916,7 +19906,7 @@
     },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -19930,7 +19920,7 @@
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -19945,7 +19935,7 @@
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -19956,7 +19946,7 @@
     },
     "node_modules/eslint/node_modules/eslint-utils": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
@@ -19970,7 +19960,7 @@
     },
     "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
@@ -19978,7 +19968,7 @@
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.12.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -19992,7 +19982,7 @@
     },
     "node_modules/eslint/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20000,7 +19990,7 @@
     },
     "node_modules/eslint/node_modules/ignore": {
       "version": "4.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -20008,12 +19998,12 @@
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/levn": {
       "version": "0.4.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -20025,7 +20015,7 @@
     },
     "node_modules/eslint/node_modules/optionator": {
       "version": "0.9.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -20041,7 +20031,7 @@
     },
     "node_modules/eslint/node_modules/prelude-ls": {
       "version": "1.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -20049,7 +20039,7 @@
     },
     "node_modules/eslint/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -20060,7 +20050,7 @@
     },
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20071,7 +20061,7 @@
     },
     "node_modules/eslint/node_modules/type-check": {
       "version": "0.4.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -20090,7 +20080,7 @@
     },
     "node_modules/espree": {
       "version": "7.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^7.4.0",
@@ -20103,7 +20093,7 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
@@ -20111,7 +20101,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -20123,7 +20113,7 @@
     },
     "node_modules/esquery": {
       "version": "1.4.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -20636,7 +20626,7 @@
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-sha256": {
@@ -20709,7 +20699,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -20993,7 +20983,7 @@
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.1.0",
@@ -21005,7 +20995,7 @@
     },
     "node_modules/flat-cache/node_modules/flatted": {
       "version": "3.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/flatted": {
@@ -21471,7 +21461,7 @@
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/functions-have-names": {
@@ -23793,7 +23783,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -24215,7 +24205,7 @@
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -24268,7 +24258,7 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
@@ -25140,7 +25130,7 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -25149,7 +25139,7 @@
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -26304,7 +26294,7 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/needle": {
@@ -27693,7 +27683,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29824,7 +29814,7 @@
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -30569,6 +30559,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -30590,6 +30581,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -30958,6 +30950,7 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/refractor": {
@@ -31036,7 +31029,7 @@
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -31533,7 +31526,7 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -32085,6 +32078,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -32549,7 +32543,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -32560,7 +32554,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -33754,7 +33748,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -34033,7 +34027,7 @@
     },
     "node_modules/table": {
       "version": "6.7.5",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
@@ -34048,7 +34042,7 @@
     },
     "node_modules/table/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -34062,7 +34056,7 @@
     },
     "node_modules/table/node_modules/slice-ansi": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -34078,7 +34072,7 @@
     },
     "node_modules/table/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -34230,7 +34224,7 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/throttle-debounce": {
@@ -34779,7 +34773,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
-      "devOptional": true,
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -34814,6 +34808,7 @@
     },
     "node_modules/typescript": {
       "version": "4.3.5",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -35390,7 +35385,7 @@
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
@@ -37007,7 +37002,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -37122,7 +37117,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -37680,8 +37675,7 @@
         },
         "acorn-import-assertions": {
           "version": "1.8.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "ajv": {
           "version": "8.6.2",
@@ -38135,6 +38129,7 @@
     },
     "@angular/compiler-cli": {
       "version": "12.2.14",
+      "dev": true,
       "requires": {
         "@babel/core": "^7.8.6",
         "@babel/types": "^7.8.6",
@@ -38153,7 +38148,8 @@
       },
       "dependencies": {
         "source-map": {
-          "version": "0.6.1"
+          "version": "0.6.1",
+          "dev": true
         }
       }
     },
@@ -39833,7 +39829,7 @@
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
@@ -39848,7 +39844,7 @@
       "dependencies": {
         "ajv": {
           "version": "6.12.6",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -39858,18 +39854,18 @@
         },
         "globals": {
           "version": "13.12.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
         },
         "ignore": {
           "version": "4.0.6",
-          "devOptional": true
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -39919,12 +39915,11 @@
       "dev": true
     },
     "@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "requires": {}
+      "version": "3.1.1"
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.0",
         "debug": "^4.1.1",
@@ -39933,7 +39928,7 @@
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "devOptional": true
+      "dev": true
     },
     "@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -40213,8 +40208,7 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -40242,8 +40236,7 @@
     },
     "@ngtools/webpack": {
       "version": "12.2.14",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@ngx-translate/core": {
       "version": "13.0.0",
@@ -40789,8 +40782,7 @@
       }
     },
     "@progress/kendo-charts": {
-      "version": "1.20.1",
-      "requires": {}
+      "version": "1.20.1"
     },
     "@progress/kendo-common": {
       "version": "0.2.1",
@@ -46964,20 +46956,13 @@
         "negotiator": "0.6.2"
       }
     },
-    "ace-builds": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.14.tgz",
-      "integrity": "sha512-NBOQlm9+7RBqRqZwimpgquaLeTJFayqb9UEPtTkpC3TkkwDnlsT/TwsCC0svjt9kEZ6G9mH5AEOHSz6Q/HrzQQ==",
-      "peer": true
-    },
     "acorn": {
       "version": "7.4.1",
-      "devOptional": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "devOptional": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -47070,6 +47055,7 @@
     },
     "ajv": {
       "version": "8.8.2",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -47078,8 +47064,7 @@
       }
     },
     "ajv-errors": {
-      "version": "1.0.1",
-      "requires": {}
+      "version": "1.0.1"
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -47093,8 +47078,7 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -47125,7 +47109,7 @@
     },
     "ansi-colors": {
       "version": "4.1.1",
-      "devOptional": true
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -47242,14 +47226,14 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       },
       "dependencies": {
         "sprintf-js": {
           "version": "1.0.3",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -47441,7 +47425,7 @@
     },
     "astral-regex": {
       "version": "2.0.0",
-      "devOptional": true
+      "dev": true
     },
     "async": {
       "version": "2.6.3",
@@ -47898,12 +47882,6 @@
     "boolbase": {
       "version": "1.0.0"
     },
-    "bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
-      "peer": true
-    },
     "bootstrap-slider": {
       "version": "10.6.2"
     },
@@ -48276,7 +48254,8 @@
       "version": "1.0.30001286"
     },
     "canonical-path": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -48484,8 +48463,7 @@
     },
     "circular-dependency-plugin": {
       "version": "5.2.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -48704,13 +48682,11 @@
       "dependencies": {
         "@angular/compiler": {
           "version": "9.0.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "@angular/core": {
           "version": "9.0.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -49771,7 +49747,7 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -50068,8 +50044,7 @@
     },
     "cssnano-utils": {
       "version": "2.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -50181,7 +50156,7 @@
     },
     "deep-is": {
       "version": "0.1.4",
-      "devOptional": true
+      "dev": true
     },
     "deep-object-diff": {
       "version": "1.1.7",
@@ -50357,7 +50332,8 @@
       "version": "1.1.2"
     },
     "dependency-graph": {
-      "version": "0.11.0"
+      "version": "0.11.0",
+      "dev": true
     },
     "deprecation": {
       "version": "2.3.1",
@@ -50474,7 +50450,7 @@
     },
     "doctrine": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -50809,8 +50785,7 @@
         },
         "ws": {
           "version": "8.2.3",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -50831,7 +50806,7 @@
     },
     "enquirer": {
       "version": "2.3.6",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }
@@ -51074,7 +51049,7 @@
     },
     "eslint": {
       "version": "7.32.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -51120,14 +51095,14 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.12.11",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
         },
         "ajv": {
           "version": "6.12.6",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -51137,14 +51112,14 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -51152,43 +51127,43 @@
         },
         "escape-string-regexp": {
           "version": "4.0.0",
-          "devOptional": true
+          "dev": true
         },
         "eslint-utils": {
           "version": "2.1.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
           },
           "dependencies": {
             "eslint-visitor-keys": {
               "version": "1.3.0",
-              "devOptional": true
+              "dev": true
             }
           }
         },
         "globals": {
           "version": "13.12.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
         },
         "has-flag": {
           "version": "4.0.0",
-          "devOptional": true
+          "dev": true
         },
         "ignore": {
           "version": "4.0.6",
-          "devOptional": true
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
-          "devOptional": true
+          "dev": true
         },
         "levn": {
           "version": "0.4.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "prelude-ls": "^1.2.1",
             "type-check": "~0.4.0"
@@ -51196,7 +51171,7 @@
         },
         "optionator": {
           "version": "0.9.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "deep-is": "^0.1.3",
             "fast-levenshtein": "^2.0.6",
@@ -51208,25 +51183,25 @@
         },
         "prelude-ls": {
           "version": "1.2.1",
-          "devOptional": true
+          "dev": true
         },
         "strip-ansi": {
           "version": "6.0.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
           "version": "7.2.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
         },
         "type-check": {
           "version": "0.4.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "prelude-ls": "^1.2.1"
           }
@@ -51235,8 +51210,7 @@
     },
     "eslint-config-prettier": {
       "version": "8.3.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -51399,8 +51373,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
       "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "4.0.0",
@@ -51461,7 +51434,7 @@
     },
     "eslint-visitor-keys": {
       "version": "2.1.0",
-      "devOptional": true
+      "dev": true
     },
     "esm": {
       "version": "3.2.25",
@@ -51469,7 +51442,7 @@
     },
     "espree": {
       "version": "7.3.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "acorn": "^7.4.0",
         "acorn-jsx": "^5.3.1",
@@ -51478,17 +51451,17 @@
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "1.3.0",
-          "devOptional": true
+          "dev": true
         }
       }
     },
     "esprima": {
       "version": "4.0.1",
-      "devOptional": true
+      "dev": true
     },
     "esquery": {
       "version": "1.4.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
       }
@@ -51849,7 +51822,7 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "devOptional": true
+      "dev": true
     },
     "fast-sha256": {
       "version": "1.3.0",
@@ -51903,7 +51876,7 @@
     },
     "file-entry-cache": {
       "version": "6.0.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
       }
@@ -52102,7 +52075,7 @@
     },
     "flat-cache": {
       "version": "3.0.4",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
@@ -52110,7 +52083,7 @@
       "dependencies": {
         "flatted": {
           "version": "3.2.4",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -52456,7 +52429,7 @@
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "devOptional": true
+      "dev": true
     },
     "functions-have-names": {
       "version": "1.2.2",
@@ -53394,8 +53367,7 @@
       }
     },
     "icss-utils": {
-      "version": "5.1.0",
-      "requires": {}
+      "version": "5.1.0"
     },
     "ieee754": {
       "version": "1.2.1"
@@ -53965,7 +53937,7 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "devOptional": true
+      "dev": true
     },
     "isobject": {
       "version": "4.0.0"
@@ -54263,7 +54235,7 @@
     },
     "js-yaml": {
       "version": "3.14.1",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -54297,7 +54269,7 @@
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "devOptional": true
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -54559,8 +54531,7 @@
     },
     "karma-jasmine-html-reporter": {
       "version": "1.7.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "karma-source-map-support": {
       "version": "1.4.0",
@@ -54615,8 +54586,7 @@
       "version": "1.7.1"
     },
     "leaflet.markercluster": {
-      "version": "1.5.3",
-      "requires": {}
+      "version": "1.5.3"
     },
     "less": {
       "version": "4.1.1",
@@ -54905,14 +54875,14 @@
     },
     "lodash.merge": {
       "version": "4.6.2",
-      "devOptional": true
+      "dev": true
     },
     "lodash.once": {
       "version": "4.1.1"
     },
     "lodash.truncate": {
       "version": "4.4.2",
-      "devOptional": true
+      "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -55177,8 +55147,7 @@
     "markdown-to-jsx": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.6.tgz",
-      "integrity": "sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g==",
-      "requires": {}
+      "integrity": "sha512-1wrIGZYwIG2gR3yfRmbr4FlQmhaAKoKTpRo4wur4fp9p0njU1Hi7vR8fj0AUKKIcPduiJmPprzmCB5B/GvlC7g=="
     },
     "marked": {
       "version": "4.0.7",
@@ -55690,7 +55659,7 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "devOptional": true
+      "dev": true
     },
     "needle": {
       "version": "2.9.1",
@@ -56647,7 +56616,7 @@
     },
     "path-key": {
       "version": "3.1.1",
-      "devOptional": true
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.7"
@@ -57117,23 +57086,19 @@
     },
     "postcss-discard-comments": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-double-position-gradients": {
       "version": "1.0.0",
@@ -57469,8 +57434,7 @@
       }
     },
     "postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "requires": {}
+      "version": "3.0.0"
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -57515,8 +57479,7 @@
     },
     "postcss-normalize-charset": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -57937,7 +57900,7 @@
     },
     "progress": {
       "version": "2.0.3",
-      "devOptional": true
+      "dev": true
     },
     "progress-stream": {
       "version": "2.0.0",
@@ -58464,6 +58427,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -58472,13 +58436,13 @@
     "react-colorful": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
-      "integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==",
-      "requires": {}
+      "integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg=="
     },
     "react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -58745,7 +58709,8 @@
       }
     },
     "reflect-metadata": {
-      "version": "0.1.13"
+      "version": "0.1.13",
+      "dev": true
     },
     "refractor": {
       "version": "3.5.0",
@@ -58802,7 +58767,7 @@
     },
     "regexpp": {
       "version": "3.2.0",
-      "devOptional": true
+      "dev": true
     },
     "regexpu-core": {
       "version": "4.8.0",
@@ -59157,7 +59122,7 @@
     },
     "rimraf": {
       "version": "3.0.2",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -59228,8 +59193,7 @@
     },
     "rxjs-for-await": {
       "version": "0.0.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2"
@@ -59544,6 +59508,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -59893,14 +59858,14 @@
     },
     "shebang-command": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "devOptional": true
+      "dev": true
     },
     "side-channel": {
       "version": "1.0.4",
@@ -60748,12 +60713,11 @@
     },
     "strip-json-comments": {
       "version": "3.1.1",
-      "devOptional": true
+      "dev": true
     },
     "style-loader": {
       "version": "3.2.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "style-to-object": {
       "version": "0.3.0",
@@ -60829,8 +60793,7 @@
           "version": "1.2.0"
         },
         "ws": {
-          "version": "7.5.6",
-          "requires": {}
+          "version": "7.5.6"
         }
       }
     },
@@ -60926,7 +60889,7 @@
     },
     "table": {
       "version": "6.7.5",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -60937,14 +60900,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "slice-ansi": {
           "version": "4.0.0",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
             "astral-regex": "^2.0.0",
@@ -60953,7 +60916,7 @@
         },
         "strip-ansi": {
           "version": "6.0.1",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
@@ -61054,7 +61017,7 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "devOptional": true
+      "dev": true
     },
     "throttle-debounce": {
       "version": "3.0.1",
@@ -61425,7 +61388,7 @@
     },
     "type-fest": {
       "version": "0.20.2",
-      "devOptional": true
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -61447,7 +61410,8 @@
       }
     },
     "typescript": {
-      "version": "4.3.5"
+      "version": "4.3.5",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.31",
@@ -61772,14 +61736,12 @@
     "use-composed-ref": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
-      "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-      "requires": {}
+      "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw=="
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "requires": {}
+      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ=="
     },
     "use-latest": {
       "version": "1.2.0",
@@ -61828,7 +61790,7 @@
     },
     "v8-compile-cache": {
       "version": "2.3.0",
-      "devOptional": true
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -62261,8 +62223,7 @@
           "version": "8.6.0"
         },
         "acorn-import-assertions": {
-          "version": "1.8.0",
-          "requires": {}
+          "version": "1.8.0"
         },
         "ajv": {
           "version": "6.12.6",
@@ -62868,8 +62829,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
       "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "webpack-hot-middleware": {
       "version": "2.25.1",
@@ -62973,7 +62933,7 @@
     },
     "which": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -63048,7 +63008,7 @@
     },
     "word-wrap": {
       "version": "1.2.3",
-      "devOptional": true
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0"
@@ -63103,8 +63063,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
       "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.23",

--- a/projects/safe/src/lib/components/widgets/scheduler/scheduler.component.html
+++ b/projects/safe/src/lib/components/widgets/scheduler/scheduler.component.html
@@ -12,6 +12,16 @@
     [selectedViewIndex]="1"
     style="height: 600px"
   >
+    <ng-template
+      kendoSchedulerEventTemplate
+      let-event="event"
+      let-resources="resources"
+    >
+      <div [ngClass]="eventEnded(event) ? 'past-event event' : 'event'">
+        {{ event.title }}
+      </div>
+    </ng-template>
+
     <kendo-scheduler-day-view> </kendo-scheduler-day-view>
 
     <kendo-scheduler-week-view> </kendo-scheduler-week-view>

--- a/projects/safe/src/lib/components/widgets/scheduler/scheduler.component.scss
+++ b/projects/safe/src/lib/components/widgets/scheduler/scheduler.component.scss
@@ -1,14 +1,23 @@
 .widget-container {
   position: relative;
 }
+.event {
+  width: 100%;
+  padding: 0.4rem;
+  height: 100%;
+}
+
+.past-event {
+  background-color: #858585;
+}
 
 :host ::ng-deep {
   multi-day-view {
     overflow: auto hidden;
-  
+
     .k-scheduler-weekview {
       min-width: 1000px;
-  
+
       .k-scheduler-times {
         position: sticky;
         left: 0;
@@ -17,10 +26,10 @@
       }
     }
   }
-  
+
   month-view {
     overflow: auto hidden;
-  
+
     .k-scheduler-monthview {
       min-width: 1000px;
     }

--- a/projects/safe/src/lib/components/widgets/scheduler/scheduler.component.ts
+++ b/projects/safe/src/lib/components/widgets/scheduler/scheduler.component.ts
@@ -100,6 +100,16 @@ export class SafeSchedulerComponent implements OnInit, AfterViewInit {
   }
 
   /**
+   * Checks if an event already ended.
+   */
+  eventEnded(event: { end: string; [key: string]: any }) {
+    const eventTime = new Date(event.end);
+    const now = new Date();
+
+    return now > eventTime;
+  }
+
+  /**
    * Exports the scheduler as a pdf.
    */
   public exportPDF() {


### PR DESCRIPTION
# Description
This PR implements the graying out feature of past events. Like the other styling tickets for this widget, I tried for a while to do it in a more "official" and "correct" manner, but ended up just doing a workaround by placing a div inside the event and giving it full width and height. Pretty sure it's not the best way to do it, but it's all I could come up with.


## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Opening the scheduler widget, with the mocked data, all events which ended before now (the red line) are grayed out. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
