### PR TITLE
refactor-1.3/OORT-454_using-safe-dividers

### DIFF
--- a/projects/back-office/src/app/app-preview/components/preview-toolbar/preview-toolbar.component.html
+++ b/projects/back-office/src/app/app-preview/components/preview-toolbar/preview-toolbar.component.html
@@ -5,4 +5,4 @@
     }}</safe-button>
   </div>
 </div>
-<mat-divider></mat-divider>
+<safe-divider style="margin: unset"></safe-divider>

--- a/projects/back-office/src/app/app-preview/components/preview-toolbar/preview-toolbar.module.ts
+++ b/projects/back-office/src/app/app-preview/components/preview-toolbar/preview-toolbar.module.ts
@@ -1,8 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PreviewToolbarComponent } from './preview-toolbar.component';
-import { MatDividerModule } from '@angular/material/divider';
-import { SafeButtonModule } from '@safe/builder';
+import { SafeButtonModule, SafeDividerModule } from '@safe/builder';
 import { TranslateModule } from '@ngx-translate/core';
 
 /**
@@ -10,7 +9,7 @@ import { TranslateModule } from '@ngx-translate/core';
  */
 @NgModule({
   declarations: [PreviewToolbarComponent],
-  imports: [CommonModule, MatDividerModule, SafeButtonModule, TranslateModule],
+  imports: [CommonModule, SafeDividerModule, SafeButtonModule, TranslateModule],
   exports: [PreviewToolbarComponent],
 })
 export class PreviewToolbarModule {}

--- a/projects/back-office/src/app/application/pages/channels/channels.component.html
+++ b/projects/back-office/src/app/application/pages/channels/channels.component.html
@@ -55,7 +55,7 @@
             <mat-icon>edit</mat-icon>
             {{ 'common.edit' | translate }}
           </button>
-          <mat-divider></mat-divider>
+          <safe-divider style="margin: unset"></safe-divider>
           <button mat-menu-item (click)="onDelete(element)">
             <mat-icon>delete</mat-icon>
             {{ 'common.delete' | translate }}

--- a/projects/back-office/src/app/application/pages/channels/channels.module.ts
+++ b/projects/back-office/src/app/application/pages/channels/channels.module.ts
@@ -12,11 +12,11 @@ import {
   SafeConfirmModalModule,
   SafeButtonModule,
   SafeModalModule,
+  SafeDividerModule,
 } from '@safe/builder';
 import { AddChannelModalComponent } from './components/add-channel-modal/add-channel-modal.component';
 import { EditChannelModalComponent } from './components/edit-channel-modal/edit-channel-modal.component';
 import { MatSelectModule } from '@angular/material/select';
-import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
@@ -43,7 +43,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MatTableModule,
     MatSelectModule,
     SafeConfirmModalModule,
-    MatDividerModule,
+    SafeDividerModule,
     SafeButtonModule,
     MatButtonModule,
     TranslateModule,

--- a/projects/back-office/src/app/application/pages/subscriptions/subscriptions.component.html
+++ b/projects/back-office/src/app/application/pages/subscriptions/subscriptions.component.html
@@ -48,7 +48,7 @@
             <mat-icon>edit</mat-icon>
             {{ 'common.edit' | translate }}
           </button>
-          <mat-divider></mat-divider>
+          <safe-divider style="margin: unset"></safe-divider>
           <button mat-menu-item color="warn" (click)="onDelete(element)">
             <mat-icon>delete</mat-icon>
             {{ 'common.delete' | translate }}

--- a/projects/back-office/src/app/application/pages/subscriptions/subscriptions.module.ts
+++ b/projects/back-office/src/app/application/pages/subscriptions/subscriptions.module.ts
@@ -17,10 +17,10 @@ import {
   SafeIconModule,
   SafeGraphQLSelectModule,
   SafeModalModule,
+  SafeDividerModule,
 } from '@safe/builder';
 import { MatSelectModule } from '@angular/material/select';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
-import { MatDividerModule } from '@angular/material/divider';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
@@ -44,7 +44,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     MatTableModule,
     SafeConfirmModalModule,
     MatAutocompleteModule,
-    MatDividerModule,
+    SafeDividerModule,
     SafeButtonModule,
     SafeIconModule,
     TranslateModule,

--- a/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.html
+++ b/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.html
@@ -108,7 +108,7 @@
                 <mat-icon>library_books</mat-icon>
                 {{ 'common.history' | translate }}
               </button>
-              <mat-divider></mat-divider>
+              <safe-divider style="margin: unset"></safe-divider>
               <button
                 *ngIf="!showDeletedRecords"
                 mat-menu-item

--- a/projects/back-office/src/app/dashboard/pages/form-records/form-records.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/form-records/form-records.module.ts
@@ -5,8 +5,11 @@ import { FormRecordsComponent } from './form-records.component';
 import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
-import { SafeRecordHistoryModule, SafeButtonModule } from '@safe/builder';
-import { MatDividerModule } from '@angular/material/divider';
+import {
+  SafeRecordHistoryModule,
+  SafeButtonModule,
+  SafeDividerModule,
+} from '@safe/builder';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatPaginatorModule } from '@angular/material/paginator';
@@ -24,7 +27,7 @@ import { UploadMenuModule } from '../../../components/upload-menu/upload-menu.mo
     MatIconModule,
     MatMenuModule,
     SafeRecordHistoryModule,
-    MatDividerModule,
+    SafeDividerModule,
     MatTooltipModule,
     SafeButtonModule,
     MatProgressSpinnerModule,

--- a/projects/back-office/src/app/dashboard/pages/forms/forms.component.html
+++ b/projects/back-office/src/app/dashboard/pages/forms/forms.component.html
@@ -158,7 +158,7 @@
           </button>
         </ng-container>
         <ng-container *ngIf="element.canDelete">
-          <mat-divider></mat-divider>
+          <safe-divider style="margin: unset"></safe-divider>
           <button mat-menu-item (click)="onDelete(element, $event)">
             <mat-icon>delete</mat-icon>
             {{ 'common.delete' | translate }}

--- a/projects/back-office/src/app/dashboard/pages/forms/forms.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/forms/forms.module.ts
@@ -13,6 +13,7 @@ import {
   SafeButtonModule,
   SafeSkeletonTableModule,
   SafeDateModule,
+  SafeDividerModule,
 } from '@safe/builder';
 import { AddFormModule } from '../../../components/add-form-modal/add-form-modal.module';
 import { MatSortModule } from '@angular/material/sort';
@@ -25,7 +26,6 @@ import {
   FormsModule as AngularFormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { MatDividerModule } from '@angular/material/divider';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { FilterComponent } from './components/filter/filter.component';
 import { TranslateModule } from '@ngx-translate/core';
@@ -52,7 +52,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MatNativeDateModule,
     MatInputModule,
     MatSelectModule,
-    MatDividerModule,
+    SafeDividerModule,
     SafeButtonModule,
     MatPaginatorModule,
     TranslateModule,

--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.component.html
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.component.html
@@ -75,7 +75,7 @@
           <mat-icon>edit</mat-icon>
           {{ 'common.edit' | translate }}
         </button>
-        <mat-divider></mat-divider>
+        <safe-divider style="margin: unset"></safe-divider>
         <button mat-menu-item color="warn" (click)="onDelete(element)">
           <mat-icon>delete</mat-icon>
           {{ 'common.delete' | translate }}

--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.module.ts
@@ -19,10 +19,10 @@ import {
   SafeIconModule,
   SafeGraphQLSelectModule,
   SafeModalModule,
+  SafeDividerModule,
 } from '@safe/builder';
 import { MatSelectModule } from '@angular/material/select';
 import { MatExpansionModule } from '@angular/material/expansion';
-import { MatDividerModule } from '@angular/material/divider';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatChipsModule } from '@angular/material/chips';
@@ -48,7 +48,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     MatTableModule,
     SafeConfirmModalModule,
     MatExpansionModule,
-    MatDividerModule,
+    SafeDividerModule,
     SafeButtonModule,
     MatPaginatorModule,
     TranslateModule,

--- a/projects/safe/src/lib/components/layout/layout.component.html
+++ b/projects/safe/src/lib/components/layout/layout.component.html
@@ -77,17 +77,17 @@
     <button mat-menu-item (click)="onOpenProfile()">
       {{ 'pages.profile.title' | translate }}
     </button>
-    <mat-divider></mat-divider>
+    <safe-divider style="margin: unset"></safe-divider>
     <button mat-menu-item (click)="onOpenPreferences()" *ngIf="showPreferences">
       {{ 'components.preferences.title' | translate }}
     </button>
     <ng-container *ngIf="user && user.isAdmin">
-      <mat-divider></mat-divider>
+      <safe-divider style="margin: unset"></safe-divider>
       <button mat-menu-item (click)="onSwitchOffice()">
         {{ 'components.header.goToPlatform' | translate }} {{ otherOffice }}
       </button>
     </ng-container>
-    <mat-divider></mat-divider>
+    <safe-divider style="margin: unset"></safe-divider>
     <button mat-menu-item (click)="logout()" class="warn">
       {{ 'components.header.logout' | translate }}
     </button>
@@ -212,7 +212,10 @@
             </div>
           </ng-container>
         </div>
-        <mat-divider *ngIf="i < filteredNavGroups.length - 1"></mat-divider>
+        <safe-divider
+          style="margin: unset"
+          *ngIf="i < filteredNavGroups.length - 1"
+        ></safe-divider>
       </ng-container>
     </mat-nav-list>
   </mat-sidenav>

--- a/projects/safe/src/lib/components/layout/layout.module.ts
+++ b/projects/safe/src/lib/components/layout/layout.module.ts
@@ -9,7 +9,6 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatListModule } from '@angular/material/list';
 import { RouterModule } from '@angular/router';
 import { DragDropModule } from '@angular/cdk/drag-drop';
-import { MatDividerModule } from '@angular/material/divider';
 import { SafeConfirmModalModule } from '../confirm-modal/confirm-modal.module';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { SafeButtonModule } from '../ui/button/button.module';
@@ -21,6 +20,7 @@ import { OverlayModule } from '@angular/cdk/overlay';
 import { SafePreferencesModalModule } from '../preferences-modal/preferences-modal.module';
 import { SafeDateModule } from '../../pipes/date/date.module';
 import { SafeBreadcrumbModule } from '../ui/breadcrumb/breadcrumb.module';
+import { SafeDividerModule } from '../ui/divider/divider.module';
 
 /**
  * SafeLayoutModule is a class used to manage all the modules and components
@@ -39,7 +39,7 @@ import { SafeBreadcrumbModule } from '../ui/breadcrumb/breadcrumb.module';
     MatSidenavModule,
     MatListModule,
     DragDropModule,
-    MatDividerModule,
+    SafeDividerModule,
     SafeConfirmModalModule,
     MatTooltipModule,
     SafeButtonModule,

--- a/projects/safe/src/lib/components/roles/components/group-list/group-list.component.html
+++ b/projects/safe/src/lib/components/roles/components/group-list/group-list.component.html
@@ -61,7 +61,7 @@
           <mat-icon>edit</mat-icon>
           {{ 'common.edit' | translate }}
         </button>
-        <mat-divider></mat-divider> -->
+        <safe-divider style="margin: unset"></safe-divider> -->
         <button mat-menu-item color="warn" (click)="onDelete(element)">
           <mat-icon>delete</mat-icon>
           {{ 'common.delete' | translate }}

--- a/projects/safe/src/lib/components/roles/components/role-list/role-list.component.html
+++ b/projects/safe/src/lib/components/roles/components/role-list/role-list.component.html
@@ -58,7 +58,7 @@
           <mat-icon>edit</mat-icon>
           {{ 'common.edit' | translate }}
         </button>
-        <mat-divider></mat-divider> -->
+        <safe-divider style="margin: unset"></safe-divider> -->
         <button mat-menu-item color="warn" (click)="onDelete(element)">
           <mat-icon>delete</mat-icon>
           {{ 'common.delete' | translate }}

--- a/projects/safe/src/lib/components/roles/components/role-list/role-list.module.ts
+++ b/projects/safe/src/lib/components/roles/components/role-list/role-list.module.ts
@@ -7,7 +7,6 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
 import { MatSortModule } from '@angular/material/sort';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
-import { MatDividerModule } from '@angular/material/divider';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -15,6 +14,7 @@ import { SafeConfirmModalModule } from '../../../confirm-modal/confirm-modal.mod
 import { SafeButtonModule } from '../../../ui/button/button.module';
 import { SafeSkeletonTableModule } from '../../../skeleton/skeleton-table/skeleton-table.module';
 import { SafeRoleListComponent } from './role-list.component';
+import { SafeDividerModule } from '../../../ui/divider/divider.module';
 
 /**
  * BackOfficeRolesModule manages modules and components
@@ -35,7 +35,7 @@ import { SafeRoleListComponent } from './role-list.component';
     SafeConfirmModalModule,
     MatSortModule,
     MatAutocompleteModule,
-    MatDividerModule,
+    SafeDividerModule,
     SafeButtonModule,
     TranslateModule,
     SafeSkeletonTableModule,

--- a/projects/safe/src/lib/components/search-menu/search-menu.component.html
+++ b/projects/safe/src/lib/components/search-menu/search-menu.component.html
@@ -20,7 +20,7 @@
       >{{ currentApplication.name }}</safe-button
     >
   </div>
-  <mat-divider *ngIf="currentApplication"></mat-divider>
+  <safe-divider *ngIf="currentApplication" style="margin: unset"></safe-divider>
   <div class="search-application-list">
     <safe-button
       *ngFor="let item of searchResults"

--- a/projects/safe/src/lib/components/search-menu/search-menu.module.ts
+++ b/projects/safe/src/lib/components/search-menu/search-menu.module.ts
@@ -7,9 +7,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { SafeButtonModule } from '../ui/button/button.module';
 import { MatIconModule } from '@angular/material/icon';
-import { MatDividerModule } from '@angular/material/divider';
 import { MatTooltipModule } from '@angular/material/tooltip';
-
+import { SafeDividerModule } from '../ui/divider/divider.module';
 /**
  * Search menu component module.
  */
@@ -23,7 +22,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     MatInputModule,
     MatIconModule,
     SafeButtonModule,
-    MatDividerModule,
+    SafeDividerModule,
     MatTooltipModule,
   ],
   exports: [SafeSearchMenuComponent],

--- a/projects/safe/src/lib/components/widget-grid/floating-options/floating-options.component.html
+++ b/projects/safe/src/lib/components/widget-grid/floating-options/floating-options.component.html
@@ -7,7 +7,10 @@
 </button>
 <mat-menu #menu="matMenu">
   <ng-container *ngFor="let item of items">
-    <mat-divider *ngIf="item.name === 'Delete'"></mat-divider>
+    <safe-divider
+      *ngIf="item.name === 'Delete'"
+      style="margin: unset"
+    ></safe-divider>
 
     <button mat-menu-item (click)="onClick(item)" [disabled]="item.disabled">
       <mat-icon>{{ item.icon }}</mat-icon>

--- a/projects/safe/src/lib/components/widget-grid/widget-grid.module.ts
+++ b/projects/safe/src/lib/components/widget-grid/widget-grid.module.ts
@@ -14,7 +14,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { SafeFloatingOptionsComponent } from './floating-options/floating-options.component';
 import { SafeTileDataComponent } from './floating-options/menu/tile-data/tile-data.component';
 import { SafeExpandedWidgetComponent } from './expanded-widget/expanded-widget.component';
-import { MatDividerModule } from '@angular/material/divider';
 import { SafeButtonModule } from '../ui/button/button.module';
 import { SafeWidgetChoiceModule } from '../widget-choice/widget-choice.module';
 import { TranslateModule } from '@ngx-translate/core';
@@ -22,7 +21,7 @@ import { LayoutModule } from '@progress/kendo-angular-layout';
 import { SafeIconModule } from '../ui/icon/icon.module';
 import { IndicatorsModule } from '@progress/kendo-angular-indicators';
 import { SafeModalModule } from '../ui/modal/modal.module';
-
+import { SafeDividerModule } from '../ui/divider/divider.module';
 /** Module for the widget-related components */
 @NgModule({
   declarations: [
@@ -45,7 +44,7 @@ import { SafeModalModule } from '../ui/modal/modal.module';
     MatTooltipModule,
     MatDialogModule,
     MatMenuModule,
-    MatDividerModule,
+    SafeDividerModule,
     SafeButtonModule,
     TranslateModule,
     SafeIconModule,

--- a/projects/safe/src/lib/components/workflow-stepper/workflow-stepper.component.html
+++ b/projects/safe/src/lib/components/workflow-stepper/workflow-stepper.component.html
@@ -1,4 +1,4 @@
-<mat-divider></mat-divider>
+<safe-divider style="margin: unset"></safe-divider>
 <div class="safe-steps" *ngIf="loading">
   <kendo-skeleton
     shape="rectangle"
@@ -32,4 +32,4 @@
   ></safe-step>
   <safe-add-step *ngIf="canUpdate" (click)="add.emit()"></safe-add-step>
 </div>
-<mat-divider></mat-divider>
+<safe-divider style="margin: unset"></safe-divider>

--- a/projects/safe/src/lib/components/workflow-stepper/workflow-stepper.module.ts
+++ b/projects/safe/src/lib/components/workflow-stepper/workflow-stepper.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { SafeWorkflowStepperComponent } from './workflow-stepper.component';
 import { SafeAddStepComponent } from './components/add-step/add-step.component';
 import { SafeStepComponent } from './components/step/step.component';
-import { MatDividerModule } from '@angular/material/divider';
 import { MatRippleModule } from '@angular/material/core';
 import { SafeIconModule } from '../ui/icon/icon.module';
 import { SafeButtonModule } from '../ui/button/public-api';
@@ -11,7 +10,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { TranslateModule } from '@ngx-translate/core';
 import { IndicatorsModule } from '@progress/kendo-angular-indicators';
-
+import { SafeDividerModule } from '../ui/divider/divider.module';
 /**
  * Module for workflow stepper component
  */
@@ -23,7 +22,7 @@ import { IndicatorsModule } from '@progress/kendo-angular-indicators';
   ],
   imports: [
     CommonModule,
-    MatDividerModule,
+    SafeDividerModule,
     MatRippleModule,
     MatTooltipModule,
     DragDropModule,


### PR DESCRIPTION
# Description

This PR updates the code base to use the SafeDividerComponent everywhere we were using the Material one previously

## Type of change
- [x] Improvement (refactor or addition to existing functionality)


# How Has This Been Tested?

Checking the dividers to see if it's all being displayed properly.

## Sreenshots

![image](https://user-images.githubusercontent.com/102038450/191856968-7e5cb3f8-8d94-4d56-a791-efe6bafc3a22.png)
# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
