### PR TITLE
Oort 271 - Custom popup for maps

### DIFF
--- a/projects/back-office/src/environments/environment.ts
+++ b/projects/back-office/src/environments/environment.ts
@@ -28,10 +28,10 @@ const authConfig: AuthConfig = {
  */
 export const environment = {
   production: false,
-  apiUrl: 'https://oort-dev.oortcloud.tech/api',
-  subscriptionApiUrl: 'wss://oort-dev.oortcloud.tech/api',
-  // apiUrl: 'http://localhost:3000',
-  // subscriptionApiUrl: 'ws://localhost:3000',
+  //apiUrl: 'https://oort-dev.oortcloud.tech/api',
+  //subscriptionApiUrl: 'wss://oort-dev.oortcloud.tech/api',
+  apiUrl: 'http://localhost:3000',
+  subscriptionApiUrl: 'ws://localhost:3000',
   frontOfficeUri: 'http://localhost:4200/',
   backOfficeUri: 'http://localhost:4200/',
   module: 'backoffice',

--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -504,7 +504,10 @@
 				"title": "Filter"
 			},
 			"hint": {
-				"fields": "Select data points below and drag them to 'selected fields' on the right",
+				"fields": {
+					"default": "Select data points below and drag them to 'selected fields' on the right",
+					"popup": "Select data points below and drag them to 'selected fields' on the right. They will be displayed in the pop-up when clicking on a marker"
+				},
 				"sortingDisabled": "Sorting fields is disabled when search is active",
 				"style": "Styling rules make records with important information stand out. When a record matches more than one rule, the first rule is used."
 			},
@@ -808,6 +811,7 @@
 							"title": "Marker layers"
 						}
 					},
+					"popup": "Pop-up",
 					"tooltip": {
 						"category": "Selecting a field will separate your records into different layers, accessible on top right corner of the map",
 						"default": {

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -504,7 +504,10 @@
 				"title": "Filtre"
 			},
 			"hint": {
-				"fields": "Sélectionnez des points de donnée ci-dessous et déplacez-les vers les 'champs sélectionnés' sur la droite",
+				"fields": {
+					"default": "Sélectionnez des points de donnée ci-dessous et déplacez-les vers les 'champs sélectionnés' sur la droite",
+					"popup": "Sélectionnez des points de donnée ci-dessous et déplacez-les vers les 'champs sélectionnés' sur la droite. Ils seront présents dans le pop-up affiché au clic sur un marqueur"
+				},
 				"sortingDisabled": "Le tri est désactivé quand la recherche est active.",
 				"style": "Les règles de style font ressortir les enregistrements contenant des informations importantes. Quand un enregistrement vérifie plusieurs règles, la première est utilisée."
 			},
@@ -808,6 +811,7 @@
 							"title": "Calque de marqueurs"
 						}
 					},
+					"popup": "Pop-up",
 					"tooltip": {
 						"category": "Sélectionnez un champ pour séparer vos enregistrements en différentes catégories",
 						"default": {

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -504,7 +504,10 @@
 				"title": "******"
 			},
 			"hint": {
-				"fields": "******",
+				"fields": {
+					"default": "******",
+					"popup": "******"
+				},
 				"sortingDisabled": "******",
 				"style": "******"
 			},
@@ -808,6 +811,7 @@
 							"title": "******"
 						}
 					},
+					"popup": "******",
 					"tooltip": {
 						"category": "******",
 						"default": {

--- a/projects/safe/src/lib/components/query-builder/query-builder.component.html
+++ b/projects/safe/src/lib/components/query-builder/query-builder.component.html
@@ -61,7 +61,18 @@
       animationDuration="0ms"
       *ngIf="form.getRawValue().name"
     >
-      <mat-tab [label]="'components.queryBuilder.fields.title' | translate">
+      <mat-tab [label]="'components.widget.settings.map.popup' | translate" *ngIf="isMap">
+        <ng-template matTabContent>
+          <safe-tab-fields
+          *ngIf="availableFields.length > 0"
+          [form]="$any(form.controls.fields)"
+          [fields]="availableFields"
+          [factory]="factory"
+          [isMap]="isMap"
+          ></safe-tab-fields>
+        </ng-template>
+      </mat-tab>
+      <mat-tab [label]="'components.queryBuilder.fields.title' | translate" *ngIf="!isMap">
         <ng-template matTabContent>
           <safe-tab-fields
             *ngIf="availableFields.length > 0"

--- a/projects/safe/src/lib/components/query-builder/query-builder.component.ts
+++ b/projects/safe/src/lib/components/query-builder/query-builder.component.ts
@@ -52,6 +52,7 @@ export class SafeQueryBuilderComponent implements OnInit {
   @Input() templates: Form[] = [];
   @Input() queryName? = '';
   @Input() layoutPreviewData: LayoutPreviewData | null = null;
+  @Input() isMap = false;
 
   // === FIELD EDITION ===
   public isField = false;

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
@@ -1,5 +1,8 @@
-<div class="info-text">
-  {{ 'components.queryBuilder.hint.fields' | translate }}
+<div class="info-text" *ngIf="isMap">
+  {{ 'components.queryBuilder.hint.fields.popup' | translate }}
+</div>
+<div class="info-text" *ngIf="!isMap">
+  {{ 'components.queryBuilder.hint.fields.default' | translate }}
 </div>
 <div cdkDropListGroup class="field-wrapper" [ngClass]="{ hidden: fieldForm }">
   <div class="field-container" *ngIf="!fieldForm">

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
@@ -24,6 +24,8 @@ import { addNewField } from '../query-builder-forms';
 export class SafeTabFieldsComponent implements OnInit, OnChanges {
   @Input() form: FormArray = new FormArray([]);
   @Input() fields: any[] = [];
+  @Input() isMap = false;
+
   // === TEMPLATE REFERENCE ===
   @Input() factory?: ComponentFactory<any>;
   @ViewChild('childTemplate', { read: ViewContainerRef })

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -112,16 +112,16 @@
           <mat-form-field appearance="outline" style="width: 100%;">
             <mat-label>{{ 'models.widget.map.latitude' | translate }}</mat-label>
             <mat-select formControlName="latitude">
-              <mat-option *ngFor="let field of selectedFields" [value]="field">
-                {{ field }}
+              <mat-option *ngFor="let field of allFields" [value]="field.name">
+                {{ field.name }}
               </mat-option>
             </mat-select>
           </mat-form-field>
           <mat-form-field appearance="outline" style="width: 100%;">
             <mat-label>{{ 'models.widget.map.longitude' | translate }}</mat-label>
             <mat-select formControlName="longitude">
-              <mat-option *ngFor="let field of selectedFields" [value]="field">
-                {{ field }}
+              <mat-option *ngFor="let field of allFields" [value]="field.name">
+                {{ field.name }}
               </mat-option>
             </mat-select>
           </mat-form-field>

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -19,16 +19,16 @@
         <mat-form-field appearance="outline">
           <mat-label>{{ 'models.widget.map.latitude' | translate }}</mat-label>
           <mat-select formControlName="latitude">
-            <mat-option *ngFor="let field of selectedFields" [value]="field">
-              {{ field }}
+            <mat-option *ngFor="let field of allFields" [value]="field.name">
+              {{ field.name }}
             </mat-option>
           </mat-select>
         </mat-form-field>
         <mat-form-field appearance="outline">
           <mat-label>{{ 'models.widget.map.longitude' | translate }}</mat-label>
           <mat-select formControlName="longitude">
-            <mat-option *ngFor="let field of selectedFields" [value]="field">
-              {{ field }}
+            <mat-option *ngFor="let field of allFields" [value]="field.name">
+              {{ field.name }}
             </mat-option>
           </mat-select>
         </mat-form-field>

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -14,6 +14,7 @@
       <safe-query-builder
         [form]="$any(tileForm.controls.query)"
         [canExpand]="false"
+        [isMap]="true"
       ></safe-query-builder>
     </div>
       <!-- <ng-container *ngIf="selectedFields.length > 0">

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -26,6 +26,7 @@ export class SafeMapSettingsComponent implements OnInit {
   @Output() change: EventEmitter<any> = new EventEmitter();
 
   public selectedFields: any[] = [];
+  public allFields: any[] = [];
   public formatedSelectedFields: any[] = [];
   public geoJSONfields: any[] = [];
 

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -4,6 +4,7 @@ import { SafeArcGISService } from '../../../services/arc-gis.service';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { createQueryForm } from './map-forms';
+import { QueryBuilderService } from '../../../services/query-builder.service';
 
 /**
  * Settings component of map widget.
@@ -25,6 +26,7 @@ export class SafeMapSettingsComponent implements OnInit {
   @Output() change: EventEmitter<any> = new EventEmitter();
 
   public selectedFields: any[] = [];
+  public allFields: any[] = [];
 
   public basemaps: any[] = [
     'Sreets',
@@ -48,7 +50,8 @@ export class SafeMapSettingsComponent implements OnInit {
 
   constructor(
     private formBuilder: FormBuilder,
-    private arcGisService: SafeArcGISService
+    private arcGisService: SafeArcGISService,
+    private queryBuilder: QueryBuilderService
   ) {}
 
   /**
@@ -101,6 +104,9 @@ export class SafeMapSettingsComponent implements OnInit {
 
     if (this.tileForm?.value.query.name) {
       this.selectedFields = this.getFields(this.tileForm?.value.query.fields);
+      this.allFields = this.queryBuilder.getFields(
+        this.tileForm?.controls.query.value.name
+      );
     }
 
     const queryForm = this.tileForm.get('query') as FormGroup;
@@ -113,6 +119,8 @@ export class SafeMapSettingsComponent implements OnInit {
     queryForm.valueChanges.subscribe((res) => {
       this.selectedFields = this.getFields(queryForm.getRawValue().fields);
     });
+
+    console.log(tileSettings.latitude);
 
     this.arcGisService.clearSelectedLayer();
     this.arcGisService.searchLayers('');

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -148,8 +148,6 @@ export class SafeMapSettingsComponent implements OnInit {
         });
     });
 
-    console.log(tileSettings.latitude);
-
     this.arcGisService.clearSelectedLayer();
     this.arcGisService.searchLayers('');
 

--- a/projects/safe/src/lib/components/widgets/map/map.component.ts
+++ b/projects/safe/src/lib/components/widgets/map/map.component.ts
@@ -127,7 +127,10 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
     this.drawMap();
     // Gets the settings from the DB.
     if (this.settings.query) {
-      const builtQuery = this.queryBuilder.buildQuery(this.settings);
+      const builtQuery = this.queryBuilder.buildQuery(
+        this.settings,
+        'latitude\nlongitude'
+      );
       this.dataQuery = this.apollo.watchQuery<any>({
         query: builtQuery,
         variables: {

--- a/projects/safe/src/lib/services/query-builder.service.ts
+++ b/projects/safe/src/lib/services/query-builder.service.ts
@@ -231,13 +231,20 @@ export class QueryBuilderService {
    * @param settings Widget settings.
    * @returns GraphQL query.
    */
-  public buildQuery(settings: any): any {
+  public buildQuery(settings: any, additionalFields?: string): any {
     const builtQuery = settings.query;
     if (builtQuery?.fields?.length > 0) {
-      const fields = ['canUpdate\ncanDelete\n'].concat(
-        this.buildFields(builtQuery.fields)
-      );
-      return this.graphqlQuery(builtQuery.name, fields);
+      if (additionalFields === undefined) {
+        const fields = ['canUpdate\ncanDelete\n'].concat(
+          this.buildFields(builtQuery.fields)
+        );
+        return this.graphqlQuery(builtQuery.name, fields);
+      } else {
+        const fields = ['canUpdate\ncanDelete\n' + additionalFields].concat(
+          this.buildFields(builtQuery.fields)
+        );
+        return this.graphqlQuery(builtQuery.name, fields);
+      }
     } else {
       return null;
     }


### PR DESCRIPTION
# Description

Before the latitude and longitude fields could only be chosen from the selected fields. Here we allow them to be selected from all the fields so that the selected fields are only the ones that show up on pop-ups.

In the case of maps, we also rename the tab "Fields" to "Pop-up" and add a little explanation message so that the users understand that these selected fields are the ones that are shown in the pop-up.

I based this ticket on Maximo's OORT-195 ticket so that I could have the different new tabs and rename one pop-up.


## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Tested on a map widget with data that is correctly shown on markers popup

## Screenshots
![image](https://user-images.githubusercontent.com/103029022/170519695-3826db3f-9175-42bb-9010-864d48177819.png)
![image](https://user-images.githubusercontent.com/103029022/170519717-e57febd1-e21f-471e-bd24-d91488c613b4.png)
![image](https://user-images.githubusercontent.com/103029022/170519775-ec2cf3a7-745f-4a10-8758-06c5b4241bae.png)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have included screenshots describing my changes if relevant
