### PR TITLE
remove null layer

### DIFF
--- a/projects/safe/src/lib/components/widgets/map/map.component.ts
+++ b/projects/safe/src/lib/components/widgets/map/map.component.ts
@@ -295,6 +295,7 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
     }
 
     // Renders all the markers
+    console.log(this.markersCategories);
     Object.keys(this.markersCategories).map((name: string) => {
       if (name !== 'null') {
         const layerName = name !== 'undefined' ? name : 'Markers';
@@ -319,7 +320,7 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
     }
 
     // Loops throught online layers and add them to the map
-    if (this.settings.onlineLayers.length > 0) {
+    if (this.settings.onlineLayers) {
       this.settings.onlineLayers.map((layer: any) => {
         this.overlays[layer.title] = L.esri.featureLayer({
           url: layer.url + '/0',

--- a/projects/safe/src/lib/components/widgets/map/map.component.ts
+++ b/projects/safe/src/lib/components/widgets/map/map.component.ts
@@ -303,11 +303,13 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
 
     // Renders all the markers
     Object.keys(this.markersCategories).map((name: string) => {
-      const layerName = name !== 'undefined' ? name : 'Markers';
-      this.overlays[layerName] = L.featureGroup
-        .subGroup(this.markersLayer, this.markersCategories[name])
-        .addTo(this.map);
-      this.overlays[layerName].type = 'Marker';
+      if (name !== 'null') {
+        const layerName = name !== 'undefined' ? name : 'Markers';
+        this.overlays[layerName] = L.featureGroup
+          .subGroup(this.markersLayer, this.markersCategories[name])
+          .addTo(this.map);
+        this.overlays[layerName].type = 'Marker';
+      }
     });
 
     // Loops throught clorophlets and adds them to the map
@@ -324,7 +326,7 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
     }
 
     // Loops throught online layers and add them to the map
-    if (this.settings.onlineLayers) {
+    if (this.settings.onlineLayers.length > 0) {
       this.settings.onlineLayers.map((layer: any) => {
         this.overlays[layer.title] = L.esri.featureLayer({
           url: layer.url + '/0',
@@ -340,7 +342,6 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
         });
       });
     }
-
     // Set ups a layer control with the new layers.
     if (Object.keys(this.overlays).length > 0) {
       this.layerControl = L.control

--- a/projects/safe/src/lib/components/widgets/map/map.component.ts
+++ b/projects/safe/src/lib/components/widgets/map/map.component.ts
@@ -295,7 +295,6 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
     }
 
     // Renders all the markers
-    console.log(this.markersCategories);
     Object.keys(this.markersCategories).map((name: string) => {
       if (name !== 'null') {
         const layerName = name !== 'undefined' ? name : 'Markers';


### PR DESCRIPTION
# Description

Previously when adding markers to a map we would see in the layers management that there would be a "null" layer. It is now removed by checking that the name of the layer is not null.

![image](https://user-images.githubusercontent.com/103029022/178432247-c4397e20-1fba-4871-a30a-52c616426739.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Adding all kind of layers to the map and checking the layers management

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
