### PR TITLE
OORT-382

### DIFF
--- a/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-clorophlet/map-clorophlet.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-clorophlet/map-clorophlet.component.ts
@@ -91,7 +91,7 @@ export class MapClorophletComponent implements OnInit {
     });
     dialogRef.afterClosed().subscribe((value) => {
       if (value) {
-        this.divisions.at(index).setValue(value);
+        this.divisions.setControl(index, divisionForm(value));
       }
     });
   }

--- a/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-clorophlets/map-clorophlets.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-clorophlets/map-clorophlets.component.ts
@@ -54,8 +54,7 @@ export class MapClorophletsComponent implements OnInit {
     });
     dialogRef.afterClosed().subscribe((value) => {
       if (value) {
-        this.clorophlets.removeAt(index);
-        this.clorophlets.insert(index, clorophletForm(value));
+        this.clorophlets.setControl(index, clorophletForm(value));
       }
     });
   }

--- a/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-markers/map-markers.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-markers/map-markers.component.ts
@@ -70,8 +70,7 @@ export class MapMarkersComponent implements OnInit {
     });
     dialogRef.afterClosed().subscribe((value) => {
       if (value) {
-        this.rules.removeAt(index);
-        this.rules.insert(index, markerRuleForm(value));
+        this.rules.setControl(index, markerRuleForm(value));
       }
     });
   }


### PR DESCRIPTION
# Description

This bug was being caused because there weren't any filter controls defined, so setValues was throwing an error whenever it was called with a value different to an empty array for the filter.filters prop

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
→ Use a geoJSON to create a choropleth layer in relation to a field in the resource used in a map 
→ Try to create a new division with a condition on a field of the form, save it 
→ Check that it did in fact save your filtering


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
