### PR TITLE
Fix 1.3.0/oort 464 grid fields editable access

### DIFF
--- a/projects/front-office/src/app/app.module.ts
+++ b/projects/front-office/src/app/app.module.ts
@@ -7,7 +7,11 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 // Http
-import { HttpClient, HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpClientModule,
+  HTTP_INTERCEPTORS,
+} from '@angular/common/http';
 
 // Env
 import { environment } from '../environments/environment';
@@ -22,7 +26,10 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { OAuthModule, OAuthService, OAuthStorage } from 'angular-oauth2-oidc';
 import { MessageService } from '@progress/kendo-angular-l10n';
-import { KendoTranslationService, SafeAuthInterceptorService } from '@safe/builder';
+import {
+  KendoTranslationService,
+  SafeAuthInterceptorService,
+} from '@safe/builder';
 import { registerLocaleData } from '@angular/common';
 import localeFr from '@angular/common/locales/fr';
 import localeEn from '@angular/common/locales/en';

--- a/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -626,7 +626,10 @@ export class SafeGridComponent implements OnInit, AfterViewInit {
       data: {
         title: field.title,
         comment: get(item, field),
-        readonly: !this.actions.update,
+        readonly:
+          !this.actions.update ||
+          !item.canUpdate ||
+          this.fields.find((val) => val.name === field).meta.readOnly,
       },
       autoFocus: false,
     });

--- a/projects/web-widgets/src/app/app.module.ts
+++ b/projects/web-widgets/src/app/app.module.ts
@@ -8,7 +8,11 @@ import {
 import { createCustomElement } from '@angular/elements';
 import { BrowserModule } from '@angular/platform-browser';
 // Http
-import { HttpClient, HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpClientModule,
+  HTTP_INTERCEPTORS,
+} from '@angular/common/http';
 import { AppComponent } from './app.component';
 import { ApplicationWidgetComponent } from './widgets/application-widget/application-widget.component';
 import { ApplicationWidgetModule } from './widgets/application-widget/application-widget.module';
@@ -29,7 +33,10 @@ import {
 } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { MessageService } from '@progress/kendo-angular-l10n';
-import { KendoTranslationService, SafeAuthInterceptorService } from '@safe/builder';
+import {
+  KendoTranslationService,
+  SafeAuthInterceptorService,
+} from '@safe/builder';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { POPUP_CONTAINER } from '@progress/kendo-angular-popup';
 import { OverlayContainer, OverlayModule } from '@angular/cdk/overlay';


### PR DESCRIPTION
# Description

The save changes button is removed when the field open in a full window is not editable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Try to open a grid field in large screen with many right access and try to modify it.

## Sreenshots

![not_editable_grid_field](https://user-images.githubusercontent.com/59767527/193036184-05f4a718-10d6-4b12-91fe-1f02ad91e1d2.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
