### PR TITLE
OORT-265 - filter available resources

### DIFF
--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -25,9 +25,9 @@
             <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
               <mat-option
                 *ngFor="let option of filteredQueries"
-                [value]="option"
+                [value]="option.name"
               >
-                {{ option }}
+                {{ option.name }}
               </mat-option>
             </mat-autocomplete>
           </mat-form-field>

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -138,7 +138,10 @@ export class SafeGridSettingsComponent implements OnInit, AfterViewInit {
     this.availableQueries = this.queryBuilder.availableQueries$;
     this.availableQueries.subscribe((res) => {
       if (res && res.length > 0) {
-        this.allQueries = res.map((x) => x.name);
+        this.allQueries = res.map((x) => ({
+          name: x.node.name,
+          query: x.node.queryName,
+        }));
         this.filteredQueries = this.filterQueries(
           this.tileForm?.value.query.name
         );
@@ -151,11 +154,12 @@ export class SafeGridSettingsComponent implements OnInit, AfterViewInit {
     this.queryName = this.tileForm.get('query')?.value.name;
     this.getQueryMetaData();
 
-    this.tileForm.get('query.name')?.valueChanges.subscribe((name) => {
-      if (name) {
+    this.tileForm?.get('query.name')?.valueChanges.subscribe((name) => {
+      const queryName = this.allQueries.find((x) => x.name === name)?.query;
+      if (queryName) {
         // Check if the query changed to clean modifications and fields for email in floating button
-        if (name !== this.queryName) {
-          this.queryName = name;
+        if (queryName !== this.queryName) {
+          this.queryName = queryName;
           this.tileForm?.get('layouts')?.setValue([]);
           this.tileForm?.get('query.template')?.setValue(null);
           this.tileForm?.get('query.template')?.enable();
@@ -390,6 +394,8 @@ export class SafeGridSettingsComponent implements OnInit, AfterViewInit {
    */
   private filterQueries(value: string): string[] {
     const filterValue = value.toLowerCase();
-    return this.allQueries.filter((x) => x.toLowerCase().includes(filterValue));
+    return this.allQueries.filter((x) =>
+      x.name.toLowerCase().includes(filterValue)
+    );
   }
 }

--- a/projects/safe/src/lib/graphql/queries.ts
+++ b/projects/safe/src/lib/graphql/queries.ts
@@ -257,6 +257,30 @@ export interface GetFormsQueryResponse {
   };
 }
 
+/** Graphql request for getting forms list with query name*/
+export const GET_FORMS_AND_QUERY_NAMES = gql`
+  query GetFormsAndQueryNames {
+    forms(getAll: true) {
+      edges {
+        node {
+          name
+          queryName
+        }
+      }
+    }
+  }
+`;
+
+/** Model for GetFormsAndQueryNamesQueryResponse object */
+export interface GetFormsAndQueryNamesQueryResponse {
+  loading: boolean;
+  forms: {
+    edges: {
+      node: Form;
+    }[];
+  };
+}
+
 // === GET RESOURCES ===
 
 /** Graphql request for getting resources */


### PR DESCRIPTION
# Description

This PR changes the frontend so in the grid settings, the user sees the forms they have access to, instead of all the datasets (which also indirectly fixes the original bug, which is also addressed in the backend PR)

## Type of change

Please delete options that are not relevant.
- [x] Improvement (refactor or addition to existing functionality)


# How Has This Been Tested?

Open the the settings for a grid widget, in the dataset field, you should only be able to see forms/resources you have access to.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
