### PR TITLE
OORT-235 fix: use ngZone to close addRecord modal

### DIFF
--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ElementRef,
   Inject,
+  NgZone,
   OnInit,
   ViewChild,
 } from '@angular/core';
@@ -97,7 +98,8 @@ export class SafeFormModalComponent implements OnInit {
     private downloadService: SafeDownloadService,
     private authService: SafeAuthService,
     private formBuilderService: SafeFormBuilderService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private ngZone: NgZone
   ) {
     this.environment = environment;
   }
@@ -330,11 +332,15 @@ export class SafeFormModalComponent implements OnInit {
             this.snackBar.openSnackBar(`Error. ${res.errors[0].message}`, {
               error: true,
             });
-            this.dialogRef.close();
+            this.ngZone.run(() => {
+              this.dialogRef.close();
+            });
           } else {
-            this.dialogRef.close({
-              template: this.data.template,
-              data: res.data?.addRecord,
+            this.ngZone.run(() => {
+              this.dialogRef.close({
+                template: this.data.template,
+                data: res.data?.addRecord,
+              });
             });
           }
         });


### PR DESCRIPTION
# Description

Use ngZone to close addRecord modal, otherwise it would freeze until next click.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tried to add new records in a resources question.

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
