### PR TITLE
OORT-238 - remove from selection

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -524,8 +524,11 @@
 			"expand": "Expand",
 			"grid": {
 				"actions": {
+					"convert": "Convert",
+					"delete": "Delete",
 					"detail": "Open detail",
-					"history": "Show history"
+					"history": "Show history",
+					"remove": "Remove from selection"
 				},
 				"empty": "No record detected",
 				"errors": {

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -525,7 +525,10 @@
 			"grid": {
 				"actions": {
 					"detail": "******",
-					"history": "******"
+					"history": "******",
+					"convert": "******",
+					"delete": "******",
+					"remove": "******"
 				},
 				"empty": "******",
 				"errors": {

--- a/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -213,6 +213,7 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
     delete: false,
     history: false,
     convert: false,
+    remove: false,
     showDetails: true,
   };
 
@@ -257,6 +258,7 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
       update: this.settings.actions?.update,
       delete: this.settings.actions?.delete,
       convert: this.settings.actions?.convert,
+      remove: this.settings.actions?.remove,
       showDetails:
         this.settings.actions &&
         typeof this.settings.actions?.showDetails !== 'undefined'
@@ -614,6 +616,12 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
         }
         break;
       }
+      case 'remove': {
+        if (event.items) {
+          this.onRemoveSelection(event.items);
+        }
+        break;
+      }
       case 'resetLayout': {
         this.resetDefaultLayout();
         break;
@@ -762,6 +770,14 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
       }
     });
   }
+
+  /**
+   * Method to remove the items selected without deleting them in forms
+   * (see widgets.ts)
+   *
+   * @param items items to remove from the selected items
+   */
+  public onRemoveSelection(items: any[]): void {}
 
   /**
    * Opens a dialog component which provide tools to convert the selected record

--- a/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -115,6 +115,7 @@ export class SafeGridComponent implements OnInit, AfterViewInit {
     delete: false,
     history: false,
     convert: false,
+    remove: false,
     showDetails: true,
   };
   @Input() hasDetails = true;

--- a/projects/safe/src/lib/components/ui/core-grid/models/grid-settings.model.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/models/grid-settings.model.ts
@@ -20,6 +20,7 @@ export interface GridSettings {
     history?: boolean;
     convert?: boolean;
     update?: boolean;
+    remove?: boolean;
     inlineEdition?: boolean;
   };
   // showDetails?: boolean;

--- a/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.component.html
+++ b/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.component.html
@@ -7,20 +7,20 @@
     kendoButton
     (click)="action.emit({ action: 'convert', items: items })"
   >
-    Convert
+    {{ 'components.widget.grid.actions.convert' | translate }}
   </button>
   <button
     *ngIf="actions.delete && canDelete"
     kendoButton
     (click)="action.emit({ action: 'delete', items: items })"
   >
-    Delete
+    {{ 'components.widget.grid.actions.delete' | translate }}
   </button>
   <button
     *ngIf="actions.remove"
     kendoButton
     (click)="action.emit({ action: 'remove', items: items })"
   >
-    Remove from selection
+    {{ 'components.widget.grid.actions.remove' | translate }}
   </button>
 </ng-container>

--- a/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.component.html
+++ b/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.component.html
@@ -16,4 +16,11 @@
   >
     Delete
   </button>
+  <button
+    *ngIf="actions.remove"
+    kendoButton
+    (click)="action.emit({ action: 'remove', items: items })"
+  >
+    Remove from selection
+  </button>
 </ng-container>

--- a/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.component.ts
@@ -15,11 +15,17 @@ export class SafeGridToolbarComponent implements OnInit {
     delete: false,
     history: false,
     convert: false,
+    remove: false,
   };
   @Output() action = new EventEmitter();
 
   get display(): boolean {
-    return this.actions.delete || this.actions.update || this.actions.convert;
+    return (
+      this.actions.delete ||
+      this.actions.update ||
+      this.actions.convert ||
+      this.actions.remove
+    );
   }
 
   get canUpdate(): boolean {

--- a/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.module.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.module.ts
@@ -2,10 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SafeGridToolbarComponent } from './toolbar.component';
 import { ButtonModule } from '@progress/kendo-angular-buttons';
+import { TranslateModule } from '@ngx-translate/core';
 
 @NgModule({
   declarations: [SafeGridToolbarComponent],
-  imports: [CommonModule, ButtonModule],
+  imports: [CommonModule, ButtonModule, TranslateModule],
   exports: [SafeGridToolbarComponent],
 })
 export class SafeGridToolbarModule {}

--- a/projects/safe/src/lib/survey/widget.ts
+++ b/projects/safe/src/lib/survey/widget.ts
@@ -467,6 +467,14 @@ export const init = (
           setGridInputs(instance, question);
         }
       });
+      instance.onRemoveSelection = (items: any[]): void => {
+        // get the id of items to remove
+        const ids: string[] = items.map((x) => (x.id ? x.id : x));
+        // remove them
+        question.value = question.value.filter((id: any) => !ids.includes(id));
+        // reload
+        setGridInputs(instance, question);
+      };
       return instance;
     }
     return null;
@@ -507,6 +515,7 @@ export const init = (
           convert: question.convert,
           update: question.update,
           inlineEdition: question.inlineEdition,
+          remove: true,
         },
       });
     }


### PR DESCRIPTION
# Description

Add a **"Remove from selection"** button on grid widget to allow the user to unselect the selected records from a resources field in a form, when filling in it.

## Type of change

- [x] Improvement (refactor or addition to existing functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Create a form with a *Resources* question, set this question as a grid (check the "Display as a grid" button in the properties panel), then fill in this form, click the "Search" button to add some records, and then select some records to remove. The "Remove from selection" button should appear and remove the records selected from the selection when pressed.

## Sreenshots

![image](https://user-images.githubusercontent.com/103410601/168982089-5b217225-081d-49db-ac2c-f200997a9077.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have included screenshots describing my changes if relevant
