### PR TITLE
OORT-406 Show legend on line charts

### DIFF
--- a/projects/safe/src/lib/components/ui/line-chart/line-chart.component.html
+++ b/projects/safe/src/lib/components/ui/line-chart/line-chart.component.html
@@ -32,6 +32,7 @@
       [data]="serie.data"
       field="field"
       categoryField="category"
+      [name]="serie.name || ''"
       [color]="serie.color"
       [labels]="labels"
     ></kendo-chart-series-item>

--- a/projects/safe/src/lib/components/ui/line-chart/line-chart.component.html
+++ b/projects/safe/src/lib/components/ui/line-chart/line-chart.component.html
@@ -1,15 +1,14 @@
 <kendo-chart
   #chart
-  [categoryAxis]="categoryAxis"
   [seriesColors]="options && options.palette"
 >
-  <!-- <kendo-chart-value-axis>
+  <kendo-chart-value-axis>
     <kendo-chart-value-axis-item
       [min]="min"
       [max]="max"
     >
     </kendo-chart-value-axis-item>
-  </kendo-chart-value-axis> -->
+  </kendo-chart-value-axis>
   <kendo-chart-title
     *ngIf="title"
     [visible]="title.visible"

--- a/projects/safe/src/lib/components/ui/line-chart/line-chart.component.ts
+++ b/projects/safe/src/lib/components/ui/line-chart/line-chart.component.ts
@@ -24,6 +24,7 @@ interface ChartLegend {
  * Interface containing the settings of the chart series
  */
 interface ChartSeries {
+  name?: string;
   color?: string;
   data: {
     category: any;

--- a/projects/safe/src/lib/components/ui/line-chart/line-chart.component.ts
+++ b/projects/safe/src/lib/components/ui/line-chart/line-chart.component.ts
@@ -70,11 +70,6 @@ export class SafeLineChartComponent implements OnInit, OnChanges {
   @ViewChild('chart')
   public chart?: ChartComponent;
 
-  public categoryAxis: CategoryAxis = {
-    type: 'date',
-    maxDivisions: 10,
-  };
-
   public labels: any;
 
   /**


### PR DESCRIPTION
# Description

Correct a bug for displaying the legend on line charts.
Also correct a bug which prevent using line charts with category fields of other types than numbers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Try to create a line chart (personally I struggled to do it but finally it is possible after some hours of trying...) with a series field.

## Screenshots
![image](https://user-images.githubusercontent.com/103410601/179947634-2528cdcc-417a-42f7-90f4-b955d2d37c49.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
