### PR TITLE
OORT-227

### DIFF
--- a/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -223,12 +223,12 @@
               </div>
             </div>
           </ng-template>
-          <!-- DISPLAY ( url ) -->
+          <!-- DISPLAY ( url / email / tel ) -->
           <ng-template
             #refSpan
             kendoGridCellTemplate
             let-dataItem="dataItem"
-            *ngIf="field.meta.type === 'url'"
+            *ngIf="['url', 'tel', 'email'].includes(field.meta.type)"
           >
             <div
               class="textbox-container"
@@ -239,6 +239,27 @@
                 href="{{ getUrl(getPropertyValue(dataItem, field.name)) }}"
                 target="_blank"
                 rel="noopener noreferrer"
+                *ngIf="field.meta.type === 'url'"
+              >
+                <div #refSpan>
+                  {{ getPropertyValue(dataItem, field.name) }}
+                </div>
+              </a>
+              <a
+                class="url-container textbox"
+                href="mailto:{{ getPropertyValue(dataItem, field.name) }}"
+                rel="noopener noreferrer"
+                *ngIf="field.meta.type === 'email'"
+              >
+                <div #refSpan>
+                  {{ getPropertyValue(dataItem, field.name) }}
+                </div>
+              </a>
+              <a
+                class="url-container textbox"
+                href="tel:{{ getPropertyValue(dataItem, field.name) }}"
+                rel="noopener noreferrer"
+                *ngIf="field.meta.type === 'tel'"
               >
                 <div #refSpan>
                   {{ getPropertyValue(dataItem, field.name) }}
@@ -361,9 +382,9 @@
           let-formGroup="formGroup"
           *ngIf="field.editor === 'text'"
         >
-          <!-- EDITION ( text / comment / url ) -->
+          <!-- EDITION ( text / comment ) -->
           <ng-container
-            *ngIf="field.meta.type === 'text' || field.meta.type === 'url'"
+            *ngIf="field.meta.type === 'text'"
           >
             <textarea
               rows="2"
@@ -372,6 +393,17 @@
               [name]="field.name"
               class="k-textbox"
             ></textarea>
+          </ng-container>
+          <!-- EDITION ( url / email / tel ) -->
+          <ng-container
+            *ngIf="['url', 'email', 'tel'].includes(field.meta.type)"
+          >
+            <input
+              [formControl]="formGroup.get(field.name)"
+              kendoGridFocusable
+              [name]="field.name"
+              class="k-textbox"
+            />
           </ng-container>
           <!-- EDITION ( color ) -->
           <ng-container *ngIf="field.meta.type === 'color'">


### PR DESCRIPTION
# Description

Add support for email fields in the grid widget. Also includes support for telephone number fields (since it is the same thing). Emails are now clickable in grid widgets, and it opens a mailto link when we click on it.
Also replace `textbox` by `input` when editing an url, an email or a telephone number (since it cannot be on several lines).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a new form with email and telephone type fields, add some records, and display it in a grid widget. We have now links for these fields so as to open them quickly.

## Sreenshots

![image](https://user-images.githubusercontent.com/103410601/168110282-46610b5b-cc72-4189-8592-f3202889bda8.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
