### PR TITLE
Fix 1.3.0/oort 455 page permissions view not updated

### DIFF
--- a/projects/back-office/src/app/application/pages/form/form.component.ts
+++ b/projects/back-office/src/app/application/pages/form/form.component.ts
@@ -251,7 +251,7 @@ export class FormComponent implements OnInit, OnDestroy {
             permissions: res.data?.editStep.permissions,
           };
           this.step = {
-            ...this.page,
+            ...this.step,
             permissions: res.data?.editStep.permissions,
           };
         });

--- a/projects/back-office/src/app/application/pages/form/form.component.ts
+++ b/projects/back-office/src/app/application/pages/form/form.component.ts
@@ -28,7 +28,6 @@ import {
 } from './graphql/mutations';
 import { switchMap } from 'rxjs/operators';
 import { TranslateService } from '@ngx-translate/core';
-import { threadId } from 'worker_threads';
 
 /**
  * Form page in application.

--- a/projects/back-office/src/app/application/pages/form/form.component.ts
+++ b/projects/back-office/src/app/application/pages/form/form.component.ts
@@ -28,6 +28,7 @@ import {
 } from './graphql/mutations';
 import { switchMap } from 'rxjs/operators';
 import { TranslateService } from '@ngx-translate/core';
+import { threadId } from 'worker_threads';
 
 /**
  * Form page in application.
@@ -249,6 +250,10 @@ export class FormComponent implements OnInit, OnDestroy {
             ...this.form,
             permissions: res.data?.editStep.permissions,
           };
+          this.step = {
+            ...this.page,
+            permissions: res.data?.editStep.permissions,
+          };
         });
     } else {
       this.apollo
@@ -262,6 +267,10 @@ export class FormComponent implements OnInit, OnDestroy {
         .subscribe((res) => {
           this.form = {
             ...this.form,
+            permissions: res.data?.editPage.permissions,
+          };
+          this.page = {
+            ...this.page,
             permissions: res.data?.editPage.permissions,
           };
         });


### PR DESCRIPTION
# Description

Fix update the form permission view by updating form page permission and form step permission in back-office/form.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] In a form page click on "Update page permissions" icon and change roles permission. Check that the form permission view has been updated by clicking on again.
- [x] In a form step (a form in workflow) click on "Update page permissions" icon and change roles permission. Check that the form permission view has been updated by clicking on again.
- [x] heck that changes haven't modified other roles permission.

## Sreenshots

![fix_form_page_permissions](https://user-images.githubusercontent.com/59767527/191906435-cdb95f08-a61b-4e83-be51-fdf2bc45e629.png)

![fix_form_step_permissions](https://user-images.githubusercontent.com/59767527/191906456-01910edb-d6f2-4cef-bca1-c9982a082ee6.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
