### PR TITLE
OORT-264

### DIFF
--- a/projects/back-office/src/environments/environment.ts
+++ b/projects/back-office/src/environments/environment.ts
@@ -28,10 +28,10 @@ const authConfig: AuthConfig = {
  */
 export const environment = {
   production: false,
-  // apiUrl: 'https://oort-dev.oortcloud.tech/api',
-  // subscriptionApiUrl: 'wss://oort-dev.oortcloud.tech/api',
-  apiUrl: 'http://localhost:3000',
-  subscriptionApiUrl: 'ws://localhost:3000',
+  apiUrl: 'https://oort-dev.oortcloud.tech/api',
+  subscriptionApiUrl: 'wss://oort-dev.oortcloud.tech/api',
+  // apiUrl: 'http://localhost:3000',
+  // subscriptionApiUrl: 'ws://localhost:3000',
   frontOfficeUri: 'http://localhost:4200/',
   backOfficeUri: 'http://localhost:4200/',
   module: 'backoffice',

--- a/projects/back-office/src/environments/environment.ts
+++ b/projects/back-office/src/environments/environment.ts
@@ -28,10 +28,10 @@ const authConfig: AuthConfig = {
  */
 export const environment = {
   production: false,
-  apiUrl: 'https://oort-dev.oortcloud.tech/api',
-  subscriptionApiUrl: 'wss://oort-dev.oortcloud.tech/api',
-  // apiUrl: 'http://localhost:3000',
-  // subscriptionApiUrl: 'ws://localhost:3000',
+  // apiUrl: 'https://oort-dev.oortcloud.tech/api',
+  // subscriptionApiUrl: 'wss://oort-dev.oortcloud.tech/api',
+  apiUrl: 'http://localhost:3000',
+  subscriptionApiUrl: 'ws://localhost:3000',
   frontOfficeUri: 'http://localhost:4200/',
   backOfficeUri: 'http://localhost:4200/',
   module: 'backoffice',

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.html
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.html
@@ -39,22 +39,26 @@
   <button mat-button color="warn" (click)="onClose()">
     {{ 'common.cancel' | translate }}
   </button>
-  <button
-    [disabled]="!survey || survey.isFirstPage"
-    mat-button
-    color="primary"
-    (click)="survey && survey.prevPage()"
-  >
-    {{ 'common.previous' | translate }}
-  </button>
-  <button
-    [disabled]="!survey || survey.isLastPage"
-    mat-button
-    color="primary"
-    (click)="survey && survey.nextPage()"
-  >
-    {{ 'common.next' | translate }}
-  </button>
+  <ng-container *ngIf="pages$ | async as pages">
+    <button
+      *ngIf="pages.length > 1"
+      [disabled]="!survey || survey.isFirstPage"
+      mat-button
+      color="primary"
+      (click)="survey && survey.prevPage()"
+    >
+      {{ 'common.previous' | translate }}
+    </button>
+    <button
+      *ngIf="pages.length > 1"
+      [disabled]="!survey || survey.isLastPage"
+      mat-button
+      color="primary"
+      (click)="survey && survey.nextPage()"
+    >
+      {{ 'common.next' | translate }}
+    </button>
+  </ng-container>
   <button mat-flat-button color="primary" (click)="submit()">
     {{ 'components.record.modal.update' | translate }}
   </button>

--- a/projects/safe/src/lib/components/form/form.component.html
+++ b/projects/safe/src/lib/components/form/form.component.html
@@ -22,7 +22,6 @@
   </kendo-dropdownlist>
 </div>
 <mat-tab-group
-  *ngIf="survey.pageCount > 1"
   animationDuration="0ms"
   [selectedIndex]="selectedTabIndex"
   (selectedIndexChange)="onShowPage($event)"
@@ -43,23 +42,23 @@
   </mat-tab>
 </mat-tab-group>
 <div #formContainer></div>
-<!-- <div *ngIf="!!survey && surveyActive" class="survey-navigation"> -->
-<!-- <div [id]="containerId"></div> -->
 <div *ngIf="surveyActive" class="survey-navigation">
-  <safe-button
-    *ngIf="survey.pageCount > 1"
-    [disabled]="survey.isFirstPage"
-    variant="primary"
-    (click)="survey.prevPage()"
-    >{{ 'common.previous' | translate }}</safe-button
-  >
-  <safe-button
-    *ngIf="survey.pageCount > 1"
-    [disabled]="survey.isLastPage"
-    variant="primary"
-    (click)="survey.nextPage()"
-    >{{ 'common.next' | translate }}</safe-button
-  >
+  <ng-container *ngIf="pages$ | async as pages">
+    <safe-button
+      *ngIf="pages.length > 1"
+      [disabled]="survey.isFirstPage"
+      variant="primary"
+      (click)="survey.prevPage()"
+      >{{ 'common.previous' | translate }}</safe-button
+    >
+    <safe-button
+      *ngIf="pages.length > 1"
+      [disabled]="survey.isLastPage"
+      variant="primary"
+      (click)="survey.nextPage()"
+      >{{ 'common.next' | translate }}</safe-button
+    >
+  </ng-container>
   <safe-button variant="primary" category="secondary" (click)="submit()">{{
     'common.save' | translate
   }}</safe-button>

--- a/projects/safe/src/lib/components/form/form.component.html
+++ b/projects/safe/src/lib/components/form/form.component.html
@@ -22,6 +22,7 @@
   </kendo-dropdownlist>
 </div>
 <mat-tab-group
+  *ngIf="survey.pageCount > 1"
   animationDuration="0ms"
   [selectedIndex]="selectedTabIndex"
   (selectedIndexChange)="onShowPage($event)"
@@ -46,12 +47,14 @@
 <!-- <div [id]="containerId"></div> -->
 <div *ngIf="surveyActive" class="survey-navigation">
   <safe-button
+    *ngIf="survey.pageCount > 1"
     [disabled]="survey.isFirstPage"
     variant="primary"
     (click)="survey.prevPage()"
     >{{ 'common.previous' | translate }}</safe-button
   >
   <safe-button
+    *ngIf="survey.pageCount > 1"
     [disabled]="survey.isLastPage"
     variant="primary"
     (click)="survey.nextPage()"

--- a/projects/safe/src/lib/components/form/form.component.scss
+++ b/projects/safe/src/lib/components/form/form.component.scss
@@ -32,8 +32,5 @@ mat-tab-group {
   justify-content: flex-end;
   gap: 8px;
   margin-top: 16px;
-
-  safe-button {
-    margin-left: 8px;
-  }
+  flex-wrap: wrap;
 }

--- a/projects/safe/src/lib/components/record-modal/record-modal.component.html
+++ b/projects/safe/src/lib/components/record-modal/record-modal.component.html
@@ -61,22 +61,26 @@
   <button mat-button color="warn" (click)="onClose()">
     {{ 'common.close' | translate }}
   </button>
-  <button
-    *ngIf="!survey.isFirstPage"
-    mat-button
-    color="primary"
-    (click)="survey.prevPage()"
-  >
-    {{ 'common.previous' | translate }}
-  </button>
-  <button
-    *ngIf="!survey.isLastPage"
-    mat-button
-    color="primary"
-    (click)="survey.nextPage()"
-  >
-    {{ 'common.next' | translate }}
-  </button>
+  <ng-container *ngIf="pages$ | async as pages">
+    <button
+      *ngIf="pages.length > 1"
+      [disabled]="survey.isFirstPage"
+      mat-button
+      color="primary"
+      (click)="survey.prevPage()"
+    >
+      {{ 'common.previous' | translate }}
+    </button>
+    <button
+      *ngIf="pages.length > 1"
+      [disabled]="survey.isLastPage"
+      mat-button
+      color="primary"
+      (click)="survey.nextPage()"
+    >
+      {{ 'common.next' | translate }}
+    </button>
+  </ng-container>
   <button *ngIf="canEdit" mat-flat-button color="primary" (click)="onEdit()">
     {{
       'common.editObject' | translate: { name: 'common.record.few' | translate }


### PR DESCRIPTION
# Description

This PR hides the tab selection for pages  and next/previous buttons on forms that have a single page

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

By going to the answer page of a form, if has multiple pages, the elements are shown, if not, they're not.

# Screenshots
![image](https://user-images.githubusercontent.com/102038450/171773893-8cfb5618-a490-453c-8a53-4e66eda2d85f.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
