### PR TITLE
OORT-392 - Change range for marker sizes in map to 0-10 and added the possibilty…

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -881,6 +881,8 @@
 							"category": "Map quick layers",
 							"color": "Color",
 							"info": "Display markers in the map for each entry of your data, binding dataset number fields to geolocation",
+							"outerSize": "Outer ring size",
+							"outerSizeDesc": "Set a multiplier for the outer ring size of the marker, set to 0 to remove it",
 							"rules": "Marker rules",
 							"rulesInfo": "Customize the size and colors of your pointers",
 							"size": "Size",

--- a/projects/safe/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-forms.ts
@@ -31,6 +31,7 @@ const DEFAULT_MARKER_RULE = {
   label: 'New rule',
   color: '#0090d1',
   size: 1,
+  outerSize: 1,
   filter: {
     logic: ['and'],
     filters: [],
@@ -119,7 +120,11 @@ export const markerRuleForm = (value?: any): FormGroup =>
     color: [get(value, 'color', DEFAULT_MARKER_RULE.color)],
     size: [
       get(value, 'size', DEFAULT_MARKER_RULE.size),
-      [Validators.min(1), Validators.max(10)],
+      [Validators.min(0), Validators.max(10)],
+    ],
+    outerSize: [
+      get(value, 'outerSize', DEFAULT_MARKER_RULE.outerSize),
+      [Validators.min(0), Validators.max(10)],
     ],
     filter: createFilterGroup(
       get(value, 'filter', DEFAULT_MARKER_RULE.filter),

--- a/projects/safe/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-forms.ts
@@ -124,7 +124,7 @@ export const markerRuleForm = (value?: any): FormGroup =>
     ],
     outerSize: [
       get(value, 'outerSize', DEFAULT_MARKER_RULE.outerSize),
-      [Validators.min(0), Validators.max(10)],
+      [Validators.min(0), Validators.max(5)],
     ],
     filter: createFilterGroup(
       get(value, 'filter', DEFAULT_MARKER_RULE.filter),

--- a/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-marker-rule/map-marker-rule.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-marker-rule/map-marker-rule.component.html
@@ -14,7 +14,21 @@
     <mat-label>{{
       'components.widget.settings.map.layers.point.size' | translate
     }}</mat-label>
-    <input type="number" matInput formControlName="size" min="1" max="10" />
+    <input type="number" matInput formControlName="size" min="0" max="10" />
+  </mat-form-field>
+  <mat-form-field appearance="outline">
+    <mat-label>{{
+      'components.widget.settings.map.layers.point.outerSize' | translate
+    }}</mat-label>
+    <input type="number" matInput formControlName="outerSize" min="0" max="5" />
+    <safe-icon
+      matSuffix
+      icon="info"
+      variant="grey"
+      [matTooltip]="
+      'components.widget.settings.map.layers.point.outerSizeDesc' | translate
+      "
+    ></safe-icon>
   </mat-form-field>
   <safe-tab-filter
     [form]="$any(form.controls.filter)"

--- a/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-marker-rule/map-marker-rule.module.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-marker-rule/map-marker-rule.module.ts
@@ -8,6 +8,9 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { TranslateModule } from '@ngx-translate/core';
 import { SafeQueryBuilderModule } from '../../../../query-builder/query-builder.module';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { SafeAlertModule } from '../../../../ui/alert/alert.module';
+import { SafeIconModule } from '../../../../ui/icon/icon.module';
 
 /**
  * Single Marker Rule configuration module.
@@ -24,6 +27,8 @@ import { SafeQueryBuilderModule } from '../../../../query-builder/query-builder.
     MatInputModule,
     MatButtonModule,
     SafeQueryBuilderModule,
+    MatTooltipModule,
+    SafeIconModule,
   ],
   exports: [MapMarkerRuleComponent],
 })

--- a/projects/safe/src/lib/components/widgets/map/map.component.ts
+++ b/projects/safe/src/lib/components/widgets/map/map.component.ts
@@ -361,7 +361,7 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
           if (applyFilters(item, rule.filter)) {
             options.color = rule.color;
             options.fillColor = rule.color;
-            options.weight *= rule.size;
+            options.weight *= rule.size * rule.outerSize;
             options.radius *= rule.size;
             Object.assign(options, { divisionID: `${rule.label}-${i}` });
           }


### PR DESCRIPTION
# Description

Modified marker rules settings to change the range for the marker size to [0-10].
A new field has been added to set the outer ring size, it works as a multiplier applied to the marker size, zero will remove it, one will let it as it was and so.

# Screenshots
 
![Screenshot from 2022-07-11 16-00-26](https://user-images.githubusercontent.com/94831019/178286504-c6f9cfa9-149c-489b-adda-64049048d9a2.png)
![Screenshot from 2022-07-11 16-00-37](https://user-images.githubusercontent.com/94831019/178286508-c56ee669-7f22-40da-8638-75a5628dc814.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] The changes have been tested using them in the app

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
