### PR TITLE
Refactor display for edition of page name field with outline and matS…

### DIFF
--- a/projects/back-office/src/app/application/pages/form/form.component.html
+++ b/projects/back-office/src/app/application/pages/form/form.component.html
@@ -28,25 +28,28 @@
     </ng-container>
     <ng-container *ngIf="formActive">
       <form [formGroup]="tabNameForm" (ngSubmit)="saveName()">
-        <mat-form-field>
+        <mat-form-field appearance="outline">
           <mat-label>{{ 'common.name' | translate }}</mat-label>
           <input matInput formControlName="tabName" type="string" />
+          <safe-button
+            matSuffix
+            type="submit"
+            [isIcon]="true"
+            icon="save"
+            variant="primary"
+            [disabled]="!tabNameForm.valid"
+          ></safe-button>
+          <safe-button
+            matSuffix
+            [isIcon]="true"
+            icon="close"
+            variant="danger"
+            (click)="toggleFormActive()"
+          ></safe-button>
         </mat-form-field>
-        <safe-button
-          type="submit"
-          [isIcon]="true"
-          icon="save"
-          variant="primary"
-          [disabled]="!tabNameForm.valid"
-        >
-        </safe-button>
-        <safe-button
-          [isIcon]="true"
-          icon="close"
-          variant="danger"
-          (click)="toggleFormActive()"
-        >
-        </safe-button>
+        
+        
+        
       </form>
     </ng-container>
   </div>

--- a/projects/back-office/src/app/application/pages/form/form.component.html
+++ b/projects/back-office/src/app/application/pages/form/form.component.html
@@ -35,7 +35,7 @@
             matSuffix
             type="submit"
             [isIcon]="true"
-            icon="save"
+            icon="done"
             variant="primary"
             [disabled]="!tabNameForm.valid"
           ></safe-button>

--- a/projects/back-office/src/app/application/pages/workflow/workflow.component.html
+++ b/projects/back-office/src/app/application/pages/workflow/workflow.component.html
@@ -73,25 +73,27 @@
     (ngSubmit)="saveName()"
     class="name-edit-container"
   >
-    <mat-form-field>
+    <mat-form-field appearance="outline">
       <mat-label>{{ 'common.name' | translate }}</mat-label>
       <input matInput formControlName="workflowName" type="string" />
+      <safe-button
+        matSuffix
+        type="submit"
+        [isIcon]="true"
+        icon="save"
+        variant="primary"
+        [disabled]="!workflowNameForm.valid"
+      >
+      </safe-button>
+      <safe-button
+        matSuffix
+        [isIcon]="true"
+        icon="close"
+        variant="danger"
+        (click)="toggleFormActive()"
+      >
+      </safe-button>
     </mat-form-field>
-    <safe-button
-      type="submit"
-      [isIcon]="true"
-      icon="save"
-      variant="primary"
-      [disabled]="!workflowNameForm.valid"
-    >
-    </safe-button>
-    <safe-button
-      [isIcon]="true"
-      icon="close"
-      variant="danger"
-      (click)="toggleFormActive()"
-    >
-    </safe-button>
   </form>
 </ng-container>
 <!-- STEPS -->

--- a/projects/back-office/src/app/application/pages/workflow/workflow.component.html
+++ b/projects/back-office/src/app/application/pages/workflow/workflow.component.html
@@ -80,7 +80,7 @@
         matSuffix
         type="submit"
         [isIcon]="true"
-        icon="save"
+        icon="done"
         variant="primary"
         [disabled]="!workflowNameForm.valid"
       >

--- a/projects/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
+++ b/projects/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
@@ -84,7 +84,7 @@
             matSuffix
             type="submit"
             [isIcon]="true"
-            icon="save"
+            icon="done"
             variant="primary"
             [disabled]="!dashboardNameForm.valid"
           >

--- a/projects/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
+++ b/projects/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
@@ -77,26 +77,28 @@
         (ngSubmit)="saveName()"
         class="name-edit-container"
       >
-        <mat-form-field>
+        <mat-form-field appearance="outline">
           <mat-label>{{ 'common.name' | translate }}</mat-label>
           <input matInput formControlName="dashboardName" type="string" />
+          <safe-button
+            matSuffix
+            type="submit"
+            [isIcon]="true"
+            icon="save"
+            variant="primary"
+            [disabled]="!dashboardNameForm.valid"
+          >
+          </safe-button>
+          <safe-button
+            matSuffix
+            mat-icon-button
+            [isIcon]="true"
+            icon="close"
+            variant="danger"
+            (click)="toggleFormActive()"
+          >
+          </safe-button>
         </mat-form-field>
-        <safe-button
-          type="submit"
-          [isIcon]="true"
-          icon="save"
-          variant="primary"
-          [disabled]="!dashboardNameForm.valid"
-        >
-        </safe-button>
-        <safe-button
-          mat-icon-button
-          [isIcon]="true"
-          icon="close"
-          variant="danger"
-          (click)="toggleFormActive()"
-        >
-        </safe-button>
       </form>
     </ng-container>
   </ng-container>

--- a/projects/back-office/src/app/dashboard/pages/form-builder/form-builder.component.html
+++ b/projects/back-office/src/app/dashboard/pages/form-builder/form-builder.component.html
@@ -8,25 +8,27 @@
 
     <ng-container *ngIf="formActive">
       <form [formGroup]="nameForm" (ngSubmit)="saveName()">
-        <mat-form-field>
+        <mat-form-field appearance="outline">
           <mat-label>{{ 'common.name' | translate }}</mat-label>
           <input matInput formControlName="formName" type="string" />
+          <safe-button
+          matSuffix
+            type="submit"
+            [isIcon]="true"
+            icon="done"
+            variant="primary"
+            [disabled]="!nameForm.valid"
+          >
+          </safe-button>
+          <safe-button
+            matSuffix
+            [isIcon]="true"
+            icon="close"
+            variant="danger"
+            (click)="toggleFormActive()"
+          >
+          </safe-button>
         </mat-form-field>
-        <safe-button
-          type="submit"
-          [isIcon]="true"
-          icon="save"
-          variant="primary"
-          [disabled]="!nameForm.valid"
-        >
-        </safe-button>
-        <safe-button
-          [isIcon]="true"
-          icon="close"
-          variant="danger"
-          (click)="toggleFormActive()"
-        >
-        </safe-button>
       </form>
     </ng-container>
     <span class="flex-spacer"></span>


### PR DESCRIPTION
# Description

Refactor display for edition of page name field.

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [ ] Check that display of page name edition with form, dashboard and workflow are the good one.

## Sreenshots

![page_name_edition](https://user-images.githubusercontent.com/59767527/197498413-b4bb044f-ba76-4537-be10-c9d60b6d9de7.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
