### PR TITLE
Oort-184

### DIFF
--- a/projects/back-office/src/app/app-preview/pages/form/form.component.ts
+++ b/projects/back-office/src/app/app-preview/pages/form/form.component.ts
@@ -84,13 +84,13 @@ export class FormComponent implements OnInit {
           .valueChanges.subscribe((res) => {
             this.page = res.data.page;
             this.apollo
-              .watchQuery<GetFormByIdQueryResponse>({
+              .query<GetFormByIdQueryResponse>({
                 query: GET_SHORT_FORM_BY_ID,
                 variables: {
                   id: this.page.content,
                 },
               })
-              .valueChanges.subscribe((res2) => {
+              .subscribe((res2) => {
                 if (res2.data) {
                   this.form = res2.data.form;
                 }

--- a/projects/safe/src/lib/components/form/form.component.ts
+++ b/projects/safe/src/lib/components/form/form.component.ts
@@ -327,7 +327,7 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
       } else {
         localStorage.removeItem(this.storageId);
         if (res.data.editRecord || res.data.addRecord.form.uniqueRecord) {
-          this.survey.clear(false, true);
+          this.survey.clear(false, false);
           if (res.data.addRecord) {
             this.record = res.data.addRecord;
             this.modifiedAt = this.record?.modifiedAt || null;
@@ -337,9 +337,6 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
           this.surveyActive = true;
         } else {
           this.survey.showCompletedPage = true;
-        }
-        if (this.form.uniqueRecord) {
-          this.selectedTabIndex = 0;
         }
         this.save.emit({
           completed: true,


### PR DESCRIPTION
# Description

So initially I misunderstood the bug because of the title of the ticket. I thought that by "reload", you meant fetching the form again from the backend when it was saved (which was only happening in the app-preview, and that puzzled me for quite a while, I couldn't figure why that was happening. Eventually, I understood why, and fixed it (I wouldn't say it was such a waste of time, cause I learned quite a bit about apollo and graphql in the process). Than, I realized I that wasn't the bug at all, but I kept the change, cause it saves a request and we have all the updated data anyway. 
The wanted behavior, however, was achieved merely by removing an if statement that was doing exactly what we didn't want the form to do on submit.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ]On submitting a form with configured as a unique record, the form no longer resets to its first available page 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
