### PR TITLE
Feat 1.3.0/oort 448 prevent system to automatically update roles

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -756,7 +756,8 @@
 					"backoffice": "Back-Office roles",
 					"selectedApplication": "Selected application",
 					"selectedGroups": "Selected groups",
-					"selectedRoles": "Selected roles"
+					"selectedRoles": "Selected roles",
+					"updateUserRoles": "Update user roles"
 				},
 				"title": "Summary"
 			},

--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -754,6 +754,7 @@
 				"roles": {
 					"application": "Application roles",
 					"backoffice": "Back-Office roles",
+					"currentRoles": "Current roles",
 					"selectedApplication": "Selected application",
 					"selectedGroups": "Selected groups",
 					"selectedRoles": "Selected roles",

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -754,6 +754,7 @@
 				"roles": {
 					"application": "Rôles d'application",
 					"backoffice": "Rôles de back-office",
+					"currentRoles": "Rôles actuels",
 					"selectedApplication": "Application sélectionnée",
 					"selectedGroups": "Groupes sélectionnés",
 					"selectedRoles": "Rôles sélectionnés",

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -756,7 +756,8 @@
 					"backoffice": "Rôles de back-office",
 					"selectedApplication": "Application sélectionnée",
 					"selectedGroups": "Groupes sélectionnés",
-					"selectedRoles": "Rôles sélectionnés"
+					"selectedRoles": "Rôles sélectionnés",
+					"updateUserRoles": "Mettre à jour les rôles d'utilisateur"
 				},
 				"title": "Résumé"
 			},

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -756,7 +756,8 @@
 					"backoffice": "******",
 					"selectedApplication": "******",
 					"selectedGroups": "******",
-					"selectedRoles": "******"
+					"selectedRoles": "******",
+					"updateUserRoles": "******"
 				},
 				"title": "******"
 			},

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -754,6 +754,7 @@
 				"roles": {
 					"application": "******",
 					"backoffice": "******",
+					"currentRoles": "******",
 					"selectedApplication": "******",
 					"selectedGroups": "******",
 					"selectedRoles": "******",

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.html
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.html
@@ -13,7 +13,6 @@
         category="secondary"
         variant="primary"
         (click)="onUpdate()" 
-        cdkFocusInitial
       >
         {{ confirmText }}
       </safe-button>

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.html
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.html
@@ -1,0 +1,24 @@
+<safe-modal>
+    <h1 mat-dialog-title>{{ title }}</h1>
+    <mat-dialog-content>{{ roles }}</mat-dialog-content>
+    <div mat-dialog-actions align="end">
+      <!-- <button mat-button mat-dialog-close>{{ cancelText }}</button>
+      <button
+        mat-flat-button
+        [color]="confirmColor"
+        cdkFocusInitial
+        [mat-dialog-close]="true"
+      >
+        {{ confirmText }}
+      </button> -->
+      <safe-button mat-dialog-close>{{ cancelText }}</safe-button>
+      <safe-button
+        category="secondary"
+        variant="primary"
+        [mat-dialog-close]="true"
+        cdkFocusInitial
+      >
+        {{ confirmText }}
+      </safe-button>
+    </div>
+  </safe-modal>

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.html
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.html
@@ -1,21 +1,18 @@
 <safe-modal>
     <h1 mat-dialog-title>{{ title }}</h1>
-    <mat-dialog-content>{{ roles }}</mat-dialog-content>
+    <mat-form-field appearance="outline">
+      <mat-select [formControl]="selectedRoles" multiple>
+        <mat-option *ngFor="let role of roles" [value]="role.id">
+          {{ role.title }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
     <div mat-dialog-actions align="end">
-      <!-- <button mat-button mat-dialog-close>{{ cancelText }}</button>
-      <button
-        mat-flat-button
-        [color]="confirmColor"
-        cdkFocusInitial
-        [mat-dialog-close]="true"
-      >
-        {{ confirmText }}
-      </button> -->
       <safe-button mat-dialog-close>{{ cancelText }}</safe-button>
       <safe-button
         category="secondary"
         variant="primary"
-        [mat-dialog-close]="true"
+        (click)="onUpdate()" 
         cdkFocusInitial
       >
         {{ confirmText }}

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.spec.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserBackRolesModalComponent } from './user-back-roles-modal.component';
+
+describe('UserBackRolesModalComponent', () => {
+  let component: UserBackRolesModalComponent;
+  let fixture: ComponentFixture<UserBackRolesModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [UserBackRolesModalComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserBackRolesModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
+
+/**
+ * This interface describes the structure of the data to be displayed in the modal
+ */
+interface DialogData {
+  roles: any[];
+}
+
+/**
+ * This component is used to change the user roles
+ */
+@Component({
+  selector: 'safe-user-back-roles-modal',
+  templateUrl: './user-back-roles-modal.component.html',
+  styleUrls: ['./user-back-roles-modal.component.scss'],
+})
+export class SafeUserBackRolesModalComponent implements OnInit {
+  public roles: any[];
+  public title: string;
+  public cancelText: string;
+  public confirmText: string;
+  public confirmColor: string;
+
+  /**
+   * The constructor function is a special function that is called when a new instance of the class is
+   * created.
+   *
+   * @param data The data to be displayed in the modal
+   * @param translate The translating service used to translate the different texts except the content of the modal
+   */
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: DialogData,
+    private translate: TranslateService
+  ) {
+    this.title = 'Select roles';
+    this.cancelText = this.translate.instant(
+      'components.userBackRolesModal.cancel'
+    );
+    this.confirmText = this.translate.instant(
+      'components.userBackRolesModal.confirm'
+    );
+    this.confirmColor = 'primary';
+    this.roles = data.roles;
+  }
+
+  ngOnInit(): void {}
+}

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.ts
@@ -1,12 +1,16 @@
-import { Component, OnInit, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Component, OnInit, Inject, Output, EventEmitter } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
+import { FormBuilder, FormControl } from '@angular/forms';
+import { Role, User } from '../../../../../models/user.model';
 
 /**
  * This interface describes the structure of the data to be displayed in the modal
  */
 interface DialogData {
-  roles: any[];
+  selectedRoles: FormControl;
+  roles: Role[];
+  edit: any;
 }
 
 /**
@@ -18,7 +22,9 @@ interface DialogData {
   styleUrls: ['./user-back-roles-modal.component.scss'],
 })
 export class SafeUserBackRolesModalComponent implements OnInit {
-  public roles: any[];
+  public edit: any;
+  public selectedRoles: FormControl;
+  public roles: Role[];
   public title: string;
   public cancelText: string;
   public confirmText: string;
@@ -30,21 +36,36 @@ export class SafeUserBackRolesModalComponent implements OnInit {
    *
    * @param data The data to be displayed in the modal
    * @param translate The translating service used to translate the different texts except the content of the modal
+   * @param dialogRef The current dialog reference
    */
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: DialogData,
-    private translate: TranslateService
+    private translate: TranslateService,
+    public dialogRef: MatDialogRef<SafeUserBackRolesModalComponent>
   ) {
-    this.title = 'Select roles';
-    this.cancelText = this.translate.instant(
-      'components.userBackRolesModal.cancel'
+    this.title = this.translate.instant(
+      'components.user.summary.roles.updateUserRoles'
     );
-    this.confirmText = this.translate.instant(
-      'components.userBackRolesModal.confirm'
-    );
+    this.cancelText = this.translate.instant('kendo.editor.dialogCancel');
+    this.confirmText = this.translate.instant('kendo.editor.dialogUpdate');
     this.confirmColor = 'primary';
+
+    this.selectedRoles = data.selectedRoles;
+    this.selectedRoles.enable();
     this.roles = data.roles;
+    this.edit = data.edit;
   }
 
   ngOnInit(): void {}
+
+  /**
+   * Update selected roles
+   */
+  onUpdate(): void {
+    const update = { roles: this.selectedRoles.value };
+    console.log(update);
+    this.edit.emit(update);
+    console.log('UPDATE');
+    this.dialogRef.close();
+  }
 }

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.component.ts
@@ -44,7 +44,7 @@ export class SafeUserBackRolesModalComponent implements OnInit {
     public dialogRef: MatDialogRef<SafeUserBackRolesModalComponent>
   ) {
     this.title = this.translate.instant(
-      'components.user.summary.roles.updateUserRoles'
+      'components.user.summary.roles.selectedRoles'
     );
     this.cancelText = this.translate.instant('kendo.editor.dialogCancel');
     this.confirmText = this.translate.instant('kendo.editor.dialogUpdate');
@@ -65,7 +65,6 @@ export class SafeUserBackRolesModalComponent implements OnInit {
     const update = { roles: this.selectedRoles.value };
     console.log(update);
     this.edit.emit(update);
-    console.log('UPDATE');
-    this.dialogRef.close();
+    this.dialogRef.close(true);
   }
 }

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.module.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.module.ts
@@ -5,6 +5,9 @@ import { MatButtonModule } from '@angular/material/button';
 import { SafeModalModule } from '../../../../ui/modal/modal.module';
 import { SafeButtonModule } from '../../../../ui/button/button.module';
 import { SafeUserBackRolesModalComponent } from './user-back-roles-modal.component';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 /**
  * SafeUserBackRolesModalModul is a class used to manage all the modules and components
@@ -18,6 +21,10 @@ import { SafeUserBackRolesModalComponent } from './user-back-roles-modal.compone
     MatButtonModule,
     SafeModalModule,
     SafeButtonModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    FormsModule,
+    ReactiveFormsModule,
   ],
   exports: [SafeUserBackRolesModalComponent],
 })

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.module.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles-modal/user-back-roles-modal.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { SafeModalModule } from '../../../../ui/modal/modal.module';
+import { SafeButtonModule } from '../../../../ui/button/button.module';
+import { SafeUserBackRolesModalComponent } from './user-back-roles-modal.component';
+
+/**
+ * SafeUserBackRolesModalModul is a class used to manage all the modules and components
+ * related to the general confirmation modals.
+ */
+@NgModule({
+  declarations: [SafeUserBackRolesModalComponent],
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    SafeModalModule,
+    SafeButtonModule,
+  ],
+  exports: [SafeUserBackRolesModalComponent],
+})
+export class SafeUserBackRolesModalModule {}

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.html
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.html
@@ -10,11 +10,11 @@
       </mat-option>
     </mat-select>
   </mat-form-field>
-
+  
   <safe-button
   variant="primary"
   category="secondary"
   type="submit"
   (click)="openDialog()"
-  >{{ 'common.saveChanges' | translate }}</safe-button>
+  >{{ 'components.user.summary.roles.updateUserRoles' | translate }}</safe-button>
 </div>

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.html
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.html
@@ -10,4 +10,11 @@
       </mat-option>
     </mat-select>
   </mat-form-field>
+
+  <safe-button
+  variant="primary"
+  category="secondary"
+  type="submit"
+  (click)="openDialog()"
+  >{{ 'common.saveChanges' | translate }}</safe-button>
 </div>

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.html
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.html
@@ -2,7 +2,7 @@
   <h2>{{ 'components.user.summary.roles.backoffice' | translate }}</h2>
   <mat-form-field appearance="outline">
     <mat-label>
-      {{ 'components.user.summary.roles.selectedRoles' | translate }}</mat-label
+      {{ 'components.user.summary.roles.currentRoles' | translate }}</mat-label
     >
     <mat-select [formControl]="selectedRoles" multiple>
       <mat-option *ngFor="let role of roles" [value]="role.id">

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.ts
@@ -26,6 +26,7 @@ export class UserBackRolesComponent implements OnInit {
       this.selectedRoles?.disable({ emitEvent: false });
     } else {
       this.selectedRoles?.enable({ emitEvent: false });
+      this.selectedRoles?.disable();
     }
   }
 
@@ -50,6 +51,7 @@ export class UserBackRolesComponent implements OnInit {
         .filter((x: Role) => !x.application)
         .map((x) => x.id)
     );
+
     /*
     this.selectedRoles.valueChanges.subscribe((value) => {
       this.edit.emit({ roles: value });

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.ts
@@ -5,6 +5,8 @@ import { get } from 'lodash';
 import { Role, User } from '../../../../models/user.model';
 import { GetRolesQueryResponse, GET_ROLES } from '../../graphql/queries';
 import { SafeSnackBarService } from '../../../../services/snackbar.service';
+import { SafeUserBackRolesModalComponent } from './user-back-roles-modal/user-back-roles-modal.component';
+import { MatDialog } from '@angular/material/dialog';
 
 /** Back-office roles section the user summary */
 @Component({
@@ -33,11 +35,13 @@ export class UserBackRolesComponent implements OnInit {
    * @param fb Angular form builder
    * @param apollo Apollo client
    * @param snackBar Shared snackbar service
+   * @param dialog Material dialogs service
    */
   constructor(
     private fb: FormBuilder,
     private apollo: Apollo,
-    private snackBar: SafeSnackBarService
+    private snackBar: SafeSnackBarService,
+    public dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
@@ -46,9 +50,11 @@ export class UserBackRolesComponent implements OnInit {
         .filter((x: Role) => !x.application)
         .map((x) => x.id)
     );
+    /*
     this.selectedRoles.valueChanges.subscribe((value) => {
       this.edit.emit({ roles: value });
     });
+    */
 
     this.loading = true;
     this.apollo
@@ -66,5 +72,18 @@ export class UserBackRolesComponent implements OnInit {
           this.snackBar.openSnackBar(err.message, { error: true });
         }
       );
+  }
+
+  /**
+   * Opens the modal "SafeUserBackRolesModal"
+   */
+  openDialog() {
+    const dialogRef = this.dialog.open(SafeUserBackRolesModalComponent, {
+      data: { roles: ['test', 'test2'] },
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      console.log('Dialog result: ${result}');
+    });
   }
 }

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.ts
@@ -17,7 +17,7 @@ import { MatDialog } from '@angular/material/dialog';
 export class UserBackRolesComponent implements OnInit {
   public roles: Role[] = [];
   @Input() user!: User;
-  selectedRoles!: FormControl;
+  public selectedRoles!: FormControl;
   @Output() edit = new EventEmitter();
 
   /** Setter for the loading state */
@@ -81,11 +81,21 @@ export class UserBackRolesComponent implements OnInit {
    */
   openDialog() {
     const dialogRef = this.dialog.open(SafeUserBackRolesModalComponent, {
-      data: { roles: ['test', 'test2'] },
+      data: {
+        selectedRoles: this.selectedRoles,
+        roles: this.roles,
+        edit: this.edit,
+      },
     });
 
     dialogRef.afterClosed().subscribe((result) => {
-      console.log('Dialog result: ${result}');
+      console.log('TEEEEEEEEEEST');
+      this.selectedRoles = this.fb.control(
+        get(this.user, 'roles', [])
+          .filter((x: Role) => !x.application)
+          .map((x) => x.id)
+      );
+      this.selectedRoles.disable();
     });
   }
 }

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-back-roles/user-back-roles.component.ts
@@ -52,12 +52,6 @@ export class UserBackRolesComponent implements OnInit {
         .map((x) => x.id)
     );
 
-    /*
-    this.selectedRoles.valueChanges.subscribe((value) => {
-      this.edit.emit({ roles: value });
-    });
-    */
-
     this.loading = true;
     this.apollo
       .query<GetRolesQueryResponse>({
@@ -77,9 +71,11 @@ export class UserBackRolesComponent implements OnInit {
   }
 
   /**
-   * Opens the modal "SafeUserBackRolesModal"
+   * Opens the modal "SafeUserBackRolesModal" with the required data.
+   * After closed, update the selectedRoles content
    */
   openDialog() {
+    const oldValue = this.selectedRoles.value;
     const dialogRef = this.dialog.open(SafeUserBackRolesModalComponent, {
       data: {
         selectedRoles: this.selectedRoles,
@@ -88,14 +84,13 @@ export class UserBackRolesComponent implements OnInit {
       },
     });
 
-    dialogRef.afterClosed().subscribe((result) => {
-      console.log('TEEEEEEEEEEST');
-      this.selectedRoles = this.fb.control(
-        get(this.user, 'roles', [])
-          .filter((x: Role) => !x.application)
-          .map((x) => x.id)
-      );
+    dialogRef.afterClosed().subscribe((isUpdated) => {
       this.selectedRoles.disable();
+      if (isUpdated) {
+        this.selectedRoles.setValue(this.selectedRoles.value);
+      } else {
+        this.selectedRoles.setValue(oldValue);
+      }
     });
   }
 }

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-roles.module.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-roles.module.ts
@@ -9,6 +9,8 @@ import { UserAppRolesComponent } from './user-app-roles/user-app-roles.component
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { UserGroupsComponent } from './user-groups/user-groups.component';
 import { SafeGraphQLSelectModule } from '../../graphql-select/graphql-select.module';
+import { SafeButtonModule } from '../../ui/button/button.module';
+import { SafeUserBackRolesModalModule } from './user-back-roles/user-back-roles-modal/user-back-roles-modal.module';
 
 /**
  * User summary roles module
@@ -28,6 +30,8 @@ import { SafeGraphQLSelectModule } from '../../graphql-select/graphql-select.mod
     FormsModule,
     ReactiveFormsModule,
     SafeGraphQLSelectModule,
+    SafeButtonModule,
+    SafeUserBackRolesModalModule,
   ],
   exports: [UserRolesComponent],
 })

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-roles.module.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-roles.module.ts
@@ -11,6 +11,7 @@ import { UserGroupsComponent } from './user-groups/user-groups.component';
 import { SafeGraphQLSelectModule } from '../../graphql-select/graphql-select.module';
 import { SafeButtonModule } from '../../ui/button/button.module';
 import { SafeUserBackRolesModalModule } from './user-back-roles/user-back-roles-modal/user-back-roles-modal.module';
+import { MatListModule } from '@angular/material/list';
 
 /**
  * User summary roles module
@@ -32,6 +33,7 @@ import { SafeUserBackRolesModalModule } from './user-back-roles/user-back-roles-
     SafeGraphQLSelectModule,
     SafeButtonModule,
     SafeUserBackRolesModalModule,
+    MatListModule,
   ],
   exports: [UserRolesComponent],
 })

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-roles.module.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-roles.module.ts
@@ -11,7 +11,6 @@ import { UserGroupsComponent } from './user-groups/user-groups.component';
 import { SafeGraphQLSelectModule } from '../../graphql-select/graphql-select.module';
 import { SafeButtonModule } from '../../ui/button/button.module';
 import { SafeUserBackRolesModalModule } from './user-back-roles/user-back-roles-modal/user-back-roles-modal.module';
-import { MatListModule } from '@angular/material/list';
 
 /**
  * User summary roles module
@@ -33,7 +32,6 @@ import { MatListModule } from '@angular/material/list';
     SafeGraphQLSelectModule,
     SafeButtonModule,
     SafeUserBackRolesModalModule,
-    MatListModule,
   ],
   exports: [UserRolesComponent],
 })


### PR DESCRIPTION
# Description

Prevent system to automatically update the roles when selecting them by adding a new modal and changing user-back-role in consequence. Also adding fields in i18n.


## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Click on new "Update user roles" button, select new roles and click on update button. See the "Current roles" field updated.
- [x] Click on new "Update user roles" button, removing roles and click on update button. See the "Current roles" field updated.
- [x] Click on new "Update user roles" button, select new roles and click on cancel button or elsewhere. See the "Current roles" remians unchanged.

## Sreenshots

![user_back_roles](https://user-images.githubusercontent.com/59767527/191201479-601531bd-0537-4db8-b80f-e4f5aadb92cd.png)

![user_back_roles_modal](https://user-images.githubusercontent.com/59767527/191201506-23ae411f-2baa-4706-9105-59a2c6273a00.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
