### PR TITLE
feat-1.4.0/AB#41414_date-operations

### DIFF
--- a/projects/safe/src/lib/components/edit-calculated-field-modal/edit-calculated-field-modal.component.ts
+++ b/projects/safe/src/lib/components/edit-calculated-field-modal/edit-calculated-field-modal.component.ts
@@ -4,7 +4,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
 import { FIELD_EDITOR_CONFIG } from '../../const/tinymce.const';
 import { SafeEditorService } from '../../services/editor/editor.service';
-import { getCalcKeys, getDataKeys } from './utils/keys';
+import { getCalcKeys, getDataKeys, getInfoKeys } from './utils/keys';
 /**
  * Interface describing the structure of the data displayed in the dialog
  */
@@ -65,7 +65,11 @@ export class SafeEditCalculatedFieldModalComponent implements OnInit {
       expression: [this.data.calculatedField?.expression, Validators.required],
       // TODO: Add display options
     });
-    const keys = [...getCalcKeys(), ...getDataKeys(this.resourceFields)];
+    const keys = [
+      ...getCalcKeys(),
+      ...getInfoKeys(),
+      ...getDataKeys(this.resourceFields),
+    ];
     this.editorService.addCalcAndKeysAutoCompleter(this.editor, keys);
   }
 

--- a/projects/safe/src/lib/components/edit-calculated-field-modal/utils/keys.ts
+++ b/projects/safe/src/lib/components/edit-calculated-field-modal/utils/keys.ts
@@ -2,6 +2,8 @@
 const DATA_PREFIX = '{{data.';
 /** Prefix for calc keys */
 const CALC_PREFIX = '{{calc.';
+/** Prefix for info keys */
+const INFO_PREFIX = '{{info.';
 /** Suffix for all keys */
 const PLACEHOLDER_SUFFIX = '}}';
 
@@ -102,6 +104,14 @@ export const getCalcKeys = (): string[] => {
     (obj) => CALC_PREFIX + obj.signature + PLACEHOLDER_SUFFIX
   );
 };
+
+/**
+ * Returns an array with the info data keys.
+ *
+ * @returns List of info keys
+ */
+export const getInfoKeys = (): string[] =>
+  ['createdAt', 'updatedAt'].map((k) => INFO_PREFIX + k + PLACEHOLDER_SUFFIX);
 
 /**
  * Returns an array with the keys for data autocompletion.


### PR DESCRIPTION
# Description

This PR includes autocompletion for info keys.
Right now, the only two are `createdAt` and `UpdatedAt`.

## Type of change

- [x] Improvement (refactor or addition to existing functionality)


# How Has This Been Tested?

By pressing { in the editor 

## Sreenshots

![image](https://user-images.githubusercontent.com/102038450/193977397-c5b3a3a0-85a1-4da5-bd07-54b8352d4085.png)
# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
