### PR TITLE
AB#33768 

### DIFF
--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+} from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import * as SurveyCreator from 'survey-creator';
 import { SafeSnackBarService } from '../../services/snackbar.service';
@@ -6,7 +13,7 @@ import * as Survey from 'survey-angular';
 import { Form } from '../../models/form.model';
 
 /* Commented types are not yet implemented.
-*/
+ */
 const QUESTION_TYPES = [
   'text',
   'checkbox',
@@ -28,11 +35,11 @@ const QUESTION_TYPES = [
   'multipletext',
   'panel',
   'paneldynamic',
-  'tagbox'
+  'tagbox',
 ];
 
 /* Allowed properties for a core question in a child form.
-*/
+ */
 const CORE_QUESTION_ALLOWED_PROPERTIES = [
   'width',
   'maxWidth',
@@ -55,7 +62,7 @@ const CORE_QUESTION_ALLOWED_PROPERTIES = [
   'placeHolder',
   'enableIf',
   'visibleIf',
-  'tooltip'
+  'tooltip',
 ];
 
 const CORE_FIELD_CLASS = 'core-question';
@@ -63,10 +70,9 @@ const CORE_FIELD_CLASS = 'core-question';
 @Component({
   selector: 'safe-form-builder',
   templateUrl: './form-builder.component.html',
-  styleUrls: ['./form-builder.component.scss']
+  styleUrls: ['./form-builder.component.scss'],
 })
 export class SafeFormBuilderComponent implements OnInit, OnChanges {
-
   @Input() form!: Form;
   @Output() save: EventEmitter<any> = new EventEmitter();
   @Output() formChange: EventEmitter<any> = new EventEmitter();
@@ -81,8 +87,7 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
   constructor(
     public dialog: MatDialog,
     private snackBar: SafeSnackBarService
-  ) {
-  }
+  ) {}
 
   ngOnInit(): void {
     const options = {
@@ -90,7 +95,7 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
       showJSONEditorTab: false,
       generateValidJSON: true,
       showTranslationTab: true,
-      questionTypes: QUESTION_TYPES
+      questionTypes: QUESTION_TYPES,
     };
 
     this.setCustomTheme();
@@ -107,34 +112,42 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
     this.surveyCreator.rightContainerActiveItem('toolbox');
     if (!this.form.structure) {
       this.surveyCreator.survey.showQuestionNumbers = 'off';
-      this.surveyCreator.survey.completedHtml = '<h3>The form has successfully been submitted.</h3>';
+      this.surveyCreator.survey.completedHtml =
+        '<h3>The form has successfully been submitted.</h3>';
     }
-    this.surveyCreator
-      .toolbox
-      .changeCategories(QUESTION_TYPES.map(x => {
+    this.surveyCreator.toolbox.changeCategories(
+      QUESTION_TYPES.map((x) => {
         return {
           name: x,
-          category: 'Question Library'
+          category: 'Question Library',
         };
-      }));
+      })
+    );
 
     // Notify parent that form structure has changed
     this.surveyCreator.onModified.add((survey, option) => {
       this.formChange.emit(survey.text);
     });
-    this.surveyCreator.survey.onUpdateQuestionCssClasses.add((_, opt) => this.onSetCustomCss(opt));
+    this.surveyCreator.survey.onUpdateQuestionCssClasses.add((_, opt) =>
+      this.onSetCustomCss(opt)
+    );
     this.surveyCreator.onTestSurveyCreated.add((sender, opt) => {
-      opt.survey.onUpdateQuestionCssClasses.add((_: any, opt2: any) => this.onSetCustomCss(opt2));
+      opt.survey.onUpdateQuestionCssClasses.add((_: any, opt2: any) =>
+        this.onSetCustomCss(opt2)
+      );
     });
 
     // === CORE QUESTIONS FOR CHILD FORM ===
     // Skip if form is core
     if (!this.form.core) {
-      const coreFields = this.form.fields?.filter(x => x.isCore).map(x => x.name) || [];
+      const coreFields =
+        this.form.fields?.filter((x) => x.isCore).map((x) => x.name) || [];
       // Remove core fields adorners
       this.surveyCreator.onElementAllowOperations.add((sender, opt) => {
         const obj = opt.obj;
-        if (!obj || !obj.page) { return; }
+        if (!obj || !obj.page) {
+          return;
+        }
         // If it is a core field
         if (coreFields.includes(obj.valueName)) {
           // Disable deleting, editing, changing type and changing if required or not
@@ -151,9 +164,14 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
       // Block core fields edition
       this.surveyCreator.onShowingProperty.add((sender, opt) => {
         const obj = opt.obj;
-        if (!obj || !obj.page) { return; }
+        if (!obj || !obj.page) {
+          return;
+        }
         // If it is a core field
-        if (coreFields.includes(obj.valueName) && !CORE_QUESTION_ALLOWED_PROPERTIES.includes(opt.property.name)) {
+        if (
+          coreFields.includes(obj.valueName) &&
+          !CORE_QUESTION_ALLOWED_PROPERTIES.includes(opt.property.name)
+        ) {
           opt.canShow = false;
         }
       });
@@ -167,11 +185,13 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
       this.surveyCreator.text = this.form.structure || '';
       if (!this.form.structure) {
         this.surveyCreator.survey.showQuestionNumbers = 'off';
-        this.surveyCreator.survey.completedHtml = '<h3>The form has successfully been submitted.</h3>';
+        this.surveyCreator.survey.completedHtml =
+          '<h3>The form has successfully been submitted.</h3>';
       }
       // skip if form is core
       if (!this.form.core) {
-        const coreFields = this.form.fields?.filter(x => x.isCore).map(x => x.name) || [];
+        const coreFields =
+          this.form.fields?.filter((x) => x.isCore).map((x) => x.name) || [];
         // Highlight core fields
         this.addCustomClassToCoreFields(coreFields);
       }
@@ -187,41 +207,35 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
   }
 
   setCustomTheme(): void {
-    const defaultThemeColorsSurvey = Survey
-      .StylesManager
-      .ThemeColors.default;
+    const defaultThemeColorsSurvey = Survey.StylesManager.ThemeColors.default;
     defaultThemeColorsSurvey['$main-color'] = this.primaryColor;
     defaultThemeColorsSurvey['$main-hover-color'] = this.primaryColor;
 
-    const defaultThemeColorsEditor = SurveyCreator
-      .StylesManager
-      .ThemeColors.default;
+    const defaultThemeColorsEditor =
+      SurveyCreator.StylesManager.ThemeColors.default;
     defaultThemeColorsEditor['$primary-color'] = this.primaryColor;
     defaultThemeColorsEditor['$secondary-color'] = this.primaryColor;
     defaultThemeColorsEditor['$primary-hover-color'] = this.primaryColor;
     defaultThemeColorsEditor['$selection-border-color'] = this.primaryColor;
 
-    Survey
-      .StylesManager
-      .applyTheme();
-    SurveyCreator
-      .StylesManager
-      .applyTheme();
+    Survey.StylesManager.applyTheme();
+    SurveyCreator.StylesManager.applyTheme();
   }
 
   /*  Custom SurveyJS method, save the form when edited.
-  */
+   */
   saveMySurvey = () => {
-    this.validateValueNames().then(() => {
-      this.save.emit(this.surveyCreator.text);
-    })
+    this.validateValueNames()
+      .then(() => {
+        this.save.emit(this.surveyCreator.text);
+      })
       .catch((error) => {
         this.snackBar.openSnackBar(error.message, { error: true });
       });
   }
 
   /*  Making sure that value names are existent and snake case, to not cause backend problems.
-  */
+   */
   private async validateValueNames(): Promise<void> {
     const object = JSON.parse(this.surveyCreator.text);
     await object.pages.forEach((page: any) => {
@@ -235,7 +249,11 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
   }
 
   private toSnakeCase(text: string): string {
-    return text.replace(/\W+/g, ' ').split(/ |\B(?=[A-Z])/).map(word => word.toLowerCase()).join('_');
+    return text
+      .replace(/\W+/g, ' ')
+      .split(/ |\B(?=[A-Z])/)
+      .map((word) => word.toLowerCase())
+      .join('_');
   }
 
   private isSnakeCase(text: string): any {
@@ -243,7 +261,7 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
   }
 
   /*  Recursively set the question names of the form.
-  */
+   */
   private setQuestionNames(element: any, page: any): void {
     if (element.type === 'panel') {
       if (element.elements) {
@@ -256,57 +274,93 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
         if (element.title) {
           element.valueName = this.toSnakeCase(element.title);
           if (!this.isSnakeCase(element.valueName)) {
-            throw new Error('The value name ' + element.valueName + ' on page '
-              + page.name + ' is invalid. Please conform to snake_case.');
+            throw new Error(
+              'The value name ' +
+                element.valueName +
+                ' on page ' +
+                page.name +
+                ' is invalid. Please conform to snake_case.'
+            );
           }
         } else {
-          throw new Error('Missing value name for an element on page '
-            + page.name + '. Please provide a valid data value name (snake_case) to save the form.');
+          throw new Error(
+            'Missing value name for an element on page ' +
+              page.name +
+              '. Please provide a valid data value name (snake_case) to save the form.'
+          );
         }
       } else {
         if (!this.isSnakeCase(element.valueName)) {
-          throw new Error('The value name ' + element.valueName + ' on page '
-            + page.name + ' is invalid. Please conform to snake_case.');
+          throw new Error(
+            'The value name ' +
+              element.valueName +
+              ' on page ' +
+              page.name +
+              ' is invalid. Please conform to snake_case.'
+          );
+        }
+      }
+      // if choices object exists, checks for duplicate values
+      if (element.choices) {
+        const values = element.choices.map(
+          (choice: { value: string; text: string }) => choice.value
+        );
+        const distinctValues = [...new Set(values)];
+
+        if (values.length > distinctValues.length){
+          throw new Error(
+            `Please provide unique values for each of the choices of question: ${element.valueName}`
+          );
         }
       }
       if (element.type === 'multipletext') {
         element.items = element.items.map((e: any) => {
           if (!e.name && !e.title) {
-            throw new Error(`Please provide name or title for each text of question: ${element.valueName}`);
+            throw new Error(
+              `Please provide name or title for each text of question: ${element.valueName}`
+            );
           }
           return {
             name: this.isSnakeCase(e.name) ? e.name : this.toSnakeCase(e.name),
-            title: e.title ? e.title : null
+            title: e.title ? e.title : null,
           };
         });
       }
       if (element.type === 'matrix') {
         element.columns = element.columns.map((x: any) => {
           return {
-            value: x.value ? this.toSnakeCase(x.value) : this.toSnakeCase(x.text ? x.text : x),
-            text: x.text ? x.text : x
+            value: x.value
+              ? this.toSnakeCase(x.value)
+              : this.toSnakeCase(x.text ? x.text : x),
+            text: x.text ? x.text : x,
           };
         });
         element.rows = element.rows.map((x: any) => {
           return {
-            value: x.value ? this.toSnakeCase(x.value) : this.toSnakeCase(x.text ? x.text : x),
-            text: x.text ? x.text : x
+            value: x.value
+              ? this.toSnakeCase(x.value)
+              : this.toSnakeCase(x.text ? x.text : x),
+            text: x.text ? x.text : x,
           };
         });
       }
       if (element.type === 'matrixdropdown') {
         element.columns = element.columns.map((x: any) => {
           return {
-            name: x.name ? this.toSnakeCase(x.name) : this.toSnakeCase(x.title ? x.title : x),
-            title: x.title ? x.title : (x.name ? x.name : x),
-            ...x.cellType && { cellType: x.cellType },
-            ...x.isRequired && { isRequired: true }
+            name: x.name
+              ? this.toSnakeCase(x.name)
+              : this.toSnakeCase(x.title ? x.title : x),
+            title: x.title ? x.title : x.name ? x.name : x,
+            ...(x.cellType && { cellType: x.cellType }),
+            ...(x.isRequired && { isRequired: true }),
           };
         });
         element.rows = element.rows.map((x: any) => {
           return {
-            value: x.value ? this.toSnakeCase(x.value) : this.toSnakeCase(x.text ? x.text : x),
-            text: x.text ? x.text : x
+            value: x.value
+              ? this.toSnakeCase(x.value)
+              : this.toSnakeCase(x.text ? x.text : x),
+            text: x.text ? x.text : x,
           };
         });
       }
@@ -314,12 +368,22 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
         if (element.relatedName) {
           element.relatedName = this.toSnakeCase(element.relatedName);
           if (!this.isSnakeCase(element.relatedName)) {
-            throw new Error('The related name ' + element.relatedName + ' on page '
-              + page.name + ' is invalid. Please conform to snake_case.');
+            throw new Error(
+              'The related name ' +
+                element.relatedName +
+                ' on page ' +
+                page.name +
+                ' is invalid. Please conform to snake_case.'
+            );
           }
         } else {
-          throw new Error('Missing related name for question ' + element.title + ' on page '
-            + page.name + '. Please provide a valid data value name (snake_case) to save the form.');
+          throw new Error(
+            'Missing related name for question ' +
+              element.title +
+              ' on page ' +
+              page.name +
+              '. Please provide a valid data value name (snake_case) to save the form.'
+          );
         }
       }
     }


### PR DESCRIPTION
# Description

This PR implements an error alert that prevents the user from saving a form that has a question with duplicate choice values.
This however doesn't account for the fact that the choices by url **may still have** duplicate values. 

Changes are on line 303-313, the rest is just linting stuff.

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Trying to save a form with duplicate values in the choices array displays an error to the user 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
