### PR TITLE
OORT-386 Allow nested fields for map settings

### DIFF
--- a/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-markers/map-markers.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-markers/map-markers.component.ts
@@ -40,11 +40,7 @@ export class MapMarkersComponent implements OnInit {
 
   ngOnInit(): void {
     // Build list of number fields
-    this.numberFields = this.formatedSelectedFields
-      .filter((field: any) =>
-        ['Int', 'Float'].includes(get(field, 'type.name', ''))
-      )
-      .map((field: any) => field.name);
+    this.numberFields = this.getNumberFields(this.formatedSelectedFields);
   }
 
   /**
@@ -82,5 +78,29 @@ export class MapMarkersComponent implements OnInit {
    */
   public removeRule(index: number): void {
     this.rules.removeAt(index);
+  }
+
+  /**
+   * Get the names of the fields with a number format
+   *
+   * @param formatedFields The list of formated fields
+   * @returns A list of fields names of type number
+   */
+  private getNumberFields(formatedFields: any[]): any[] {
+    return formatedFields
+      .filter((field: any) =>
+        ['Int', 'Float'].includes(get(field, 'type.name', ''))
+      )
+      .map((field) => field.name)
+      .concat(
+        formatedFields
+          .filter((field) => field.fields)
+          .map((field) =>
+            this.getNumberFields(field.fields).map(
+              (numberField) => `${field.name}.${numberField}`
+            )
+          )
+          .reduce((res, subFields) => res.concat(subFields), [])
+      );
   }
 }

--- a/projects/safe/src/lib/components/widgets/map/map-popup/map-popup.component.scss
+++ b/projects/safe/src/lib/components/widgets/map/map-popup/map-popup.component.scss
@@ -1,12 +1,13 @@
 div {
-  max-width: 350px;
+  // max-width: 350px;
   display: flex;
   flex-direction: column;
   gap: 2px;
+  // width: 350px;
 }
 
 span {
   display: flex;
   gap: 0 8px;
-  flex-wrap: wrap;
+  // flex-wrap: wrap;
 }

--- a/projects/safe/src/lib/components/widgets/map/map.component.ts
+++ b/projects/safe/src/lib/components/widgets/map/map.component.ts
@@ -345,29 +345,13 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
   }
 
   /**
-   * Get the value of a concatenate field name, with dots.
-   *
-   * @param record The record with the values of the answer
-   * @param field The querying field, in 'parent.child' format
-   * @returns The value of the field
-   */
-  private getFieldValue(record: any, field: string): any {
-    return field
-      .split('.')
-      .reduce(
-        (parentField, childField) => parentField[childField] || undefined,
-        record
-      );
-  }
-
-  /**
    * Creates a marker with the data passed and adds it to the correspondant category.
    *
    * @param item data of the marker
    */
   private setMarker(item: any): void {
-    const latitude = Number(this.getFieldValue(item, this.settings.latitude));
-    const longitude = Number(this.getFieldValue(item, this.settings.longitude));
+    const latitude = Number(null);
+    const longitude = Number(get(item, this.settings.longitude, null));
     if (!isNaN(latitude) && latitude >= -90 && latitude <= 90) {
       if (!isNaN(longitude) && longitude >= -180 && longitude <= 180) {
         // Sets the style of the marker depending on the rules applied.
@@ -385,7 +369,7 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
 
         // Creates the marker and adds it to the correct category.
         const marker = L.circleMarker([latitude, longitude], options);
-        const category = this.getFieldValue(item, this.settings.category);
+        const category = get(item, this.settings.category, null);
         if (!this.markersCategories[category]) {
           this.markersCategories[category] = [];
         }
@@ -399,7 +383,9 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
           const instance = popupContent.instance;
           instance.data = item;
           instance.fields = this.fields;
-          this.popupMarker = L.popup({})
+          this.popupMarker = L.popup({
+            width: 350,
+          })
             .setLatLng([latitude, longitude])
             .setContent(div)
             .addTo(this.map);

--- a/projects/safe/src/lib/components/widgets/map/map.component.ts
+++ b/projects/safe/src/lib/components/widgets/map/map.component.ts
@@ -345,13 +345,29 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
   }
 
   /**
+   * Get the value of a concatenate field name, with dots.
+   *
+   * @param record The record with the values of the answer
+   * @param field The querying field, in 'parent.child' format
+   * @returns The value of the field
+   */
+  private getFieldValue(record: any, field: string): any {
+    return field
+      .split('.')
+      .reduce(
+        (parentField, childField) => parentField[childField] || undefined,
+        record
+      );
+  }
+
+  /**
    * Creates a marker with the data passed and adds it to the correspondant category.
    *
    * @param item data of the marker
    */
   private setMarker(item: any): void {
-    const latitude = Number(item[this.settings.latitude]);
-    const longitude = Number(item[this.settings.longitude]);
+    const latitude = Number(this.getFieldValue(item, this.settings.latitude));
+    const longitude = Number(this.getFieldValue(item, this.settings.longitude));
     if (!isNaN(latitude) && latitude >= -90 && latitude <= 90) {
       if (!isNaN(longitude) && longitude >= -180 && longitude <= 180) {
         // Sets the style of the marker depending on the rules applied.
@@ -369,10 +385,11 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
 
         // Creates the marker and adds it to the correct category.
         const marker = L.circleMarker([latitude, longitude], options);
-        if (!this.markersCategories[item[this.settings.category]]) {
-          this.markersCategories[item[this.settings.category]] = [];
+        const category = this.getFieldValue(item, this.settings.category);
+        if (!this.markersCategories[category]) {
+          this.markersCategories[category] = [];
         }
-        this.markersCategories[item[this.settings.category]].push(marker);
+        this.markersCategories[category].push(marker);
         marker.bindPopup(() => {
           const div = document.createElement('div');
           const popupContent = this.domService.appendComponentToBody(


### PR DESCRIPTION
# Description

Allow the nested fields, selected in the data selection of map settings, to be used for latitude, longitude, category, filters of markers rules, and filters of choropleths.


## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Try to use nested fields for the different settings listed in the description, and check that they apply correctly on the map.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
