### PR TITLE
can now select resource + form to attach records from grid

### DIFF
--- a/projects/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -1,5 +1,6 @@
 <form [formGroup]="formGroup" class="form-container">
   <div class="form-group">
+    <!-- Button status -->
     <div style="display: flex; justify-content: space-between">
       <mat-slide-toggle formControlName="show">{{
         'components.widget.settings.grid.buttons.enable' | translate
@@ -13,18 +14,25 @@
       </safe-button>
     </div>
     <ng-container *ngIf="formGroup.value.show">
+      <!-- Name -->
       <mat-form-field appearance="outline">
         <mat-label>{{ 'common.name' | translate }}</mat-label>
         <input matInput formControlName="name" type="string" />
       </mat-form-field>
+
+      <!-- Select all records of query -->
       <mat-checkbox formControlName="selectAll">{{
         'components.widget.settings.grid.buttons.callback.selectAllRecords'
           | translate
       }}</mat-checkbox>
+
+      <!-- Select only visible records -->
       <mat-checkbox formControlName="selectPage">{{
         'components.widget.settings.grid.buttons.callback.selectAllRecordsActivePage'
           | translate
       }}</mat-checkbox>
+
+      <!-- Prefill form with selected records -->
       <ng-container *ngIf="relatedForms.length > 0">
         <mat-checkbox formControlName="prefillForm">{{
           'components.widget.settings.grid.buttons.callback.prefill' | translate
@@ -42,15 +50,19 @@
         </div>
       </ng-container>
 
+      <!-- Workflow actions -->
       <ng-container *ngIf="!isDashboard">
+        <!-- Go to next step -->
         <mat-checkbox formControlName="goToNextStep">{{
           'components.widget.settings.grid.buttons.callback.workflow.next'
             | translate
         }}</mat-checkbox>
+        <!-- Close workflow -->
         <mat-checkbox formControlName="closeWorkflow">{{
           'components.widget.settings.grid.buttons.callback.workflow.close'
             | translate
         }}</mat-checkbox>
+        <!-- Confirm action -->
         <mat-form-field
           appearance="outline"
           class="sub-parameters"
@@ -63,9 +75,13 @@
           <input matInput formControlName="confirmationText" type="string" />
         </mat-form-field>
       </ng-container>
+
+      <!-- Auto save edited records -->
       <mat-checkbox formControlName="autoSave">{{
         'components.widget.settings.grid.buttons.callback.save' | translate
       }}</mat-checkbox>
+
+      <!-- Auto edition of selected records -->
       <div class="update-form">
         <mat-checkbox formControlName="modifySelectedRows">{{
           'components.widget.settings.grid.buttons.callback.modify' | translate
@@ -148,6 +164,8 @@
           </safe-button>
         </div>
       </div>
+
+      <!-- Attach record to another resource record -->
       <ng-container *ngIf="relatedForms.length > 0">
         <mat-checkbox formControlName="attachToRecord">
           {{
@@ -168,19 +186,40 @@
         </mat-checkbox>
       </ng-container>
       <div *ngIf="formGroup.value.attachToRecord" class="sub-parameters">
+        <!-- Selection of target resource -->
         <mat-form-field appearance="outline">
+          <mat-label>{{ 'common.resource.one' | translate }}</mat-label>
+          <mat-select
+            formControlName="targetResource"
+            [compareWith]="compareFields"
+          >
+            <mat-option>--</mat-option>
+            <mat-option
+              *ngFor="let resource of relatedResources"
+              [value]="resource.id"
+            >
+              {{ resource.name }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <!-- Selection of target template -->
+        <mat-form-field appearance="outline" *ngIf="targetResource">
           <mat-label>{{ 'models.form.select' | translate }}</mat-label>
           <mat-select
             formControlName="targetForm"
             [compareWith]="compareFields"
           >
             <mat-option>--</mat-option>
-            <mat-option *ngFor="let form of relatedForms" [value]="form">
+            <mat-option
+              *ngFor="let form of targetResource.forms"
+              [value]="form.id"
+            >
               {{ form.name }}
             </mat-option>
           </mat-select>
         </mat-form-field>
-        <ng-container *ngIf="formGroup.value.targetForm">
+        <ng-container *ngIf="targetResource">
+          <!-- Single field to display for quick selection -->
           <mat-form-field appearance="outline">
             <mat-label>{{
               'components.widget.settings.grid.buttons.callback.displayField'
@@ -189,7 +228,7 @@
             <mat-select formControlName="targetFormField">
               <mat-option>--</mat-option>
               <mat-option
-                *ngFor="let field of formGroup.value.targetForm.fields"
+                *ngFor="let field of targetResource.fields"
                 [value]="field.name"
               >
                 {{ field.name }}
@@ -197,7 +236,8 @@
             </mat-select>
           </mat-form-field>
         </ng-container>
-        <ng-container *ngIf="formGroup.value.targetForm">
+        <ng-container *ngIf="targetResource">
+          <!-- Selection of fields to display for advanced selection -->
           <safe-query-builder
             [form]="$any(formGroup.controls.targetFormQuery)"
             [canSelectDataSet]="false"
@@ -205,6 +245,8 @@
           </safe-query-builder>
         </ng-container>
       </div>
+
+      <!-- Send notification -->
       <mat-checkbox formControlName="notify">
         {{ 'components.channel.dropdown.select' | translate }}
         <safe-icon
@@ -236,6 +278,8 @@
           <input matInput formControlName="notificationMessage" type="string" />
         </mat-form-field>
       </div>
+
+      <!-- Publish on a channel -->
       <mat-checkbox formControlName="publish">
         {{ 'common.publish' | translate }}
         <safe-icon
@@ -261,6 +305,8 @@
           </mat-select>
         </mat-form-field>
       </div>
+
+      <!-- Send email -->
       <mat-checkbox formControlName="sendMail">{{
         'components.widget.settings.grid.buttons.callback.sendMail' | translate
       }}</mat-checkbox>

--- a/projects/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -12,6 +12,7 @@ import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Channel } from '../../../../models/channel.model';
 import { Form } from '../../../../models/form.model';
+import { Resource } from '../../../../models/resource.model';
 import { ContentType } from '../../../../models/page.model';
 import { SafeWorkflowService } from '../../../../services/workflow/workflow.service';
 import { Subscription } from 'rxjs';
@@ -24,6 +25,7 @@ import { QueryBuilderService } from '../../../../services/query-builder/query-bu
 import { MatDialog } from '@angular/material/dialog';
 import { EMAIL_EDITOR_CONFIG } from '../../../../const/tinymce.const';
 import { SafeEditorService } from '../../../../services/editor/editor.service';
+import { createQueryForm } from '../../../query-builder/query-builder-forms';
 
 /** List fo disabled fields */
 const DISABLED_FIELDS = ['id', 'createdAt', 'modifiedAt'];
@@ -56,6 +58,9 @@ export class ButtonConfigComponent implements OnInit, OnDestroy {
   @Input() fields: any[] = [];
   @Input() channels: Channel[] = [];
   @Input() relatedForms: Form[] = [];
+
+  public targetResource?: Resource;
+  public relatedResources: Resource[] = [];
 
   // Indicate is the page is a single dashboard.
   public isDashboard = false;
@@ -199,18 +204,6 @@ export class ButtonConfigComponent implements OnInit, OnDestroy {
       this.formGroup?.get('targetForm')?.updateValueAndValidity();
     });
 
-    this.formGroup?.get('targetForm')?.valueChanges.subscribe((value) => {
-      if (value) {
-        this.formGroup
-          ?.get('targetFormField')
-          ?.setValidators(Validators.required);
-      } else {
-        this.formGroup?.get('targetFormField')?.clearValidators();
-        this.formGroup?.get('targetFormField')?.setValue(null);
-      }
-      this.formGroup?.get('targetFormField')?.updateValueAndValidity();
-    });
-
     this.formGroup?.get('sendMail')?.valueChanges.subscribe((value) => {
       if (value) {
         this.formGroup
@@ -227,20 +220,48 @@ export class ButtonConfigComponent implements OnInit, OnDestroy {
 
     this.emails = [...this.formGroup?.get('distributionList')?.value];
 
-    this.formGroup?.get('targetForm')?.valueChanges.subscribe((target) => {
-      if (target?.name) {
-        const queryName = this.queryBuilder.getQueryNameFromResourceName(
-          target?.name || ''
-        );
-        this.formGroup?.get('targetFormQuery.name')?.setValue(queryName);
-        this.formGroup
-          ?.get('targetFormQuery.fields')
-          ?.setValidators([Validators.required]);
+    this.formGroup?.get('targetResource')?.valueChanges.subscribe((value) => {
+      if (value) {
+        this.targetResource = this.relatedResources.find((x) => x.id === value);
+        if (this.targetResource) {
+          this.formGroup?.get('targetForm')?.setValidators(Validators.required);
+          this.formGroup
+            ?.get('targetFormField')
+            ?.setValidators(Validators.required);
+          this.formGroup
+            ?.get('targetFormQuery.name')
+            ?.setValue(this.targetResource.queryName);
+          this.formGroup
+            ?.get('targetFormQuery.fields')
+            ?.setValidators([Validators.required]);
+        } else {
+          this.formGroup?.get('targetForm')?.clearValidators();
+          this.formGroup?.get('targetForm')?.setValue(null);
+          this.formGroup?.get('targetFormField')?.clearValidators();
+          this.formGroup?.get('targetFormField')?.setValue(null);
+          this.formGroup?.get('targetFormQuery')?.clearValidators();
+        }
       } else {
-        this.formGroup?.get('targetFormQuery')?.clearValidators();
+        this.targetResource = undefined;
+        this.formGroup?.get('targetForm')?.clearValidators();
+        this.formGroup.get('targetForm')?.setValue(null);
+        this.formGroup?.get('targetFormField')?.clearValidators();
+        this.formGroup?.get('targetFormField')?.setValue(null);
+        this.formGroup
+          .get('targetFormQuery')
+          ?.patchValue(createQueryForm(null, false));
       }
+      this.formGroup?.get('targetForm')?.updateValueAndValidity();
+      this.formGroup?.get('targetFormField')?.updateValueAndValidity();
       this.formGroup?.get('targetFormQuery')?.updateValueAndValidity();
     });
+
+    this.setRelatedResources();
+    if (this.formGroup.value.targetResource) {
+      this.targetResource = this.relatedResources.find(
+        (x) => x.id === this.formGroup.value.targetResource
+      );
+    }
 
     this.formGroup
       ?.get('sendMail')
@@ -285,6 +306,20 @@ export class ButtonConfigComponent implements OnInit, OnDestroy {
           this.formGroup?.get('selectAll')?.updateValueAndValidity();
         }
       });
+  }
+
+  /** Set list of resources user can attach a record to */
+  private setRelatedResources(): void {
+    const resources: Resource[] = [];
+    for (const form of this.relatedForms) {
+      const resource = resources.find((x) => x.id === form.resource?.id);
+      if (resource) {
+        resource.forms?.push(form);
+      } else {
+        resources.push({ ...form.resource, forms: [form] } as Resource);
+      }
+    }
+    this.relatedResources = resources;
   }
 
   /**

--- a/projects/safe/src/lib/components/widgets/grid-settings/graphql/queries.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/graphql/queries.ts
@@ -71,6 +71,12 @@ export const GET_GRID_RESOURCE_META = gql`
         id
         name
         fields
+        resource {
+          id
+          queryName
+          name
+          fields
+        }
       }
       layouts(ids: $layoutIds, first: $first) {
         edges {

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -49,13 +49,10 @@ export const createButtonFormGroup = (value: any): FormGroup => {
           )
         : []
     ),
-    attachToRecord: [
-      value && value.attachToRecord ? value.attachToRecord : false,
-    ],
-    targetForm: [value && value.targetForm ? value.targetForm : null],
-    targetFormField: [
-      value && value.targetFormField ? value.targetFormField : null,
-    ],
+    attachToRecord: [get(value, 'attachToRecord', false)],
+    targetResource: [get(value, 'targetResource', null)],
+    targetForm: [get(value, 'targetForm', null)],
+    targetFormField: [get(value, 'targetFormField', null)],
     targetFormQuery: createQueryForm(
       value && value.targetFormQuery ? value.targetFormQuery : null,
       Boolean(value && value.targetForm)

--- a/projects/safe/src/lib/components/widgets/grid/graphql/queries.ts
+++ b/projects/safe/src/lib/components/widgets/grid/graphql/queries.ts
@@ -1,8 +1,8 @@
 import { gql } from 'apollo-angular';
 import { Record } from '../../../../models/record.model';
+import { Form } from '../../../../models/form.model';
 
 // === GET RECORD BY ID ===
-
 /** Graphql request for getting a record by its id */
 export const GET_RECORD_BY_ID = gql`
   query GetRecordById($id: ID!) {
@@ -35,7 +35,6 @@ export interface GetRecordByIdQueryResponse {
 }
 
 // === GET RECORD DETAILS ===
-
 /** Graphql request for getting record details by its id */
 export const GET_RECORD_DETAILS = gql`
   query GetRecordDetails($id: ID!) {
@@ -202,3 +201,20 @@ export const GET_QUERY_TYPES = gql`
     }
   }
 `;
+
+// === GET FORM ===
+/** Graphql query for getting a form by its id */
+export const GET_FORM_BY_ID = gql`
+  query GetFormById($id: ID!) {
+    form(id: $id) {
+      id
+      name
+      fields
+    }
+  }
+`;
+
+/** Interface for getFormByIdQueryResponse object */
+export interface GetFormByIdQueryResponse {
+  form: Form;
+}

--- a/projects/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -17,6 +17,8 @@ import {
   GET_RECORD_DETAILS,
   GetRecordByIdQueryResponse,
   GET_RECORD_BY_ID,
+  GetFormByIdQueryResponse,
+  GET_FORM_BY_ID,
 } from './graphql/queries';
 import {
   Component,
@@ -437,82 +439,101 @@ export class SafeGridWidgetComponent implements OnInit {
    * The inputs comes from 'attach to record' button from grid component
    *
    * @param selectedRecords The list of selected records
-   * @param targetForm The targetted form
+   * @param targetForm Target template id
    * @param targetFormField The form field
    * @param targetFormQuery The form query
    */
   private async promisedAttachToRecord(
     selectedRecords: string[],
-    targetForm: Form,
+    targetForm: string,
     targetFormField: string,
     targetFormQuery: any
   ): Promise<void> {
-    const dialogRef = this.dialog.open(SafeChooseRecordModalComponent, {
-      data: {
-        targetForm,
-        targetFormField,
-        targetFormQuery,
-      },
-    });
-    const value = await Promise.resolve(dialogRef.afterClosed().toPromise());
-    if (value && value.record) {
-      this.apollo
-        .query<GetRecordByIdQueryResponse>({
-          query: GET_RECORD_BY_ID,
-          variables: {
-            id: value.record,
-          },
-        })
-        .subscribe((res) => {
-          const resourceField = targetForm.fields?.find(
-            (field) =>
-              field.resource && field.resource === this.settings.resource
+    this.apollo
+      .query<GetFormByIdQueryResponse>({
+        query: GET_FORM_BY_ID,
+        variables: {
+          id: targetForm,
+        },
+      })
+      .subscribe(async (getForm) => {
+        if (getForm.data.form) {
+          const form = getForm.data.form;
+          const dialogRef = this.dialog.open(SafeChooseRecordModalComponent, {
+            data: {
+              targetForm: form,
+              targetFormField,
+              targetFormQuery,
+            },
+          });
+          const value = await Promise.resolve(
+            dialogRef.afterClosed().toPromise()
           );
-          let data = res.data.record.data;
-          const key = resourceField.name;
-          if (resourceField.type === 'resource') {
-            data = { ...data, [key]: selectedRecords[0] };
-          } else {
-            if (data[key]) {
-              data = { ...data, [key]: data[key].concat(selectedRecords) };
-            } else {
-              data = { ...data, [key]: selectedRecords };
-            }
-          }
-          this.apollo
-            .mutate<EditRecordMutationResponse>({
-              mutation: EDIT_RECORD,
-              variables: {
-                id: value.record,
-                data,
-              },
-            })
-            .subscribe((res2) => {
-              if (res2.data) {
-                const record = res2.data.editRecord;
-                if (record) {
-                  this.snackBar.openSnackBar(
-                    this.translate.instant(
-                      'models.record.notifications.rowsAdded',
-                      {
-                        field: record.data[targetFormField],
-                        length: selectedRecords.length,
-                        value: key,
-                      }
-                    )
-                  );
-                  this.dialog.open(SafeFormModalComponent, {
-                    disableClose: true,
-                    data: {
-                      recordId: record.id,
-                    },
-                    autoFocus: false,
-                  });
+          if (value && value.record) {
+            this.apollo
+              .query<GetRecordByIdQueryResponse>({
+                query: GET_RECORD_BY_ID,
+                variables: {
+                  id: value.record,
+                },
+              })
+              .subscribe((getRecord) => {
+                const resourceField = form.fields?.find(
+                  (field) =>
+                    field.resource && field.resource === this.settings.resource
+                );
+                let data = getRecord.data.record.data;
+                const key = resourceField.name;
+                if (resourceField.type === 'resource') {
+                  data = { ...data, [key]: selectedRecords[0] };
+                } else {
+                  if (data[key]) {
+                    data = {
+                      ...data,
+                      [key]: data[key].concat(selectedRecords),
+                    };
+                  } else {
+                    data = { ...data, [key]: selectedRecords };
+                  }
                 }
-              }
-            });
-        });
-    }
+                this.apollo
+                  .mutate<EditRecordMutationResponse>({
+                    mutation: EDIT_RECORD,
+                    variables: {
+                      id: value.record,
+                      template: targetForm,
+                      data,
+                    },
+                  })
+                  .subscribe((editRecord) => {
+                    if (editRecord.data) {
+                      const record = editRecord.data.editRecord;
+                      if (record) {
+                        this.snackBar.openSnackBar(
+                          this.translate.instant(
+                            'models.record.notifications.rowsAdded',
+                            {
+                              field: record.data[targetFormField],
+                              length: selectedRecords.length,
+                              value: key,
+                            }
+                          )
+                        );
+                        this.dialog.open(SafeFormModalComponent, {
+                          disableClose: true,
+                          data: {
+                            recordId: record.id,
+                            template: targetForm,
+                          },
+                          autoFocus: false,
+                        });
+                      }
+                    }
+                  });
+              });
+          }
+        }
+      });
   }
 
   /**


### PR DESCRIPTION
# Description

The way the AttachToRecord feature is done was changed.
Instead of directly choosing a form that contained a resource question from the resource of a grid, we allow the user to select a dataset linked to that resource and then the template for this dataset.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
