### PR TITLE
Fix for series chart aggregations

### DIFF
--- a/projects/safe/src/lib/components/widgets/chart/chart.component.ts
+++ b/projects/safe/src/lib/components/widgets/chart/chart.component.ts
@@ -48,6 +48,7 @@ export class SafeChartComponent implements OnChanges, OnDestroy {
 
   /**
    * Get filename from the date and widget title
+   *
    * @returns filename
    */
   get fileName(): string {
@@ -167,11 +168,39 @@ export class SafeChartComponent implements OnChanges, OnDestroy {
             JSON.stringify(res.data.recordsAggregation)
           );
           if (get(this.settings, 'chart.aggregation.mapping.series', null)) {
-            const groups = groupBy(aggregationData, 'series');
-            this.series = Object.keys(groups).map((key) => ({
-              name: key,
-              data: groups[key],
-            }));
+            const groups: any = {}; //groupBy(aggregationData, 'series');
+            const mockGroups: any[] = [];
+            aggregationData.map((data: any) => {
+              if (!groups[data.series]) {
+                groups[data.series] = [];
+              }
+              groups[data.series].push(data);
+              if (
+                !mockGroups.find((group) => group.category === data.category)
+              ) {
+                mockGroups.push({ category: data.category });
+              }
+            });
+
+            this.series = [];
+            Object.keys(groups).map((key) => {
+              const data: any[] = groups[key];
+              let currentIndex = -1;
+              mockGroups.map((group: any) => {
+                const i = data.findIndex(
+                  (dataGroup) => dataGroup.category === group.category
+                );
+                if (i === -1) {
+                  data.splice(++currentIndex, 0, group);
+                } else {
+                  currentIndex = i;
+                }
+              });
+              this.series.push({
+                name: key,
+                data,
+              });
+            });
           } else {
             this.series = [
               {

--- a/projects/safe/src/lib/components/widgets/chart/chart.component.ts
+++ b/projects/safe/src/lib/components/widgets/chart/chart.component.ts
@@ -3,7 +3,6 @@ import {
   Input,
   OnChanges,
   OnDestroy,
-  SimpleChanges,
   ViewChild,
 } from '@angular/core';
 import { saveAs } from '@progress/kendo-file-saver';
@@ -14,8 +13,7 @@ import { SafePieChartComponent } from '../../ui/pie-chart/pie-chart.component';
 import { SafeDonutChartComponent } from '../../ui/donut-chart/donut-chart.component';
 import { SafeColumnChartComponent } from '../../ui/column-chart/column-chart.component';
 import { SafeBarChartComponent } from '../../ui/bar-chart/bar-chart.component';
-import get from 'lodash/get';
-import groupBy from 'lodash/groupBy';
+import { uniq, get, groupBy } from 'lodash';
 
 /**
  * Default file name for chart exports
@@ -168,38 +166,24 @@ export class SafeChartComponent implements OnChanges, OnDestroy {
             JSON.stringify(res.data.recordsAggregation)
           );
           if (get(this.settings, 'chart.aggregation.mapping.series', null)) {
-            const groups: any = {}; //groupBy(aggregationData, 'series');
-            const mockGroups: any[] = [];
-            aggregationData.map((data: any) => {
-              if (!groups[data.series]) {
-                groups[data.series] = [];
-              }
-              groups[data.series].push(data);
-              if (
-                !mockGroups.find((group) => group.category === data.category)
-              ) {
-                mockGroups.push({ category: data.category });
-              }
-            });
-
-            this.series = [];
-            Object.keys(groups).map((key) => {
-              const data: any[] = groups[key];
-              let currentIndex = -1;
-              mockGroups.map((group: any) => {
-                const i = data.findIndex(
-                  (dataGroup) => dataGroup.category === group.category
-                );
-                if (i === -1) {
-                  data.splice(++currentIndex, 0, group);
-                } else {
-                  currentIndex = i;
-                }
-              });
-              this.series.push({
+            const groups = groupBy(aggregationData, 'series');
+            const categories = uniq(
+              aggregationData.map((x: any) => x.category)
+            );
+            this.series = Object.keys(groups).map((key) => {
+              const rawData = groups[key];
+              const data = Array.from(
+                categories,
+                (category) =>
+                  rawData.find((x) => x.category === category) || {
+                    category,
+                    field: null,
+                  }
+              );
+              return {
                 name: key,
                 data,
-              });
+              };
             });
           } else {
             this.series = [


### PR DESCRIPTION
# Description

Changed the logic on the chart component to be correctly sorted.

The solution was to provide empty objects for each category so the data would be sorted in all series.

## Screenshots

![Screenshot from 2022-07-14 14-41-16](https://user-images.githubusercontent.com/94831019/178985483-1049664c-3234-4e27-9e92-43c58a4d87ca.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] The changes have been tested replicating the ticket environment and creating new ones.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
