### PR TITLE
OORT-365 - filter in resources / resource questions

### DIFF
--- a/projects/safe/src/lib/survey/components/resource.ts
+++ b/projects/safe/src/lib/survey/components/resource.ts
@@ -14,6 +14,7 @@ import { buildSearchButton, buildAddButton } from './utils';
 import get from 'lodash/get';
 import { Question, QuestionResource } from '../types';
 import { JsonMetadata, SurveyModel } from 'survey-angular';
+import { TestBed } from '@angular/core/testing';
 
 /**
  * Inits the resource question component of for survey.
@@ -149,6 +150,12 @@ export const init = (
           btn.style.border = 'none';
           btn.style.padding = '10px';
           htmlElement.appendChild(btn);
+          const text = document.createElement('p');
+          text.innerText =
+            'If no custom filter is defined, grid filters will be used to get the available options';
+          text.style.margin = '0';
+          text.style.opacity = '0.8';
+          htmlElement.appendChild(text);
           btn.onclick = (ev: any) => {
             const currentQuestion = editor.object;
             getResourceById({ id: currentQuestion.resource }).subscribe(
@@ -541,6 +548,12 @@ export const init = (
       }
     },
     populateChoices: (question: QuestionResource): void => {
+      // Apply grid filters when no filter is applied to the custom question
+      if (filters.length === 1 && filters[0].field === '') {
+        if (question.gridFieldsSettings.filter) {
+          filters = question.gridFieldsSettings.filter;
+        }
+      }
       if (question.resource) {
         getResourceById({ id: question.resource, filters }).subscribe(
           (response) => {

--- a/projects/safe/src/lib/survey/components/resources.ts
+++ b/projects/safe/src/lib/survey/components/resources.ts
@@ -172,6 +172,12 @@ export const init = (
           btn.style.border = 'none';
           btn.style.padding = '10px';
           htmlElement.appendChild(btn);
+          const text = document.createElement('p');
+          text.innerText =
+            'If no custom filter is defined, grid filters will be used to get the available options';
+          text.style.margin = '0';
+          text.style.opacity = '0.8';
+          htmlElement.appendChild(text);
           btn.onclick = (ev: any) => {
             const currentQuestion = editor.object;
             getResourceById({ id: currentQuestion.resource }).subscribe(
@@ -666,6 +672,12 @@ export const init = (
       }
     },
     populateChoices: (question: any, field?: string): void => {
+      // Apply grid filters when no filter is applied to the custom question
+      if (filters.length === 1 && filters[0].field === '') {
+        if (question.gridFieldsSettings.filter) {
+          filters = question.gridFieldsSettings.filter;
+        }
+      }
       if (question.displayAsGrid) {
         if (question.selectQuestion) {
           const f = field ? field : question.filteryBy;


### PR DESCRIPTION
# Description

Change custom questions behavior fro resource and resources.
You can now use the search grid configuration for filtering the available options, this will work by default, using the grid filters if no custom filter is defined.

An explanation of this feature has been added below the grid configuration button (It should be easy to remove if you find it's not necessary).

## Screenshots

![Screenshot from 2022-08-09 14-07-29](https://user-images.githubusercontent.com/94831019/183643339-f7d80d12-3fd9-4b99-9b88-d50a36b6c160.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] The new feature has been tested setting up some filters in the grid configuration and checking if they are applied on selection of choices (For resource and resources questions)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
