### PR TITLE
Feat-1.3.0/AB#28319 New logic fields for resources resource forms

### DIFF
--- a/projects/safe/src/lib/services/form-builder.service.ts
+++ b/projects/safe/src/lib/services/form-builder.service.ts
@@ -1,11 +1,10 @@
-import { Injectable, Injector, NgZone } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import * as Survey from 'survey-angular';
 import { SafeReferenceDataService } from './reference-data.service';
 import { renderGlobalProperties } from '../survey/render-global-properties';
 import { EditRecordMutationResponse, EDIT_RECORD } from '../graphql/mutations';
 import { Apollo } from 'apollo-angular';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
 
 /**
  * Shared form builder service.

--- a/projects/safe/src/lib/survey/components/resource.ts
+++ b/projects/safe/src/lib/survey/components/resource.ts
@@ -421,6 +421,24 @@ export const init = (
           obj && obj.resource && !obj.selectQuestion,
         visibleIndex: 4,
       });
+
+      Survey.Serializer.addProperty('resource', {
+        name: 'newRecords',
+        category: 'Custom Questions',
+        visible: false,
+      });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'afterAddingANewRecord',
+        // type: 'expression',
+        category: 'logic',
+      });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'afterLinkingExistingRecord',
+        // type: 'expression',
+        category: 'logic',
+      });
     },
     /**
      * Get the resource after the question is loaded

--- a/projects/safe/src/lib/survey/components/resources.ts
+++ b/projects/safe/src/lib/survey/components/resources.ts
@@ -557,6 +557,24 @@ export const init = (
         visibleIf: (obj: any) => obj.resource && !obj.selectQuestion,
         visibleIndex: 4,
       });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'newRecords',
+        category: 'Custom Questions',
+        visible: false,
+      });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'afterAddingANewRecord',
+        // type: 'expression',
+        category: 'logic',
+      });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'afterLinkingExistingRecord',
+        // type: 'expression',
+        category: 'logic',
+      });
     },
     /**
      * Fetch the resources when the question is loaded

--- a/projects/safe/src/lib/survey/components/utils.ts
+++ b/projects/safe/src/lib/survey/components/utils.ts
@@ -112,6 +112,9 @@ export const buildAddButton = (
               newItem,
               ...question.contentQuestion.choices,
             ];
+            question.newRecords = question.newRecords
+              ? question.newRecords.concat(res.data.id)
+              : [res.data.id];
             question.value = question.value.concat(res.data.id);
           } else {
             const newItem = {
@@ -122,6 +125,7 @@ export const buildAddButton = (
               newItem,
               ...question.contentQuestion.choices,
             ];
+            question.newRecords = res.data.id;
             question.value = res.data.id;
           }
         }


### PR DESCRIPTION
# Description

In the form builder, two new fields have been added in the logic tab for resources and resource (custom questions). This new fields give the possibility to assign a value to a field in a resource depending if it has just been created or selected from the existing ones. The formulae to use is {`resource field`}="`value`".

For now the new fields search for the first occurrence of the formulae in its content and uses that, in case there isn't, the field is ignored.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] The new features have been tested replicating a simpler version of what they have in WHO. I created two new core forms, where one has a drop-down with two options, and the other having a resources selection.
Adding a new/selecting a record in the resource field of the second form triggers the correspondent logic on form saving.  

## Screenshots

New options in the logic tab for resources/resource
![Screenshot from 2022-10-05 14-53-03](https://user-images.githubusercontent.com/94831019/194066307-c9368f0c-00eb-4958-b4d1-bdc15fb12802.png)

The resource form selected on the resources field (relevant for testing)
![Screenshot from 2022-10-05 14-52-37](https://user-images.githubusercontent.com/94831019/194066303-26657e46-499e-4260-af02-6fb471fd3c40.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
