### PR TITLE
Remove focus on first question

### DIFF
--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -224,6 +224,7 @@ export class SafeFormModalComponent implements OnInit {
       };
     }
     this.survey.showNavigationButtons = false;
+    this.survey.focusFirstQuestionAutomatic = false;
     this.survey.render(this.containerId);
     this.setPages();
     this.survey.onComplete.add(this.onComplete);

--- a/projects/safe/src/lib/components/form/form.component.ts
+++ b/projects/safe/src/lib/components/form/form.component.ts
@@ -188,6 +188,7 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
       this.survey.locale = 'en';
     }
 
+    this.survey.focusFirstQuestionAutomatic = false;
     this.survey.showNavigationButtons = false;
     this.setPages();
     this.survey.onComplete.add(this.onComplete);

--- a/projects/safe/src/lib/components/record-modal/record-modal.component.ts
+++ b/projects/safe/src/lib/components/record-modal/record-modal.component.ts
@@ -147,6 +147,7 @@ export class SafeRecordModalComponent implements OnInit {
     this.survey.locale = this.data.locale ? this.data.locale : 'en';
     this.survey.mode = 'display';
     this.survey.showNavigationButtons = 'none';
+    this.survey.focusFirstQuestionAutomatic = false;
     this.survey.showProgressBar = 'off';
     this.survey.render(this.containerId);
     this.setPages();
@@ -162,6 +163,7 @@ export class SafeRecordModalComponent implements OnInit {
       this.surveyNext.locale = this.data.locale ? this.data.locale : 'en';
       this.surveyNext.mode = 'display';
       this.surveyNext.showNavigationButtons = 'none';
+      this.surveyNext.focusFirstQuestionAutomatic = false;
       this.surveyNext.showProgressBar = 'off';
       // Set list of updated questions
       const updatedQuestions: string[] = [];

--- a/projects/safe/src/lib/survey/widget.ts
+++ b/projects/safe/src/lib/survey/widget.ts
@@ -63,6 +63,7 @@ export const init = (
         },
       });
       survey.Serializer.removeProperty('expression', 'readOnly');
+      survey.Serializer.removeProperty('survey', 'focusFirstQuestionAutomatic');
       survey.Serializer.addProperty('expression', {
         name: 'readOnly:boolean',
         type: 'boolean',


### PR DESCRIPTION
# Description

Before, when opening a form, it focused on the first question, making it hard to use the form.
Here we set the default value of the SurveyJS property called FocusFirstQuestionAutomatic to false so that by default, the form doesn't focus on the first question. We also removed the property called FocusFirstQuestionAutomatic in the survey widget, so that it removes the possibility to add the focus in the settings in the survey.

## Type of change

- Improvement (refactor or addition to existing functionality)

## How Has This Been Tested?

- Opening the different forms we can see that it does not focus on the first question anymore. And when editing these forms, the option on focusing on the first question is not there anymore.

## Remarks

In the survey settings, between the settings "The question required symbol(s)" and "Question error location" there is now a weird blank space. I am not sure that it's linked to what I did nor do I know how to resolve that issue without looking more into it. 
