### PR TITLE
Feat 1.2.0/ab#28319 new logic fields for resources resource forms

### DIFF
--- a/projects/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/projects/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -208,7 +208,8 @@ export class SafeFormModalComponent implements OnInit {
    */
   private initSurvey(): void {
     this.survey = this.formBuilderService.createSurvey(
-      this.form?.structure || ''
+      this.form?.structure || '',
+      this.record
     );
     this.survey.onClearFiles.add((survey: Survey.SurveyModel, options: any) =>
       this.onClearFiles(survey, options)

--- a/projects/safe/src/lib/components/form/form.component.ts
+++ b/projects/safe/src/lib/components/form/form.component.ts
@@ -135,7 +135,8 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
       )}</h3>`;
 
     this.survey = this.formBuilderService.createSurvey(
-      JSON.stringify(structure)
+      JSON.stringify(structure),
+      this.record
     );
     this.survey.onClearFiles.add((survey: Survey.SurveyModel, options: any) =>
       this.onClearFiles(survey, options)

--- a/projects/safe/src/lib/components/record-modal/record-modal.component.ts
+++ b/projects/safe/src/lib/components/record-modal/record-modal.component.ts
@@ -160,7 +160,8 @@ export class SafeRecordModalComponent implements OnInit {
     // INIT SURVEY
     addCustomFunctions(Survey, this.authService, this.apollo, this.record);
     this.survey = this.formBuilderService.createSurvey(
-      this.form?.structure || ''
+      this.form?.structure || '',
+      this.record
     );
     this.survey.onDownloadFile.add((survey: Survey.SurveyModel, options: any) =>
       this.onDownloadFile(survey, options)
@@ -183,7 +184,8 @@ export class SafeRecordModalComponent implements OnInit {
     this.setPages();
     if (this.data.compareTo) {
       this.surveyNext = this.formBuilderService.createSurvey(
-        this.form?.structure || ''
+        this.form?.structure || '',
+        this.record
       );
       this.survey.onDownloadFile.add(
         (survey: Survey.SurveyModel, options: any) =>

--- a/projects/safe/src/lib/services/form-builder.service.ts
+++ b/projects/safe/src/lib/services/form-builder.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Record } from '../models/record.model';
 import { Apollo } from 'apollo-angular';
 import * as Survey from 'survey-angular';
 import { renderCustomProperties } from '../survey/custom-properties';
@@ -25,9 +26,10 @@ export class SafeFormBuilderService {
    * Creates new survey from the structure and add on complete expression to it.
    *
    * @param structure form structure
+   * @param oldRec record that'll be edited, if any
    * @returns New survey
    */
-  createSurvey(structure: string): Survey.Survey {
+  createSurvey(structure: string, oldRec?: Record): Survey.Survey {
     const survey = new Survey.Model(structure);
     survey.onAfterRenderQuestion.add(renderCustomProperties(this.domService));
     // Logic management for resource and resources logic
@@ -35,8 +37,15 @@ export class SafeFormBuilderService {
       for (const page of survey.toJSON().pages) {
         for (const element of page.elements) {
           if (element.type === 'resources' || element.type === 'resource') {
+            // if its a single record, the value will be string
+            // so we account for that by putting it in an array
+            const iterator =
+              element.type === 'resources'
+                ? survey.getValue(element.name)
+                : [survey.getValue(element.name)];
+
             const regex = /{\s*(\b.*\b)\s*}\s*=\s*"(.*)"/g;
-            for (const record of survey.getValue(element.name)) {
+            for (const record of iterator) {
               let operation: any;
               if (
                 element.newCreatedRecords &&
@@ -47,7 +56,13 @@ export class SafeFormBuilderService {
                 operation = regex.exec(element.afterRecordCreation); // divide string into groups for key : value mapping
               } else if (element.afterRecordSelection) {
                 regex.lastIndex = 0; // ensure that regex restarts
-                operation = regex.exec(element.afterRecordSelection); // divide string into groups for key : value mapping
+                const cond =
+                  element.type === 'resources'
+                    ? oldRec && !oldRec.data[element.name].includes(record)
+                    : oldRec && !(oldRec.data[element.name] === record);
+
+                // only updates those records that were not in the old value for the field
+                if (cond) operation = regex.exec(element.afterRecordSelection); // divide string into groups for key : value mapping
               }
               this.updateRecord(record, operation);
             }

--- a/projects/safe/src/lib/services/form-builder.service.ts
+++ b/projects/safe/src/lib/services/form-builder.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
+import { Apollo } from 'apollo-angular';
 import * as Survey from 'survey-angular';
 import { renderCustomProperties } from '../survey/custom-properties';
 import { DomService } from './dom.service';
+import { EditRecordMutationResponse, EDIT_RECORD } from '../graphql/mutations';
 
 /**
  * Shared form builder service.
@@ -16,7 +18,7 @@ export class SafeFormBuilderService {
    *
    * @param domService The dom service
    */
-  constructor(private domService: DomService) {}
+  constructor(private domService: DomService, private apollo: Apollo) {}
 
   /**
    * Creates new survey from the structure and add on complete expression to it.
@@ -27,12 +29,55 @@ export class SafeFormBuilderService {
   createSurvey(structure: string): Survey.Survey {
     const survey = new Survey.Model(structure);
     survey.onAfterRenderQuestion.add(renderCustomProperties(this.domService));
-    const onCompleteExpression = survey.toJSON().onCompleteExpression;
-    if (onCompleteExpression) {
-      survey.onCompleting.add(() => {
-        survey.runExpression(onCompleteExpression);
-      });
-    }
+    // Logic management for resource and resources logic
+    survey.onCompleting.add(() => {
+      for (const page of survey.toJSON().pages) {
+        for (const element of page.elements) {
+          if (element.type === 'resources' || element.type === 'resource') {
+            const regex = /{\s*(\b.*\b)\s*}\s*=\s*"(.*)"/g;
+            for (const record of survey.getValue(element.name)) {
+              let operation: any;
+              if (
+                element.newRecords &&
+                element.newRecords.includes(record) &&
+                element.afterAddingANewRecord
+              ) {
+                operation = regex.exec(element.afterAddingANewRecord);
+              } else if (element.afterLinkingExistingRecord) {
+                operation = regex.exec(element.afterLinkingExistingRecord);
+              }
+              this.updateRecord(record, operation);
+            }
+          }
+        }
+      }
+    });
+    // const onCompleteExpression = survey.toJSON().onCompleteExpression;
+    // if (onCompleteExpression) {
+    //   survey.onCompleting.add(() => {
+    //     survey.runExpression(onCompleteExpression);
+    //   });
+    // }
     return survey;
+  }
+
+  /**
+   * Updates the field with the specified information.
+   *
+   * @param id Id of the record to update
+   * @param operation Operation to execute
+   */
+  private updateRecord(id: string, operation: any): void {
+    if (id && operation) {
+      this.apollo
+        .mutate<EditRecordMutationResponse>({
+          mutation: EDIT_RECORD,
+          variables: {
+            id,
+            data: { [operation[1]]: operation[2] },
+          },
+        })
+        .subscribe(() => {});
+    }
   }
 }

--- a/projects/safe/src/lib/services/form-builder.service.ts
+++ b/projects/safe/src/lib/services/form-builder.service.ts
@@ -17,6 +17,7 @@ export class SafeFormBuilderService {
    * Constructor of the service
    *
    * @param domService The dom service
+   * @param apollo Apollo service
    */
   constructor(private domService: DomService, private apollo: Apollo) {}
 
@@ -38,13 +39,15 @@ export class SafeFormBuilderService {
             for (const record of survey.getValue(element.name)) {
               let operation: any;
               if (
-                element.newRecords &&
-                element.newRecords.includes(record) &&
-                element.afterAddingANewRecord
+                element.newCreatedRecords &&
+                element.newCreatedRecords.includes(record) &&
+                element.afterRecordCreation
               ) {
-                operation = regex.exec(element.afterAddingANewRecord);
-              } else if (element.afterLinkingExistingRecord) {
-                operation = regex.exec(element.afterLinkingExistingRecord);
+                regex.lastIndex = 0; // ensure that regex restarts
+                operation = regex.exec(element.afterRecordCreation); // divide string into groups for key : value mapping
+              } else if (element.afterRecordSelection) {
+                regex.lastIndex = 0; // ensure that regex restarts
+                operation = regex.exec(element.afterRecordSelection); // divide string into groups for key : value mapping
               }
               this.updateRecord(record, operation);
             }
@@ -52,12 +55,6 @@ export class SafeFormBuilderService {
         }
       }
     });
-    // const onCompleteExpression = survey.toJSON().onCompleteExpression;
-    // if (onCompleteExpression) {
-    //   survey.onCompleting.add(() => {
-    //     survey.runExpression(onCompleteExpression);
-    //   });
-    // }
     return survey;
   }
 

--- a/projects/safe/src/lib/survey/components/resource.ts
+++ b/projects/safe/src/lib/survey/components/resource.ts
@@ -462,6 +462,24 @@ export const init = (
         visibleIf: (obj: any) => obj.resource && !obj.selectQuestion,
         visibleIndex: 4,
       });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'newRecords',
+        category: 'Custom Questions',
+        visible: false,
+      });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'afterAddingANewRecord',
+        // type: 'expression',
+        category: 'logic',
+      });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'afterLinkingExistingRecord',
+        // type: 'expression',
+        category: 'logic',
+      });
     },
     /**
      * Get the resource after the question is loaded

--- a/projects/safe/src/lib/survey/components/resource.ts
+++ b/projects/safe/src/lib/survey/components/resource.ts
@@ -463,19 +463,19 @@ export const init = (
         visibleIndex: 4,
       });
 
-      Survey.Serializer.addProperty('resources', {
+      Survey.Serializer.addProperty('resource', {
         name: 'newCreatedRecords',
         category: 'Custom Questions',
         visible: false,
       });
 
-      Survey.Serializer.addProperty('resources', {
+      Survey.Serializer.addProperty('resource', {
         name: 'afterRecordCreation',
         // type: 'expression',
         category: 'logic',
       });
 
-      Survey.Serializer.addProperty('resources', {
+      Survey.Serializer.addProperty('resource', {
         name: 'afterRecordSelection',
         // type: 'expression',
         category: 'logic',

--- a/projects/safe/src/lib/survey/components/resource.ts
+++ b/projects/safe/src/lib/survey/components/resource.ts
@@ -464,19 +464,19 @@ export const init = (
       });
 
       Survey.Serializer.addProperty('resources', {
-        name: 'newRecords',
+        name: 'newCreatedRecords',
         category: 'Custom Questions',
         visible: false,
       });
 
       Survey.Serializer.addProperty('resources', {
-        name: 'afterAddingANewRecord',
+        name: 'afterRecordCreation',
         // type: 'expression',
         category: 'logic',
       });
 
       Survey.Serializer.addProperty('resources', {
-        name: 'afterLinkingExistingRecord',
+        name: 'afterRecordSelection',
         // type: 'expression',
         category: 'logic',
       });

--- a/projects/safe/src/lib/survey/components/resources.ts
+++ b/projects/safe/src/lib/survey/components/resources.ts
@@ -544,19 +544,19 @@ export const init = (
       });
 
       Survey.Serializer.addProperty('resources', {
-        name: 'newRecords',
+        name: 'newCreatedRecords',
         category: 'Custom Questions',
         visible: false,
       });
 
       Survey.Serializer.addProperty('resources', {
-        name: 'afterAddingANewRecord',
+        name: 'afterRecordCreation',
         // type: 'expression',
         category: 'logic',
       });
 
       Survey.Serializer.addProperty('resources', {
-        name: 'afterLinkingExistingRecord',
+        name: 'afterRecordSelection',
         // type: 'expression',
         category: 'logic',
       });

--- a/projects/safe/src/lib/survey/components/resources.ts
+++ b/projects/safe/src/lib/survey/components/resources.ts
@@ -542,6 +542,24 @@ export const init = (
         visibleIf: (obj: any) => obj.resource && !obj.selectQuestion,
         visibleIndex: 4,
       });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'newRecords',
+        category: 'Custom Questions',
+        visible: false,
+      });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'afterAddingANewRecord',
+        // type: 'expression',
+        category: 'logic',
+      });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'afterLinkingExistingRecord',
+        // type: 'expression',
+        category: 'logic',
+      });
     },
     /**
      * Fetch the resources when the question is loaded

--- a/projects/safe/src/lib/survey/components/utils.ts
+++ b/projects/safe/src/lib/survey/components/utils.ts
@@ -105,6 +105,9 @@ export const buildAddButton = (
               newItem,
               ...question.contentQuestion.choices,
             ];
+            question.newRecords = question.newRecords
+              ? question.newRecords.concat(res.data.id)
+              : [res.data.id];
             question.value = question.value.concat(res.data.id);
           } else {
             const newItem = {
@@ -115,6 +118,7 @@ export const buildAddButton = (
               newItem,
               ...question.contentQuestion.choices,
             ];
+            question.newRecords = res.data.id;
             question.value = res.data.id;
           }
         }

--- a/projects/safe/src/lib/survey/components/utils.ts
+++ b/projects/safe/src/lib/survey/components/utils.ts
@@ -105,8 +105,8 @@ export const buildAddButton = (
               newItem,
               ...question.contentQuestion.choices,
             ];
-            question.newRecords = question.newRecords
-              ? question.newRecords.concat(res.data.id)
+            question.newCreatedRecords = question.newCreatedRecords
+              ? question.newCreatedRecords.concat(res.data.id)
               : [res.data.id];
             question.value = question.value.concat(res.data.id);
           } else {
@@ -118,7 +118,7 @@ export const buildAddButton = (
               newItem,
               ...question.contentQuestion.choices,
             ];
-            question.newRecords = res.data.id;
+            question.newCreatedRecords = res.data.id;
             question.value = res.data.id;
           }
         }

--- a/projects/safe/src/lib/survey/custom-properties.ts
+++ b/projects/safe/src/lib/survey/custom-properties.ts
@@ -35,13 +35,6 @@ export const initCustomProperties = (Survey: any, environment: any): void => {
       options.request.setRequestHeader('Authorization', `Bearer ${token}`);
     }
   };
-  // add the onCompleteExpression property to the survey
-  Survey.Serializer.addProperty('survey', {
-    name: 'onCompleteExpression:expression',
-    type: 'expression',
-    visibleIndex: 350,
-    category: 'logic',
-  });
 };
 
 /**

--- a/projects/safe/src/lib/utils/custom-functions.ts
+++ b/projects/safe/src/lib/utils/custom-functions.ts
@@ -1,5 +1,4 @@
 import { Apollo } from 'apollo-angular';
-import { EDIT_RECORDS } from '../graphql/mutations';
 import { Record } from '../models/record.model';
 import { SafeAuthService } from '../services/auth.service';
 
@@ -41,20 +40,6 @@ const addCustomFunctions = (
     const result = new Date(params[0]);
     result.setDate(result.getDate() + Number(params[1]));
     return result;
-  });
-  survey.FunctionFactory.Instance.register('editSelected', (params: any[]) => {
-    const records = params[0];
-    const fieldName = params[1];
-    const value = params[2];
-    apollo
-      .mutate({
-        mutation: EDIT_RECORDS,
-        variables: {
-          ids: records,
-          data: { [fieldName]: value },
-        },
-      })
-      .subscribe();
   });
 };
 


### PR DESCRIPTION
# Description

Implements modifications made by [PR 960](https://github.com/ReliefApplications/oort-frontend/pull/960)

Add two new fields in order to:
- edit related records newly created by a resource.s question when completing form
- edit related records newly attached to a resource.s question when completing form

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] The new features have been tested replicating a simpler version of what they have in WHO. I created two new core forms, where one has a drop-down with two options, and the other having a resources selection.
Adding a new/selecting a record in the resource field of the second form triggers the correspondent logic on form saving.

## Sreenshots

Check linked PR for screenshots

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
