### PR TITLE
OORT-183

### DIFF
--- a/projects/safe/src/lib/components/form/form.component.ts
+++ b/projects/safe/src/lib/components/form/form.component.ts
@@ -154,7 +154,7 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
       );
     }
 
-    // cached data is the priorit
+    // cached data is the priority
     if (cachedData) {
       this.survey.data = cachedData;
     } else if (this.form.uniqueRecord && this.form.uniqueRecord.data) {

--- a/projects/safe/src/lib/components/form/form.component.ts
+++ b/projects/safe/src/lib/components/form/form.component.ts
@@ -154,18 +154,15 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
       );
     }
 
-    if (this.form.uniqueRecord && this.form.uniqueRecord.data) {
+    // cached data is the priorit
+    if (cachedData) {
+      this.survey.data = cachedData;
+    } else if (this.form.uniqueRecord && this.form.uniqueRecord.data) {
       this.survey.data = this.form.uniqueRecord.data;
       this.modifiedAt = this.form.uniqueRecord.modifiedAt || null;
-    } else {
-      if (cachedData) {
-        this.survey.data = cachedData;
-      } else {
-        if (this.record && this.record.data) {
-          this.survey.data = this.record.data;
-          this.modifiedAt = this.record.modifiedAt || null;
-        }
-      }
+    } else if (this.record && this.record.data) {
+      this.survey.data = this.record.data;
+      this.modifiedAt = this.record.modifiedAt || null;
     }
 
     if (this.survey.getUsedLocales().length > 1) {


### PR DESCRIPTION
# Description

This PR increases the priority of the initial data of a form. If a form has localStorage cached and also is a unique record, the cache will still have precedence

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Open a form that has unicity configured ⟶ change the values of the fields ⟶ refresh the page ⟶ the form data should be loaded from localStorage (local changes)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
