### PR TITLE
Fix 1.4.0/oort 481 resource page tab not appear as selected

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/resource/resource.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/resource.component.ts
@@ -15,7 +15,7 @@ import { TranslateService } from '@ngx-translate/core';
 /**
  * Array of tab names sorted by position index.
  */
-const ROUTE_TABS: string[] = ['records', 'forms', 'layouts', 'aggregations'];
+const ROUTE_TABS: string[] = ['records', 'forms', 'layouts', 'aggregations', 'calculated-fields'];
 
 /**
  * Component used to display resource in a table.
@@ -54,6 +54,7 @@ export class ResourceComponent implements OnInit {
   ngOnInit(): void {
     const routeTab: string = this.router.url.split('/').pop() || '';
     this.selectedTab = ROUTE_TABS.findIndex((tab) => tab === routeTab);
+    console.log(this.selectedTab);
     this.id = this.route.snapshot.paramMap.get('id') || '';
     if (this.id !== null) {
       this.getResourceData();

--- a/projects/back-office/src/app/dashboard/pages/resource/resource.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/resource.component.ts
@@ -15,7 +15,13 @@ import { TranslateService } from '@ngx-translate/core';
 /**
  * Array of tab names sorted by position index.
  */
-const ROUTE_TABS: string[] = ['records', 'forms', 'layouts', 'aggregations', 'calculated-fields'];
+const ROUTE_TABS: string[] = [
+  'records',
+  'forms',
+  'layouts',
+  'aggregations',
+  'calculated-fields',
+];
 
 /**
  * Component used to display resource in a table.

--- a/projects/back-office/src/app/dashboard/pages/resource/resource.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/resource.component.ts
@@ -60,7 +60,6 @@ export class ResourceComponent implements OnInit {
   ngOnInit(): void {
     const routeTab: string = this.router.url.split('/').pop() || '';
     this.selectedTab = ROUTE_TABS.findIndex((tab) => tab === routeTab);
-    console.log(this.selectedTab);
     this.id = this.route.snapshot.paramMap.get('id') || '';
     if (this.id !== null) {
       this.getResourceData();


### PR DESCRIPTION
# Description

When reloading any tab of resource page, the tab appear as selected

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Reloading any tab of resource page, the tab appear as selected

## Sreenshots

![records_tab_appear_as_selected](https://user-images.githubusercontent.com/59767527/197508360-1742f7ee-4ec8-41af-bbe4-cec8b60702b4.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
