### PR TITLE
Oort 296

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -777,6 +777,8 @@
 							},
 							"prefill": "Pre-fill form with selected data",
 							"save": "Auto-save",
+							"selectAllRecords": "Select all records",
+							"selectAllRecordsActivePage": "Select all records on the active page",
 							"selectDisplay": "Select displayed fields",
 							"sendMail": "Send mail",
 							"workflow": {

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -777,6 +777,8 @@
 							},
 							"prefill": "Préremplir le formulaire avec les données sélectionnées",
 							"save": "Sauvegarder automatiquement",
+							"selectAllRecords": "Sélectionner tous les enregistrements",
+							"selectAllRecordsActivePage": "Sélectionner tous les enregistrements sur la page active",
 							"selectDisplay": "Sélectionner les champs affichés",
 							"sendMail": "Envoyer le mail",
 							"workflow": {

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -777,6 +777,8 @@
 							},
 							"prefill": "******",
 							"save": "******",
+							"selectAllRecords": "******",
+							"selectAllRecordsActivePage": "******",
 							"selectDisplay": "******",
 							"sendMail": "******",
 							"workflow": {

--- a/projects/safe/src/lib/components/preferences-modal/preferences-modal.component.html
+++ b/projects/safe/src/lib/components/preferences-modal/preferences-modal.component.html
@@ -11,10 +11,8 @@
     <mat-tab-group vertical animationDuration="0ms">
       <mat-tab>
         <ng-template mat-tab-label>
-          <div class="tab-label">
-            <safe-icon icon="language" [size]="18"></safe-icon>
-            <span>{{ 'components.preferences.language' | translate }}</span>
-          </div>
+          <safe-icon icon="language" [size]="18"></safe-icon>
+          <span>{{ 'components.preferences.language' | translate }}</span>
         </ng-template>
         <div class="form-group">
           <!-- LANGUAGE SELECTION -->

--- a/projects/safe/src/lib/components/widgets/grid-settings/floating-button-settings/floating-button-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/floating-button-settings/floating-button-settings.component.html
@@ -18,12 +18,14 @@
           <mat-label>{{ 'common.name' | translate }}</mat-label>
           <input matInput formControlName="name" type="string" />
         </mat-form-field>
-        <mat-checkbox formControlName="selectAll"
-          >Select all records</mat-checkbox
-        >
-        <mat-checkbox formControlName="selectPage"
-          >Select all records on the active page</mat-checkbox
-        >
+        <mat-checkbox formControlName="selectAll">{{
+          'components.widget.settings.grid.buttons.callback.selectAllRecords'
+            | translate
+        }}</mat-checkbox>
+        <mat-checkbox formControlName="selectPage">{{
+          'components.widget.settings.grid.buttons.callback.selectAllRecordsActivePage'
+            | translate
+        }}</mat-checkbox>
         <ng-container *ngIf="relatedForms.length > 0">
           <mat-checkbox formControlName="prefillForm">{{
             'components.widget.settings.grid.buttons.callback.prefill'

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -4,13 +4,11 @@
       <!-- MAIN PARAMETERS / SELECTION OF LAYOUTS -->
       <mat-tab>
         <ng-template mat-tab-label>
-          <div class="tab-label">
-            <safe-icon icon="preview" [size]="25"></safe-icon>
-            <span>{{ 'common.general' | translate }}</span>
-          </div>
+          <safe-icon icon="preview" [size]="24"></safe-icon>
+          <span>{{ 'common.general' | translate }}</span>
         </ng-template>
         <div class="form-group">
-          <div class="form-group-title">{{ 'common.general' | translate }}</div>
+          <h2>{{ 'common.general' | translate }}</h2>
           <mat-form-field appearance="outline">
             <mat-label>{{ 'common.title' | translate }}</mat-label>
             <input matInput formControlName="title" type="string" />
@@ -54,9 +52,9 @@
           </ng-container>
         </div>
         <div class="form-group" *ngIf="queryName">
-          <div class="form-group-title">
+          <h2>
             {{ 'components.widget.settings.grid.layouts.title' | translate }}
-          </div>
+          </h2>
           <safe-layouts-parameters
             [form]="form"
             [resource]="resource"
@@ -67,15 +65,15 @@
       <!-- AVAILABLE ACTIONS -->
       <mat-tab>
         <ng-template mat-tab-label>
-          <div class="tab-label">
-            <safe-icon icon="toggle_on" [size]="25"></safe-icon>
-            <span>{{ 'components.widget.settings.grid.actions.title' | translate }}</span>
-          </div>
+          <safe-icon icon="toggle_on" [size]="24"></safe-icon>
+          <span>{{
+            'components.widget.settings.grid.actions.title' | translate
+          }}</span>
         </ng-template>
         <div formGroupName="actions" class="form-group">
-          <div class="form-group-title">
+          <h2>
             {{ 'components.widget.settings.grid.actions.title' | translate }}
-          </div>
+          </h2>
           <mat-slide-toggle formControlName="delete">
             {{ 'components.widget.settings.grid.actions.delete' | translate }}
           </mat-slide-toggle>
@@ -107,15 +105,15 @@
       <!-- BUTTONS -->
       <mat-tab>
         <ng-template mat-tab-label>
-          <div class="tab-label">
-            <safe-icon icon="bolt" [size]="25"></safe-icon>
-            <span>{{ 'components.widget.settings.grid.buttons.title' | translate }}</span>
-          </div>
+          <safe-icon icon="bolt" [size]="24"></safe-icon>
+          <span>{{
+            'components.widget.settings.grid.buttons.title' | translate
+          }}</span>
         </ng-template>
         <div class="form-group">
-          <div class="form-group-title">
+          <h2>
             {{ 'components.widget.settings.grid.buttons.title' | translate }}
-          </div>
+          </h2>
           <div class="info-text">
             {{ 'components.widget.settings.grid.hint.buttons' | translate }}
           </div>

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -1,145 +1,174 @@
 <ng-container *ngIf="tileForm">
   <form [formGroup]="tileForm">
-    <!-- MAIN PARAMETERS -->
-    <div class="form-group">
-      <div class="form-group-title">{{ 'common.general' | translate }}</div>
-      <mat-form-field appearance="outline">
-        <mat-label>{{ 'common.title' | translate }}</mat-label>
-        <input matInput formControlName="title" type="string" />
-      </mat-form-field>
-      <ng-container formGroupName="query">
-        <div class="form-group-row">
+    <mat-tab-group vertical animationDuration="0ms">
+      <!-- MAIN PARAMETERS / SELECTION OF LAYOUTS -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <div class="tab-label">
+            <safe-icon icon="preview" [size]="25"></safe-icon>
+            <span>{{ 'common.general' | translate }}</span>
+          </div>
+        </ng-template>
+        <div class="form-group">
+          <div class="form-group-title">{{ 'common.general' | translate }}</div>
           <mat-form-field appearance="outline">
-            <mat-label>{{
-              'components.queryBuilder.dataset.select' | translate
-            }}</mat-label>
-            <input
-              type="text"
-              [placeholder]="
-                'components.queryBuilder.dataset.select' | translate
-              "
-              matInput
-              formControlName="name"
-              [matAutocomplete]="auto"
-            />
-            <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
-              <mat-option
-                *ngFor="let option of filteredQueries"
-                [value]="option"
-              >
-                {{ option }}
-              </mat-option>
-            </mat-autocomplete>
+            <mat-label>{{ 'common.title' | translate }}</mat-label>
+            <input matInput formControlName="title" type="string" />
           </mat-form-field>
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'models.form.template' | translate }}</mat-label>
-            <mat-select formControlName="template">
-              <mat-option>-</mat-option>
-              <mat-option
-                *ngFor="let template of templates"
-                [value]="template.id"
-                >{{ template.name }}</mat-option
-              >
-            </mat-select>
-          </mat-form-field>
+          <ng-container formGroupName="query">
+            <div class="form-group-row">
+              <mat-form-field appearance="outline">
+                <mat-label>{{
+                  'components.queryBuilder.dataset.select' | translate
+                }}</mat-label>
+                <input
+                  type="text"
+                  [placeholder]="
+                    'components.queryBuilder.dataset.select' | translate
+                  "
+                  matInput
+                  formControlName="name"
+                  [matAutocomplete]="auto"
+                />
+                <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
+                  <mat-option
+                    *ngFor="let option of filteredQueries"
+                    [value]="option"
+                  >
+                    {{ option }}
+                  </mat-option>
+                </mat-autocomplete>
+              </mat-form-field>
+              <mat-form-field appearance="outline">
+                <mat-label>{{ 'models.form.template' | translate }}</mat-label>
+                <mat-select formControlName="template">
+                  <mat-option>-</mat-option>
+                  <mat-option
+                    *ngFor="let template of templates"
+                    [value]="template.id"
+                    >{{ template.name }}</mat-option
+                  >
+                </mat-select>
+              </mat-form-field>
+            </div>
+          </ng-container>
         </div>
-      </ng-container>
-    </div>
-    <!-- SELECTION OF LAYOUTS -->
-    <div class="form-group" *ngIf="queryName">
-      <div class="form-group-title">
-        {{ 'components.widget.settings.grid.layouts.title' | translate }}
-      </div>
-      <safe-layouts-parameters
-        [form]="form"
-        [resource]="resource"
-        [selectedLayouts]="$any(tileForm).get('layouts')"
-      ></safe-layouts-parameters>
-    </div>
-    <!-- AVAILABLE ACTIONS -->
-    <div formGroupName="actions" class="form-group">
-      <div class="form-group-title">
-        {{ 'components.widget.settings.grid.actions.title' | translate }}
-      </div>
-      <mat-slide-toggle formControlName="delete">
-        {{ 'components.widget.settings.grid.actions.delete' | translate }}
-      </mat-slide-toggle>
-      <mat-slide-toggle formControlName="history">
-        {{ 'components.widget.settings.grid.actions.show' | translate }}
-      </mat-slide-toggle>
-      <mat-slide-toggle formControlName="convert">
-        {{ 'components.widget.settings.grid.actions.convert' | translate }}
-      </mat-slide-toggle>
-      <mat-slide-toggle formControlName="update">
-        {{ 'components.widget.settings.grid.actions.update' | translate }}
-      </mat-slide-toggle>
-      <mat-slide-toggle formControlName="inlineEdition">
-        {{ 'components.widget.settings.grid.actions.inline' | translate }}
-      </mat-slide-toggle>
-      <mat-slide-toggle formControlName="addRecord">
-        {{ 'components.widget.settings.grid.actions.add' | translate }}
-      </mat-slide-toggle>
-      <mat-slide-toggle formControlName="export">
-        {{ 'components.widget.settings.grid.actions.export' | translate }}
-      </mat-slide-toggle>
-      <mat-slide-toggle formControlName="showDetails">
-        {{ 'components.widget.settings.grid.actions.showDetails' | translate }}
-      </mat-slide-toggle>
-    </div>
-    <!-- BUTTONS -->
-    <div class="form-group">
-      <div class="form-group-title">
-        {{ 'components.widget.settings.grid.buttons.title' | translate }}
-      </div>
-      <div class="info-text">
-        {{ 'components.widget.settings.grid.hint.buttons' | translate }}
-      </div>
-      <safe-button
-        icon="add"
-        variant="primary"
-        class="add-button"
-        (click)="addFloatingButton()"
-      >
-        {{ 'components.widget.settings.grid.buttons.create' | translate }}
-      </safe-button>
-      <mat-tab-group
-        mat-align-tabs="start"
-        animationDuration="0ms"
-        dynamicHeight
-        style="min-height: 500px"
-        [(selectedIndex)]="tabIndex"
-        *ngIf="floatingButtons.length > 0"
-      >
-        <ng-container *ngFor="let floatingButton of floatingButtons.controls">
-          <mat-tab>
-            <ng-template mat-tab-label>
-              {{
-                floatingButton.value.name.length > 0
-                  ? floatingButton.value.name
-                  : ('components.widget.settings.grid.buttons.defaultName'
-                    | translate)
-              }}
-              <safe-icon
-                *ngIf="floatingButton.invalid"
-                style="padding-left: 2px"
-                icon="error_outline"
-                [inline]="true"
-                [size]="18"
-                variant="danger"
-              ></safe-icon>
-            </ng-template>
-            <ng-template matTabContent>
-              <safe-floating-button-settings
-                [buttonForm]="$any(floatingButton)"
-                [fields]="fields"
-                [channels]="channels"
-                [relatedForms]="relatedForms"
-                (deleteButton)="deleteFloatingButton()"
-              ></safe-floating-button-settings>
-            </ng-template>
-          </mat-tab>
-        </ng-container>
-      </mat-tab-group>
-    </div>
+        <div class="form-group" *ngIf="queryName">
+          <div class="form-group-title">
+            {{ 'components.widget.settings.grid.layouts.title' | translate }}
+          </div>
+          <safe-layouts-parameters
+            [form]="form"
+            [resource]="resource"
+            [selectedLayouts]="$any(tileForm).get('layouts')"
+          ></safe-layouts-parameters>
+        </div>
+      </mat-tab>
+      <!-- AVAILABLE ACTIONS -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <div class="tab-label">
+            <safe-icon icon="toggle_on" [size]="25"></safe-icon>
+            <span>{{ 'components.widget.settings.grid.actions.title' | translate }}</span>
+          </div>
+        </ng-template>
+        <div formGroupName="actions" class="form-group">
+          <div class="form-group-title">
+            {{ 'components.widget.settings.grid.actions.title' | translate }}
+          </div>
+          <mat-slide-toggle formControlName="delete">
+            {{ 'components.widget.settings.grid.actions.delete' | translate }}
+          </mat-slide-toggle>
+          <mat-slide-toggle formControlName="history">
+            {{ 'components.widget.settings.grid.actions.show' | translate }}
+          </mat-slide-toggle>
+          <mat-slide-toggle formControlName="convert">
+            {{ 'components.widget.settings.grid.actions.convert' | translate }}
+          </mat-slide-toggle>
+          <mat-slide-toggle formControlName="update">
+            {{ 'components.widget.settings.grid.actions.update' | translate }}
+          </mat-slide-toggle>
+          <mat-slide-toggle formControlName="inlineEdition">
+            {{ 'components.widget.settings.grid.actions.inline' | translate }}
+          </mat-slide-toggle>
+          <mat-slide-toggle formControlName="addRecord">
+            {{ 'components.widget.settings.grid.actions.add' | translate }}
+          </mat-slide-toggle>
+          <mat-slide-toggle formControlName="export">
+            {{ 'components.widget.settings.grid.actions.export' | translate }}
+          </mat-slide-toggle>
+          <mat-slide-toggle formControlName="showDetails">
+            {{
+              'components.widget.settings.grid.actions.showDetails' | translate
+            }}
+          </mat-slide-toggle>
+        </div>
+      </mat-tab>
+      <!-- BUTTONS -->
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <div class="tab-label">
+            <safe-icon icon="bolt" [size]="25"></safe-icon>
+            <span>{{ 'components.widget.settings.grid.buttons.title' | translate }}</span>
+          </div>
+        </ng-template>
+        <div class="form-group">
+          <div class="form-group-title">
+            {{ 'components.widget.settings.grid.buttons.title' | translate }}
+          </div>
+          <div class="info-text">
+            {{ 'components.widget.settings.grid.hint.buttons' | translate }}
+          </div>
+          <safe-button
+            icon="add"
+            variant="primary"
+            class="add-button"
+            (click)="addFloatingButton()"
+          >
+            {{ 'components.widget.settings.grid.buttons.create' | translate }}
+          </safe-button>
+          <mat-tab-group
+            mat-align-tabs="start"
+            animationDuration="0ms"
+            dynamicHeight
+            style="min-height: 500px"
+            [(selectedIndex)]="tabIndex"
+            *ngIf="floatingButtons.length > 0"
+          >
+            <ng-container
+              *ngFor="let floatingButton of floatingButtons.controls"
+            >
+              <mat-tab>
+                <ng-template mat-tab-label>
+                  {{
+                    floatingButton.value.name.length > 0
+                      ? floatingButton.value.name
+                      : ('components.widget.settings.grid.buttons.defaultName'
+                        | translate)
+                  }}
+                  <safe-icon
+                    *ngIf="floatingButton.invalid"
+                    style="padding-left: 2px"
+                    icon="error_outline"
+                    [inline]="true"
+                    [size]="18"
+                    variant="danger"
+                  ></safe-icon>
+                </ng-template>
+                <ng-template matTabContent>
+                  <safe-floating-button-settings
+                    [buttonForm]="$any(floatingButton)"
+                    [fields]="fields"
+                    [channels]="channels"
+                    [relatedForms]="relatedForms"
+                    (deleteButton)="deleteFloatingButton()"
+                  ></safe-floating-button-settings>
+                </ng-template>
+              </mat-tab>
+            </ng-container>
+          </mat-tab-group>
+        </div>
+      </mat-tab>
+    </mat-tab-group>
   </form>
 </ng-container>

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.scss
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.scss
@@ -9,3 +9,14 @@
   width: min-content;
   align-self: flex-end;
 }
+
+.tab-label {
+  display: flex;
+  gap: 6px;
+  align-content: center;
+  align-items: center;
+
+  safe-icon {
+    height: 26.5px;
+  }
+}

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.scss
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.scss
@@ -10,13 +10,11 @@
   align-self: flex-end;
 }
 
-.tab-label {
+form {
   display: flex;
-  gap: 6px;
-  align-content: center;
-  align-items: center;
+  height: 100%;
 
-  safe-icon {
-    height: 26.5px;
+  mat-tab-group {
+    flex: 1;
   }
 }

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -337,6 +337,7 @@ $safe-theme: mat.define-light-theme($safe-primary, $safe-accent, $safe-warn);
 
 .form-group {
   &:not(td) {
+    padding-left: 32px;
     display: flex;
     flex-direction: column;
 
@@ -350,7 +351,7 @@ $safe-theme: mat.define-light-theme($safe-primary, $safe-accent, $safe-warn);
     }
 
     .form-group-title {
-      font-weight: bold;
+      font-weight: 500;
       font-size: 16px;
       margin-bottom: 12px;
       border-bottom: 1px solid darkgray;
@@ -591,7 +592,18 @@ mat-tab-group[vertical] {
 
   & > .mat-tab-body-wrapper {
     width: 100%;
-    margin-left: 32px;
+
+    & > .mat-tab-body {
+      & > .mat-tab-body-content {
+        transition: all ease 200ms;
+      }
+      & > .mat-tab-body-content[style*="transform: translate3d(100%, 0px, 0px)"] {
+        transform: translate3d(0px, 100%, 0px) !important;
+      }
+      & > .mat-tab-body-content[style*="transform: translate3d(-100%, 0px, 0px)"] {
+        transform: translate3d(0px, -100%, 0px) !important;
+      }
+    }
   }
 }
 

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -337,7 +337,6 @@ $safe-theme: mat.define-light-theme($safe-primary, $safe-accent, $safe-warn);
 
 .form-group {
   &:not(td) {
-    padding-left: 32px;
     display: flex;
     flex-direction: column;
 
@@ -572,6 +571,14 @@ mat-tab-group[vertical] {
           opacity: 1;
           background-color: #f5f5f5;
         }
+
+        .mat-tab-label-content {
+          gap: 6px;
+
+          safe-icon {
+            display: flex;
+          }
+        }
       }
 
       &::after {
@@ -596,6 +603,7 @@ mat-tab-group[vertical] {
     & > .mat-tab-body {
       & > .mat-tab-body-content {
         transition: all ease 200ms;
+        padding-left: 32px;
       }
       & > .mat-tab-body-content[style*="transform: translate3d(100%, 0px, 0px)"] {
         transform: translate3d(0px, 100%, 0px) !important;


### PR DESCRIPTION
# Description

The organisation of the grid settings modal is changed to look more like the preferences modal with vertical tabs for the different categories of settings. 
There is also a few cosmetic changes : we changed the way the padding/margins were handled so that when disabling an action the button is not clipped anymore. There were also a few buttons in the quick action buttons tabs that were hardcoded and thus not translated into French. 


## Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Tested by displaying the settings modal in a grid 

## Screenshots

![image](https://user-images.githubusercontent.com/103029022/173306252-04b974f8-ec07-478d-9752-4b6750dff042.png)

![image](https://user-images.githubusercontent.com/103029022/173307300-e91f5b1f-097c-4350-9a37-4a241c7b0f73.png)

![image](https://user-images.githubusercontent.com/103029022/173306974-717b0417-edfd-4264-9e38-127ab8d2cc26.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
