### PR TITLE
Fix 1.3.0/oort 483 layouts duplicated on grid

### DIFF
--- a/projects/safe/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.ts
+++ b/projects/safe/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.ts
@@ -92,7 +92,10 @@ export class AddLayoutModalComponent implements OnInit {
     this.selectedLayoutControl.valueChanges.subscribe((value) => {
       if (value) {
         this.dialogRef.close(
-          this.layoutSelect?.elements.getValue().find((x) => x.id === value)
+          {
+            value: this.layoutSelect?.elements.getValue().find((x) => x.id === value),
+            created: false,
+          }
         );
       }
     });
@@ -114,7 +117,12 @@ export class AddLayoutModalComponent implements OnInit {
           .addLayout(layout, this.resource?.id, this.form?.id)
           .subscribe((res) => {
             if (res.data?.addLayout) {
-              this.dialogRef.close(res.data.addLayout);
+              this.dialogRef.close(
+                {
+                  value: res.data.addLayout,
+                  created: true,
+                }
+              );
             } else {
               this.dialogRef.close();
             }

--- a/projects/safe/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.ts
+++ b/projects/safe/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.ts
@@ -91,12 +91,12 @@ export class AddLayoutModalComponent implements OnInit {
 
     this.selectedLayoutControl.valueChanges.subscribe((value) => {
       if (value) {
-        this.dialogRef.close(
-          {
-            value: this.layoutSelect?.elements.getValue().find((x) => x.id === value),
-            created: false,
-          }
-        );
+        this.dialogRef.close({
+          value: this.layoutSelect?.elements
+            .getValue()
+            .find((x) => x.id === value),
+          created: false,
+        });
       }
     });
   }
@@ -117,12 +117,10 @@ export class AddLayoutModalComponent implements OnInit {
           .addLayout(layout, this.resource?.id, this.form?.id)
           .subscribe((res) => {
             if (res.data?.addLayout) {
-              this.dialogRef.close(
-                {
-                  value: res.data.addLayout,
-                  created: true,
-                }
-              );
+              this.dialogRef.close({
+                value: res.data.addLayout,
+                created: true,
+              });
             } else {
               this.dialogRef.close();
             }

--- a/projects/safe/src/lib/components/grid-layout/layout-table/layout-table.component.ts
+++ b/projects/safe/src/lib/components/grid-layout/layout-table/layout-table.component.ts
@@ -100,11 +100,13 @@ export class LayoutTableComponent implements OnInit, OnChanges {
         resource: this.resource,
       },
     });
-    dialogRef.afterClosed().subscribe((value) => {
-      if (value) {
-        this.allLayouts.push(value);
+    dialogRef.afterClosed().subscribe((res) => {
+      if (res) {
+        if (res.created) {
+          this.allLayouts.push(res.value);
+        }
         this.selectedLayouts?.setValue(
-          this.selectedLayouts?.value.concat(value.id)
+          this.selectedLayouts?.value.concat(res.value.id)
         );
       }
     });

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -177,8 +177,7 @@ export class SafeGridSettingsComponent implements OnInit, AfterViewInit {
     this.fields = this.queryBuilder.getFields(this.queryName);
     const query = this.queryBuilder.sourceQuery(this.queryName);
     if (query) {
-      const layoutIDs: string[] | undefined =
-        this.formGroup?.get('layouts')?.value;
+      const layoutIDs: string[] = [];
       query.subscribe((res1: { data: any }) => {
         // eslint-disable-next-line no-underscore-dangle
         const source = res1.data[`_${this.queryName}Meta`]._source;

--- a/projects/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -127,7 +127,11 @@ export class SafeGridWidgetComponent implements OnInit {
           first: this.settings.layouts?.length,
         })
         .then((res) => {
-          this.layouts = res.edges.map((edge) => edge.node);
+          this.layouts = res.edges
+            .map((edge) => edge.node)
+            .sort(
+              (a, b) => this.settings.layouts.indexOf(a.id) - this.settings.layouts.indexOf(b.id)
+            );
           this.layout = this.layouts[0] || null;
           this.gridSettings = {
             ...this.settings,

--- a/projects/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -130,7 +130,9 @@ export class SafeGridWidgetComponent implements OnInit {
           this.layouts = res.edges
             .map((edge) => edge.node)
             .sort(
-              (a, b) => this.settings.layouts.indexOf(a.id) - this.settings.layouts.indexOf(b.id)
+              (a, b) =>
+                this.settings.layouts.indexOf(a.id) -
+                this.settings.layouts.indexOf(b.id)
             );
           this.layout = this.layouts[0] || null;
           this.gridSettings = {


### PR DESCRIPTION
# Description

fix layouts in grid settings: avoid duplication when loading a layout, fix layouts display and order.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Add a layout in a grid, check that it appear only once.
- [x] Open settings of a grid already containing one or more layouts, add a layout and check that it is correctly displayed.
- [x] Change the layouts order in grid settings, check that the choice of layouts in the grid view is the same.

## Sreenshots

![grid_layouts_settings](https://user-images.githubusercontent.com/59767527/198534560-93344d7b-0838-462a-8b4c-f26367511861.png)

![grid_layouts_view](https://user-images.githubusercontent.com/59767527/198534575-535ba131-1b12-4740-b462-6c5f82e4e435.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
