### PR TITLE
Feat-1.4.0/AB#42000 Download files in summary cards

### DIFF
--- a/projects/safe/src/lib/components/widgets/summary-card/parser/utils.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/parser/utils.ts
@@ -91,7 +91,6 @@ const replaceRecordFields = (
 ): string => {
   const fieldsValue = getFieldsValue(record);
   let formattedHtml = html;
-  let numberOfFiles = 0;
   if (fields) {
     for (const field of fields) {
       const value = fieldsValue[field.name];
@@ -163,8 +162,8 @@ const replaceRecordFields = (
             );
             convertedValue +=
               '<button type="file" ' +
-              `number="${numberOfFiles++}" ` +
-              `occurence="${i++}" ` +
+              `field="${field.name}" ` +
+              `index="${i++}" ` +
               'style="border: none; padding: 4px 6px; cursor: pointer" title="' +
               file.name +
               '">' +
@@ -172,7 +171,7 @@ const replaceRecordFields = (
               fileIcon +
               '"></span>' +
               fileName +
-              '</button>';
+              '</button>'; // add elements to be able to identify file when clicking on button
           }
           break;
         case 'owner':

--- a/projects/safe/src/lib/components/widgets/summary-card/parser/utils.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/parser/utils.ts
@@ -91,6 +91,7 @@ const replaceRecordFields = (
 ): string => {
   const fieldsValue = getFieldsValue(record);
   let formattedHtml = html;
+  let numberOfFiles = 0;
   if (fields) {
     for (const field of fields) {
       const value = fieldsValue[field.name];
@@ -108,7 +109,7 @@ const replaceRecordFields = (
           convertedValue =
             '<a href="mailto: ' +
             value +
-            '" target="_blank">' +
+            '">' +
             applyLayoutFormat(value, field) +
             '</a>';
           break;
@@ -147,7 +148,8 @@ const replaceRecordFields = (
           break;
         case 'file':
           convertedValue = '';
-          for (const file of value) {
+          for (let i = 0; value[i]; ) {
+            const file = value[i];
             const fileExt = file.name.split('.').pop();
             const fileIcon =
               fileExt && ICON_EXTENSIONS[fileExt]
@@ -160,7 +162,10 @@ const replaceRecordFields = (
               field
             );
             convertedValue +=
-              '<button style="border: none; padding: 4px 6px;" title="' +
+              '<button type="file" ' +
+              `number="${numberOfFiles++}" ` +
+              `occurence="${i++}" ` +
+              'style="border: none; padding: 4px 6px; cursor: pointer" title="' +
               file.name +
               '">' +
               ' <span class="k-icon ' +
@@ -173,7 +178,7 @@ const replaceRecordFields = (
         case 'owner':
         case 'users':
         case 'resources':
-          convertedValue = value.length + ' items';
+          convertedValue = (value ? value.length : 0) + ' items';
           break;
         default:
           convertedValue = applyLayoutFormat(value, field);

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
@@ -1,1 +1,1 @@
-<div class="html-content" [innerHTML]="formattedHtml"></div>
+<div class="html-content" (click)="click($event)" [innerHTML]="formattedHtml"></div>

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
@@ -1,1 +1,1 @@
-<div class="html-content" (click)="click($event)" [innerHTML]="formattedHtml"></div>
+<div class="html-content" (click)="onClick($event)" [innerHTML]="formattedHtml"></div>

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -9,6 +9,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { SafeDownloadService } from '../../../../services/download/download.service';
 import { Record } from '../../../../models/record.model';
 import { parseHtml } from '../parser/utils';
+import get from 'lodash/get';
 
 /**
  * Content component of Single Item of Summary Card.
@@ -59,18 +60,16 @@ export class SummaryCardItemContentComponent implements OnInit, OnChanges {
    *
    * @param event Click event
    */
-  public click(event: any) {
+  public onClick(event: any) {
     const type = event.target.getAttribute('type');
     if (type === 'file') {
-      const position = event.target.getAttribute('number');
-      const occurence = event.target.getAttribute('occurence');
-      const name = this.fields.filter((field) => field.type === 'file')[
-        position
-      ].name;
-      const data = this.record?.data;
-      const file = data[name] ? data[name][occurence] : null;
-      const path = `download/file/${file.content}`;
-      this.downloadService.getFile(path, file.type, file.name);
+      const fieldName = event.target.getAttribute('field');
+      const index = event.target.getAttribute('index');
+      const file = get(this.record, `data.${fieldName}[${index}]`, null);
+      if (file) {
+        const path = `download/file/${file.content}`;
+        this.downloadService.getFile(path, file.type, file.name);
+      }
     }
   }
 }

--- a/projects/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -6,6 +6,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { SafeDownloadService } from '../../../../services/download/download.service';
 import { Record } from '../../../../models/record.model';
 import { parseHtml } from '../parser/utils';
 
@@ -31,8 +32,12 @@ export class SummaryCardItemContentComponent implements OnInit, OnChanges {
    * Content component of Single Item of Summary Card.
    *
    * @param sanitizer Sanitizes the cards content so angular can show it up.
+   * @param downloadService Used to download file type fields
    */
-  constructor(private sanitizer: DomSanitizer) {}
+  constructor(
+    private sanitizer: DomSanitizer,
+    private downloadService: SafeDownloadService
+  ) {}
 
   ngOnInit(): void {
     this.formattedHtml = this.sanitizer.bypassSecurityTrustHtml(
@@ -47,5 +52,25 @@ export class SummaryCardItemContentComponent implements OnInit, OnChanges {
     this.formattedHtml = this.sanitizer.bypassSecurityTrustHtml(
       parseHtml(this.html, this.record, this.aggregationData, this.fields)
     );
+  }
+
+  /**
+   * Manages all data types that require some extra functions
+   *
+   * @param event Click event
+   */
+  public click(event: any) {
+    const type = event.target.getAttribute('type');
+    if (type === 'file') {
+      const position = event.target.getAttribute('number');
+      const occurence = event.target.getAttribute('occurence');
+      const name = this.fields.filter((field) => field.type === 'file')[
+        position
+      ].name;
+      const data = this.record?.data;
+      const file = data[name] ? data[name][occurence] : null;
+      const path = `download/file/${file.content}`;
+      this.downloadService.getFile(path, file.type, file.name);
+    }
   }
 }


### PR DESCRIPTION
# Description

The ticket was about adding the possibility for file downloads in the summary cards, as we have for grids.
The proposed solution was to check for away to inject template elements in the summary card, but this resulted incompatible with inner-html.
The solution I found consisted on listening for click events on the wrapper element for inner-html, identify file elements and execute the necessary code. This solution will also be compatible for future implementations of other complex fields in the summary cards.


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] The downloads have been tested including a file field in a summary card and clicking in the rendered file.

## Screenshots

No visual changes, screenshots not required.

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
