### PR TITLE
OORT-205

### DIFF
--- a/projects/safe/src/lib/services/query-builder.service.ts
+++ b/projects/safe/src/lib/services/query-builder.service.ts
@@ -307,7 +307,12 @@ export class QueryBuilderService {
    * @returns Query name
    */
   public getQueryNameFromResourceName(resourceName: string): any {
-    const nameTrimmed = resourceName.replace(/\s/g, '').toLowerCase();
+    const nameTrimmed = resourceName
+      .replace(/_|-/g, '')
+      .replace(/\s+(?=\d)/g, '_')
+      .replace(/\s/g, '')
+      .toLowerCase();
+
     return (
       this.availableQueries
         .getValue()


### PR DESCRIPTION
# Description

This PR fixes a bug that was causing the query builder not to show when the action 'attach to record' was selected. This happened because the `getQueryNameFromResourceName` didn't consider some cases in which the the resource name contained underscores, hyphens or spaces followed by numbers. I wasn't able to locate where the query names are being generated, but the changes I made work for all the resource names I came up with. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

In a workflow, create a grid widget and select a dataset that is linked to another resource. In the action buttons, the option to attach to record should appear. Upon selecting the dataset, the query builder should now correctly be shown. Resource names listed above are working.

- [x] A A
- [x] B_B
- [x] C-C
- [x] C 1
- [x] AAA


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
