### PR TITLE
OORT-355

### DIFF
--- a/projects/safe/src/lib/components/widgets/grid-settings/add-layout/add-layout.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/add-layout/add-layout.component.html
@@ -9,6 +9,7 @@
       category="secondary"
       [block]="true"
       (click)="nextStep = true"
+      [disabled]="layouts.length < 1"
       >{{
         'components.widget.settings.grid.layouts.add.choice.load' | translate
       }}</safe-button

--- a/projects/safe/src/lib/components/widgets/grid-settings/add-layout/add-layout.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/add-layout/add-layout.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import {
   MatDialog,
   MatDialogRef,
@@ -29,7 +29,7 @@ interface DialogData {
   templateUrl: './add-layout.component.html',
   styleUrls: ['./add-layout.component.scss'],
 })
-export class AddLayoutComponent implements OnInit {
+export class AddLayoutComponent {
   private form?: Form;
   private resource?: Resource;
   public layouts: Layout[] = [];
@@ -53,8 +53,6 @@ export class AddLayoutComponent implements OnInit {
     this.form = data.form;
     this.resource = data.resource;
   }
-
-  ngOnInit(): void {}
 
   /**
    * Opens the panel to create a new layout.


### PR DESCRIPTION
# Description

Disabled load layout button if there are no existing layouts

## Type of change

Please delete options that are not relevant.
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

On the layout selection modal, if there are no layouts created for the resource, the button will be disabled

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
