### PR TITLE
AB#39529 Bug of card items teleporting

### DIFF
--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -17,6 +17,7 @@
         *ngFor="let card of settings.cards; let i = index"
         [colSpan]="card.width > colsNumber ? colsNumber : card.width"
         [rowSpan]="card.height"
+        class="kendo-tilelayout-item-correction"
       >
         <kendo-tilelayout-item-header class="widget-header">
           <span class="widget-title" [title]="card.title">{{

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.scss
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card.component.scss
@@ -10,6 +10,16 @@ kendo-tilelayout {
     overflow: hidden;
     box-shadow: 0 2px 5px 0 rgba(134, 134, 134, 0.2);
 
+    &.kendo-tilelayout-item-correction {
+      /** Revert the css changes made by kendo when we click on the header */
+      position: relative !important;
+      left: unset !important;
+      top: unset !important;
+      width: unset !important;
+      height: unset !important;
+      z-index: 0 !important;
+    }
+
     .widget-options,
     .widget-handle {
       position: absolute;


### PR DESCRIPTION
# Description
Fix a bug where the first card item teleport itself when clicked on the header.

Cause: nesting tile-layouts. The tile layout kendo component is not supposed to be nested inside another one, so it breaks because of some interns stuffs .

Solution: prevent kendo to change the css properties on a click action, by adding the same properties with their values before the click and the *important* tag in a class (not on the component itself since the javascript code of kendo changes the value of the component properties).


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Click on the header of the first card. Also tested with a button in the header.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Linting does not generate new warnings
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
