### PR TITLE
OORT-449 Vertical tabs for summary card settings

### DIFF
--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/card-modal.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/card-modal.component.html
@@ -5,61 +5,79 @@
   <mat-dialog-content>
     <form [formGroup]="form">
       <mat-tab-group
+        vertical
+        animationDuration="0ms"
         #tabGroup
         (selectedTabChange)="handleTabChange($event)"
         [selectedIndex]="0"
       >
         <!-- Selection of data source -->
-        <mat-tab
-          [label]="
-            'components.widget.settings.summaryCard.card.dataSource.title'
-              | translate
-          "
-        >
-          <safe-data-source-tab
-            [form]="form"
-            [selectedResource]="selectedResource"
-            [selectedLayout]="selectedLayout"
-            (layoutChange)="handleLayoutChange($event)"
-          ></safe-data-source-tab>
+        <mat-tab>
+          <ng-template mat-tab-label>
+            <safe-icon icon="settings" [size]="24"></safe-icon>
+            <span>{{ 'components.widget.settings.summaryCard.card.dataSource.title' | translate }}</span>
+          </ng-template>
+          <ng-template matTabContent>
+            <safe-data-source-tab
+              [form]="form"
+              [selectedResource]="selectedResource"
+              [selectedLayout]="selectedLayout"
+              (layoutChange)="handleLayoutChange($event)"
+            ></safe-data-source-tab>
+          </ng-template>
         </mat-tab>
         <!-- Selection of record -->
         <mat-tab
-          [label]="
-            'components.widget.settings.summaryCard.card.valueSelector.title'
-              | translate
-          "
           *ngIf="!form.get('isDynamic')?.value"
         >
-          <safe-value-selector-tab
-            [form]="form"
-            [settings]="selectedLayout"
-          ></safe-value-selector-tab>
+          <ng-template mat-tab-label>
+            <safe-icon icon="list" [size]="24"></safe-icon>
+            <span>{{ 'components.widget.settings.summaryCard.card.valueSelector.title' | translate }}</span>
+          </ng-template>
+          <ng-template matTabContent>
+            <safe-value-selector-tab
+              [form]="form"
+              [settings]="selectedLayout"
+            ></safe-value-selector-tab>
+          </ng-template>
         </mat-tab>
         <!-- Card display settings -->
-        <mat-tab [label]="'common.display' | translate">
-          <safe-display-tab [form]="form"></safe-display-tab>
+        <mat-tab>
+          <ng-template mat-tab-label>
+            <safe-icon icon="display_settings" [size]="24"></safe-icon>
+            <span>{{ 'common.display' | translate }}</span>
+          </ng-template>
+          <ng-template matTabContent>
+            <safe-display-tab [form]="form"></safe-display-tab>
+          </ng-template>
         </mat-tab>
         <!-- Card text editor -->
-        <mat-tab
-          [label]="
-            'components.widget.settings.summaryCard.card.textEditor.title'
-              | translate
-          "
-        >
-          <safe-text-editor-tab
-            *ngIf="isEditorTab()"
-            [form]="form"
-            [fields]="fields"
-          ></safe-text-editor-tab>
+        <mat-tab>
+          <ng-template mat-tab-label>
+            <safe-icon icon="article" [size]="24"></safe-icon>
+            <span>{{ 'components.widget.settings.summaryCard.card.textEditor.title' | translate }}</span>
+          </ng-template>
+          <ng-template matTabContent>
+            <safe-text-editor-tab
+              *ngIf="isEditorTab()"
+              [form]="form"
+              [fields]="fields"
+            ></safe-text-editor-tab>
+          </ng-template>
         </mat-tab>
         <!-- Preview of card -->
         <mat-tab [label]="'common.preview' | translate">
-          <safe-preview-tab
-            [html]="form.value.html"
-            [record]="selectedRecord"
-            [fields]="fields"
-          ></safe-preview-tab>
+          <ng-template mat-tab-label>
+            <safe-icon icon="preview" [size]="24"></safe-icon>
+            <span>{{ 'common.preview' | translate }}</span>
+          </ng-template>
+          <ng-template matTabContent>
+            <safe-preview-tab
+              [html]="form.value.html"
+              [record]="selectedRecord"
+              [fields]="fields"
+            ></safe-preview-tab>
+          </ng-template>
         </mat-tab>
       </mat-tab-group>
     </form>


### PR DESCRIPTION
# Description

Summary card-settings tabs are now displayed vertically, as we have for grid-settings.
Not sure about what icons should be used. I selected what made more sense for me, but maybe we should create a list of icons for each type of setting/tab to have more cohesion.

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Checked in the app

## Screenshots

![Screenshot from 2022-09-21 15-54-47](https://user-images.githubusercontent.com/94831019/191526527-24edd062-908b-43f9-9a96-f7f75a79ea0f.png)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
