### PR TITLE
OORT-298

### DIFF
--- a/projects/safe/src/lib/components/ui/bar-chart/bar-chart.component.html
+++ b/projects/safe/src/lib/components/ui/bar-chart/bar-chart.component.html
@@ -30,7 +30,13 @@
       [data]="serie.data"
       [name]="serie.name || ''"
       [color]="serie.color"
-      [labels]="labels"
-    ></kendo-chart-series-item>
+    >
+      <kendo-chart-series-item-labels
+        *ngIf="labelContent"
+        position="outsideEnd"
+        color="#000"
+        [content]="labelContent"
+      ></kendo-chart-series-item-labels>
+    </kendo-chart-series-item>
   </kendo-chart-series>
 </kendo-chart>

--- a/projects/safe/src/lib/components/ui/bar-chart/bar-chart.component.ts
+++ b/projects/safe/src/lib/components/ui/bar-chart/bar-chart.component.ts
@@ -25,6 +25,7 @@ interface ChartSeries {
 
 interface ChartLabels {
   showValue: boolean;
+  valueType: string;
 }
 
 interface ChartOptions {
@@ -69,25 +70,72 @@ export class SafeBarChartComponent implements OnInit, OnChanges {
   @ViewChild('chart')
   public chart?: ChartComponent;
 
-  public labels: any;
-
-  constructor() {}
+  /**
+   * The function which returns the Chart series label content.
+   * Content is defined on the component init.
+   *
+   * @param e - Event which with the specific label data
+   * @return Returns a string which will be used as the label content
+   */
+  public labelContent: ((e: any) => string) | null = null;
 
   ngOnInit(): void {
     this.min = get(this.options, 'axes.x.min');
     this.max = get(this.options, 'axes.x.max');
-    this.labels = {
-      visible: get(this.options, 'labels.showValue'),
-    };
     this.stack = this.series.length > 1 ? get(this.options, 'stack') : false;
+    this.setLabelContent();
   }
 
   ngOnChanges(): void {
     this.min = get(this.options, 'axes.x.min');
     this.max = get(this.options, 'axes.x.max');
-    this.labels = {
-      visible: get(this.options, 'labels.showValue'),
-    };
     this.stack = this.series.length > 1 ? get(this.options, 'stack') : false;
+  }
+
+  /**
+   * Set label content method.
+   */
+  private setLabelContent(): void {
+    const showCategory = get(this.options, 'labels.showCategory', false);
+    const showValue = get(this.options, 'labels.showValue', false);
+    const valueType = get(this.options, 'labels.valueType', 'value');
+
+    if (showCategory) {
+      if (showValue) {
+        switch (valueType) {
+          case 'percentage': {
+            this.labelContent = (e: any): string =>
+              e.category && e.percentage
+                ? `${e.category}
+                ${(parseFloat(e.percentage) * 100).toFixed(2)}%`
+                : '';
+            break;
+          }
+          default: {
+            this.labelContent = (e: any): string =>
+              e.category && e.value ? e.category + '\n' + e.value : '';
+            break;
+          }
+        }
+      } else {
+        this.labelContent = (e: any): string => e.category || '';
+      }
+    } else {
+      if (showValue) {
+        switch (valueType) {
+          case 'percentage': {
+            this.labelContent = (e: any): string =>
+              e.percentage
+                ? (parseFloat(e.percentage) * 100).toFixed(2) + '%'
+                : '';
+            break;
+          }
+          default: {
+            this.labelContent = (e: any): string => e.value || '';
+            break;
+          }
+        }
+      }
+    }
   }
 }

--- a/projects/safe/src/lib/components/ui/column-chart/column-chart.component.html
+++ b/projects/safe/src/lib/components/ui/column-chart/column-chart.component.html
@@ -30,8 +30,13 @@
       categoryField="category"
       [name]="serie.name || ''"
       [color]="serie.color"
-      [labels]="labels"
     >
+      <kendo-chart-series-item-labels
+        *ngIf="labelContent"
+        position="outsideEnd"
+        color="#000"
+        [content]="labelContent"
+      ></kendo-chart-series-item-labels>
     </kendo-chart-series-item>
   </kendo-chart-series>
 </kendo-chart>

--- a/projects/safe/src/lib/components/ui/column-chart/column-chart.component.ts
+++ b/projects/safe/src/lib/components/ui/column-chart/column-chart.component.ts
@@ -25,6 +25,7 @@ interface ChartSeries {
 
 interface ChartLabels {
   showValue: boolean;
+  valueType: string;
 }
 
 interface ChartOptions {
@@ -69,25 +70,72 @@ export class SafeColumnChartComponent implements OnInit, OnChanges {
   @ViewChild('chart')
   public chart?: ChartComponent;
 
-  public labels: any;
-
-  constructor() {}
+  /**
+   * The function which returns the Chart series label content.
+   * Content is defined on the component init.
+   *
+   * @param e - Event which with the specific label data
+   * @return Returns a string which will be used as the label content
+   */
+  public labelContent: ((e: any) => string) | null = null;
 
   ngOnInit(): void {
     this.min = get(this.options, 'axes.y.min');
     this.max = get(this.options, 'axes.y.max');
-    this.labels = {
-      visible: get(this.options, 'labels.showValue'),
-    };
     this.stack = this.series.length > 1 ? get(this.options, 'stack') : false;
+    this.setLabelContent();
   }
 
   ngOnChanges(): void {
     this.min = get(this.options, 'axes.y.min');
     this.max = get(this.options, 'axes.y.max');
-    this.labels = {
-      visible: get(this.options, 'labels.showValue'),
-    };
     this.stack = this.series.length > 1 ? get(this.options, 'stack') : false;
+  }
+
+  /**
+   * Set label content method.
+   */
+  private setLabelContent(): void {
+    const showCategory = get(this.options, 'labels.showCategory', false);
+    const showValue = get(this.options, 'labels.showValue', false);
+    const valueType = get(this.options, 'labels.valueType', 'value');
+
+    if (showCategory) {
+      if (showValue) {
+        switch (valueType) {
+          case 'percentage': {
+            this.labelContent = (e: any): string =>
+              e.category && e.percentage
+                ? `${e.category}
+                ${(parseFloat(e.percentage) * 100).toFixed(2)}%`
+                : '';
+            break;
+          }
+          default: {
+            this.labelContent = (e: any): string =>
+              e.category && e.value ? e.category + '\n' + e.value : '';
+            break;
+          }
+        }
+      } else {
+        this.labelContent = (e: any): string => e.category || '';
+      }
+    } else {
+      if (showValue) {
+        switch (valueType) {
+          case 'percentage': {
+            this.labelContent = (e: any): string =>
+              e.percentage
+                ? (parseFloat(e.percentage) * 100).toFixed(2) + '%'
+                : '';
+            break;
+          }
+          default: {
+            this.labelContent = (e: any): string => e.value || '';
+            break;
+          }
+        }
+      }
+    }
   }
 }

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
@@ -199,7 +199,9 @@
                   appearance="outline"
                   *ngIf="
                     chartForm.value.labels.showValue &&
-                    (type.name === 'donut' || type.name === 'pie')
+                    (['donut', 'pie'].includes(type.name) ||
+                      (['bar', 'column'].includes(type.name) &&
+                        aggregationForm.value.mapping.series))
                   "
                 >
                   <mat-label>{{
@@ -314,7 +316,10 @@
             <!-- === SERIES AND STACKS PARAMETERS === -->
             <mat-expansion-panel
               formGroupName="stack"
-              *ngIf="['bar', 'column'].includes(type.name) && aggregationForm.value.mapping.series"
+              *ngIf="
+                ['bar', 'column'].includes(type.name) &&
+                aggregationForm.value.mapping.series
+              "
             >
               <mat-expansion-panel-header>
                 <mat-panel-title>

--- a/projects/safe/src/lib/components/widgets/chart-settings/charts/chart.ts
+++ b/projects/safe/src/lib/components/widgets/chart-settings/charts/chart.ts
@@ -79,7 +79,11 @@ export class Chart {
         valueType: [
           {
             value: get(labels, 'valueType', 'value'),
-            disabled: !get(labels, 'showValue', false),
+            disabled:
+              !get(labels, 'showValue', false) ||
+              (['bar', 'column'].includes(get(settings, 'type', '')) &&
+                (!get(stack, 'usePercentage', false) ||
+                  !get(stack, 'enable', false))),
           },
         ],
       }),
@@ -197,7 +201,13 @@ export class Chart {
     // Update of labels
     this.form.get('labels.showValue')?.valueChanges.subscribe((value) => {
       if (value) {
-        this.form.get('labels.valueType')?.enable();
+        if (['bar', 'column'].includes(this.form.get('type')?.value)) {
+          if (
+            this.form.get('stack.usePercentage')?.value &&
+            this.form.get('stack.enable')?.value
+          )
+            this.form.get('labels.valueType')?.enable();
+        } else this.form.get('labels.valueType')?.enable();
       } else {
         this.form.get('labels.valueType')?.disable();
       }
@@ -209,6 +219,30 @@ export class Chart {
         this.form.get('stack.usePercentage')?.enable();
       } else {
         this.form.get('stack.usePercentage')?.disable();
+      }
+    });
+
+    // update label value type based on stack settings
+    this.form.get('stack.usePercentage')?.valueChanges.subscribe((value) => {
+      if (value) {
+        if (this.form.get('labels.showValue'))
+          this.form.get('labels.valueType')?.enable();
+      } else {
+        this.form.get('labels.valueType')?.setValue('value');
+        this.form.get('labels.valueType')?.disable();
+      }
+    });
+
+    this.form.get('stack.enable')?.valueChanges.subscribe((value) => {
+      if (value) {
+        if (
+          this.form.get('stack.usePercentage')?.value &&
+          this.form.get('labels.showValue')
+        )
+          this.form.get('labels.valueType')?.enable();
+      } else {
+        this.form.get('labels.valueType')?.setValue('value');
+        this.form.get('labels.valueType')?.disable();
       }
     });
   }


### PR DESCRIPTION
# Description

This PR enables percentage labels for column/bar charts when they're stacked.

There is one problem I couldn't solve, it isn't directly related to the changes I made, but they make it more apparent. So, whenever we plot the series and stack the bars/columns, a bar (with 0 height) would be plotted whenever the category doesn't have a particular series)

![bug](https://user-images.githubusercontent.com/102038450/173487679-4632d200-ab05-47e2-8eb3-4738b41cff55.gif)
_notice the green square appears whenever I hover the category_

So this became a problem in this PR, because it'd try to pull labels from nonexistent data, and the labels would just say `undefined` and cover the category label. To prevent this, I'm just returning an empty string if the data is undefined, but still, there is a transparent (but apparent) square on top of the category label.
 
## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

In a bar or column chart, select the a series value. In the display tab, select 'Plot series' and 'Use percentage'. That will allow for you to select the value type for the labels. By selecting percentage, the chart should now display the percentage instead of the values.

![Peek 2022-06-02 15-31](https://user-images.githubusercontent.com/102038450/173488372-e22febaa-606d-4c14-a48a-7b741594780c.gif)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
