### PR TITLE
Feat 1.3.0/oort 446 hide some parts of help of tinymce

### DIFF
--- a/projects/safe/src/lib/const/tinymce.const.ts
+++ b/projects/safe/src/lib/const/tinymce.const.ts
@@ -50,6 +50,6 @@ export const EMAIL_EDITOR_CONFIG = {
   file_browser_callback: false, // removes possibility to upload files
   help_tabs: [
     'shortcuts', // the default shortcuts tab
-    'keyboardnav' // the default keyboard navigation tab
-  ]
+    'keyboardnav', // the default keyboard navigation tab
+  ],
 };

--- a/projects/safe/src/lib/const/tinymce.const.ts
+++ b/projects/safe/src/lib/const/tinymce.const.ts
@@ -48,4 +48,8 @@ export const EMAIL_EDITOR_CONFIG = {
   contextmenu: 'link image imagetools table',
   content_style: 'body { font-family: Roboto, "Helvetica Neue", sans-serif; }',
   file_browser_callback: false, // removes possibility to upload files
+  help_tabs: [
+    'shortcuts', // the default shortcuts tab
+    'keyboardnav' // the default keyboard navigation tab
+  ]
 };


### PR DESCRIPTION
# Description

Hide plugins and version parts of the 'help' of tinymce by adding a help_tabs field with the desired values.


## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Go to a grid setting, enable quick action buttons, click on send email and click on help

## Sreenshots
![help_mail_improvment](https://user-images.githubusercontent.com/59767527/190583027-075617a4-31d2-490c-894d-226044079143.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
