### PR TITLE
OORT-162

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -361,6 +361,13 @@
 				"exitMessage": "There are unsaved changes on your form. Are you sure you want to exit?"
 			}
 		},
+		"formBuilder": {
+			"errors": {
+				"invalidRelatedName": "Provided related name ({{name}}) for question {{question}} on page {{page}} is invalid. Please provide a valid related name (snake case format) to save the form.",
+				"missingRelatedName": "Missing related name for question {{question}} on page {{page}}. Please provide a valid data value name (snake case format) to save the form.",
+				"missingTemplate": "Missing related resource template for question {{question}} on page {{page}}. Please select a template to save the form."
+			}
+		},
 		"forms": {
 			"isCore": "Is core",
 			"parent": "Parent form"

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -361,6 +361,13 @@
 				"exitMessage": "******"
 			}
 		},
+		"formBuilder": {
+			"errors": {
+				"invalidRelatedName": "******",
+				"missingRelatedName": "******",
+				"missingTemplate": "******"
+			}
+		},
 		"forms": {
 			"isCore": "******",
 			"parent": "******"

--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -12,6 +12,7 @@ import * as SurveyCreator from 'survey-creator';
 import { SafeSnackBarService } from '../../services/snackbar.service';
 import * as Survey from 'survey-angular';
 import { Form } from '../../models/form.model';
+import { TranslateService } from '@ngx-translate/core';
 
 /* Commented types are not yet implemented.
  */
@@ -87,7 +88,8 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
   constructor(
     @Inject('environment') environment: any,
     public dialog: MatDialog,
-    private snackBar: SafeSnackBarService
+    private snackBar: SafeSnackBarService,
+    private translate: TranslateService
   ) {
     this.environment = environment;
   }
@@ -366,30 +368,38 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
           element.relatedName = this.toSnakeCase(element.relatedName);
           if (!this.isSnakeCase(element.relatedName)) {
             throw new Error(
-              'The related name ' +
-                element.relatedName +
-                ' on page ' +
-                page.name +
-                ' is invalid. Please conform to snake_case.'
+              this.translate.instant(
+                'components.formBuilder.errors.invalidRelatedName',
+                {
+                  name: element.relatedName,
+                  question: element.name,
+                  page: page.name,
+                }
+              )
             );
           }
         } else {
+          console.log(element);
           throw new Error(
-            'Missing related name for question ' +
-              element.title +
-              ' on page ' +
-              page.name +
-              '. Please provide a valid data value name (snake_case) to save the form.'
+            this.translate.instant(
+              'components.formBuilder.errors.missingRelatedName',
+              {
+                question: element.name,
+                page: page.name,
+              }
+            )
           );
         }
 
         if (element.addRecord && !element.addTemplate) {
           throw new Error(
-            'Missing add records template for question ' +
-              element.title +
-              ' on page ' +
-              page.name +
-              '. Please select a template to save the form.'
+            this.translate.instant(
+              'components.formBuilder.errors.missingTemplate',
+              {
+                question: element.name,
+                page: page.name,
+              }
+            )
           );
         }
       }

--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -382,6 +382,16 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
               '. Please provide a valid data value name (snake_case) to save the form.'
           );
         }
+
+        if (element.addRecord && !element.addTemplate) {
+          throw new Error(
+            'Missing add records template for question ' +
+              element.title +
+              ' on page ' +
+              page.name +
+              '. Please select a template to save the form.'
+          );
+        }
       }
     }
   }

--- a/projects/safe/src/lib/components/form-builder/form-builder.module.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.module.ts
@@ -3,10 +3,16 @@ import { CommonModule } from '@angular/common';
 import { SafeFormBuilderComponent } from './form-builder.component';
 import { SafeFormModalModule } from '../form-modal/form-modal.module';
 import { MatDialogModule } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
 
 @NgModule({
   declarations: [SafeFormBuilderComponent],
-  imports: [CommonModule, SafeFormModalModule, MatDialogModule],
+  imports: [
+    CommonModule,
+    SafeFormModalModule,
+    MatDialogModule,
+    TranslateModule,
+  ],
   exports: [SafeFormBuilderComponent],
 })
 export class SafeFormBuilderModule {}

--- a/projects/safe/src/lib/survey/components/resource.ts
+++ b/projects/safe/src/lib/survey/components/resource.ts
@@ -236,7 +236,7 @@ export const init = (
             // return !hasUniqueRecord(obj.resource);
           }
         },
-        visibleIndex: 3,
+        visibleIndex: 2,
       });
       survey.Serializer.addProperty('resource', {
         name: 'canSearch:boolean',

--- a/projects/safe/src/lib/survey/components/resources.ts
+++ b/projects/safe/src/lib/survey/components/resources.ts
@@ -274,7 +274,7 @@ export const init = (
             // return !hasUniqueRecord(obj.resource);
           }
         },
-        visibleIndex: 3,
+        visibleIndex: 2,
       });
       survey.Serializer.addProperty('resources', {
         name: 'canDelete:boolean',


### PR DESCRIPTION
# Description

This PR changes the position of the add template dropdown on the form properties so it's easier to see it being displayed when the user checks the add new records checkbox. Also, a new error is thrown whenever a user tries to save the survey having checked the checkbox but not selected a template.

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

This GIF shows the test being made
![select_template_error (1)](https://user-images.githubusercontent.com/102038450/162435374-23c9df92-603c-4b61-98c1-9b310400f49d.gif)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
