### PR TITLE
AB#41417 Format layout field display is now possible

### DIFF
--- a/projects/back-office/src/environments/environment.ts
+++ b/projects/back-office/src/environments/environment.ts
@@ -31,10 +31,10 @@ const authConfig: AuthConfig = {
  */
 export const environment = {
   production: false,
-  // apiUrl: 'https://oort-dev.oortcloud.tech/api',
-  // subscriptionApiUrl: 'wss://oort-dev.oortcloud.tech/api',
-  apiUrl: 'http://localhost:3000',
-  subscriptionApiUrl: 'ws://localhost:3000',
+  apiUrl: 'https://oort-dev.oortcloud.tech/api',
+  subscriptionApiUrl: 'wss://oort-dev.oortcloud.tech/api',
+  // apiUrl: 'http://localhost:3000',
+  // subscriptionApiUrl: 'ws://localhost:3000',
   frontOfficeUri: 'http://localhost:4200/',
   backOfficeUri: 'http://localhost:4200/',
   module: 'backoffice',

--- a/projects/back-office/src/environments/environment.ts
+++ b/projects/back-office/src/environments/environment.ts
@@ -31,10 +31,10 @@ const authConfig: AuthConfig = {
  */
 export const environment = {
   production: false,
-  apiUrl: 'https://oort-dev.oortcloud.tech/api',
-  subscriptionApiUrl: 'wss://oort-dev.oortcloud.tech/api',
-  // apiUrl: 'http://localhost:3000',
-  // subscriptionApiUrl: 'ws://localhost:3000',
+  // apiUrl: 'https://oort-dev.oortcloud.tech/api',
+  // subscriptionApiUrl: 'wss://oort-dev.oortcloud.tech/api',
+  apiUrl: 'http://localhost:3000',
+  subscriptionApiUrl: 'ws://localhost:3000',
   frontOfficeUri: 'http://localhost:4200/',
   backOfficeUri: 'http://localhost:4200/',
   module: 'backoffice',

--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -569,6 +569,10 @@
 			},
 			"fields": {
 				"available": "Available fields",
+				"format": {
+					"info": "Left empty to ignore formatting",
+					"title": "Display format"
+				},
 				"search": "Search fields...",
 				"selected": "Selected fields",
 				"title": "Fields"

--- a/projects/safe/src/lib/components/query-builder/query-builder-forms.ts
+++ b/projects/safe/src/lib/components/query-builder/query-builder-forms.ts
@@ -87,6 +87,7 @@ export const addNewField = (field: any, newField?: boolean): FormGroup => {
           field.label ? field.label : prettifyLabel(field.name),
           Validators.required,
         ],
+        format: [field.format ? field.format : null],
       });
     }
   }

--- a/projects/safe/src/lib/components/query-builder/query-builder-forms.ts
+++ b/projects/safe/src/lib/components/query-builder/query-builder-forms.ts
@@ -87,7 +87,7 @@ export const addNewField = (field: any, newField?: boolean): FormGroup => {
           field.label ? field.label : prettifyLabel(field.name),
           Validators.required,
         ],
-        format: [field.format ? field.format : null],
+        format: [get(field, 'format', null)],
       });
     }
   }

--- a/projects/safe/src/lib/components/query-builder/query-builder.module.ts
+++ b/projects/safe/src/lib/components/query-builder/query-builder.module.ts
@@ -34,6 +34,7 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { SafeTabPaginationComponent } from './tab-pagination/tab-pagination.component';
 import { SafeFilterModule } from '../filter/filter.module';
 import { DateFilterEditorComponent } from './date-filter-editor/date-filter-editor.component';
+import { EditorModule, TINYMCE_SCRIPT_SRC } from '@tinymce/tinymce-angular';
 
 /**
  * SafeQueryBuilderModule is a class used to manage all the modules and components
@@ -79,6 +80,7 @@ import { DateFilterEditorComponent } from './date-filter-editor/date-filter-edit
     SafeCoreGridModule,
     MatDatepickerModule,
     SafeFilterModule,
+    EditorModule,
   ],
   exports: [
     SafeQueryBuilderComponent,
@@ -86,6 +88,9 @@ import { DateFilterEditorComponent } from './date-filter-editor/date-filter-edit
     SafeTabFilterComponent,
     SafeTabSortComponent,
     SafeTabPaginationComponent,
+  ],
+  providers: [
+    { provide: TINYMCE_SCRIPT_SRC, useValue: 'tinymce/tinymce.min.js' },
   ],
 })
 export class SafeQueryBuilderModule {}

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
@@ -147,6 +147,11 @@
             <input matInput formControlName="label" type="text" />
           </mat-form-field>
         </div>
+        <h3 style="margin: 0">{{ 'components.queryBuilder.fields.format.title' | translate }}</h3>
+        <div class="info-text" style="margin-bottom: 10px;">
+          {{ 'components.queryBuilder.fields.format.info' | translate }}
+        </div>
+        <editor [init]="editor" formControlName="format"></editor>
       </form>
     </ng-container>
     <ng-container

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
@@ -212,7 +212,6 @@ export class SafeTabFieldsComponent implements OnInit, OnChanges {
    */
   public onEdit(index: number): void {
     this.fieldForm = this.form.at(index) as FormGroup;
-    console.log(this.fieldForm.value);
     if (this.fieldForm.value.kind === 'SCALAR') {
       const dataKeys = getDataKeys([
         { name: this.fieldForm.controls.name.value },

--- a/projects/safe/src/lib/components/role-summary/role-details/role-details.component.ts
+++ b/projects/safe/src/lib/components/role-summary/role-details/role-details.component.ts
@@ -82,7 +82,6 @@ export class RoleDetailsComponent implements OnInit {
     const url = `http://localhost:3000/roles/${this.role.id}/summary`;
     this.http.get(url).subscribe((res: any) => {
       this.roleStats = res;
-      console.log(res);
     });
   }
 

--- a/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -179,7 +179,7 @@
               [style]="getStyle(dataItem, field.name)"
             >
               <div #refSpan class="textbox">
-                {{ getPropertyValue(dataItem, field.name) }}
+                {{ applyFieldFormat(getPropertyValue(dataItem, field.name), field) }}
               </div>
               <button
                 kendoButton
@@ -208,7 +208,7 @@
             >
               <div #refSpan class="textbox" *ngIf="field.meta.type === 'time'">
                 {{
-                  getPropertyValue(dataItem, field.name) | safeDate: 'shortTime'
+                  applyFieldFormat(getPropertyValue(dataItem, field.name) | safeDate: 'shortTime', field)
                 }}
               </div>
               <div
@@ -216,11 +216,11 @@
                 class="textbox"
                 *ngIf="['datetime', 'datetime-local'].includes(field.meta.type)"
               >
-                {{ getPropertyValue(dataItem, field.name) | safeDate: 'short' }}
+                {{ applyFieldFormat(getPropertyValue(dataItem, field.name) | safeDate: 'short', field) }}
               </div>
               <div #refSpan class="textbox" *ngIf="field.meta.type === 'date'">
                 {{
-                  getPropertyValue(dataItem, field.name) | safeDate: 'shortDate'
+                  applyFieldFormat(getPropertyValue(dataItem, field.name) | safeDate: 'shortDate', field)
                 }}
               </div>
             </div>
@@ -244,7 +244,7 @@
                 rel="noopener noreferrer"
               >
                 <div #refSpan>
-                  {{ getPropertyValue(dataItem, field.name) }}
+                  {{ applyFieldFormat(getPropertyValue(dataItem, field.name), field) }}
                 </div>
               </a>
               <a
@@ -255,7 +255,7 @@
                 rel="noopener noreferrer"
               >
                 <div #refSpan>
-                  {{ getPropertyValue(dataItem, field.name) }}
+                  {{ applyFieldFormat(getPropertyValue(dataItem, field.name), field) }}
                 </div>
               </a>
               <a
@@ -266,7 +266,7 @@
                 rel="noopener noreferrer"
               >
                 <div #refSpan>
-                  {{ getPropertyValue(dataItem, field.name) }}
+                  {{ applyFieldFormat(getPropertyValue(dataItem, field.name), field) }}
                 </div>
               </a>
               <button
@@ -309,7 +309,7 @@
               [style]="getStyle(dataItem, field.name)"
             >
               <div #refSpan class="textbox">
-                {{ getPropertyValue(dataItem, field.name) }}
+                {{ applyFieldFormat(getPropertyValue(dataItem, field.name), field) }}
               </div>
               <button
                 kendoButton
@@ -375,7 +375,7 @@
               class="textbox-container"
               [style]="getStyle(dataItem, field.name)"
             >
-              {{ getPropertyValue(dataItem, field.name) }}
+              {{ applyFieldFormat(getPropertyValue(dataItem, field.name), field) }}
             </div>
           </ng-template>
         </ng-container>
@@ -524,10 +524,13 @@
                 [style]="getStyle(dataItem, field.name)"
               >
                 {{
-                  getReferenceDataPropertyValue(
-                    dataItem,
-                    field.name,
-                    subField.meta.name
+                  applyFieldFormat(
+                    getReferenceDataPropertyValue(
+                      dataItem,
+                      field.name,
+                      subField.meta.name
+                    ),
+                    field
                   )
                 }}
               </div>
@@ -585,7 +588,7 @@
             class="textbox-container"
             [style]="getStyle(dataItem, field.name)"
           >
-            {{ getPropertyValue(dataItem, field.name) }}
+            {{ applyFieldFormat(getPropertyValue(dataItem, field.name), field) }}
           </div>
         </ng-template>
         <ng-template
@@ -629,7 +632,7 @@
               class="file"
             >
               <span [class]="'k-icon ' + getFileIcon(file.name)"></span>
-              <span class="textbox">{{ removeFileExtension(file.name) }}</span>
+              <span class="textbox">{{ applyFieldFormat(removeFileExtension(file.name), field) }}</span>
             </button>
           </div>
         </ng-template>

--- a/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -49,6 +49,7 @@ import { SafeExportComponent } from '../export/export.component';
 import { GridLayout } from '../models/grid-layout.model';
 import { SafeErrorsModalComponent } from '../errors-modal/errors-modal.component';
 import { get, intersection } from 'lodash';
+import { applyLayoutFormat } from '../../../widgets/summary-card/parser/utils';
 
 /**
  * Factory for creating scroll strategy
@@ -695,5 +696,16 @@ export class SafeGridComponent implements OnInit, AfterViewInit {
     return fileExt && ICON_EXTENSIONS[fileExt]
       ? name.slice(0, name.lastIndexOf(fileExt) - 1)
       : name;
+  }
+
+  /**
+   * Calls layout format from utils.ts to get the formated fields
+   *
+   * @param name Content of the field as a string
+   * @param field Field data
+   * @returns Formatted field content as a string
+   */
+  public applyFieldFormat(name: string | null, field: any): string | null {
+    return applyLayoutFormat(name, field);
   }
 }

--- a/projects/safe/src/lib/components/widgets/summary-card/parser/utils.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/parser/utils.ts
@@ -265,7 +265,7 @@ export const getCalcKeys = (): string[] => {
  *
  * @param name Original value of the field
  * @param field Field information, used to get field name and format
- * @returns Formated field
+ * @returns Formatted field value
  */
 export const applyLayoutFormat = (
   name: string | null,

--- a/projects/safe/src/lib/components/widgets/summary-card/parser/utils.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/parser/utils.ts
@@ -96,14 +96,25 @@ const replaceRecordFields = (
       switch (field.type) {
         case 'url':
           convertedValue =
-            '<a href="' + value + '" target="_blank">' + value + '</a>';
+            '<a href="' +
+            value +
+            '" target="_blank">' +
+            applyLayoutFormat(value, field) +
+            '</a>';
           break;
         case 'email':
           convertedValue =
-            '<a href="mailto: ' + value + '" target="_blank">' + value + '</a>';
+            '<a href="mailto: ' +
+            value +
+            '" target="_blank">' +
+            applyLayoutFormat(value, field) +
+            '</a>';
           break;
         case 'date':
-          convertedValue = new Date(value).toLocaleString().split(',')[0];
+          convertedValue = applyLayoutFormat(
+            new Date(value).toLocaleString().split(',')[0],
+            field
+          );
           break;
         case 'datetime':
           const date = new Date(value);
@@ -114,14 +125,16 @@ const replaceRecordFields = (
               ? '0' + date.getMinutes()
               : date.getMinutes();
           const time = date.getHours() >= 12 ? 'PM' : 'AM';
-          convertedValue =
+          convertedValue = applyLayoutFormat(
             date.toLocaleString().split(',')[0] +
-            ', ' +
-            hour +
-            ':' +
-            minutes +
-            ' ' +
-            time;
+              ', ' +
+              hour +
+              ':' +
+              minutes +
+              ' ' +
+              time,
+            field
+          );
           break;
         case 'boolean':
           const checked = value ? 'checked' : '';
@@ -138,10 +151,12 @@ const replaceRecordFields = (
               fileExt && ICON_EXTENSIONS[fileExt]
                 ? ICON_EXTENSIONS[fileExt]
                 : 'k-i-file';
-            const fileName =
+            const fileName = applyLayoutFormat(
               fileExt && ICON_EXTENSIONS[fileExt]
                 ? file.name.slice(0, file.name.lastIndexOf(fileExt) - 1)
-                : file.name;
+                : file.name,
+              field
+            );
             convertedValue +=
               '<button style="border: none; padding: 4px 6px;" title="' +
               file.name +
@@ -159,88 +174,12 @@ const replaceRecordFields = (
           convertedValue = value.length + ' items';
           break;
         default:
-          convertedValue = value;
+          convertedValue = applyLayoutFormat(value, field);
           break;
       }
-      //   if ( field.type === 'url' && value ) { // Formats urls
-      //     convertedValue =
-      //       '<a href="' + value + '" target="_blank">' + value + '</a>';
-      //   } else if ( field.type === 'email' && value ) { // Formats emails
-      //     convertedValue =
-      //       '<a href="mailto: ' + value + '" target="_blank">' + value + '</a>';
-      //   } else if ( field.type === 'date' && value ) { // Formats dates
-      //     const date = new Date(value);
-      //     convertedValue = date.toLocaleString().split(',')[0];
-      //   } else if (
-      //     // Formats date and time
-      //     field.type === 'DateTime' &&
-      //     value
-      //   ) {
-      //     const date = new Date(value);
-      //     const hour =
-      //       date.getHours() >= 12 ? date.getHours() - 12 : date.getHours();
-      //     const minutes =
-      //       date.getMinutes() < 10 ? '0' + date.getMinutes() : date.getMinutes();
-      //     const time = date.getHours() >= 12 ? 'PM' : 'AM';
-      //     convertedValue =
-      //       date.toLocaleString().split(',')[0] +
-      //       ', ' +
-      //       hour +
-      //       ':' +
-      //       minutes +
-      //       ' ' +
-      //       time;
-      //   } else if (
-      //     // Formats booleans
-      //     field.type === 'Boolean'
-      //   ) {
-      //     const checked = value ? 'checked' : '';
-      //     convertedValue =
-      //       '<input type="checkbox" style="margin: 0; height: 16px; width: 16px;" ' +
-      //       checked +
-      //       ' disabled></input>';
-      //   } else if (
-      //     // Formats file inputs
-      //     field.type === 'JSON' &&
-      //     value &&
-      //     value.length > 0 &&
-      //     typeof value[0] !== 'string'
-      //   ) {
-      //     convertedValue = '';
-      //     for (const file of value) {
-      //       const fileExt = file.name.split('.').pop();
-      //       const fileIcon =
-      //         fileExt && ICON_EXTENSIONS[fileExt]
-      //           ? ICON_EXTENSIONS[fileExt]
-      //           : 'k-i-file';
-      //       const fileName =
-      //         fileExt && ICON_EXTENSIONS[fileExt]
-      //           ? file.name.slice(0, file.name.lastIndexOf(fileExt) - 1)
-      //           : file.name;
-      //       convertedValue +=
-      //         '<button style="border: none; padding: 4px 6px;" title="' +
-      //         file.name +
-      //         '">' +
-      //         fileName +
-      //         ' <span class="k-icon ' +
-      //         fileIcon +
-      //         '"></span>' +
-      //         '</button>';
-      //     }
-      //   } else if (
-      //     // Formats custom questions
-      //     field.kind === 'LIST' &&
-      //     value &&
-      //     value.length > 0
-      //   ) {
-      //     convertedValue = value.length + ' items';
-      //   } else {
-      //     // Anything else
-      //     convertedValue = value;
-      //   }
 
       const regex = new RegExp(`${DATA_PREFIX}${field.name}\\b`, 'gi');
-      formattedHtml = formattedHtml.replace(regex, convertedValue as string);
+      formattedHtml = formattedHtml.replace(regex, convertedValue);
     }
   }
   return formattedHtml;
@@ -319,4 +258,26 @@ export const getDataKeys = (fields: any): string[] =>
 export const getCalcKeys = (): string[] => {
   const calcObjects = Object.values(calcFunctions);
   return calcObjects.map((obj) => CALC_PREFIX + obj.signature);
+};
+
+/**
+ * Applies layout field format ignoring html tags
+ *
+ * @param name Original value of the field
+ * @param field Field information, used to get field name and format
+ * @returns Formated field
+ */
+export const applyLayoutFormat = (
+  name: string | null,
+  field: any
+): string | null => {
+  if (name && field.layoutFormat && field.layoutFormat.length > 1) {
+    const regex = new RegExp(`${DATA_PREFIX}${field.name}\\b`, 'gi');
+    const value = field.layoutFormat
+      .replace(/<(.|\n)*?>/g, '')
+      .replace(regex, name);
+    return applyOperations(value);
+  } else {
+    return name;
+  }
 };

--- a/projects/safe/src/lib/const/tinymce.const.ts
+++ b/projects/safe/src/lib/const/tinymce.const.ts
@@ -59,3 +59,20 @@ export const EMAIL_EDITOR_CONFIG: RawEditorSettings = {
     'keyboardnav', // the default keyboard navigation tab
   ],
 };
+
+/** Field Editor tinymce configuration. */
+export const FIELD_EDITOR_CONFIG: RawEditorSettings = {
+  suffix: '.min',
+  plugins: '',
+  imagetools_cors_hosts: ['picsum.photos'],
+  menubar: false,
+  toolbar: false,
+  importcss_append: true,
+  height: 90,
+  quickbars_selection_toolbar: '',
+  content_style: 'body { font-family: Roboto, "Helvetica Neue", sans-serif; }',
+  help_tabs: [
+    'shortcuts', // the default shortcuts tab
+    'keyboardnav', // the default keyboard navigation tab
+  ],
+};

--- a/projects/safe/src/lib/services/form-builder.service.ts
+++ b/projects/safe/src/lib/services/form-builder.service.ts
@@ -41,7 +41,6 @@ export class SafeFormBuilderService {
         survey.runExpression(onCompleteExpression);
       });
     }
-    console.log(fields);
     if (fields.length > 0) {
       for (const f of fields.filter((x) => !x.automated)) {
         const accessible = !!f.canSee;
@@ -49,7 +48,6 @@ export class SafeFormBuilderService {
         const hidden: boolean = (f.canSee !== undefined && !f.canSee) || false;
         const disabled: boolean =
           (f.canUpdate !== undefined && !f.canUpdate) || false;
-        console.log('there');
         survey.getQuestionByName(f.name).visible = !hidden && accessible;
         survey.getQuestionByName(f.name).readOnly = disabled || !editable;
       }

--- a/projects/safe/src/lib/services/grid.service.ts
+++ b/projects/safe/src/lib/services/grid.service.ts
@@ -139,6 +139,7 @@ export class SafeGridService {
               name: fullName,
               title,
               type: f.type,
+              layoutFormat: f.format,
               format: this.getFieldFormat(f.type),
               editor: this.getFieldEditor(f.type),
               filter: !options.filter ? '' : this.getFieldFilter(f.type),


### PR DESCRIPTION
# Description

A new field has been added to scalar fields edition in layouts where you can set the format it will use when its data is shown in grids and layouts.
This new field uses tinymce for the content edition, the editor has been stripped down to work as a text-area with auto completion properties (see screenshots*). You can use `@data.<field>` to indicate where will be the field value inserted in the format. `@calc` functions are also available.
In the grids the formatting is ignored for booleans and custom fields (owners, resources...). The formatting is also ignored when editing a field.
In the summary cards the logic has been applied but it will require further work to make it compatible with layout queries.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] The changes have been tested using the new features in the app, and making sure everything works.

## Screenshots

![Screenshot from 2022-09-28 08-18-53](https://user-images.githubusercontent.com/94831019/192713024-983c57c3-ec88-44b9-99fe-9fe6273a6841.png)
![Screenshot from 2022-09-28 08-31-33](https://user-images.githubusercontent.com/94831019/192713030-d73ffdb6-813d-4ddd-962c-3da182d77d6a.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
