### PR TITLE
fix-1.3.0/OORT-492_load-aggregations-bug

### DIFF
--- a/projects/safe/src/lib/components/aggregation/add-aggregation-modal/add-aggregation-modal.component.ts
+++ b/projects/safe/src/lib/components/aggregation/add-aggregation-modal/add-aggregation-modal.component.ts
@@ -7,10 +7,7 @@ import {
 import { Form } from '../../../models/form.model';
 import { Resource } from '../../../models/resource.model';
 import { SafeEditAggregationModalComponent } from '../edit-aggregation-modal/edit-aggregation-modal.component';
-import {
-  Aggregation,
-  AggregationConnection,
-} from '../../../models/aggregation.model';
+import { Aggregation } from '../../../models/aggregation.model';
 import { SafeAggregationService } from '../../../services/aggregation/aggregation.service';
 import {
   GetResourceAggregationsResponse,
@@ -24,7 +21,7 @@ import { SafeGraphQLSelectComponent } from '../../graphql-select/graphql-select.
  * Data needed for the dialog, should contain an aggregations array, a form and a resource
  */
 interface DialogData {
-  aggregations: AggregationConnection;
+  aggregations: Aggregation[];
   form?: Form;
   resource?: Resource;
 }
@@ -69,7 +66,7 @@ export class AddAggregationModalComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public data: DialogData,
     private aggregationService: SafeAggregationService
   ) {
-    this.aggregations = data.aggregations.edges.map((x) => x.node);
+    this.aggregations = data.aggregations;
     this.form = data.form;
     this.resource = data.resource;
   }

--- a/projects/safe/src/lib/components/aggregation/add-aggregation-modal/add-aggregation-modal.component.ts
+++ b/projects/safe/src/lib/components/aggregation/add-aggregation-modal/add-aggregation-modal.component.ts
@@ -7,7 +7,10 @@ import {
 import { Form } from '../../../models/form.model';
 import { Resource } from '../../../models/resource.model';
 import { SafeEditAggregationModalComponent } from '../edit-aggregation-modal/edit-aggregation-modal.component';
-import { Aggregation } from '../../../models/aggregation.model';
+import {
+  Aggregation,
+  AggregationConnection,
+} from '../../../models/aggregation.model';
 import { SafeAggregationService } from '../../../services/aggregation/aggregation.service';
 import {
   GetResourceAggregationsResponse,
@@ -21,7 +24,7 @@ import { SafeGraphQLSelectComponent } from '../../graphql-select/graphql-select.
  * Data needed for the dialog, should contain an aggregations array, a form and a resource
  */
 interface DialogData {
-  aggregations: Aggregation[];
+  aggregations: AggregationConnection;
   form?: Form;
   resource?: Resource;
 }
@@ -66,7 +69,7 @@ export class AddAggregationModalComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public data: DialogData,
     private aggregationService: SafeAggregationService
   ) {
-    this.aggregations = data.aggregations;
+    this.aggregations = data.aggregations.edges.map((x) => x.node);
     this.form = data.form;
     this.resource = data.resource;
   }

--- a/projects/safe/src/lib/components/aggregation/aggregation-table/aggregation-table.component.ts
+++ b/projects/safe/src/lib/components/aggregation/aggregation-table/aggregation-table.component.ts
@@ -92,9 +92,7 @@ export class AggregationTableComponent implements OnInit, OnChanges {
   public onAdd(): void {
     const dialogRef = this.dialog.open(AddAggregationModalComponent, {
       data: {
-        aggregations: this.form
-          ? this.form.aggregations
-          : this.resource?.aggregations,
+        aggregations: this.allAggregations,
         form: this.form,
         resource: this.resource,
       },

--- a/projects/safe/src/lib/components/widgets/chart-settings/graphql/queries.ts
+++ b/projects/safe/src/lib/components/widgets/chart-settings/graphql/queries.ts
@@ -44,7 +44,7 @@ export interface GetResourcesQueryResponse {
 
 /** Graphql request to get resource */
 export const GET_RESOURCE = gql`
-  query GetResource($id: ID!, $aggregationId: ID) {
+  query GetResource($id: ID!, $aggregationIds: [ID]) {
     resource(id: $id) {
       id
       name
@@ -53,7 +53,7 @@ export const GET_RESOURCE = gql`
         id
         name
       }
-      aggregations(ids: [$aggregationId]) {
+      aggregations(ids: $aggregationIds) {
         edges {
           node {
             id

--- a/projects/safe/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.ts
+++ b/projects/safe/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.ts
@@ -132,7 +132,8 @@ export class TabMainComponent implements OnInit {
   public addAggregation(): void {
     const dialogRef = this.dialog.open(AddAggregationModalComponent, {
       data: {
-        aggregations: this.resource?.aggregations,
+        aggregations:
+          this.resource?.aggregations?.edges.map((x) => x.node) || [],
         resource: this.resource,
       },
     });

--- a/projects/safe/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.ts
+++ b/projects/safe/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.ts
@@ -90,7 +90,7 @@ export class TabMainComponent implements OnInit {
         query: GET_RESOURCE,
         variables: {
           id,
-          aggregationId,
+          aggregationIds: aggregationId ? [aggregationId] : null,
         },
       })
       .subscribe((res) => {


### PR DESCRIPTION
# Description

This PR fixes a problem where existing agrregations weren't being loaded properly (this also fixes the initial problem detailed in the ticket)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* Create a chart
* Select a resource, you’re sure there’s not yet any aggregation for
* Add aggregation
* See modal, and check disabled status of ‘load existing aggregation’

## Sreenshots
![Peek 2022-10-27 10-29](https://user-images.githubusercontent.com/102038450/198934445-8ca5c927-0a2a-4c30-aeee-95f5ff74ad4f.gif)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
