### PR TITLE
OORT-416

### DIFF
--- a/projects/safe/src/lib/services/grid.service.ts
+++ b/projects/safe/src/lib/services/grid.service.ts
@@ -4,6 +4,7 @@ import { prettifyLabel } from '../utils/prettify';
 import get from 'lodash/get';
 import { SafeApiProxyService } from './api-proxy.service';
 import { MULTISELECT_TYPES } from '../components/ui/core-grid/grid/grid.constants';
+import { TranslateService } from '@ngx-translate/core';
 
 /** List of disabled fields */
 const DISABLED_FIELDS = [
@@ -39,10 +40,12 @@ export class SafeGridService {
    *
    * @param formBuilder Angular form builder
    * @param apiProxyService Shared API proxy service
+   * @param translate Translate service
    */
   constructor(
     private formBuilder: FormBuilder,
-    private apiProxyService: SafeApiProxyService
+    private apiProxyService: SafeApiProxyService,
+    private translate: TranslateService
   ) {}
 
   /**
@@ -264,11 +267,15 @@ export class SafeGridService {
         }
       }
       if (meta.choices) {
+        console.log(meta.choices, this.translate.currentLang);
         metaFields[fieldName] = {
           ...meta,
           choices: meta.choices.map((choice: any) => ({
             value: choice.value,
-            text: choice.text.default || choice.text,
+            text:
+              choice.text[this.translate.currentLang] ||
+              choice.text.default ||
+              choice.text,
           })),
         };
       }


### PR DESCRIPTION
# Description

Fix an issue with grid choices localization, the code was always ignoring translations, even when the choices had a translation for the selected app language.

The logic now is checking for `text.<lang> `-> `text.default` -> `text`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Selecting choices in the grid now shows them translated if possible

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
