### PR TITLE
AB#34846 Summary Cards - Link to datasource

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -918,6 +918,7 @@
 							"title": "Data source"
 						},
 						"display": {
+							"dataSource": "Show link to data source",
 							"header": "Header",
 							"title": "Display"
 						},
@@ -939,6 +940,9 @@
 					"dynamic": "Dynamic",
 					"static": "Static"
 				}
+			},
+			"summaryCard": {
+				"dataSource": "Data Source"
 			}
 		}
 	},

--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -942,7 +942,10 @@
 				}
 			},
 			"summaryCard": {
-				"dataSource": "Data Source"
+				"dataSource": "Data Source",
+				"errors": {
+					"invalidSource": "The data source is invalid: please edit the settings."
+				}
 			}
 		}
 	},

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -942,7 +942,10 @@
 				}
 			},
 			"summaryCard": {
-				"dataSource": "Source"
+				"dataSource": "Source",
+				"errors": {
+					"invalidSource": "La source de données est invalide : veuillez modifier les paramètres."
+				}
 			}
 		}
 	},

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -918,7 +918,8 @@
 							"title": "Source de données"
 						},
 						"display": {
-							"header": "Title",
+							"dataSource": "Afficher le lien vers la source de données",
+							"header": "Titre",
 							"title": "Affichage"
 						},
 						"preview": {},
@@ -939,6 +940,9 @@
 					"dynamic": "Dynamique",
 					"static": "Statique"
 				}
+			},
+			"summaryCard": {
+				"dataSource": "Source"
 			}
 		}
 	},

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -918,6 +918,7 @@
 							"title": "******"
 						},
 						"display": {
+							"dataSource": "******",
 							"header": "******",
 							"title": "******"
 						},
@@ -939,6 +940,9 @@
 					"dynamic": "******",
 					"static": "******"
 				}
+			},
+			"summaryCard": {
+				"dataSource": "******"
 			}
 		}
 	},

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -942,7 +942,10 @@
 				}
 			},
 			"summaryCard": {
-				"dataSource": "******"
+				"dataSource": "******",
+				"errors": {
+					"invalidSource": "******"
+				}
 			}
 		}
 	},

--- a/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.html
+++ b/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.html
@@ -1,18 +1,19 @@
+<safe-button
+  [isIcon]="true"
+  icon="close"
+  variant="danger"
+  mat-dialog-close
+  class="close-modal"
+  (click)="closeModal(false)"
+></safe-button>
 <h2 mat-dialog-title *ngIf="selectable">
   {{
     'common.searchObject'
       | translate: { name: ('common.record.few' | translate) }
   }}
 </h2>
-<div mat-dialog-title class="dialog-title" *ngIf="!selectable">
+<div mat-dialog-title *ngIf="!selectable">
   <h2>{{ 'common.record.few' | translate }}</h2>
-  <safe-button
-    [isIcon]="true"
-    icon="close"
-    variant="danger"
-    mat-dialog-close
-    (click)="closeModal(false)"
-  ></safe-button>
 </div>
 <mat-dialog-content>
   <safe-core-grid
@@ -29,12 +30,7 @@
   <button mat-button matDialogClose (click)="closeModal(false)">
     {{ 'common.cancel' | translate }}
   </button>
-  <button
-    mat-flat-button
-    matDialogClose
-    color="primary"
-    (click)="closeModal()"
-  >
+  <button mat-flat-button matDialogClose color="primary" (click)="closeModal()">
     {{ 'common.select' | translate }}
   </button>
 </mat-dialog-actions>

--- a/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.html
+++ b/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.html
@@ -1,9 +1,19 @@
-<h2 mat-dialog-title>
+<h2 mat-dialog-title *ngIf="selectable">
   {{
     'common.searchObject'
       | translate: { name: ('common.record.few' | translate) }
   }}
 </h2>
+<div mat-dialog-title class="dialog-title" *ngIf="!selectable">
+  <h2>{{ 'common.record.few' | translate }}</h2>
+  <safe-button
+    [isIcon]="true"
+    icon="close"
+    variant="danger"
+    mat-dialog-close
+    (click)="closeModal(false)"
+  ></safe-button>
+</div>
 <mat-dialog-content>
   <safe-core-grid
     [settings]="gridSettings"
@@ -15,7 +25,7 @@
   >
   </safe-core-grid>
 </mat-dialog-content>
-<mat-dialog-actions align="end">
+<mat-dialog-actions align="end" *ngIf="selectable">
   <button mat-button matDialogClose (click)="closeModal(false)">
     {{ 'common.cancel' | translate }}
   </button>
@@ -24,7 +34,6 @@
     matDialogClose
     color="primary"
     (click)="closeModal()"
-    *ngIf="selectable"
   >
     {{ 'common.select' | translate }}
   </button>

--- a/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.scss
+++ b/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.scss
@@ -1,0 +1,15 @@
+.dialog-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  h2 {
+    margin: 0;
+  }
+
+  safe-button {
+    height: 1em;
+    display: flex;
+    align-items: center;
+  }
+}

--- a/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.scss
+++ b/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.scss
@@ -1,15 +1,5 @@
-.dialog-title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  h2 {
-    margin: 0;
-  }
-
-  safe-button {
-    height: 1em;
-    display: flex;
-    align-items: center;
-  }
+.close-modal {
+  position: absolute;
+  top: 0;
+  right: 0;
 }

--- a/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.ts
+++ b/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.ts
@@ -7,8 +7,8 @@ import { GridSettings } from '../ui/core-grid/models/grid-settings.model';
  */
 interface DialogData {
   gridSettings: any;
-  multiselect: boolean;
-  selectedRows: string[];
+  multiselect?: boolean;
+  selectedRows?: string[];
   selectable?: boolean;
 }
 
@@ -22,8 +22,7 @@ interface DialogData {
 })
 export class SafeResourceGridModalComponent implements OnInit {
   public multiSelect = false;
-  public gridSettings: GridSettings = {};
-
+  public gridSettings: GridSettings;
   public selectedRows: any[] = [];
 
   /**
@@ -47,7 +46,11 @@ export class SafeResourceGridModalComponent implements OnInit {
     public dialogRef: MatDialogRef<SafeResourceGridModalComponent>,
     private ref: ApplicationRef
   ) {
-    this.multiSelect = this.data.multiselect;
+    if (this.data.multiselect !== undefined)
+      this.multiSelect = this.data.multiselect;
+    if (this.data.selectedRows !== undefined)
+      this.selectedRows = [...this.data.selectedRows];
+
     if (this.data.gridSettings.sort && !this.data.gridSettings.sort.field) {
       delete this.data.gridSettings.sort;
     }
@@ -55,15 +58,12 @@ export class SafeResourceGridModalComponent implements OnInit {
       query: this.data.gridSettings,
       actions: {
         delete: false,
-        history: true,
+        history: false,
         convert: false,
         update: false,
         inlineEdition: false,
       },
     };
-    if (this.data.selectedRows) {
-      this.selectedRows = [...this.data.selectedRows];
-    }
     this.ref.tick();
   }
 

--- a/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.module.ts
+++ b/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.module.ts
@@ -9,6 +9,7 @@ import { SafeApplicationDropdownModule } from '../application-dropdown/applicati
 import { SafeRecordDropdownModule } from '../record-dropdown/record-dropdown.module';
 import { SafeCoreGridModule } from '../ui/core-grid/core-grid.module';
 import { TranslateModule } from '@ngx-translate/core';
+import { SafeButtonModule } from '../ui/button/button.module';
 
 /**
  * Resource grid modal component module.
@@ -24,6 +25,7 @@ import { TranslateModule } from '@ngx-translate/core';
     SafeApplicationDropdownModule,
     SafeRecordDropdownModule,
     SafeCoreGridModule,
+    SafeButtonModule,
     TranslateModule,
   ],
   exports: [SafeResourceGridModalComponent],

--- a/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -47,7 +47,7 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { SafeExportComponent } from '../export/export.component';
 import { GridLayout } from '../models/grid-layout.model';
 import { SafeErrorsModalComponent } from '../errors-modal/errors-modal.component';
-import { get } from 'lodash';
+import { get, intersection } from 'lodash';
 
 /**
  * Factory for creating scroll strategy
@@ -122,6 +122,8 @@ export class SafeGridComponent implements OnInit, AfterViewInit {
   public gradientSettings = GRADIENT_SETTINGS;
   public editing = false;
 
+  private readonly rowActions = ['update', 'delete', 'history', 'convert'];
+
   // === ACTIONS ===
   @Input() actions = {
     add: false,
@@ -137,7 +139,14 @@ export class SafeGridComponent implements OnInit, AfterViewInit {
 
   /** @returns A boolean indicating if actions are enabled */
   get hasEnabledActions(): boolean {
-    return Object.values(this.actions).includes(true);
+    return (
+      intersection(
+        Object.keys(this.actions).filter(
+          (key: string) => get(this.actions, key, false) === true
+        ),
+        this.rowActions
+      ).length > 0
+    );
   }
 
   // === DISPLAY ===

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display-tab.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display-tab.component.html
@@ -18,7 +18,7 @@
     </div>
     <mat-divider class="space-divider"></mat-divider>
     <mat-slide-toggle formControlName="showDatasourceLink" class="form-field slide-toggle-field">
-      Show link to datasource
+      {{ 'components.widget.settings.summaryCard.card.display.dataSource' | translate }}
     </mat-slide-toggle>
   </div>
 </form>

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display-tab.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display-tab.component.html
@@ -17,7 +17,7 @@
       </mat-form-field>
     </div>
     <mat-divider class="space-divider"></mat-divider>
-    <mat-slide-toggle formControlName="showDatasourceLink" class="form-field slide-toggle-field">
+    <mat-slide-toggle formControlName="showDatasourceLink" class="slide-toggle-field">
       {{ 'components.widget.settings.summaryCard.card.display.dataSource' | translate }}
     </mat-slide-toggle>
   </div>

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display-tab.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display-tab.component.html
@@ -17,7 +17,7 @@
       </mat-form-field>
     </div>
     <mat-divider class="space-divider"></mat-divider>
-    <mat-slide-toggle formControlName="showDatasourceLink" class="slide-toggle-field">
+    <mat-slide-toggle formControlName="showDataSourceLink" class="slide-toggle-field">
       {{ 'components.widget.settings.summaryCard.card.display.dataSource' | translate }}
     </mat-slide-toggle>
   </div>

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display-tab.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display-tab.component.html
@@ -16,5 +16,9 @@
         <input matInput formControlName="width" type="number" />
       </mat-form-field>
     </div>
+    <mat-divider class="space-divider"></mat-divider>
+    <mat-slide-toggle formControlName="showDatasourceLink" class="form-field slide-toggle-field">
+      Show link to datasource
+    </mat-slide-toggle>
   </div>
 </form>

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display-tab.component.scss
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display-tab.component.scss
@@ -3,3 +3,13 @@
     flex: 1;
   }
 }
+
+.space-divider {
+  margin-top: .5em;
+  margin-bottom: 2.5em;
+}
+
+.slide-toggle-field {
+  margin-left: 10px;
+  margin-bottom: 1em;
+}

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display.module.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/display-tab/display.module.ts
@@ -1,8 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { TranslateModule } from '@ngx-translate/core';
 import { SafeDisplayTabComponent } from './display-tab.component';
 
@@ -16,6 +18,8 @@ import { SafeDisplayTabComponent } from './display-tab.component';
     MatFormFieldModule,
     ReactiveFormsModule,
     MatInputModule,
+    MatDividerModule,
+    MatSlideToggleModule,
   ],
   exports: [SafeDisplayTabComponent],
 })

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
@@ -1,5 +1,6 @@
 import { gql } from 'apollo-angular';
 import { Record } from '../../../../models/record.model';
+import { Layout } from '../../../../models/layout.model';
 
 // === GET RECORD BY ID ===
 /** Graphql request for getting a record by its id */
@@ -30,4 +31,27 @@ export const GET_RECORD_BY_ID = gql`
 export interface GetRecordByIdQueryResponse {
   loading: boolean;
   record: Record;
+}
+
+/** Graphql request for getting resource meta date for a grid */
+export const GET_RESOURCE_LAYOUTS = gql`
+  query GetResource($id: ID!) {
+    resource(id: $id) {
+      layouts {
+        id
+        query
+      }
+    }
+  }
+`;
+
+/** Model for GetResourceByIdQueryResponse object */
+export interface GetResourceLayoutsByIdQueryResponse {
+  loading: boolean;
+  resource: {
+    layouts: {
+      id: Layout['id'];
+      query: Layout['query'];
+    }[];
+  };
 }

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -48,7 +48,8 @@
               (click)="openDatasource(card.value)"
               *ngIf="card.value.showDatasourceLink"
             >
-              Datasource <safe-icon icon="open_in_new" [inline]="true"></safe-icon>
+              {{ 'components.widget.summaryCard.dataSource' | translate }}
+              <safe-icon icon="open_in_new" [inline]="true"></safe-icon>
             </button>
           </div>
         </kendo-tilelayout-item-header>

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -45,8 +45,8 @@
             <button
               mat-button
               color="primary"
-              (click)="openDatasource(card.value)"
-              *ngIf="card.value.showDatasourceLink"
+              (click)="openDataSource(card.value)"
+              *ngIf="card.value.showDataSourceLink"
             >
               {{ 'components.widget.summaryCard.dataSource' | translate }}
               <safe-icon icon="open_in_new" [inline]="true"></safe-icon>

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -41,6 +41,16 @@
           <span class="widget-title" [title]="card.value.title">{{
             card.value.title
           }}</span>
+          <div class="floating-button">
+            <button
+              mat-button
+              color="primary"
+              (click)="openDatasource(card.value)"
+              *ngIf="card.value.showDatasourceLink"
+            >
+              Datasource <safe-icon icon="open_in_new" [inline]="true"></safe-icon>
+            </button>
+          </div>
         </kendo-tilelayout-item-header>
         <safe-button
           icon="more_vert"

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.scss
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.scss
@@ -40,10 +40,6 @@ kendo-tilelayout {
       cursor: grab;
       pointer-events: none;
     }
-
-    .widget-header {
-      padding-left: 15px !important;
-    }
   }
 }
 

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.scss
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.scss
@@ -40,6 +40,10 @@ kendo-tilelayout {
       cursor: grab;
       pointer-events: none;
     }
+
+    .widget-header {
+      padding-left: 15px !important;
+    }
   }
 }
 

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -175,6 +175,7 @@ export class SafeSummaryCardSettingsComponent implements OnInit, AfterViewInit {
       layout: [get(value, 'layout', [])],
       record: get(value, 'record', null),
       html: get(value, 'html', null),
+      showDatasourceLink: get(value, 'showDatasourceLink', false),
     });
   }
 
@@ -335,4 +336,11 @@ export class SafeSummaryCardSettingsComponent implements OnInit, AfterViewInit {
     }
     return fields;
   }
+
+  /**
+   * Open the datasource modal
+   *
+   * @param card The card to open
+   */
+  public openDatasource(card: any) {}
 }

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -14,8 +14,10 @@ import {
   TileLayoutReorderEvent,
   TileLayoutResizeEvent,
 } from '@progress/kendo-angular-layout';
+import { TranslateService } from '@ngx-translate/core';
 import { Apollo } from 'apollo-angular';
 import { get, has, clone } from 'lodash';
+import { SafeSnackBarService } from '../../../services/snackbar.service';
 import { SafeAddCardComponent } from './add-card/add-card.component';
 import { SafeCardModalComponent } from './card-modal/card-modal.component';
 import { SafeResourceGridModalComponent } from '../../search-resource-grid-modal/search-resource-grid-modal.component';
@@ -90,12 +92,16 @@ export class SafeSummaryCardSettingsComponent implements OnInit, AfterViewInit {
    * @param dialog Material Dialog Service.
    * @param apollo Used for getting the records query.
    * @param sanitizer Sanitizes the cards content so angular can show it up.
+   * @param snackBar snackbar service for error messages
+   * @param translate translation service
    */
   constructor(
     private fb: FormBuilder,
     private dialog: MatDialog,
     private apollo: Apollo,
-    private sanitizer: DomSanitizer
+    private sanitizer: DomSanitizer,
+    private snackBar: SafeSnackBarService,
+    private translate: TranslateService
   ) {}
 
   /**
@@ -349,9 +355,10 @@ export class SafeSummaryCardSettingsComponent implements OnInit, AfterViewInit {
    * @param card The card to open
    */
   public async openDatasource(card: any) {
-    const id = `${card.resource}-${card.layout}`;
-    if (!has(this.cardQueries, id)) {
-      // load and save the query object if not already saved
+    // the key of the layout used to save it, to not load it each time
+    const key = `${card.resource}-${card.layout}`;
+    // load and save the query of the layout if not already saved
+    if (!has(this.cardQueries, key)) {
       const res = await this.apollo
         .query<GetResourceLayoutsByIdQueryResponse>({
           query: GET_RESOURCE_LAYOUTS,
@@ -362,16 +369,26 @@ export class SafeSummaryCardSettingsComponent implements OnInit, AfterViewInit {
         .toPromise();
       if (!res.errors) {
         const layouts = res.data?.resource?.layouts || [];
-        Object.assign(this.cardQueries, {
-          [id]: layouts.find((l) => l.id === card.layout)?.query,
-        });
+        const query = layouts.find((l) => l.id === card.layout)?.query;
+        if (query) {
+          Object.assign(this.cardQueries, { [key]: query });
+        }
       }
     }
-    const query = get(this.cardQueries, id);
-    this.dialog.open(SafeResourceGridModalComponent, {
-      data: {
-        gridSettings: clone(query),
-      },
-    });
+    const cardQuery = get(this.cardQueries, key, null);
+    if (cardQuery) {
+      this.dialog.open(SafeResourceGridModalComponent, {
+        data: {
+          gridSettings: clone(cardQuery),
+        },
+      });
+    } else {
+      this.snackBar.openSnackBar(
+        this.translate.instant(
+          'components.widget.summaryCard.errors.invalidSource'
+        ),
+        { error: true }
+      );
+    }
   }
 }

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -187,7 +187,7 @@ export class SafeSummaryCardSettingsComponent implements OnInit, AfterViewInit {
       layout: [get(value, 'layout', [])],
       record: get(value, 'record', null),
       html: get(value, 'html', null),
-      showDatasourceLink: get(value, 'showDatasourceLink', false),
+      showDataSourceLink: get(value, 'showDataSourceLink', false),
     });
   }
 
@@ -350,11 +350,11 @@ export class SafeSummaryCardSettingsComponent implements OnInit, AfterViewInit {
   }
 
   /**
-   * Open the datasource modal
+   * Open the data source modal
    *
    * @param card The card to open
    */
-  public async openDatasource(card: any) {
+  public async openDataSource(card: any) {
     // the key of the layout used to save it, to not load it each time
     const key = `${card.resource}-${card.layout}`;
     // load and save the query of the layout if not already saved
@@ -381,6 +381,7 @@ export class SafeSummaryCardSettingsComponent implements OnInit, AfterViewInit {
         data: {
           gridSettings: clone(cardQuery),
         },
+        panelClass: 'closable-dialog',
       });
     } else {
       this.snackBar.openSnackBar(

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.module.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.module.ts
@@ -15,6 +15,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatDividerModule } from '@angular/material/divider';
 import { SafeAddCardModule } from './add-card/add-card.module';
 import { SafeCardModalModule } from './card-modal/card-modal.module';
+import { MatButtonModule } from '@angular/material/button';
 
 /** Summary Card Settings Module */
 @NgModule({
@@ -36,6 +37,7 @@ import { SafeCardModalModule } from './card-modal/card-modal.module';
     MatDividerModule,
     SafeAddCardModule,
     SafeCardModalModule,
+    MatButtonModule,
   ],
   exports: [SafeSummaryCardSettingsComponent],
 })

--- a/projects/safe/src/lib/components/widgets/summary-card/graphql/queries.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/graphql/queries.ts
@@ -1,5 +1,6 @@
 import { gql } from 'apollo-angular';
 import { Record } from '../../../../models/record.model';
+import { Layout } from '../../../../models/layout.model';
 
 // === GET RECORD BY ID ===
 /** Graphql request for getting a record by its id */
@@ -30,4 +31,27 @@ export const GET_RECORD_BY_ID = gql`
 export interface GetRecordByIdQueryResponse {
   loading: boolean;
   record: Record;
+}
+
+/** Graphql request for getting resource meta date for a grid */
+export const GET_RESOURCE_LAYOUTS = gql`
+  query GetResource($id: ID!) {
+    resource(id: $id) {
+      layouts {
+        id
+        query
+      }
+    }
+  }
+`;
+
+/** Model for GetResourceByIdQueryResponse object */
+export interface GetResourceLayoutsByIdQueryResponse {
+  loading: boolean;
+  resource: {
+    layouts: {
+      id: Layout['id'];
+      query: Layout['query'];
+    }[];
+  };
 }

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -22,6 +22,16 @@
           <span class="widget-title" [title]="card.title">{{
             card.title
           }}</span>
+          <div class="floating-button">
+            <button
+              mat-button
+              color="primary"
+              (click)="openDatasource(card)"
+              *ngIf="card.showDatasourceLink"
+            >
+              Datasource <safe-icon icon="open_in_new" [inline]="true"></safe-icon>
+            </button>
+          </div>
         </kendo-tilelayout-item-header>
         <div
           class="card-content"

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -29,7 +29,8 @@
               (click)="openDatasource(card)"
               *ngIf="card.showDatasourceLink"
             >
-              Datasource <safe-icon icon="open_in_new" [inline]="true"></safe-icon>
+              {{ 'components.widget.summaryCard.dataSource' | translate }}
+              <safe-icon icon="open_in_new" [inline]="true"></safe-icon>
             </button>
           </div>
         </kendo-tilelayout-item-header>

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -26,8 +26,8 @@
             <button
               mat-button
               color="primary"
-              (click)="openDatasource(card)"
-              *ngIf="card.showDatasourceLink"
+              (click)="openDataSource(card)"
+              *ngIf="card.showDataSourceLink"
             >
               {{ 'components.widget.summaryCard.dataSource' | translate }}
               <safe-icon icon="open_in_new" [inline]="true"></safe-icon>

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.scss
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.scss
@@ -30,6 +30,10 @@ kendo-tilelayout {
       cursor: grab;
       pointer-events: none;
     }
+
+    .widget-header {
+      padding: 0 5px 0 15px !important;
+    }
   }
 }
 

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -148,4 +148,11 @@ export class SafeSummaryCardComponent implements OnInit {
     }
     return fields;
   }
+
+  /**
+   * Open the datasource modal
+   *
+   * @param card The card to open
+   */
+  public openDatasource(card: any) {}
 }

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -69,7 +69,6 @@ export class SafeSummaryCardComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    console.log(this.settings);
     this.getCardsContent(this.settings.cards);
   }
 
@@ -169,11 +168,11 @@ export class SafeSummaryCardComponent implements OnInit {
   }
 
   /**
-   * Open the datasource modal
+   * Open the dataSource modal
    *
    * @param card The card to open
    */
-  public async openDatasource(card: any) {
+  public async openDataSource(card: any) {
     // the key of the layout used to save it, to not load it each time
     const key = `${card.resource}-${card.layout}`;
     // load and save the query of the layout if not already saved
@@ -200,6 +199,7 @@ export class SafeSummaryCardComponent implements OnInit {
         data: {
           gridSettings: clone(cardQuery),
         },
+        panelClass: 'closable-dialog',
       });
     } else {
       this.snackBar.openSnackBar(

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card.module.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card.module.ts
@@ -6,6 +6,7 @@ import { SafeSummaryCardComponent } from './summary-card.component';
 import { SafeButtonModule } from '../../ui/button/button.module';
 import { SafeIconModule } from '../../ui/icon/icon.module';
 import { MatButtonModule } from '@angular/material/button';
+import { TranslateModule } from '@ngx-translate/core';
 
 /** Summary Card Widget Module */
 @NgModule({
@@ -17,6 +18,7 @@ import { MatButtonModule } from '@angular/material/button';
     PDFExportModule,
     SafeIconModule,
     MatButtonModule,
+    TranslateModule,
   ],
   exports: [SafeSummaryCardComponent],
 })

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card.module.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card.module.ts
@@ -1,14 +1,23 @@
 import { LayoutModule } from '@progress/kendo-angular-layout';
+import { PDFExportModule } from '@progress/kendo-angular-pdf-export';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SafeSummaryCardComponent } from './summary-card.component';
 import { SafeButtonModule } from '../../ui/button/button.module';
-import { PDFExportModule } from '@progress/kendo-angular-pdf-export';
+import { SafeIconModule } from '../../ui/icon/icon.module';
+import { MatButtonModule } from '@angular/material/button';
 
 /** Summary Card Widget Module */
 @NgModule({
   declarations: [SafeSummaryCardComponent],
-  imports: [CommonModule, LayoutModule, SafeButtonModule, PDFExportModule],
+  imports: [
+    CommonModule,
+    LayoutModule,
+    SafeButtonModule,
+    PDFExportModule,
+    SafeIconModule,
+    MatButtonModule,
+  ],
   exports: [SafeSummaryCardComponent],
 })
 export class SafeSummaryCardModule {}

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -550,6 +550,7 @@ body {
   }
 }
 
+.closable-dialog,
 .tile-settings-dialog,
 .expanded-widget-dialog {
   mat-dialog-container {

--- a/projects/safe/src/lib/survey/components/utils.ts
+++ b/projects/safe/src/lib/survey/components/utils.ts
@@ -39,6 +39,7 @@ export const buildSearchButton = (
             : [],
           selectable: true,
         },
+        panelClass: 'closable-dialog',
       });
       dialogRef.afterClosed().subscribe((rows: any[]) => {
         if (!rows) {


### PR DESCRIPTION
# Description

Add a link to data source for summary cards. **Only for resources data** for the moment.
* Add a setting to show or hide the link
* Add the link as a button on the header of a summary card
* Show an error if the source cannot be loaded
* Re-use the `SafeResourceGridModalComponent` to show the resource, with a little style update when the `selectable` option is set to false.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Create a summary card with a resource as data source, and check the "show datasource link" option.
Then on the card, click on the "Data Source" button.

**Warning**: the click on the button will not work if the summary card is the first one of the widget, because of a bug (the summary card is moved randomly when we click the header of the card). Should be corrected in another ticket.

## Screenshots

![image](https://user-images.githubusercontent.com/103410601/184838102-161fbe06-f7a7-4a9f-bd00-8a3b86c5fa48.png)
![image](https://user-images.githubusercontent.com/103410601/184838290-af076a0a-ce34-422e-9630-8a6e3af2b8b4.png)
![image](https://user-images.githubusercontent.com/103410601/184838548-4125e46d-c43f-4c57-8db0-d4cacf71abad.png)




# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Linting does not generate new warnings
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
