### PR TITLE
fix-1.3.0/OORT-488_side-nav-error

### DIFF
--- a/projects/safe/src/lib/components/layout/layout.component.html
+++ b/projects/safe/src/lib/components/layout/layout.component.html
@@ -132,7 +132,7 @@
   <mat-sidenav
     class="sidenav"
     #nav
-    [mode]="largeDevice && nav.opened ? 'side' : 'over'"
+    [mode]="largeDevice ? 'side' : 'over'"
     [opened]="largeDevice"
   >
     <ng-container *ngIf="leftSidenav">

--- a/projects/safe/src/lib/components/layout/layout.component.html
+++ b/projects/safe/src/lib/components/layout/layout.component.html
@@ -138,7 +138,7 @@
     <ng-container *ngIf="leftSidenav">
       <ng-container
         [ngTemplateOutlet]="leftSidenav"
-        [ngTemplateOutletContext]="nav"
+        [ngTemplateOutletContext]="{ $implicit: nav }"
       ></ng-container>
     </ng-container>
   </mat-sidenav>


### PR DESCRIPTION
# Description

This PR fixes a NG0100 error when changing the screen size and triggering the side nav to open

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By changing the display size of the window and toggling the side nav 

## Sreenshots
![Peek 2022-10-18 16-56](https://user-images.githubusercontent.com/102038450/198166080-6dc06ec2-8210-4304-9e4d-2e4cccb2198c.gif)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
