### PR TITLE
add french translation in update record modal

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -387,6 +387,12 @@
 					}
 				}
 			},
+			"modal": {
+				"update": {
+					"confirmUpdateRow": "Do you confirm the update of this row ?",
+					"updateRow": "Update row"
+				}
+			},
 			"summary": {
 				"cache": {
 					"clear": "Clear cache",

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -387,6 +387,12 @@
 					}
 				}
 			},
+			"modal": {
+				"update": {
+					"confirmUpdateRow": "Voulez-vous vraiment mettre à jour cette ligne ?",
+					"updateRow": "Mise à jour de la ligne"
+				}
+			},
 			"summary": {
 				"cache": {
 					"clear": "Vider le cache",

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -387,6 +387,12 @@
 					}
 				}
 			},
+			"modal": {
+				"update": {
+					"confirmUpdateRow": "******",
+					"updateRow": "******"
+				}
+			},
 			"summary": {
 				"cache": {
 					"clear": "******",

--- a/projects/safe/src/lib/components/confirm-modal/confirm-modal.component.ts
+++ b/projects/safe/src/lib/components/confirm-modal/confirm-modal.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
 
 interface DialogData {
   title?: string;
@@ -15,13 +16,16 @@ interface DialogData {
   styleUrls: ['./confirm-modal.component.scss'],
 })
 export class SafeConfirmModalComponent implements OnInit {
-  public title = 'Confirm';
+  public title = this.translate.instant('common.confirm');
   public content = '';
-  public cancelText = 'Cancel';
-  public confirmText = 'Confirm';
+  public cancelText = this.translate.instant('common.cancel');
+  public confirmText = this.translate.instant('common.confirm');
   public confirmColor = 'primary';
 
-  constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: DialogData,
+    private translate: TranslateService
+  ) {
     if (data.title) {
       this.title = data.title;
     }

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -285,11 +285,13 @@ export class SafeFormModalComponent implements OnInit {
     if (this.data.askForConfirm) {
       const dialogRef = this.dialog.open(SafeConfirmModalComponent, {
         data: {
-          title: `Update row${rowsSelected > 1 ? 's' : ''}`,
-          content: `Do you confirm the update of ${rowsSelected} row${
-            rowsSelected > 1 ? 's' : ''
-          } ?`,
-          confirmText: 'Confirm',
+          title: this.translate.instant(
+            'components.form.modal.update.updateRow'
+          ),
+          content: this.translate.instant(
+            'components.form.modal.update.confirmUpdateRow'
+          ),
+          confirmText: this.translate.instant('common.confirm'),
           confirmColor: 'primary',
         },
       });


### PR DESCRIPTION
# Description

Previously when trying to modify a row in a grid, the confirmation popup was in English and not in French. It is now translated. 

We can only modify one row at a time so I lightly changed the way we handle that. 


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested when trying to modify a row in a form in a dashboard

## Sreenshots

![image](https://user-images.githubusercontent.com/103029022/168838285-49084f92-af83-4ae1-8c33-3aba34ab6c9b.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have included screenshots describing my changes if relevant
