### PR TITLE
Oort 187

### DIFF
--- a/projects/safe/src/lib/services/grid.service.ts
+++ b/projects/safe/src/lib/services/grid.service.ts
@@ -270,16 +270,8 @@ export class SafeGridService {
       otherText?: string;
     }
   ): { value: string; text: string }[] {
-    const choices = choicesByUrl.path ? [...res[choicesByUrl.path]] : [...res];
-    if (choicesByUrl.hasOther) {
-      choices.push({
-        [choicesByUrl.value || 'value']: 'other',
-        [choicesByUrl.text || 'text']: choicesByUrl.otherText
-          ? choicesByUrl.otherText
-          : 'Other',
-      });
-    }
-    return choices
+    let choices = choicesByUrl.path ? [...res[choicesByUrl.path]] : [...res];
+    choices = choices
       ? choices.map((x: any) => ({
           value: (choicesByUrl.value ? x[choicesByUrl.value] : x).toString(),
           text: choicesByUrl.text
@@ -289,6 +281,13 @@ export class SafeGridService {
             : x,
         }))
       : [];
+    if (choicesByUrl.hasOther) {
+      choices.push({
+        value: 'other',
+        text: choicesByUrl.otherText ? choicesByUrl.otherText : 'Other',
+      });
+    }
+    return choices;
   }
 
   /**

--- a/projects/safe/src/lib/services/grid.service.ts
+++ b/projects/safe/src/lib/services/grid.service.ts
@@ -267,13 +267,16 @@ export class SafeGridService {
       value?: string;
       text?: string;
       hasOther?: boolean;
+      otherText?: string;
     }
   ): { value: string; text: string }[] {
     const choices = choicesByUrl.path ? [...res[choicesByUrl.path]] : [...res];
     if (choicesByUrl.hasOther) {
       choices.push({
         [choicesByUrl.value || 'value']: 'other',
-        [choicesByUrl.text || 'text']: 'Other',
+        [choicesByUrl.text || 'text']: choicesByUrl.otherText
+          ? choicesByUrl.otherText
+          : 'Other',
       });
     }
     return choices


### PR DESCRIPTION
# Description

Add support for custom text on "other" option for dropdowns with choices loaded by an url. This PR works with another PR for backend.
It also corrects a bug when the `value` and `text` keys defined by the survey author are the same: in this case, the other option was not selected when displaying the answers in the grid widget.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Create a survey with choices by url, an "other" option, and a custom text for this "other" option. Create a record, then display the results in a grid widget. In the list of choices for the dropdown question, the other option should be displayed with the custom text previously defined.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
