### PR TITLE
OORT-410 Unify info icons

### DIFF
--- a/projects/back-office/src/app/application/pages/position/position.component.html
+++ b/projects/back-office/src/app/application/pages/position/position.component.html
@@ -43,7 +43,7 @@
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr
-      class="clickable"
+      class="cursor-pointer"
       mat-row
       *matRowDef="let row; columns: displayedColumns"
       [routerLink]="[row.id]"

--- a/projects/back-office/src/app/application/pages/subscriptions/components/subscription-modal/subscription-modal.component.html
+++ b/projects/back-office/src/app/application/pages/subscriptions/components/subscription-modal/subscription-modal.component.html
@@ -60,7 +60,7 @@
         ></safe-button>
         <safe-icon
           icon="info"
-          class="clickable"
+          class="cursor-pointer"
           variant="grey"
           matSuffix
           [matTooltip]="'components.application.subscription.modal.hint.listenTo' | translate"

--- a/projects/back-office/src/app/application/pages/subscriptions/components/subscription-modal/subscription-modal.component.html
+++ b/projects/back-office/src/app/application/pages/subscriptions/components/subscription-modal/subscription-modal.component.html
@@ -57,11 +57,14 @@
           icon="close"
           aria-label="Clear"
           (click)="routingKey = ''"
-        >
-        </safe-button>
-        <mat-hint>{{
-          'components.application.subscription.modal.hint.listenTo' | translate
-        }}</mat-hint>
+        ></safe-button>
+        <safe-icon
+          icon="info"
+          class="clickable"
+          variant="grey"
+          matSuffix
+          [matTooltip]="'components.application.subscription.modal.hint.listenTo' | translate"
+        ></safe-icon>
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>{{

--- a/projects/back-office/src/app/application/pages/subscriptions/subscriptions.module.ts
+++ b/projects/back-office/src/app/application/pages/subscriptions/subscriptions.module.ts
@@ -12,11 +12,16 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTableModule } from '@angular/material/table';
 import { SubscriptionsRoutingModule } from './subscriptions-routing.module';
-import { SafeConfirmModalModule, SafeButtonModule } from '@safe/builder';
+import {
+  SafeConfirmModalModule,
+  SafeButtonModule,
+  SafeIconModule,
+} from '@safe/builder';
 import { MatSelectModule } from '@angular/material/select';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatDividerModule } from '@angular/material/divider';
 import { TranslateModule } from '@ngx-translate/core';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [SubscriptionsComponent, SubscriptionModalComponent],
@@ -38,7 +43,9 @@ import { TranslateModule } from '@ngx-translate/core';
     MatAutocompleteModule,
     MatDividerModule,
     SafeButtonModule,
+    SafeIconModule,
     TranslateModule,
+    MatTooltipModule,
   ],
 })
 export class SubscriptionsModule {}

--- a/projects/back-office/src/app/components/add-form/add-form.component.html
+++ b/projects/back-office/src/app/components/add-form/add-form.component.html
@@ -19,7 +19,7 @@
             class="icon-inline"
             variant="grey"
             [inline]="true"
-            [size]="18"
+            [size]="19"
             [matTooltip]="'components.form.create.tooltip.resource' | translate"
           ></safe-icon>
         </mat-radio-button>
@@ -30,7 +30,7 @@
             class="icon-inline"
             variant="grey"
             [inline]="true"
-            [size]="18"
+            [size]="19"
             [matTooltip]="'components.form.create.tooltip.inherit' | translate"
           ></safe-icon>
         </mat-radio-button>
@@ -65,7 +65,7 @@
               class="icon-inline"
               variant="grey"
               [inline]="true"
-              [size]="18"
+              [size]="19"
               [matTooltip]="'components.form.create.tooltip.template' | translate"
             ></safe-icon>
           </mat-slide-toggle>

--- a/projects/back-office/src/app/components/add-form/add-form.component.html
+++ b/projects/back-office/src/app/components/add-form/add-form.component.html
@@ -12,26 +12,28 @@
         />
       </mat-form-field>
       <mat-radio-group formControlName="newResource" class="form-radio-group">
-        <span class="info-row">
-          <mat-radio-button [value]="true">{{
-            'components.form.create.choice.resource' | translate
-          }}</mat-radio-button>
-          <mat-icon
-            class="info-icon"
+        <mat-radio-button [value]="true">
+          {{ 'components.form.create.choice.resource' | translate }}
+          <safe-icon
+            icon="info_outline"
+            class="icon-inline"
+            variant="grey"
+            [inline]="true"
+            [size]="18"
             [matTooltip]="'components.form.create.tooltip.resource' | translate"
-            >info</mat-icon
-          >
-        </span>
-        <span class="info-row">
-          <mat-radio-button [value]="false">{{
-            'components.form.create.choice.inherit' | translate
-          }}</mat-radio-button>
-          <mat-icon
-            class="info-icon"
+          ></safe-icon>
+        </mat-radio-button>
+        <mat-radio-button [value]="false">
+          {{ 'components.form.create.choice.inherit' | translate }}
+          <safe-icon
+            icon="info_outline"
+            class="icon-inline"
+            variant="grey"
+            [inline]="true"
+            [size]="18"
             [matTooltip]="'components.form.create.tooltip.inherit' | translate"
-            >info</mat-icon
-          >
-        </span>
+          ></safe-icon>
+        </mat-radio-button>
       </mat-radio-group>
       <ng-container *ngIf="!addForm.value.newResource">
         <mat-form-field appearance="outline">
@@ -53,22 +55,20 @@
           </mat-select>
         </mat-form-field>
         <ng-container *ngIf="addForm.controls.resource.value !== null">
-          <div class="info-row">
-            <mat-slide-toggle
-              formControlName="inheritsTemplate"
-              class="form-slide-toggle"
-              >{{
-                'components.form.create.choice.template' | translate
-              }}</mat-slide-toggle
-            >
-            <mat-icon
-              class="info-icon"
-              [matTooltip]="
-                'components.form.create.tooltip.template' | translate
-              "
-              >info</mat-icon
-            >
-          </div>
+          <mat-slide-toggle
+            formControlName="inheritsTemplate"
+            class="form-slide-toggle"
+          >
+            {{ 'components.form.create.choice.template' | translate }}
+            <safe-icon
+              icon="info_outline"
+              class="icon-inline"
+              variant="grey"
+              [inline]="true"
+              [size]="18"
+              [matTooltip]="'components.form.create.tooltip.template' | translate"
+            ></safe-icon>
+          </mat-slide-toggle>
           <ng-container *ngIf="addForm.controls.inheritsTemplate.value">
             <mat-form-field appearance="outline">
               <mat-label>{{

--- a/projects/back-office/src/app/components/add-form/add-form.component.html
+++ b/projects/back-office/src/app/components/add-form/add-form.component.html
@@ -16,10 +16,9 @@
           {{ 'components.form.create.choice.resource' | translate }}
           <safe-icon
             icon="info_outline"
-            class="icon-inline"
             variant="grey"
             [inline]="true"
-            [size]="19"
+            [size]="18"
             [matTooltip]="'components.form.create.tooltip.resource' | translate"
           ></safe-icon>
         </mat-radio-button>
@@ -27,10 +26,9 @@
           {{ 'components.form.create.choice.inherit' | translate }}
           <safe-icon
             icon="info_outline"
-            class="icon-inline"
             variant="grey"
             [inline]="true"
-            [size]="19"
+            [size]="18"
             [matTooltip]="'components.form.create.tooltip.inherit' | translate"
           ></safe-icon>
         </mat-radio-button>
@@ -62,10 +60,9 @@
             {{ 'components.form.create.choice.template' | translate }}
             <safe-icon
               icon="info_outline"
-              class="icon-inline"
               variant="grey"
               [inline]="true"
-              [size]="19"
+              [size]="18"
               [matTooltip]="'components.form.create.tooltip.template' | translate"
             ></safe-icon>
           </mat-slide-toggle>

--- a/projects/back-office/src/app/components/add-form/add-form.module.ts
+++ b/projects/back-office/src/app/components/add-form/add-form.module.ts
@@ -9,10 +9,10 @@ import { MatInputModule } from '@angular/material/input';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatChipsModule } from '@angular/material/chips';
 import { TranslateModule } from '@ngx-translate/core';
+import { SafeIconModule } from '@safe/builder';
 
 @NgModule({
   declarations: [AddFormComponent],
@@ -22,7 +22,6 @@ import { TranslateModule } from '@ngx-translate/core';
     ReactiveFormsModule,
     MatFormFieldModule,
     MatInputModule,
-    MatIconModule,
     MatSelectModule,
     MatDialogModule,
     MatButtonModule,
@@ -31,6 +30,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MatSlideToggleModule,
     MatChipsModule,
     TranslateModule,
+    SafeIconModule,
   ],
   exports: [AddFormComponent],
 })

--- a/projects/back-office/src/app/dashboard/pages/advanced-settings/advanced-settings.component.html
+++ b/projects/back-office/src/app/dashboard/pages/advanced-settings/advanced-settings.component.html
@@ -14,10 +14,9 @@
         {{ 'components.users.advancedSettings.userManagement.local.title' | translate }}
         <safe-icon
           icon="info_outline"
-          class="icon-inline"
           variant="grey"
           [inline]="true"
-          [size]="19"
+          [size]="18"
           [matTooltip]="
             'components.users.advancedSettings.userManagement.local.tooltip'
               | translate
@@ -31,10 +30,9 @@
         }}
         <safe-icon
           icon="info_outline"
-          class="icon-inline"
           variant="grey"
           [inline]="true"
-          [size]="19"
+          [size]="18"
           [matTooltip]="
             'components.users.advancedSettings.userManagement.external.tooltip'
               | translate

--- a/projects/back-office/src/app/dashboard/pages/advanced-settings/advanced-settings.component.html
+++ b/projects/back-office/src/app/dashboard/pages/advanced-settings/advanced-settings.component.html
@@ -17,7 +17,7 @@
           class="icon-inline"
           variant="grey"
           [inline]="true"
-          [size]="18"
+          [size]="19"
           [matTooltip]="
             'components.users.advancedSettings.userManagement.local.tooltip'
               | translate
@@ -34,7 +34,7 @@
           class="icon-inline"
           variant="grey"
           [inline]="true"
-          [size]="18"
+          [size]="19"
           [matTooltip]="
             'components.users.advancedSettings.userManagement.external.tooltip'
               | translate

--- a/projects/back-office/src/app/dashboard/pages/advanced-settings/advanced-settings.component.html
+++ b/projects/back-office/src/app/dashboard/pages/advanced-settings/advanced-settings.component.html
@@ -10,14 +10,13 @@
 <form [formGroup]="settingForm" *ngIf="!loading">
   <div formGroupName="userManagement" class="form-group">
     <mat-radio-group formControlName="local" class="form-radio-group">
-      <mat-radio-button [value]="true"
-        >{{
-          'components.users.advancedSettings.userManagement.local.title'
-            | translate
-        }}<safe-icon
-          [inline]="true"
+      <mat-radio-button [value]="true">
+        {{ 'components.users.advancedSettings.userManagement.local.title' | translate }}
+        <safe-icon
           icon="info_outline"
+          class="icon-inline"
           variant="grey"
+          [inline]="true"
           [size]="18"
           [matTooltip]="
             'components.users.advancedSettings.userManagement.local.tooltip'
@@ -25,15 +24,16 @@
           "
         ></safe-icon
       ></mat-radio-button>
-      <mat-radio-button [value]="false"
-        >{{
+      <mat-radio-button [value]="false">
+        {{
           'components.users.advancedSettings.userManagement.external.title'
             | translate
         }}
         <safe-icon
-          [inline]="true"
           icon="info_outline"
+          class="icon-inline"
           variant="grey"
+          [inline]="true"
           [size]="18"
           [matTooltip]="
             'components.users.advancedSettings.userManagement.external.tooltip'

--- a/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.html
+++ b/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.html
@@ -146,7 +146,7 @@
   <tr
     mat-row
     *matRowDef="let row; columns: displayedColumns"
-    class="clickable"
+    class="cursor-pointer"
     [routerLink]="['/settings/apiconfigurations', row.id]"
   ></tr>
 </table>

--- a/projects/back-office/src/app/dashboard/pages/applications/applications.component.html
+++ b/projects/back-office/src/app/dashboard/pages/applications/applications.component.html
@@ -130,7 +130,7 @@
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr
-      class="clickable"
+      class="cursor-pointer"
       mat-row
       *matRowDef="let row; columns: displayedColumns"
       [routerLink]="['/applications', row.id]"

--- a/projects/back-office/src/app/dashboard/pages/dashboards/dashboards.component.html
+++ b/projects/back-office/src/app/dashboard/pages/dashboards/dashboards.component.html
@@ -45,7 +45,7 @@
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr
-      class="clickable"
+      class="cursor-pointer"
       mat-row
       *matRowDef="let row; columns: displayedColumns"
       [routerLink]="['/dashboards', row.id]"

--- a/projects/back-office/src/app/dashboard/pages/forms/forms.component.html
+++ b/projects/back-office/src/app/dashboard/pages/forms/forms.component.html
@@ -172,7 +172,7 @@
   <tr
     mat-row
     *matRowDef="let row; columns: displayedColumns"
-    [ngClass]="{ clickable: row.canCreateRecords && row.status === 'active' }"
+    [ngClass]="{ 'cursor-pointer': row.canCreateRecords && row.status === 'active' }"
     [routerLink]="
       row.canCreateRecords && row.status === 'active'
         ? ['/forms/answer', row.id]

--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/components/pull-job-modal/pull-job-modal.component.html
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/components/pull-job-modal/pull-job-modal.component.html
@@ -51,7 +51,7 @@
           />
           <safe-icon
             icon="info"
-            class="clickable"
+            class="cursor-pointer"
             variant="grey"
             matSuffix
             [matTooltip]="'components.pullJob.modal.hint.schedule' | translate"
@@ -85,7 +85,7 @@
           />
           <safe-icon
             icon="info"
-            class="clickable"
+            class="cursor-pointer"
             variant="grey"
             matSuffix
             [matTooltip]="'components.pullJob.modal.hint.url' | translate"
@@ -103,7 +103,7 @@
           />
           <safe-icon
             icon="info"
-            class="clickable"
+            class="cursor-pointer"
             variant="grey"
             matSuffix
             [matTooltip]="'components.pullJob.modal.hint.path' | translate"

--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/components/pull-job-modal/pull-job-modal.component.html
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/components/pull-job-modal/pull-job-modal.component.html
@@ -12,7 +12,7 @@
     <div class="form-group">
       <div class="form-group-row">
         <mat-form-field appearance="outline" style="flex: 1">
-          <mat-label>{{ 'common.name' | translate }} *</mat-label>
+          <mat-label>{{ 'common.name' | translate }}</mat-label>
           <input
             type="text"
             [placeholder]="'common.placeholder.name' | translate"
@@ -49,11 +49,13 @@
             matInput
             formControlName="schedule"
           />
-          <mat-icon
+          <safe-icon
+            icon="info"
+            class="clickable"
+            variant="grey"
             matSuffix
             [matTooltip]="'components.pullJob.modal.hint.schedule' | translate"
-            >info</mat-icon
-          >
+          ></safe-icon>
         </mat-form-field>
         <mat-form-field appearance="outline" style="flex: 1">
           <mat-label>{{ 'common.apiConfiguration.one' | translate }}</mat-label>
@@ -81,11 +83,13 @@
             matInput
             formControlName="url"
           />
-          <mat-icon
+          <safe-icon
+            icon="info"
+            class="clickable"
+            variant="grey"
             matSuffix
             [matTooltip]="'components.pullJob.modal.hint.url' | translate"
-            >info</mat-icon
-          >
+          ></safe-icon>
         </mat-form-field>
         <mat-form-field appearance="outline" style="flex: 1">
           <mat-label>{{ 'models.pullJob.path' | translate }}</mat-label>
@@ -97,11 +101,13 @@
             matInput
             formControlName="path"
           />
-          <mat-icon
+          <safe-icon
+            icon="info"
+            class="clickable"
+            variant="grey"
             matSuffix
             [matTooltip]="'components.pullJob.modal.hint.path' | translate"
-            >info</mat-icon
-          >
+          ></safe-icon>
         </mat-form-field>
       </div>
       <div class="form-group-row">

--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.module.ts
@@ -16,6 +16,7 @@ import {
   SafeConfirmModalModule,
   SafeButtonModule,
   SafeSkeletonTableModule,
+  SafeIconModule,
 } from '@safe/builder';
 import { MatSelectModule } from '@angular/material/select';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -50,6 +51,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     TranslateModule,
     MatChipsModule,
     SafeSkeletonTableModule,
+    SafeIconModule,
   ],
 })
 export class PullJobsModule {}

--- a/projects/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
+++ b/projects/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
@@ -162,7 +162,7 @@
       />
       <safe-icon
         icon="info"
-        class="clickable"
+        class="cursor-pointer"
         variant="grey"
         matSuffix
         [matTooltip]="'pages.referenceData.tooltip.graphQLFilter' | translate"

--- a/projects/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
+++ b/projects/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
@@ -161,9 +161,10 @@
         "
       />
       <safe-icon
-        matSuffix
         icon="info"
+        class="clickable"
         variant="grey"
+        matSuffix
         [matTooltip]="'pages.referenceData.tooltip.graphQLFilter' | translate"
       ></safe-icon>
     </mat-form-field>

--- a/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.html
+++ b/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.html
@@ -97,7 +97,7 @@
   <tr
     mat-row
     *matRowDef="let row; columns: displayedColumns"
-    class="clickable"
+    class="cursor-pointer"
     [routerLink]="['/referencedata', row.id]"
   ></tr>
 </table>

--- a/projects/back-office/src/app/dashboard/pages/resource/resource.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/resource.component.html
@@ -296,7 +296,7 @@
             mat-row
             *matRowDef="let row; columns: displayedColumnsForms"
             [ngClass]="{
-              clickable: row.canCreateRecords && row.status === 'active'
+              'cursor-pointer': row.canCreateRecords && row.status === 'active'
             }"
             [routerLink]="
               row.canCreateRecords && row.status === 'active'

--- a/projects/back-office/src/app/dashboard/pages/resources/resources.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resources/resources.component.html
@@ -69,7 +69,7 @@
 
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr
-    class="clickable"
+    class="cursor-pointer"
     mat-row
     *matRowDef="let row; columns: displayedColumns"
     [routerLink]="['/resources', row.id]"

--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -672,7 +672,7 @@
 				"disallowRecordAccessibility": "Disallow this role to see records of {{form}}",
 				"disallowRecordCreation": "Disallow this role to create records with {{form}}",
 				"disallowRecordDeletion": "Disallow this role to remove records from {{form}}",
-				"disallowRecordUpate": "Disallow this role to update records from {{form}}",
+				"disallowRecordUpdate": "Disallow this role to update records from {{form}}",
 				"hideFeature": "Hide {{page}} from this role",
 				"showFeature": "Show {{page}} to this role"
 			},

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -4,9 +4,9 @@
 		"add": "Ajouter",
 		"advancedSettings": "Paramètres avancés",
 		"aggregation": {
-			"few": "Aggrégations",
-			"none": "Aucune aggrégation",
-			"one": "Aggrégation"
+			"few": "Agrégations",
+			"none": "Aucune agrégation",
+			"one": "Agrégation"
 		},
 		"apiConfiguration": {
 			"few": "Configurations d'API",
@@ -195,7 +195,7 @@
 		},
 		"row": {
 			"few": "Rangées",
-			"none": "Auncune rangée",
+			"none": "Aucune rangée",
 			"one": "Rangée"
 		},
 		"save": "Sauvegarder",
@@ -259,7 +259,7 @@
 			"groupBy": "Regrouper par",
 			"groupingRules": "Grouper par",
 			"mapping": {
-				"category": "Categorie",
+				"category": "Catégorie",
 				"field": "Valeur",
 				"series": "Séries"
 			},
@@ -290,7 +290,7 @@
 			},
 			"tooltip": {
 				"addFields": "Ajouter de nouveaux champs au document.",
-				"custom": "Définit une fonction ou une expression d'aggrégation personnalisée en JavaScript.",
+				"custom": "Définit une fonction ou une expression d'agrégation personnalisée en JavaScript.",
 				"filter": "Retourne un tableau contenant uniquement les éléments qui vérifient la condition.",
 				"group": "Regroupe les documents mis en entrée par l'expression 'id' qui a été spécifiée et qui sort un document pour chaque regroupement.",
 				"sort": "Trie tous les documents mis en entrée et les retourne vers la pipeline dans l'ordre.",
@@ -391,8 +391,8 @@
 					"title": "Depuis la ressource"
 				},
 				"tooltip": {
-					"inherit": "Creates a child form using a template from the resource linked to the core form",
-					"resource": "Creates a core form that allows the creation of children forms linked to this core form. It will also create a new resource.",
+					"inherit": "Crée un formulaire hérité en utilisant comme modèle la ressource liée à un formulaire source.",
+					"resource": "Crée un formulaire source permettant la création de formulaire hérités liés à celui-ci. Crée aussi une nouvelle ressource liée.",
 					"template": "Si aucun modèle n'est sélectionné, la structure principale sera chargée"
 				}
 			},
@@ -672,7 +672,7 @@
 				"disallowRecordAccessibility": "Interdire ce rôle pour voir les enregistrements de {{form}}",
 				"disallowRecordCreation": "Interdire à ce rôle de créer des enregistrements dans {{form}}",
 				"disallowRecordDeletion": "Interdire ce rôle pour supprimer des enregistrements de {{form}}",
-				"disallowRecordUpate": "Interdire ce rôle pour mettre à jour les enregistrements de {{form}}",
+				"disallowRecordUpdate": "Interdire ce rôle pour mettre à jour les enregistrements de {{form}}",
 				"hideFeature": "Masquer {{page}} pour ce rôle",
 				"showFeature": "Afficher {{page}} pour ce rôle"
 			},
@@ -739,7 +739,7 @@
 			"chart": {
 				"errors": {
 					"aggregation": {
-						"invalid": "Aggrégation invalide"
+						"invalid": "Agrégation invalide"
 					}
 				}
 			},
@@ -872,7 +872,7 @@
 						}
 					},
 					"hint": {
-						"buttons": "Les boutons d'action rapides apparaitront dans le widget et vous permettront de réaliser chacune des actions ci-dessous"
+						"buttons": "Les boutons d'action rapides apparaîtront dans le widget et vous permettront de réaliser chacune des actions ci-dessous"
 					},
 					"layouts": {
 						"add": {
@@ -992,7 +992,7 @@
 			"columnsApply": "Appliquer",
 			"columnsReset": "Réinitialiser",
 			"detailCollapse": "Réduire",
-			"detailExpand": "Etendre",
+			"detailExpand": "Étendre",
 			"filter": "Filtrer",
 			"filterAfterOperator": "Est après",
 			"filterAfterOrEqualOperator": "Est après ou égal à",
@@ -1029,7 +1029,7 @@
 			"filterStartsWithOperator": "Commence par",
 			"gridLabel": "Table de données",
 			"groupCollapse": "Réduire le groupe",
-			"groupExpand": "Etendre le groupe",
+			"groupExpand": "Étendre le groupe",
 			"groupPanelEmpty": "Faites glisser un en-tête de colonne et déposez-le ici pour grouper par cette colonne",
 			"loading": "Chargement",
 			"lock": "Verrouiller",
@@ -1053,7 +1053,7 @@
 			"sortedAscending": "Trié par ordre croissant",
 			"sortedDefault": "Non trié",
 			"sortedDescending": "Trié par ordre décroissant",
-			"stick": "Epingler",
+			"stick": "Épingler",
 			"unlock": "Déverrouiller",
 			"unstick": "Désépingler"
 		},

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -672,7 +672,7 @@
 				"disallowRecordAccessibility": "****** {{form}}",
 				"disallowRecordCreation": "****** {{form}}",
 				"disallowRecordDeletion": "****** {{form}}",
-				"disallowRecordUpate": "****** {{form}}",
+				"disallowRecordUpdate": "****** {{form}}",
 				"hideFeature": "****** {{page}} ******",
 				"showFeature": "****** {{page}} ******"
 			},

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.html
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.html
@@ -26,8 +26,10 @@
           <safe-icon
             *ngIf="page.containsErrors"
             icon="error"
+            class="icon-inline"
             variant="danger"
             [inline]="true"
+            [size]="20"
           ></safe-icon>
         </ng-template>
       </mat-tab>

--- a/projects/safe/src/lib/components/form-modal/form-modal.component.html
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.html
@@ -26,7 +26,6 @@
           <safe-icon
             *ngIf="page.containsErrors"
             icon="error"
-            class="icon-inline"
             variant="danger"
             [inline]="true"
             [size]="20"

--- a/projects/safe/src/lib/components/form/form.component.html
+++ b/projects/safe/src/lib/components/form/form.component.html
@@ -35,7 +35,6 @@
       <safe-icon
         *ngIf="page.containsErrors"
         icon="error"
-        class="icon-inline"
         variant="danger"
         [inline]="true"
         [size]="20"

--- a/projects/safe/src/lib/components/form/form.component.html
+++ b/projects/safe/src/lib/components/form/form.component.html
@@ -35,8 +35,10 @@
       <safe-icon
         *ngIf="page.containsErrors"
         icon="error"
+        class="icon-inline"
         variant="danger"
         [inline]="true"
+        [size]="20"
       ></safe-icon>
     </ng-template>
   </mat-tab>

--- a/projects/safe/src/lib/components/layout/layout.component.html
+++ b/projects/safe/src/lib/components/layout/layout.component.html
@@ -94,10 +94,10 @@
   </mat-menu>
   <mat-menu #notificationMenu="matMenu">
     <div class="notification-menu">
-      <a (click)="onMarkAllNotificationsAsRead()"
-        >{{ 'components.notifications.readAll' | translate
-        }}<mat-icon [inline]="true"> check_circle_outline </mat-icon></a
-      >
+      <a (click)="onMarkAllNotificationsAsRead()">
+        {{ 'components.notifications.readAll' | translate }}
+        <mat-icon [inline]="true">check_circle_outline</mat-icon>
+      </a>
       <button
         mat-menu-item
         (click)="onNotificationClick(notification)"

--- a/projects/safe/src/lib/components/preferences-modal/preferences-modal.component.scss
+++ b/projects/safe/src/lib/components/preferences-modal/preferences-modal.component.scss
@@ -1,29 +1,5 @@
-:host {
-  // display: flex;
-  // height: 100%;
-  // flex-direction: column;
-  // position: relative;
-}
-
-mat-dialog-content {
-  padding-left: 0;
-  // flex-grow: 1;
-  // max-height: initial;
-}
-
 .close-settings {
   position: absolute;
   top: 0;
   right: 0;
-}
-
-.tab-label {
-  display: flex;
-  gap: 6px;
-  align-content: center;
-  align-items: center;
-
-  safe-icon {
-    height: 20px;
-  }
 }

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
@@ -113,7 +113,7 @@
       <safe-icon
         *ngIf="searchSelected"
         icon="info"
-        class="floating-info clickable"
+        class="floating-info cursor-pointer"
         variant="grey"
         [size]="32"
         [matTooltip]="

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
@@ -112,8 +112,8 @@
       </div>
       <safe-icon
         *ngIf="searchSelected"
-        class="floating-info"
         icon="info"
+        class="floating-info clickable"
         variant="grey"
         [size]="32"
         [matTooltip]="

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.scss
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.scss
@@ -97,6 +97,6 @@
 
 .floating-info {
   position: absolute;
-  bottom: 40px;
+  bottom: 52px;
   right: 12px;
 }

--- a/projects/safe/src/lib/components/search-menu/search-menu.component.html
+++ b/projects/safe/src/lib/components/search-menu/search-menu.component.html
@@ -4,7 +4,7 @@
 <mat-form-field appearance="outline">
   <input
     matInput
-    placeholder="Search"
+    [placeholder]="'common.placeholder.search' | translate"
     [(ngModel)]="search"
     (ngModelChange)="onSearch()"
     autocomplete="off"

--- a/projects/safe/src/lib/components/search-menu/search-menu.module.ts
+++ b/projects/safe/src/lib/components/search-menu/search-menu.module.ts
@@ -25,6 +25,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     SafeButtonModule,
     MatDividerModule,
     MatTooltipModule,
+    TranslateModule,
   ],
   exports: [SafeSearchMenuComponent],
 })

--- a/projects/safe/src/lib/components/search-menu/search-menu.module.ts
+++ b/projects/safe/src/lib/components/search-menu/search-menu.module.ts
@@ -25,7 +25,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     SafeButtonModule,
     MatDividerModule,
     MatTooltipModule,
-    TranslateModule,
   ],
   exports: [SafeSearchMenuComponent],
 })

--- a/projects/safe/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.html
+++ b/projects/safe/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.html
@@ -15,10 +15,9 @@
         }}
         <safe-icon
           icon="info_outline"
-          class="icon-inline"
           variant="grey"
           [inline]="true"
-          [size]="19"
+          [size]="18"
           [matTooltip]="
             'components.aggregationBuilder.tooltip.' + stageForm.value.type
               | translate

--- a/projects/safe/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.html
+++ b/projects/safe/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.html
@@ -14,16 +14,16 @@
             | translate
         }}
         <safe-icon
-          class="info-tooltip"
-          [size]="18"
+          icon="info_outline"
+          class="icon-inline"
           variant="grey"
+          [inline]="true"
+          [size]="19"
           [matTooltip]="
             'components.aggregationBuilder.tooltip.' + stageForm.value.type
               | translate
           "
           matTooltipPosition="right"
-          icon="info_outline"
-          [inline]="true"
         ></safe-icon>
       </mat-panel-title>
     </mat-expansion-panel-header>

--- a/projects/safe/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.scss
+++ b/projects/safe/src/lib/components/ui/aggregation-builder/pipeline/pipeline.component.scss
@@ -3,7 +3,3 @@
   flex-direction: column;
   gap: 12px;
 }
-
-.info-tooltip {
-  padding-left: 4px;
-}

--- a/projects/safe/src/lib/components/ui/icon/icon.component.ts
+++ b/projects/safe/src/lib/components/ui/icon/icon.component.ts
@@ -18,6 +18,7 @@ export class SafeIconComponent implements OnInit {
 
   @Input() size = 24;
 
+  /** @returns A getter that returns the display style of the host element. */
   @HostBinding('style.display') get display() {
     return this.inline ? 'inline-flex' : 'flex';
   }

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
@@ -32,11 +32,11 @@
             {{ 'common.aggregation.one' | translate }}
             <safe-icon
               *ngIf="aggregationForm.invalid"
-              style="padding-left: 2px"
               icon="error_outline"
+              class="icon-inline"
+              variant="danger"
               [inline]="true"
               [size]="18"
-              variant="danger"
             ></safe-icon>
           </ng-template>
           <safe-aggregation-builder

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
@@ -33,7 +33,6 @@
             <safe-icon
               *ngIf="aggregationForm.invalid"
               icon="error_outline"
-              class="icon-inline"
               variant="danger"
               [inline]="true"
               [size]="18"

--- a/projects/safe/src/lib/components/widgets/grid-settings/floating-button-settings/floating-button-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/floating-button-settings/floating-button-settings.component.html
@@ -164,10 +164,9 @@
             {{ 'components.widget.settings.grid.buttons.callback.attach' | translate }}
             <safe-icon
               icon="info_outline"
-              class="icon-inline"
               variant="grey"
               [inline]="true"
-              [size]="19"
+              [size]="18"
               [matTooltip]="
                 'components.widget.settings.grid.buttons.tooltip.attach'
                   | translate
@@ -218,9 +217,8 @@
           {{ 'components.channel.dropdown.select' | translate }}
           <safe-icon
             icon="info_outline"
-            class="icon-inline"
             variant="grey"
-            [size]="19"
+            [size]="18"
             [inline]="true"
             [matTooltip]="
               'components.widget.settings.grid.buttons.tooltip.notify'
@@ -255,9 +253,8 @@
           {{ 'common.publish' | translate }}
           <safe-icon
             icon="info_outline"
-            class="icon-inline"
             variant="grey"
-            [size]="19"
+            [size]="18"
             [inline]="true"
             [matTooltip]="
               'components.widget.settings.grid.buttons.tooltip.publish'

--- a/projects/safe/src/lib/components/widgets/grid-settings/floating-button-settings/floating-button-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/floating-button-settings/floating-button-settings.component.html
@@ -159,24 +159,23 @@
             </safe-button>
           </div>
         </div>
-        <span class="info-row" *ngIf="relatedForms.length > 0">
-          <mat-checkbox formControlName="attachToRecord">{{
-            'components.widget.settings.grid.buttons.callback.attach'
-              | translate
-          }}</mat-checkbox>
-          <safe-icon
-            style="padding-left: 2px"
-            icon="info_outline"
-            variant="grey"
-            [size]="18"
-            [inline]="true"
-            [matTooltip]="
-              'components.widget.settings.grid.buttons.tooltip.attach'
-                | translate
-            "
-            matTooltipPosition="right"
-          ></safe-icon>
-        </span>
+        <ng-container *ngIf="relatedForms.length > 0">
+          <mat-checkbox formControlName="attachToRecord">
+            {{ 'components.widget.settings.grid.buttons.callback.attach' | translate }}
+            <safe-icon
+              icon="info_outline"
+              class="icon-inline"
+              variant="grey"
+              [inline]="true"
+              [size]="18"
+              [matTooltip]="
+                'components.widget.settings.grid.buttons.tooltip.attach'
+                  | translate
+              "
+              matTooltipPosition="right"
+            ></safe-icon>
+          </mat-checkbox>
+        </ng-container>
         <div *ngIf="buttonForm.value.attachToRecord" class="sub-parameters">
           <mat-form-field appearance="outline">
             <mat-label>{{ 'models.form.select' | translate }}</mat-label>
@@ -215,13 +214,11 @@
             </safe-query-builder>
           </ng-container>
         </div>
-        <span class="info-row">
-          <mat-checkbox formControlName="notify">{{
-            'components.channel.dropdown.select' | translate
-          }}</mat-checkbox>
+        <mat-checkbox formControlName="notify">
+          {{ 'components.channel.dropdown.select' | translate }}
           <safe-icon
-            style="padding-left: 2px"
             icon="info_outline"
+            class="icon-inline"
             variant="grey"
             [size]="18"
             [inline]="true"
@@ -231,7 +228,7 @@
             "
             matTooltipPosition="right"
           ></safe-icon>
-        </span>
+        </mat-checkbox>
         <div *ngIf="buttonForm.value.notify" class="sub-parameters">
           <mat-form-field appearance="outline">
             <mat-label>{{ 'common.channel.one' | translate }}</mat-label>
@@ -254,13 +251,11 @@
             />
           </mat-form-field>
         </div>
-        <span class="info-row">
-          <mat-checkbox formControlName="publish">{{
-            'common.publish' | translate
-          }}</mat-checkbox>
+        <mat-checkbox formControlName="publish">
+          {{ 'common.publish' | translate }}
           <safe-icon
-            style="padding-left: 2px"
             icon="info_outline"
+            class="icon-inline"
             variant="grey"
             [size]="18"
             [inline]="true"
@@ -270,7 +265,7 @@
             "
             matTooltipPosition="right"
           ></safe-icon>
-        </span>
+        </mat-checkbox>
         <div *ngIf="buttonForm.value.publish" class="sub-parameters">
           <mat-form-field appearance="outline">
             <mat-label>{{ 'common.channel.one' | translate }}</mat-label>

--- a/projects/safe/src/lib/components/widgets/grid-settings/floating-button-settings/floating-button-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/floating-button-settings/floating-button-settings.component.html
@@ -167,7 +167,7 @@
               class="icon-inline"
               variant="grey"
               [inline]="true"
-              [size]="18"
+              [size]="19"
               [matTooltip]="
                 'components.widget.settings.grid.buttons.tooltip.attach'
                   | translate
@@ -220,7 +220,7 @@
             icon="info_outline"
             class="icon-inline"
             variant="grey"
-            [size]="18"
+            [size]="19"
             [inline]="true"
             [matTooltip]="
               'components.widget.settings.grid.buttons.tooltip.notify'
@@ -257,7 +257,7 @@
             icon="info_outline"
             class="icon-inline"
             variant="grey"
-            [size]="18"
+            [size]="19"
             [inline]="true"
             [matTooltip]="
               'components.widget.settings.grid.buttons.tooltip.publish'

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -147,7 +147,6 @@
                   <safe-icon
                     *ngIf="floatingButton.invalid"
                     icon="error_outline"
-                    class="icon-inline"
                     variant="danger"
                     [inline]="true"
                     [size]="18"

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -146,11 +146,11 @@
                   }}
                   <safe-icon
                     *ngIf="floatingButton.invalid"
-                    style="padding-left: 2px"
                     icon="error_outline"
+                    class="icon-inline"
+                    variant="danger"
                     [inline]="true"
                     [size]="18"
-                    variant="danger"
                   ></safe-icon>
                 </ng-template>
                 <ng-template matTabContent>

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -42,10 +42,10 @@
         {{ 'models.widget.map.zoom' | translate }}
         <safe-icon
           icon="info_outline"
-          class="icon-inline clickable"
+          class="cursor-pointer"
           variant="grey"
           [inline]="true"
-          [size]="19"
+          [size]="18"
           [matTooltip]="
             'components.widget.settings.map.display.latitude' | translate
           "
@@ -66,7 +66,7 @@
           <input type="number" matInput formControlName="centerLat" />
           <safe-icon
             icon="info"
-            class="clickable"
+            class="cursor-pointer"
             variant="grey"
             matSuffix
             [matTooltip]="
@@ -85,7 +85,7 @@
           <input type="number" matInput formControlName="centerLong" />
           <safe-icon
             icon="info"
-            class="clickable"
+            class="cursor-pointer"
             variant="grey"
             matSuffix
             [matTooltip]="

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -45,7 +45,7 @@
           class="icon-inline clickable"
           variant="grey"
           [inline]="true"
-          [size]="18"
+          [size]="19"
           [matTooltip]="
             'components.widget.settings.map.display.latitude' | translate
           "

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -41,13 +41,14 @@
       <mat-label>
         {{ 'models.widget.map.zoom' | translate }}
         <safe-icon
-          icon="info"
+          icon="info_outline"
+          class="icon-inline clickable"
+          variant="grey"
+          [inline]="true"
+          [size]="18"
           [matTooltip]="
             'components.widget.settings.map.display.latitude' | translate
           "
-          [inline]="true"
-          [size]="16"
-          variant="grey"
         ></safe-icon>
       </mat-label>
       <mat-slider
@@ -64,9 +65,10 @@
           </mat-label>
           <input type="number" matInput formControlName="centerLat" />
           <safe-icon
-            matSuffix
             icon="info"
+            class="clickable"
             variant="grey"
+            matSuffix
             [matTooltip]="
               'components.widget.settings.map.tooltip.default.latitude'
                 | translate
@@ -82,9 +84,10 @@
           </mat-label>
           <input type="number" matInput formControlName="centerLong" />
           <safe-icon
-            matSuffix
             icon="info"
+            class="clickable"
             variant="grey"
+            matSuffix
             [matTooltip]="
               'components.widget.settings.map.tooltip.default.longitude'
                 | translate

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -536,22 +536,9 @@ body {
   align-items: center;
 }
 
-.info-icon {
-  color: #939393;
-  font-size: 22px;
-  cursor: pointer;
-}
-
 .info-text {
   color: #939393;
   margin-bottom: 32px;
-}
-
-.info-row {
-  display: flex;
-  .info-icon {
-    margin-left: 6px;
-  }
 }
 
 // === SURVEY BUILDER ===

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -530,6 +530,12 @@ body {
   margin: 0 4px;
 }
 
+// Correct a bug of angular, see https://github.com/angular/components/issues/14311
+.mat-form-field-suffix, .mat-form-field-prefix {
+  display: inline-flex;
+  align-items: center;
+}
+
 .info-icon {
   color: #939393;
   font-size: 22px;

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -524,6 +524,12 @@ body {
 }
 
 // === UTILS ===
+
+.icon-inline {
+  vertical-align: text-bottom;
+  margin: 0 4px;
+}
+
 .info-icon {
   color: #939393;
   font-size: 22px;

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -235,6 +235,40 @@ $safe-theme: mat.define-light-theme($safe-primary, $safe-accent, $safe-warn);
   }
 }
 
+// === RADIO STYlING ===
+@mixin radio($theme) {
+  .mat-radio-label-content {
+    safe-icon {
+      vertical-align: text-bottom;
+    }
+  }
+}
+
+// === SLIDE TOGGLE STYLING ===
+@mixin slide-toggle($theme) {
+  .mat-slide-toggle-content {
+    safe-icon {
+      vertical-align: text-bottom;
+    }
+  }
+}
+
+// === EXPANSION PANEL STYLING ===
+@mixin expansion-panel($theme) {
+  .mat-expansion-panel-header-title {
+    gap: 4px;
+  }
+}
+
+// === CHECKBOX STYLING ===
+@mixin checkbox($theme) {
+  .mat-checkbox-label {
+    safe-icon {
+      vertical-align: text-bottom;
+    }
+  }
+}
+
 // === GLOBAL STYLES ==
 .mat-table {
   box-shadow: 0 2px 5px 0 rgba(219, 134, 134, 0.2);
@@ -300,12 +334,6 @@ $safe-theme: mat.define-light-theme($safe-primary, $safe-accent, $safe-warn);
     white-space: nowrap;
     text-overflow: ellipsis;
     margin: 0;
-  }
-}
-
-.clickable {
-  &:hover {
-    cursor: pointer;
   }
 }
 
@@ -399,10 +427,15 @@ $safe-theme: mat.define-light-theme($safe-primary, $safe-accent, $safe-warn);
   }
 }
 
+// === ADDITIONAL MATERIAL STYLING ===
 @include mat.all-component-themes($safe-theme);
 @include chip($safe-theme);
 @include button($safe-theme);
 @include alert($safe-theme);
+@include radio($safe-theme);
+@include slide-toggle($safe-theme);
+@include expansion-panel($safe-theme);
+@include checkbox($safe-theme);
 @include custom-theme($safe-theme);
 
 html,
@@ -524,12 +557,6 @@ body {
 }
 
 // === UTILS ===
-
-.icon-inline {
-  vertical-align: text-bottom;
-  margin: 0 4px;
-}
-
 // Correct a bug of angular, see https://github.com/angular/components/issues/14311
 .mat-form-field-suffix, .mat-form-field-prefix {
   display: inline-flex;
@@ -546,7 +573,10 @@ body {
   color: mat.get-color-from-palette($safe-warn) !important;
 }
 
+// === KENDO THEME ===
 @import 'theme.scss';
+// === UTILITY ===
+@import 'utils.scss';
 
 // === VERTICAL TABS ===
 mat-tab-group[vertical] {

--- a/projects/safe/src/lib/style/utils.scss
+++ b/projects/safe/src/lib/style/utils.scss
@@ -1,0 +1,4 @@
+// === UTILS ===
+.cursor-pointer {
+  cursor: pointer;
+}


### PR DESCRIPTION
# Description

Unify info icons on the release 1.3.0. 

Note that for inline icons, we always need to add margin on left and right sides, and to align it with the text. It would be better to includes these css properties in the safe-icon component, however it breaks other component which use the safe-icon (like safe-button) so I preferred to keep these properties in a class which has to be always added.
As a consequence, I also added this class to other inline safe-icons (not only the info ones).


## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Open pages and modals which use info icons.

## Screenshots

![image](https://user-images.githubusercontent.com/103410601/179727005-52e551ed-f6ca-4a5b-adbe-74b920c212d5.png)
![image](https://user-images.githubusercontent.com/103410601/179727104-84bcb3f1-27e6-4193-8dca-7de92f1952bb.png)
![image](https://user-images.githubusercontent.com/103410601/179727299-76c08049-c9af-4fd4-99fd-084a2096a1a8.png)
![image](https://user-images.githubusercontent.com/103410601/179727549-f2f38b9a-8390-49c8-8c9c-26dd0eb9f153.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
