### PR TITLE
fix form records, has the same display than for resource records tab.

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.html
+++ b/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.html
@@ -76,16 +76,18 @@
         [stickyEnd]="column === '_actions'"
       >
         <ng-container *ngIf="!defaultColumns.includes(column)">
-          <th mat-header-cell *matHeaderCellDef class="table-column">
-            {{ column }}
+          <th mat-header-cell *matHeaderCellDef>
+            <div>{{ column }}</div>
           </th>
-          <td mat-cell *matCellDef="let element" class="table-column">
+          <td mat-cell *matCellDef="let element">
             <div>{{ element.data[column] }}</div>
           </td>
         </ng-container>
         <ng-container *ngIf="column === '_incrementalId'">
-          <th mat-header-cell *matHeaderCellDef class="table-column">ID</th>
-          <td mat-cell *matCellDef="let element" class="table-column">
+          <th mat-header-cell *matHeaderCellDef>
+            <div>ID</div>
+          </th>
+          <td mat-cell *matCellDef="let element">
             <div>{{ element.incrementalId }}</div>
           </td>
         </ng-container>

--- a/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.html
+++ b/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.html
@@ -1,10 +1,16 @@
-<div class="page-header">
-  <h1 class="page-title">
+<!-- Header -->
+<div class="flex mb-6 justify-between gap-4">
+  <!-- Title -->
+  <h1 class="!m-0">
     {{
-      showDeletedRecords ? 'List of archived records' : 'List of active records'
+      (showDeletedRecords
+        ? 'components.records.archived'
+        : 'components.records.active'
+      ) | translate
     }}
   </h1>
-  <div class="actions" *ngIf="!loading">
+  <!-- Actions -->
+  <div *ngIf="!loading" class="flex gap-2 items-center flex-wrap justify-end">
     <safe-button
       *ngIf="form.canUpdate && !showDeletedRecords"
       icon="search_off"
@@ -46,7 +52,6 @@
       (click)="showUpload = !showUpload"
       cdkOverlayOrigin
       #uploadTrigger="cdkOverlayOrigin"
-      style="margin-left: 1rem"
     >
       {{
         'common.uploadObject'
@@ -66,10 +71,12 @@
     </ng-template>
   </div>
 </div>
-<mat-spinner diameter="45" class="page-loader" *ngIf="loading"></mat-spinner>
-<ng-container *ngIf="!loading">
-  <div class="table-container">
-    <table mat-table [dataSource]="dataSource">
+<!-- Table container -->
+<div class="overflow-x-hidden">
+  <!-- Table scroll container -->
+  <div class="overflow-auto">
+    <!-- Records table -->
+    <table *ngIf="!loading" mat-table [dataSource]="dataSource">
       <ng-container
         *ngFor="let column of displayedColumns"
         [matColumnDef]="column"
@@ -147,12 +154,18 @@
       ></tr>
     </table>
   </div>
-  <mat-paginator
-    [disabled]="loadingMore"
-    [pageSize]="pageInfo.pageSize"
-    [length]="pageInfo.length"
-    aria-label="Select page of records"
-    (page)="onPage($event)"
-  >
-  </mat-paginator>
-</ng-container>
+</div>
+<safe-skeleton-table
+  *ngIf="loading"
+  [columns]="displayedColumns"
+  [actions]="true"
+>
+</safe-skeleton-table>
+<mat-paginator
+  [disabled]="loadingMore"
+  [pageSize]="pageInfo.pageSize"
+  [length]="pageInfo.length"
+  aria-label="Select page of records"
+  (page)="onPage($event)"
+>
+</mat-paginator>

--- a/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.scss
@@ -1,11 +1,3 @@
-.actions {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end !important;
-  text-align: end;
-  margin-left: auto;
-}
-
 table {
   div {
     max-height: 48px;
@@ -14,12 +6,4 @@ table {
     text-overflow: ellipsis;
     max-width: 240px;
   }
-}
-
-.table-container {
-  overflow-x: auto;
-}
-
-input {
-  margin-left: 1rem;
 }

--- a/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.scss
+++ b/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.scss
@@ -6,9 +6,7 @@
   margin-left: auto;
 }
 
-.table-column {
-  padding: 0px 4px;
-
+table {
   div {
     max-height: 48px;
     white-space: nowrap;

--- a/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.ts
@@ -17,7 +17,6 @@ import {
   RestoreRecordMutationResponse,
   RESTORE_RECORD,
 } from './graphql/mutations';
-import { extractColumns } from '../../../utils/extractColumns';
 import {
   SafeRecordHistoryComponent,
   SafeLayoutService,

--- a/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/form-records/form-records.component.ts
@@ -29,6 +29,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { SafeDownloadService, Record } from '@safe/builder';
 import { Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
+import get from 'lodash/get';
 
 /** Default items per query, for pagination */
 const ITEMS_PER_PAGE = 10;
@@ -208,13 +209,16 @@ export class FormRecordsComponent implements OnInit, OnDestroy {
    */
   private setDisplayedColumns(): void {
     let columns: any[] = [];
-    const structure = JSON.parse(this.form.structure);
-    if (structure && structure.pages) {
-      for (const page of JSON.parse(this.form.structure).pages) {
-        extractColumns(page, columns, this.form.metaData);
-      }
+    for (const field of this.form.fields) {
+      columns.push(field.name);
     }
-    columns = columns.concat(DEFAULT_COLUMNS);
+    const metadata = get(this.form, 'metadata', []);
+    columns = columns
+      .filter((x) => {
+        const fieldMeta = metadata.find((y: any) => y.name === x);
+        return get(fieldMeta, 'canSee', false);
+      })
+      .concat(DEFAULT_COLUMNS);
     this.displayedColumns = columns;
   }
 

--- a/projects/back-office/src/app/dashboard/pages/form-records/form-records.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/form-records/form-records.module.ts
@@ -9,9 +9,9 @@ import {
   SafeRecordHistoryModule,
   SafeButtonModule,
   SafeDividerModule,
+  SafeSkeletonTableModule,
 } from '@safe/builder';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { TranslateModule } from '@ngx-translate/core';
 import { OverlayModule } from '@angular/cdk/overlay';
@@ -30,11 +30,11 @@ import { UploadMenuModule } from '../../../components/upload-menu/upload-menu.mo
     SafeDividerModule,
     MatTooltipModule,
     SafeButtonModule,
-    MatProgressSpinnerModule,
     MatPaginatorModule,
     TranslateModule,
     OverlayModule,
     UploadMenuModule,
+    SafeSkeletonTableModule,
   ],
   exports: [FormRecordsComponent],
 })

--- a/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
@@ -1,5 +1,7 @@
+<!-- Header -->
 <div *ngIf="!loading" class="flex justify-end mb-6">
-  <div class="flex gap-2 items-center flex-wrap">
+  <!-- Actions -->
+  <div class="flex gap-2 items-center flex-wrap justify-end">
     <safe-button
       *ngIf="resource.canUpdate && !showDeletedRecords"
       icon="search_off"
@@ -60,8 +62,11 @@
     </ng-template>
   </div>
 </div>
+<!-- Table container -->
 <div class="overflow-x-hidden">
+  <!-- Table scroll container -->
   <div class="overflow-auto">
+    <!-- Records table -->
     <table *ngIf="!loading" mat-table [dataSource]="dataSource">
       <ng-container
         *ngFor="let column of displayedColumnsRecords"

--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -675,6 +675,8 @@
 			}
 		},
 		"records": {
+			"active": "Active records",
+			"archived": "Archived records",
 			"showActive": "Show active records",
 			"showArchived": "Show archived records",
 			"upload": {

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -675,6 +675,8 @@
 			}
 		},
 		"records": {
+			"active": "Enregistrements actifs",
+			"archived": "Enregistrements archivés",
 			"showActive": "Voir les enregistrements actifs",
 			"showArchived": "Voir les enregistrements archivés",
 			"upload": {

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -675,6 +675,8 @@
 			}
 		},
 		"records": {
+			"active": "******",
+			"archived": "******",
 			"showActive": "******",
 			"showArchived": "******",
 			"upload": {


### PR DESCRIPTION
# Description

Fix form records and add the same display than the resource records tab.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Go in a resource view of a form, check that the display works and is the same than the resource records tab.

## Sreenshots

![forms_records](https://user-images.githubusercontent.com/59767527/198206947-8ab9523d-bdfe-4559-85c7-c9dc7adeef0b.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
