### PR TITLE
Oort 399

### DIFF
--- a/projects/safe/src/lib/components/record-modal/record-modal.component.html
+++ b/projects/safe/src/lib/components/record-modal/record-modal.component.html
@@ -83,7 +83,7 @@
   </ng-container>
   <button *ngIf="canEdit" mat-flat-button color="primary" (click)="onEdit()">
     {{
-      'common.editObject' | translate: { name: 'common.record.few' | translate }
+      'common.editObject' | translate: { name: 'common.record.one' | translate }
     }}
   </button>
 </mat-dialog-actions>


### PR DESCRIPTION
# Description

The i18n key used in the singular record edit modal was wrong since it was using the plural expression. It is replaced by the correct singular key

![image](https://user-images.githubusercontent.com/103029022/178443399-a992fb74-f892-4ae5-a435-794cddfe7f62.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Clicking on the details in a row in a grid

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
