### PR TITLE
OORT-312 : Change login redirection for 1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@progress/kendo-drawing": "^1.15.0",
         "@progress/kendo-licensing": "^1.2.1",
         "@progress/kendo-recurrence": "^1.0.2",
-        "@progress/kendo-theme-default": "4.43.0",
+        "@progress/kendo-theme-default": "^4.43.0",
         "@storybook/builder-webpack5": "^6.5.6",
         "@storybook/manager-webpack5": "^6.5.6",
         "@tinymce/tinymce-angular": "^4.2.4",

--- a/projects/safe/src/lib/services/auth.service.ts
+++ b/projects/safe/src/lib/services/auth.service.ts
@@ -138,13 +138,12 @@ export class SafeAuthService {
       localStorage.getItem('redirect') || this.oauthService.redirectUri;
     return this.oauthService
       .loadDiscoveryDocumentAndLogin()
-      .then(() => this.isDoneLoading.next(true))
       .then(() => {
         this.isDoneLoading.next(true);
         localStorage.removeItem('redirect');
       })
-      .catch(() => {
-        console.error('issue when loading file');
+      .catch((err) => {
+        console.error(err);
         this.isDoneLoading.next(false);
       });
   }

--- a/projects/safe/src/lib/services/auth.service.ts
+++ b/projects/safe/src/lib/services/auth.service.ts
@@ -129,10 +129,24 @@ export class SafeAuthService {
    * @returns A promise that resolves to void.
    */
   public initLoginSequence(): Promise<void> {
+    const redirectUri = new URL(location.href);
+    redirectUri.search = '';
+    if (redirectUri.pathname !== '/') {
+      localStorage.setItem('redirect', redirectUri.href);
+    }
+    this.oauthService.redirectUri =
+      localStorage.getItem('redirect') || this.oauthService.redirectUri;
     return this.oauthService
       .loadDiscoveryDocumentAndLogin()
       .then(() => this.isDoneLoading.next(true))
-      .catch(() => this.isDoneLoading.next(true));
+      .then(() => {
+        this.isDoneLoading.next(true);
+        localStorage.removeItem('redirect');
+      })
+      .catch(() => {
+        console.error('issue when loading file');
+        this.isDoneLoading.next(false);
+      });
   }
 
   /**


### PR DESCRIPTION
# Description

Previously when a user was given a link to a specific form/application, after login they were redirected to the Oort home page and not to the form/application. This is now fixed by storing a deep copy of the url into the localStorage and removing an attribute from it (does not work otherwise). 

There is two branches, this is the one for the 1.2 and the other is for the 1.3 because I made the mistake of not reading the ticket correctly.

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Tested by trying to access a specific application from icognito mode

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
