### PR TITLE
Refactor 1.3.0/oort 477 replace small mat form field

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.html
+++ b/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.html
@@ -3,13 +3,12 @@
     <div class="top">
       <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
         <mat-icon matPrefix>search</mat-icon>
+        <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
         <input
-          id="custom-search"
           matInput
           [ngModel]="searchText"
           (keyup)="applyFilter('', $event)"
           type="search"
-          [placeholder]="'common.placeholder.search' | translate"
         />
       </mat-form-field>
       <safe-button

--- a/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.html
+++ b/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.html
@@ -1,7 +1,7 @@
 <div class="header">
   <div class="filters">
     <div class="top">
-      <mat-form-field appearance="outline">
+      <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
         <mat-icon matPrefix>search</mat-icon>
         <input
           id="custom-search"
@@ -27,7 +27,7 @@
       </safe-button>
     </div>
     <div class="advanced" [style.display]="!showFilters ? 'none' : ''">
-      <mat-form-field appearance="outline">
+      <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
         <mat-label>{{ 'common.status' | translate }}</mat-label>
         <mat-select
           [ngModel]="statusFilter"

--- a/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.scss
@@ -17,11 +17,6 @@
     mat-form-field {
       margin-top: -0.25em;
 
-      #custom-search {
-        position: relative;
-        top: -0.15em;
-      }
-
       .p-0 {
         // no padding fields
         &.mat-form-field {

--- a/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.scss
@@ -14,36 +14,6 @@
       gap: 16px;
       flex-wrap: wrap;
     }
-    mat-form-field {
-      margin-top: -0.25em;
-
-      .p-0 {
-        // no padding fields
-        &.mat-form-field {
-          .mat-form-field-wrapper {
-            padding: 0 !important;
-          }
-        }
-      }
-    
-      .mat-form-field-sm {
-        // small form-field
-        &.mat-form-field {
-          .mat-form-field-label-wrapper {
-            top: -1.4em;
-          }
-        }
-    
-        .mat-form-field-flex > .mat-form-field-infix {
-          padding: 0.42em 0px !important;
-        }
-    
-        &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-          transform: translateY(-1.1em) scale(0.75);
-          width: 133.33333%;
-        }
-      }
-    }
   }
 
   .actions {

--- a/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.scss
@@ -21,19 +21,33 @@
         position: relative;
         top: -0.15em;
       }
-    }
-    ::ng-deep .mat-form-field-flex > .mat-form-field-infix {
-      padding: 0.42em 0px !important;
-    }
-    ::ng-deep .mat-form-field-label-wrapper {
-      top: -1.4em;
-    }
 
-    ::ng-deep
-      .mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float
-      .mat-form-field-label {
-      transform: translateY(-1.1em) scale(0.75);
-      width: 133.33333%;
+      .p-0 {
+        // no padding fields
+        &.mat-form-field {
+          .mat-form-field-wrapper {
+            padding: 0 !important;
+          }
+        }
+      }
+    
+      .mat-form-field-sm {
+        // small form-field
+        &.mat-form-field {
+          .mat-form-field-label-wrapper {
+            top: -1.4em;
+          }
+        }
+    
+        .mat-form-field-flex > .mat-form-field-infix {
+          padding: 0.42em 0px !important;
+        }
+    
+        &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+          transform: translateY(-1.1em) scale(0.75);
+          width: 133.33333%;
+        }
+      }
     }
   }
 

--- a/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.html
+++ b/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.html
@@ -1,6 +1,6 @@
 <div [formGroup]="form" class="applications-filter">
   <div class="top">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-icon matPrefix>search</mat-icon>
       <input
         id="custom-search"
@@ -24,7 +24,7 @@
     </safe-button>
   </div>
   <div class="advanced" *ngIf="show">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-label>{{ 'common.input.dateRange' | translate }}</mat-label>
       <mat-date-range-input [rangePicker]="rangePicker">
         <input formControlName="startDate" matStartDate />
@@ -49,7 +49,7 @@
         </mat-date-range-picker-actions>
       </mat-date-range-picker>
     </mat-form-field>
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-label>{{ 'common.status' | translate }}</mat-label>
       <mat-select formControlName="status">
         <mat-option>-</mat-option>

--- a/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.html
+++ b/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.html
@@ -2,12 +2,11 @@
   <div class="top">
     <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-icon matPrefix>search</mat-icon>
+      <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
       <input
-        id="custom-search"
         matInput
         [formControl]="search"
         type="search"
-        [placeholder]="'common.placeholder.search' | translate"
       />
       <mat-spinner *ngIf="loading" diameter="24" matSuffix></mat-spinner>
     </mat-form-field>

--- a/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.scss
@@ -14,18 +14,32 @@
       position: relative;
       top: -0.15em;
     }
-  }
-  ::ng-deep .mat-form-field-flex > .mat-form-field-infix {
-    padding: 0.42em 0px !important;
-  }
-  ::ng-deep .mat-form-field-label-wrapper {
-    top: -1.4em;
-  }
 
-  ::ng-deep
-    .mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float
-    .mat-form-field-label {
-    transform: translateY(-1.1em) scale(0.75);
-    width: 133.33333%;
+    .p-0 {
+      // no padding fields
+      &.mat-form-field {
+        .mat-form-field-wrapper {
+          padding: 0 !important;
+        }
+      }
+    }
+  
+    .mat-form-field-sm {
+      // small form-field
+      &.mat-form-field {
+        .mat-form-field-label-wrapper {
+          top: -1.4em;
+        }
+      }
+  
+      .mat-form-field-flex > .mat-form-field-infix {
+        padding: 0.42em 0px !important;
+      }
+  
+      &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+        transform: translateY(-1.1em) scale(0.75);
+        width: 133.33333%;
+      }
+    }
   }
 }

--- a/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.scss
@@ -7,34 +7,4 @@
     gap: 16px;
     flex-wrap: wrap;
   }
-  mat-form-field {
-    margin-top: -0.25em;
-
-    .p-0 {
-      // no padding fields
-      &.mat-form-field {
-        .mat-form-field-wrapper {
-          padding: 0 !important;
-        }
-      }
-    }
-  
-    .mat-form-field-sm {
-      // small form-field
-      &.mat-form-field {
-        .mat-form-field-label-wrapper {
-          top: -1.4em;
-        }
-      }
-  
-      .mat-form-field-flex > .mat-form-field-infix {
-        padding: 0.42em 0px !important;
-      }
-  
-      &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-        transform: translateY(-1.1em) scale(0.75);
-        width: 133.33333%;
-      }
-    }
-  }
 }

--- a/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.scss
@@ -10,11 +10,6 @@
   mat-form-field {
     margin-top: -0.25em;
 
-    #custom-search {
-      position: relative;
-      top: -0.15em;
-    }
-
     .p-0 {
       // no padding fields
       &.mat-form-field {

--- a/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.html
+++ b/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.html
@@ -1,6 +1,6 @@
 <div [formGroup]="form" class="forms-filter">
   <div class="top">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-icon matPrefix>search</mat-icon>
       <input
         id="custom-search"
@@ -25,7 +25,7 @@
     </safe-button>
   </div>
   <div class="advanced" *ngIf="show">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-label>{{ 'common.input.dateRange' | translate }}</mat-label>
       <mat-date-range-input [rangePicker]="rangePicker">
         <input formControlName="startDate" matStartDate />
@@ -50,7 +50,7 @@
         </mat-date-range-picker-actions>
       </mat-date-range-picker>
     </mat-form-field>
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-label>{{ 'common.status' | translate }}</mat-label>
       <mat-select formControlName="status">
         <mat-option>-</mat-option>
@@ -65,7 +65,7 @@
         </mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-label>{{ 'components.forms.isCore' | translate }}</mat-label>
       <mat-select formControlName="core">
         <mat-option>-</mat-option>

--- a/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.html
+++ b/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.html
@@ -2,12 +2,11 @@
   <div class="top">
     <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-icon matPrefix>search</mat-icon>
+      <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
       <input
-        id="custom-search"
         matInput
         [formControl]="search"
         type="search"
-        [placeholder]="'common.placeholder.search' | translate"
       />
       <mat-spinner *ngIf="loading" diameter="24" matSuffix></mat-spinner>
     </mat-form-field>

--- a/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.scss
@@ -14,18 +14,32 @@
       position: relative;
       top: -0.15em;
     }
-  }
-  ::ng-deep .mat-form-field-flex > .mat-form-field-infix {
-    padding: 0.42em 0px !important;
-  }
-  ::ng-deep .mat-form-field-label-wrapper {
-    top: -1.4em;
-  }
 
-  ::ng-deep
-    .mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float
-    .mat-form-field-label {
-    transform: translateY(-1.1em) scale(0.75);
-    width: 133.33333%;
+    .p-0 {
+      // no padding fields
+      &.mat-form-field {
+        .mat-form-field-wrapper {
+          padding: 0 !important;
+        }
+      }
+    }
+  
+    .mat-form-field-sm {
+      // small form-field
+      &.mat-form-field {
+        .mat-form-field-label-wrapper {
+          top: -1.4em;
+        }
+      }
+  
+      .mat-form-field-flex > .mat-form-field-infix {
+        padding: 0.42em 0px !important;
+      }
+  
+      &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+        transform: translateY(-1.1em) scale(0.75);
+        width: 133.33333%;
+      }
+    }
   }
 }

--- a/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.scss
@@ -7,34 +7,4 @@
     gap: 16px;
     flex-wrap: wrap;
   }
-  mat-form-field {
-    margin-top: -0.25em;
-
-    .p-0 {
-      // no padding fields
-      &.mat-form-field {
-        .mat-form-field-wrapper {
-          padding: 0 !important;
-        }
-      }
-    }
-  
-    .mat-form-field-sm {
-      // small form-field
-      &.mat-form-field {
-        .mat-form-field-label-wrapper {
-          top: -1.4em;
-        }
-      }
-  
-      .mat-form-field-flex > .mat-form-field-infix {
-        padding: 0.42em 0px !important;
-      }
-  
-      &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-        transform: translateY(-1.1em) scale(0.75);
-        width: 133.33333%;
-      }
-    }
-  }
 }

--- a/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.scss
@@ -10,11 +10,6 @@
   mat-form-field {
     margin-top: -0.25em;
 
-    #custom-search {
-      position: relative;
-      top: -0.15em;
-    }
-
     .p-0 {
       // no padding fields
       &.mat-form-field {

--- a/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.html
+++ b/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.html
@@ -1,7 +1,7 @@
 <div class="header">
   <div class="filters">
     <div class="top">
-      <mat-form-field appearance="outline">
+      <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
         <mat-icon matPrefix>search</mat-icon>
         <input
           id="custom-search"

--- a/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.html
+++ b/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.html
@@ -3,13 +3,12 @@
     <div class="top">
       <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
         <mat-icon matPrefix>search</mat-icon>
+        <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
         <input
-          id="custom-search"
           matInput
           [ngModel]="searchText"
           (keyup)="applyFilter('', $event)"
           type="search"
-          [placeholder]="'common.placeholder.search' | translate"
         />
       </mat-form-field>
     </div>

--- a/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.scss
@@ -17,11 +17,6 @@
     mat-form-field {
       margin-top: -0.25em;
 
-      #custom-search {
-        position: relative;
-        top: -0.15em;
-      }
-
       .p-0 {
         // no padding fields
         &.mat-form-field {

--- a/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.scss
@@ -14,36 +14,6 @@
       gap: 16px;
       flex-wrap: wrap;
     }
-    mat-form-field {
-      margin-top: -0.25em;
-
-      .p-0 {
-        // no padding fields
-        &.mat-form-field {
-          .mat-form-field-wrapper {
-            padding: 0 !important;
-          }
-        }
-      }
-    
-      .mat-form-field-sm {
-        // small form-field
-        &.mat-form-field {
-          .mat-form-field-label-wrapper {
-            top: -1.4em;
-          }
-        }
-    
-        .mat-form-field-flex > .mat-form-field-infix {
-          padding: 0.42em 0px !important;
-        }
-    
-        &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-          transform: translateY(-1.1em) scale(0.75);
-          width: 133.33333%;
-        }
-      }
-    }
   }
 
   .actions {

--- a/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.scss
@@ -21,19 +21,33 @@
         position: relative;
         top: -0.15em;
       }
-    }
-    ::ng-deep .mat-form-field-flex > .mat-form-field-infix {
-      padding: 0.42em 0px !important;
-    }
-    ::ng-deep .mat-form-field-label-wrapper {
-      top: -1.4em;
-    }
 
-    ::ng-deep
-      .mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float
-      .mat-form-field-label {
-      transform: translateY(-1.1em) scale(0.75);
-      width: 133.33333%;
+      .p-0 {
+        // no padding fields
+        &.mat-form-field {
+          .mat-form-field-wrapper {
+            padding: 0 !important;
+          }
+        }
+      }
+    
+      .mat-form-field-sm {
+        // small form-field
+        &.mat-form-field {
+          .mat-form-field-label-wrapper {
+            top: -1.4em;
+          }
+        }
+    
+        .mat-form-field-flex > .mat-form-field-infix {
+          padding: 0.42em 0px !important;
+        }
+    
+        &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+          transform: translateY(-1.1em) scale(0.75);
+          width: 133.33333%;
+        }
+      }
     }
   }
 

--- a/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.html
@@ -1,6 +1,6 @@
 <div [formGroup]="form" class="resources-filter">
   <div class="top">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-icon matPrefix>search</mat-icon>
       <input
         id="custom-search"
@@ -25,7 +25,7 @@
     </safe-button>
   </div>
   <div class="advanced" *ngIf="show">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-label>{{ 'common.input.dateRange' | translate }}</mat-label>
       <mat-date-range-input [rangePicker]="rangePicker">
         <input formControlName="startDate" matStartDate />

--- a/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.html
@@ -2,12 +2,11 @@
   <div class="top">
     <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-icon matPrefix>search</mat-icon>
+      <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
       <input
-        id="custom-search"
         matInput
         [formControl]="search"
         type="search"
-        [placeholder]="'common.placeholder.search' | translate"
       />
       <mat-spinner *ngIf="loading" diameter="24" matSuffix></mat-spinner>
     </mat-form-field>

--- a/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.scss
@@ -14,18 +14,32 @@
       position: relative;
       top: -0.15em;
     }
-  }
-  ::ng-deep .mat-form-field-flex > .mat-form-field-infix {
-    padding: 0.42em 0px !important;
-  }
-  ::ng-deep .mat-form-field-label-wrapper {
-    top: -1.4em;
-  }
 
-  ::ng-deep
-    .mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float
-    .mat-form-field-label {
-    transform: translateY(-1.1em) scale(0.75);
-    width: 133.33333%;
+    .p-0 {
+      // no padding fields
+      &.mat-form-field {
+        .mat-form-field-wrapper {
+          padding: 0 !important;
+        }
+      }
+    }
+  
+    .mat-form-field-sm {
+      // small form-field
+      &.mat-form-field {
+        .mat-form-field-label-wrapper {
+          top: -1.4em;
+        }
+      }
+  
+      .mat-form-field-flex > .mat-form-field-infix {
+        padding: 0.42em 0px !important;
+      }
+  
+      &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+        transform: translateY(-1.1em) scale(0.75);
+        width: 133.33333%;
+      }
+    }
   }
 }

--- a/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.scss
@@ -7,34 +7,4 @@
     gap: 16px;
     flex-wrap: wrap;
   }
-  mat-form-field {
-    margin-top: -0.25em;
-
-    .p-0 {
-      // no padding fields
-      &.mat-form-field {
-        .mat-form-field-wrapper {
-          padding: 0 !important;
-        }
-      }
-    }
-  
-    .mat-form-field-sm {
-      // small form-field
-      &.mat-form-field {
-        .mat-form-field-label-wrapper {
-          top: -1.4em;
-        }
-      }
-  
-      .mat-form-field-flex > .mat-form-field-infix {
-        padding: 0.42em 0px !important;
-      }
-  
-      &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-        transform: translateY(-1.1em) scale(0.75);
-        width: 133.33333%;
-      }
-    }
-  }
 }

--- a/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.scss
@@ -10,11 +10,6 @@
   mat-form-field {
     margin-top: -0.25em;
 
-    #custom-search {
-      position: relative;
-      top: -0.15em;
-    }
-
     .p-0 {
       // no padding fields
       &.mat-form-field {

--- a/projects/safe/src/lib/components/role-summary/role-features/role-features.component.html
+++ b/projects/safe/src/lib/components/role-summary/role-features/role-features.component.html
@@ -1,5 +1,5 @@
 <div class="search-bar">
-  <mat-form-field appearance="outline">
+  <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
     <mat-icon matPrefix>search</mat-icon>
     <input
       id="feature-search"

--- a/projects/safe/src/lib/components/role-summary/role-features/role-features.component.html
+++ b/projects/safe/src/lib/components/role-summary/role-features/role-features.component.html
@@ -1,12 +1,11 @@
 <div class="search-bar">
   <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
     <mat-icon matPrefix>search</mat-icon>
+    <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
     <input
-      id="feature-search"
       matInput
       [(ngModel)]="search"
       type="search"
-      [placeholder]="'common.placeholder.search' | translate"
     />
     <safe-button
       matSuffix

--- a/projects/safe/src/lib/components/role-summary/role-features/role-features.component.scss
+++ b/projects/safe/src/lib/components/role-summary/role-features/role-features.component.scss
@@ -13,20 +13,32 @@
       position: relative;
       top: -0.15em;
     }
-  }
-  ::ng-deep .mat-form-field-flex > .mat-form-field-infix {
-    padding: 0.42em 0px !important;
-  }
-  ::ng-deep .mat-form-field-label-wrapper {
-    top: -1.4em;
-  }
-  ::ng-deep
-    .mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float
-    .mat-form-field-label {
-    transform: translateY(-1.1em) scale(0.75);
-    width: 133.33333%;
-  }
-  ::ng-deep .mat-form-field-wrapper {
-    padding-bottom: 0;
+
+    .p-0 {
+      // no padding fields
+      &.mat-form-field {
+        .mat-form-field-wrapper {
+          padding: 0 !important;
+        }
+      }
+    }
+  
+    .mat-form-field-sm {
+      // small form-field
+      &.mat-form-field {
+        .mat-form-field-label-wrapper {
+          top: -1.4em;
+        }
+      }
+  
+      .mat-form-field-flex > .mat-form-field-infix {
+        padding: 0.42em 0px !important;
+      }
+  
+      &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+        transform: translateY(-1.1em) scale(0.75);
+        width: 133.33333%;
+      }
+    }
   }
 }

--- a/projects/safe/src/lib/components/role-summary/role-features/role-features.component.scss
+++ b/projects/safe/src/lib/components/role-summary/role-features/role-features.component.scss
@@ -9,11 +9,6 @@
   justify-content: flex-end;
 
   mat-form-field {
-    #feature-search {
-      position: relative;
-      top: -0.15em;
-    }
-
     .p-0 {
       // no padding fields
       &.mat-form-field {

--- a/projects/safe/src/lib/components/role-summary/role-features/role-features.component.scss
+++ b/projects/safe/src/lib/components/role-summary/role-features/role-features.component.scss
@@ -7,33 +7,4 @@
 .search-bar {
   display: flex;
   justify-content: flex-end;
-
-  mat-form-field {
-    .p-0 {
-      // no padding fields
-      &.mat-form-field {
-        .mat-form-field-wrapper {
-          padding: 0 !important;
-        }
-      }
-    }
-  
-    .mat-form-field-sm {
-      // small form-field
-      &.mat-form-field {
-        .mat-form-field-label-wrapper {
-          top: -1.4em;
-        }
-      }
-  
-      .mat-form-field-flex > .mat-form-field-infix {
-        padding: 0.42em 0px !important;
-      }
-  
-      &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-        transform: translateY(-1.1em) scale(0.75);
-        width: 133.33333%;
-      }
-    }
-  }
 }

--- a/projects/safe/src/lib/components/role-summary/role-resources-filter/role-resources-filter.component.html
+++ b/projects/safe/src/lib/components/role-summary/role-resources-filter/role-resources-filter.component.html
@@ -1,6 +1,6 @@
 <div [formGroup]="form" class="resources-filter">
   <div class="top">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-icon matPrefix>search</mat-icon>
       <input
         id="custom-search"
@@ -25,7 +25,7 @@
     </safe-button>
   </div>
   <div class="advanced" *ngIf="show">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-label>{{ 'common.input.dateRange' | translate }}</mat-label>
       <mat-date-range-input [rangePicker]="rangePicker">
         <input formControlName="startDate" matStartDate />

--- a/projects/safe/src/lib/components/role-summary/role-resources-filter/role-resources-filter.component.html
+++ b/projects/safe/src/lib/components/role-summary/role-resources-filter/role-resources-filter.component.html
@@ -2,12 +2,11 @@
   <div class="top">
     <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-icon matPrefix>search</mat-icon>
+      <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
       <input
-        id="custom-search"
         matInput
         [formControl]="search"
         type="search"
-        [placeholder]="'common.placeholder.search' | translate"
       />
       <mat-spinner *ngIf="loading" diameter="24" matSuffix></mat-spinner>
     </mat-form-field>

--- a/projects/safe/src/lib/components/role-summary/role-resources-filter/role-resources-filter.component.scss
+++ b/projects/safe/src/lib/components/role-summary/role-resources-filter/role-resources-filter.component.scss
@@ -14,18 +14,32 @@
       position: relative;
       top: -0.15em;
     }
-  }
-  ::ng-deep .mat-form-field-flex > .mat-form-field-infix {
-    padding: 0.42em 0px !important;
-  }
-  ::ng-deep .mat-form-field-label-wrapper {
-    top: -1.4em;
-  }
 
-  ::ng-deep
-    .mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float
-    .mat-form-field-label {
-    transform: translateY(-1.1em) scale(0.75);
-    width: 133.33333%;
+    .p-0 {
+      // no padding fields
+      &.mat-form-field {
+        .mat-form-field-wrapper {
+          padding: 0 !important;
+        }
+      }
+    }
+  
+    .mat-form-field-sm {
+      // small form-field
+      &.mat-form-field {
+        .mat-form-field-label-wrapper {
+          top: -1.4em;
+        }
+      }
+  
+      .mat-form-field-flex > .mat-form-field-infix {
+        padding: 0.42em 0px !important;
+      }
+  
+      &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+        transform: translateY(-1.1em) scale(0.75);
+        width: 133.33333%;
+      }
+    }
   }
 }

--- a/projects/safe/src/lib/components/role-summary/role-resources-filter/role-resources-filter.component.scss
+++ b/projects/safe/src/lib/components/role-summary/role-resources-filter/role-resources-filter.component.scss
@@ -7,34 +7,4 @@
     gap: 16px;
     flex-wrap: wrap;
   }
-  mat-form-field {
-    margin-top: -0.25em;
-
-    .p-0 {
-      // no padding fields
-      &.mat-form-field {
-        .mat-form-field-wrapper {
-          padding: 0 !important;
-        }
-      }
-    }
-  
-    .mat-form-field-sm {
-      // small form-field
-      &.mat-form-field {
-        .mat-form-field-label-wrapper {
-          top: -1.4em;
-        }
-      }
-  
-      .mat-form-field-flex > .mat-form-field-infix {
-        padding: 0.42em 0px !important;
-      }
-  
-      &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-        transform: translateY(-1.1em) scale(0.75);
-        width: 133.33333%;
-      }
-    }
-  }
 }

--- a/projects/safe/src/lib/components/role-summary/role-resources-filter/role-resources-filter.component.scss
+++ b/projects/safe/src/lib/components/role-summary/role-resources-filter/role-resources-filter.component.scss
@@ -10,11 +10,6 @@
   mat-form-field {
     margin-top: -0.25em;
 
-    #custom-search {
-      position: relative;
-      top: -0.15em;
-    }
-
     .p-0 {
       // no padding fields
       &.mat-form-field {

--- a/projects/safe/src/lib/components/roles/components/group-list/group-list.component.html
+++ b/projects/safe/src/lib/components/roles/components/group-list/group-list.component.html
@@ -1,13 +1,12 @@
 <div class="header">
   <div class="filters">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-icon matPrefix>search</mat-icon>
+      <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
       <input
-        id="custom-search"
         matInput
         (keyup)="applyFilter($event)"
         type="search"
-        [placeholder]="'common.placeholder.search' | translate"
       />
     </mat-form-field>
   </div>

--- a/projects/safe/src/lib/components/roles/components/group-list/group-list.component.scss
+++ b/projects/safe/src/lib/components/roles/components/group-list/group-list.component.scss
@@ -5,38 +5,6 @@
   justify-content: space-between;
   align-items: top;
 
-  .filters {
-    mat-form-field {
-
-      .p-0 {
-        // no padding fields
-        &.mat-form-field {
-          .mat-form-field-wrapper {
-            padding: 0 !important;
-          }
-        }
-      }
-    
-      .mat-form-field-sm {
-        // small form-field
-        &.mat-form-field {
-          .mat-form-field-label-wrapper {
-            top: -1.4em;
-          }
-        }
-    
-        .mat-form-field-flex > .mat-form-field-infix {
-          padding: 0.42em 0px !important;
-        }
-    
-        &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-          transform: translateY(-1.1em) scale(0.75);
-          width: 133.33333%;
-        }
-      }
-    }
-  }
-
   .actions {
     margin-left: auto;
   }

--- a/projects/safe/src/lib/components/roles/components/group-list/group-list.component.scss
+++ b/projects/safe/src/lib/components/roles/components/group-list/group-list.component.scss
@@ -7,15 +7,33 @@
 
   .filters {
     mat-form-field {
-      margin-top: -0.25em;
 
-      #custom-search {
-        position: relative;
-        top: -0.15em;
+      .p-0 {
+        // no padding fields
+        &.mat-form-field {
+          .mat-form-field-wrapper {
+            padding: 0 !important;
+          }
+        }
       }
-    }
-    ::ng-deep .mat-form-field-flex > .mat-form-field-infix {
-      padding: 0.42em 0px !important;
+    
+      .mat-form-field-sm {
+        // small form-field
+        &.mat-form-field {
+          .mat-form-field-label-wrapper {
+            top: -1.4em;
+          }
+        }
+    
+        .mat-form-field-flex > .mat-form-field-infix {
+          padding: 0.42em 0px !important;
+        }
+    
+        &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+          transform: translateY(-1.1em) scale(0.75);
+          width: 133.33333%;
+        }
+      }
     }
   }
 

--- a/projects/safe/src/lib/components/roles/components/role-list/role-list.component.html
+++ b/projects/safe/src/lib/components/roles/components/role-list/role-list.component.html
@@ -1,14 +1,13 @@
 <div class="header">
   <div class="filters">
-    <mat-form-field appearance="outline">
+    <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
       <mat-icon matPrefix>search</mat-icon>
+      <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
       <input
-        id="custom-search"
         matInput
         [ngModel]="searchText"
         (keyup)="applyFilter('', $event)"
         type="search"
-        [placeholder]="'common.placeholder.search' | translate"
       />
     </mat-form-field>
   </div>

--- a/projects/safe/src/lib/components/roles/components/role-list/role-list.component.scss
+++ b/projects/safe/src/lib/components/roles/components/role-list/role-list.component.scss
@@ -5,38 +5,6 @@
   justify-content: space-between;
   align-items: top;
 
-  .filters {
-    mat-form-field {
-
-      .p-0 {
-        // no padding fields
-        &.mat-form-field {
-          .mat-form-field-wrapper {
-            padding: 0 !important;
-          }
-        }
-      }
-    
-      .mat-form-field-sm {
-        // small form-field
-        &.mat-form-field {
-          .mat-form-field-label-wrapper {
-            top: -1.4em;
-          }
-        }
-    
-        .mat-form-field-flex > .mat-form-field-infix {
-          padding: 0.42em 0px !important;
-        }
-    
-        &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-          transform: translateY(-1.1em) scale(0.75);
-          width: 133.33333%;
-        }
-      }
-    }
-  }
-
   .actions {
     margin-left: auto;
   }

--- a/projects/safe/src/lib/components/roles/components/role-list/role-list.component.scss
+++ b/projects/safe/src/lib/components/roles/components/role-list/role-list.component.scss
@@ -7,15 +7,33 @@
 
   .filters {
     mat-form-field {
-      margin-top: -0.25em;
 
-      #custom-search {
-        position: relative;
-        top: -0.15em;
+      .p-0 {
+        // no padding fields
+        &.mat-form-field {
+          .mat-form-field-wrapper {
+            padding: 0 !important;
+          }
+        }
       }
-    }
-    ::ng-deep .mat-form-field-flex > .mat-form-field-infix {
-      padding: 0.42em 0px !important;
+    
+      .mat-form-field-sm {
+        // small form-field
+        &.mat-form-field {
+          .mat-form-field-label-wrapper {
+            top: -1.4em;
+          }
+        }
+    
+        .mat-form-field-flex > .mat-form-field-infix {
+          padding: 0.42em 0px !important;
+        }
+    
+        &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+          transform: translateY(-1.1em) scale(0.75);
+          width: 133.33333%;
+        }
+      }
     }
   }
 

--- a/projects/safe/src/lib/components/users/users.component.html
+++ b/projects/safe/src/lib/components/users/users.component.html
@@ -3,13 +3,12 @@
     <div class="top">
       <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
         <mat-icon matPrefix>search</mat-icon>
+        <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
         <input
-          id="custom-search"
           matInput
           [ngModel]="searchText"
           (keyup)="applyFilter('', $event)"
           type="search"
-          [placeholder]="'common.placeholder.search' | translate"
         />
       </mat-form-field>
       <safe-button

--- a/projects/safe/src/lib/components/users/users.component.html
+++ b/projects/safe/src/lib/components/users/users.component.html
@@ -1,7 +1,7 @@
 <div class="header">
   <div class="filters">
     <div class="top">
-      <mat-form-field appearance="outline">
+      <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
         <mat-icon matPrefix>search</mat-icon>
         <input
           id="custom-search"
@@ -27,7 +27,7 @@
       </safe-button>
     </div>
     <div class="advanced" [style.display]="!showFilters ? 'none' : ''">
-      <mat-form-field appearance="outline">
+      <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
         <mat-label>{{ 'common.title' | translate }}</mat-label>
         <mat-select
           [ngModel]="roleFilter"

--- a/projects/safe/src/lib/components/users/users.component.scss
+++ b/projects/safe/src/lib/components/users/users.component.scss
@@ -16,12 +16,7 @@
     }
     mat-form-field {
       margin-top: -0.25em;
-
-      #custom-search {
-        position: relative;
-        top: -0.15em;
-      }
-
+      
       .p-0 {
         // no padding fields
         &.mat-form-field {

--- a/projects/safe/src/lib/components/users/users.component.scss
+++ b/projects/safe/src/lib/components/users/users.component.scss
@@ -21,19 +21,33 @@
         position: relative;
         top: -0.15em;
       }
-    }
-    ::ng-deep .mat-form-field-flex > .mat-form-field-infix {
-      padding: 0.42em 0px !important;
-    }
-    ::ng-deep .mat-form-field-label-wrapper {
-      top: -1.4em;
-    }
 
-    ::ng-deep
-      .mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float
-      .mat-form-field-label {
-      transform: translateY(-1.1em) scale(0.75);
-      width: 133.33333%;
+      .p-0 {
+        // no padding fields
+        &.mat-form-field {
+          .mat-form-field-wrapper {
+            padding: 0 !important;
+          }
+        }
+      }
+    
+      .mat-form-field-sm {
+        // small form-field
+        &.mat-form-field {
+          .mat-form-field-label-wrapper {
+            top: -1.4em;
+          }
+        }
+    
+        .mat-form-field-flex > .mat-form-field-infix {
+          padding: 0.42em 0px !important;
+        }
+    
+        &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+          transform: translateY(-1.1em) scale(0.75);
+          width: 133.33333%;
+        }
+      }
     }
   }
 

--- a/projects/safe/src/lib/components/users/users.component.scss
+++ b/projects/safe/src/lib/components/users/users.component.scss
@@ -14,36 +14,6 @@
       gap: 16px;
       flex-wrap: wrap;
     }
-    mat-form-field {
-      margin-top: -0.25em;
-      
-      .p-0 {
-        // no padding fields
-        &.mat-form-field {
-          .mat-form-field-wrapper {
-            padding: 0 !important;
-          }
-        }
-      }
-    
-      .mat-form-field-sm {
-        // small form-field
-        &.mat-form-field {
-          .mat-form-field-label-wrapper {
-            top: -1.4em;
-          }
-        }
-    
-        .mat-form-field-flex > .mat-form-field-infix {
-          padding: 0.42em 0px !important;
-        }
-    
-        &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-          transform: translateY(-1.1em) scale(0.75);
-          width: 133.33333%;
-        }
-      }
-    }
   }
 
   .actions {

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -275,6 +275,33 @@ $safe-theme: mat.define-light-theme($safe-primary, $safe-accent, $safe-warn);
       vertical-align: text-bottom;
     }
   }
+
+  .p-0 {
+    // no padding fields
+    &.mat-form-field {
+      .mat-form-field-wrapper {
+        padding: 0 !important;
+      }
+    }
+  }
+
+  .mat-form-field-sm {
+    // small form-field
+    &.mat-form-field {
+      .mat-form-field-label-wrapper {
+        top: -1.4em;
+      }
+    }
+
+    .mat-form-field-flex > .mat-form-field-infix {
+      padding: 0.42em 0px !important;
+    }
+
+    &.mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
+      transform: translateY(-1.1em) scale(0.75);
+      width: 133.33333%;
+    }
+  }
 }
 
 @mixin modal($theme) {


### PR DESCRIPTION
# Description

Replace all 'small' mat-form-fields with new scss and use mat-label instead of placeholder.

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Check the aspect of all search bars. 

## Sreenshots

![mat-form-field](https://user-images.githubusercontent.com/59767527/197169046-92d9c9b9-a586-48f0-be80-9e73b229f30f.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
