### PR TITLE
OORT-309 - keep null values in aggreg

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -679,7 +679,8 @@
 					"aggregation": {
 						"invalid": "Invalid aggregation"
 					}
-				}
+				},
+				"groupedByNull": "Unspecified"
 			},
 			"expand": "Expand",
 			"grid": {

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -679,7 +679,8 @@
 					"aggregation": {
 						"invalid": "Aggrégation invalide"
 					}
-				}
+				},
+				"groupedByNull": "Non spécifié"
 			},
 			"expand": "Étendre",
 			"grid": {

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -679,7 +679,8 @@
 					"aggregation": {
 						"invalid": "******"
 					}
-				}
+				},
+				"groupedByNull": "******"
 			},
 			"expand": "******",
 			"grid": {


### PR DESCRIPTION
# Description

This PR implements a check for the category of the response of the GetCustomAggregation query and convert a potential null value to a string so it can be displayed in the map legend.

## Type of change

- [x] Improvement (refactor or addition to existing functionality)


# How Has This Been Tested?

Create an chart, and set a group stage for your field that has some null values, when saving, the chart should correctly display the legend for the null values 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
