### PR TITLE
Fix 1.3.0/oort 485 prevent form being saved

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -1408,6 +1408,7 @@
 				"multipletext": {
 					"missingName": "Please provide name or title for each text of question: {{question}}"
 				},
+				"selectApplication": "Missing value application for an element on page {{page}}. Please select at least one application in properties of {{question}} to save the form.",
 				"snakecase": "The value name {{name}} on page {{page}} is invalid. Please conform to snake_case."
 			},
 			"questionsCategories": {

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -1408,6 +1408,7 @@
 				"multipletext": {
 					"missingName": "Veuillez configurer un nom ou titre pour chaque champ de text de la question : {{question}}"
 				},
+				"selectApplication": "Application manquante pour un élément de la page : {{page}}. Veuillez sélectionner au moins une application dans les propriétés de {{question}} pour sauvegarder le formulaire.",
 				"snakecase": "Le nom de valeur {{name}} de la page {{page}} est invalide. Veuillez configurer un nom valide (en format snake_case) pour sauvegarder le formulaire."
 			},
 			"questionsCategories": {

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -1408,6 +1408,7 @@
 				"multipletext": {
 					"missingName": "****** {{question}}"
 				},
+				"selectApplication": "****** {{page}} ****** {{question}} ******",
 				"snakecase": "****** {{name}} ****** {{page}} ******"
 			},
 			"questionsCategories": {

--- a/projects/safe/src/lib/components/application-dropdown/application-dropdown.component.ts
+++ b/projects/safe/src/lib/components/application-dropdown/application-dropdown.component.ts
@@ -101,6 +101,8 @@ export class SafeApplicationDropdownComponent implements OnInit {
         query: GET_APPLICATIONS,
         variables: {
           first: ITEMS_PER_PAGE,
+          sortField: 'name',
+          sortOrder: 'asc',
         },
       });
 

--- a/projects/safe/src/lib/components/application-dropdown/graphql/queries.ts
+++ b/projects/safe/src/lib/components/application-dropdown/graphql/queries.ts
@@ -5,8 +5,8 @@ import { Application } from '../../../models/application.model';
 
 /** Graphql request for getting the list of applications */
 export const GET_APPLICATIONS = gql`
-  query GetApplications($first: Int, $afterCursor: ID, $filter: JSON) {
-    applications(first: $first, afterCursor: $afterCursor, filter: $filter) {
+  query GetApplications($first: Int, $afterCursor: ID, $filter: JSON, $sortField: String, $sortOrder: String) {
+    applications(first: $first, afterCursor: $afterCursor, filter: $filter, sortField: $sortField, sortOrder: $sortOrder) {
       edges {
         node {
           id

--- a/projects/safe/src/lib/components/application-dropdown/graphql/queries.ts
+++ b/projects/safe/src/lib/components/application-dropdown/graphql/queries.ts
@@ -5,8 +5,20 @@ import { Application } from '../../../models/application.model';
 
 /** Graphql request for getting the list of applications */
 export const GET_APPLICATIONS = gql`
-  query GetApplications($first: Int, $afterCursor: ID, $filter: JSON, $sortField: String, $sortOrder: String) {
-    applications(first: $first, afterCursor: $afterCursor, filter: $filter, sortField: $sortField, sortOrder: $sortOrder) {
+  query GetApplications(
+    $first: Int
+    $afterCursor: ID
+    $filter: JSON
+    $sortField: String
+    $sortOrder: String
+  ) {
+    applications(
+      first: $first
+      afterCursor: $afterCursor
+      filter: $filter
+      sortField: $sortField
+      sortOrder: $sortOrder
+    ) {
       edges {
         node {
           id

--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -481,15 +481,11 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
     // Check that at least an application is selected in the properties of users and owner question
     if (['users', 'owner'].includes(element.getType())) {
       if (!element.applications) {
-        console.log('USER and OWNER error');
         throw new Error(
-          this.translate.instant(
-            'pages.formBuilder.errors.selectApplication',
-            {
-              question: element.name,
-              page: page.name,
-            }
-          )
+          this.translate.instant('pages.formBuilder.errors.selectApplication', {
+            question: element.name,
+            page: page.name,
+          })
         );
       }
     }

--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -478,6 +478,21 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
         );
       }
     }
+    // Check that at least an application is selected in the properties of users and owner question
+    if (['users', 'owner'].includes(element.getType())) {
+      if (!element.applications) {
+        console.log('USER and OWNER error');
+        throw new Error(
+          this.translate.instant(
+            'pages.formBuilder.errors.selectApplication',
+            {
+              question: element.name,
+              page: page.name,
+            }
+          )
+        );
+      }
+    }
     // if the element contains other elements, apply the same rule on them
     if (element.elements) {
       element.elements.forEach((elt: AnyQuestion) =>


### PR DESCRIPTION
# Description

Prevent form with Users custom question from being saved if Applications property is missing.

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Create a form with Users and Owner questions, don't fill the applications field and check that it is impossible to save.
- [x] Fill the applications field and check that it is possible to save.

## Sreenshots

![users_and_owner](https://user-images.githubusercontent.com/59767527/198035444-24cdeaa8-f368-4fa0-8b7b-c35153fd6fee.png)

![application_sorted](https://user-images.githubusercontent.com/59767527/198035388-4689432c-3b4c-4ae0-8041-4b85310c6637.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
