### PR TITLE
OORT 150 - C'hange display of widget choice for mobile

### DIFF
--- a/projects/safe/src/lib/components/widget-choice/widget-choice.component.scss
+++ b/projects/safe/src/lib/components/widget-choice/widget-choice.component.scss
@@ -40,7 +40,9 @@
   box-shadow: 0px 4px 4px rgba(47, 56, 62, 0.15);
   border-radius: 8px;
   height: 64px;
-  max-width: 568px;
+  width: fit-content;
+  overflow: auto;
+  max-width: 90%;
   margin: auto;
   pointer-events: auto;
   cursor: move;


### PR DESCRIPTION
# Description

Before we had an issue with the display of the widget choice bar on mobile (the bar would not cover the entire width of the different choices). It is fixed and we added the possibility to scroll to see all the choices if the screen is not wide enough. Below we have an example with an Iphone 5 and its small screen :


![image](https://user-images.githubusercontent.com/103029022/167375353-63ddbe0f-292e-4fe8-914c-484ef8f65086.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] It has been tested using the tool directly implemented by Firefox on different kind of mobile phones, recent or old
- [x] It has also been tested by checking that everything is still displayed correctly while using a computer screen

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
