### PR TITLE
feat-1.3.0/OORT-495_responsive-filters

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.html
+++ b/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.html
@@ -1,7 +1,7 @@
-<div class="flex gap-8 justify-between mb-8">
+<div class="flex gap-8 justify-between mb-8 flex-col sm:flex-row">
   <!-- Filters -->
   <div class="flex flex-col gap-4">
-    <div class="flex flex-wrap gap-2 items-center">
+    <div class="flex flex-wrap gap-2 sm:items-center flex-col sm:flex-row">
       <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
         <mat-icon matPrefix>search</mat-icon>
         <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
@@ -16,6 +16,7 @@
         icon="filter_list"
         category="tertiary"
         variant="primary"
+        blockBreakpoint="sm"
         (click)="showFilters = !showFilters"
         class="filters-toggle"
       >
@@ -27,7 +28,10 @@
       </safe-button>
     </div>
     <div *ngIf="showFilters" class="flex flex-wrap gap-2 items-center">
-      <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
+      <mat-form-field
+        appearance="outline"
+        class="mat-form-field-sm p-0 grow sm:grow-0"
+      >
         <mat-label>{{ 'common.status' | translate }}</mat-label>
         <mat-select
           [ngModel]="statusFilter"
@@ -51,7 +55,7 @@
     </div>
   </div>
   <!-- Actions -->
-  <div class="flex items-center">
+  <div class="flex items-center self-end sm:self-start">
     <safe-button
       icon="add"
       category="secondary"

--- a/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.html
+++ b/projects/back-office/src/app/dashboard/pages/applications/components/filter/filter.component.html
@@ -1,5 +1,5 @@
 <div [formGroup]="form" class="flex flex-col gap-4">
-  <div class="flex flex-wrap gap-2 items-center">
+  <div class="flex flex-wrap gap-2 flex-col sm:flex-row sm:items-center">
     <mat-form-field appearance="outline" class="p-0 mat-form-field-sm">
       <mat-icon matPrefix>search</mat-icon>
       <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
@@ -10,6 +10,7 @@
       icon="filter_list"
       category="tertiary"
       variant="primary"
+      blockBreakpoint="sm"
       (click)="show = !show"
       >{{
         show
@@ -18,7 +19,10 @@
       }}
     </safe-button>
   </div>
-  <div *ngIf="show" class="flex flex-wrap gap-2 items-center">
+  <div
+    *ngIf="show"
+    class="flex flex-wrap gap-2 sm:items-center flex-col sm:flex-row"
+  >
     <mat-form-field class="p-0 mat-form-field-sm" appearance="outline">
       <mat-label>{{ 'common.input.dateRange' | translate }}</mat-label>
       <mat-date-range-input [rangePicker]="rangePicker">
@@ -59,7 +63,7 @@
         </mat-option>
       </mat-select>
     </mat-form-field>
-    <safe-button variant="danger" (click)="clear()">{{
+    <safe-button variant="danger" (click)="clear()" blockBreakpoint="sm">{{
       'common.filter.clear' | translate
     }}</safe-button>
   </div>

--- a/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.html
+++ b/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.html
@@ -10,8 +10,8 @@
       icon="filter_list"
       category="tertiary"
       variant="primary"
+      blockBreakpoint="sm"
       (click)="show = !show"
-      [block]="innerWidth <= 640"
     >
       {{
         show
@@ -78,9 +78,9 @@
     </mat-form-field>
     <safe-button
       variant="danger"
-      [category]="innerWidth <= 640 ? 'secondary' : 'primary'"
+      category="primary"
       (click)="clear()"
-      [block]="innerWidth <= 640"
+      blockBreakpoint="sm"
       >{{ 'common.filter.clear' | translate }}</safe-button
     >
   </div>

--- a/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/forms/components/filter/filter.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  OnInit,
-  Output,
-  Input,
-  HostListener,
-} from '@angular/core';
+import { Component, EventEmitter, OnInit, Output, Input } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
@@ -24,8 +17,6 @@ export class FilterComponent implements OnInit {
   @Output() filter = new EventEmitter<any>();
   @Input() loading = false;
 
-  public innerWidth!: number;
-
   /**
    * Filter component of forms page
    *
@@ -34,7 +25,6 @@ export class FilterComponent implements OnInit {
   constructor(private formBuilder: FormBuilder) {}
 
   ngOnInit(): void {
-    this.innerWidth = window.innerWidth;
     this.form = this.formBuilder.group({
       name: [''],
       startDate: [null],
@@ -53,16 +43,6 @@ export class FilterComponent implements OnInit {
       .subscribe((value) => {
         this.form.controls.name.setValue(value);
       });
-  }
-
-  /**
-   * Updates the innerWidth variable.
-   *
-   * @param event Window resize event
-   */
-  @HostListener('window:resize', ['$event'])
-  onResize(event: any): void {
-    this.innerWidth = window.innerWidth;
   }
 
   /**

--- a/projects/back-office/src/app/dashboard/pages/forms/forms.component.html
+++ b/projects/back-office/src/app/dashboard/pages/forms/forms.component.html
@@ -2,7 +2,7 @@
   <!-- FILTERING -->
   <app-filter (filter)="onFilter($event)" [loading]="updating"></app-filter>
   <!-- ACTIONS -->
-  <div class="flex items-center">
+  <div class="flex items-center self-end sm:self-auto">
     <safe-button
       icon="add"
       category="secondary"

--- a/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.html
+++ b/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.html
@@ -1,31 +1,28 @@
-<div class="flex gap-8 justify-between mb-8">
+<div
+  class="flex gap-2 sm:items-center flex-col sm:flex-row mb-8 sm:justify-between"
+>
   <!-- Filters -->
-  <div class="flex flex-col gap-4">
-    <div class="flex flex-wrap gap-2 items-center">
-      <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
-        <mat-icon matPrefix>search</mat-icon>
-        <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
-        <input
-          matInput
-          [ngModel]="searchText"
-          (keyup)="applyFilter('', $event)"
-          type="search"
-        />
-      </mat-form-field>
-    </div>
-  </div>
+  <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
+    <mat-icon matPrefix>search</mat-icon>
+    <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
+    <input
+      matInput
+      [ngModel]="searchText"
+      (keyup)="applyFilter('', $event)"
+      type="search"
+    />
+  </mat-form-field>
   <!-- Actions -->
-  <div class="flex items-center">
-    <safe-button
-      icon="add"
-      category="secondary"
-      variant="primary"
-      (click)="onAdd()"
-      *ngIf="canAdd"
-    >
-      {{ 'models.referenceData.add' | translate }}
-    </safe-button>
-  </div>
+  <safe-button
+    icon="add"
+    category="secondary"
+    variant="primary"
+    class="self-end sm:self-start"
+    (click)="onAdd()"
+    *ngIf="canAdd"
+  >
+    {{ 'models.referenceData.add' | translate }}
+  </safe-button>
 </div>
 
 <!-- Table container -->

--- a/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.html
@@ -1,5 +1,5 @@
 <div [formGroup]="form" class="flex flex-col gap-4">
-  <div class="flex flex-wrap gap-2 items-center">
+  <div class="flex flex-wrap gap-2 sm:items-center flex-col sm:flex-row">
     <mat-form-field class="p-0 mat-form-field-sm" appearance="outline">
       <mat-icon matPrefix>search</mat-icon>
       <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
@@ -10,6 +10,7 @@
       icon="filter_list"
       category="tertiary"
       variant="primary"
+      blockBreakpoint="sm"
       (click)="show = !show"
     >
       {{
@@ -20,7 +21,10 @@
     </safe-button>
   </div>
   <div *ngIf="show" class="flex flex-wrap gap-2 items-center">
-    <mat-form-field class="p-0 mat-form-field-sm" appearance="outline">
+    <mat-form-field
+      class="p-0 mat-form-field-sm grow sm:grow-0"
+      appearance="outline"
+    >
       <mat-label>{{ 'common.input.dateRange' | translate }}</mat-label>
       <mat-date-range-input [rangePicker]="rangePicker">
         <input formControlName="startDate" matStartDate />
@@ -45,7 +49,7 @@
         </mat-date-range-picker-actions>
       </mat-date-range-picker>
     </mat-form-field>
-    <safe-button variant="danger" (click)="clear()">
+    <safe-button variant="danger" (click)="clear()" blockBreakpoint="sm">
       {{ 'common.filter.clear' | translate }}
     </safe-button>
   </div>

--- a/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resources/filter/filter.component.html
@@ -20,11 +20,8 @@
       }}
     </safe-button>
   </div>
-  <div *ngIf="show" class="flex flex-wrap gap-2 items-center">
-    <mat-form-field
-      class="p-0 mat-form-field-sm grow sm:grow-0"
-      appearance="outline"
-    >
+  <div *ngIf="show" class="flex gap-2 sm:items-center flex-col sm:flex-row">
+    <mat-form-field class="p-0 mat-form-field-sm" appearance="outline">
       <mat-label>{{ 'common.input.dateRange' | translate }}</mat-label>
       <mat-date-range-input [rangePicker]="rangePicker">
         <input formControlName="startDate" matStartDate />

--- a/projects/back-office/src/app/dashboard/pages/resources/resources.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resources/resources.component.html
@@ -1,11 +1,11 @@
-<div class="flex gap-8 justify-between mb-8">
+<div class="flex gap-8 justify-between mb-8 flex-col sm:flex-row">
   <!-- FILTERING -->
   <app-filter
     (filter)="onFilter($event)"
     [loading]="filterLoading"
   ></app-filter>
   <!-- ACTIONS -->
-  <div class="flex items-center">
+  <div class="flex items-center self-end sm:self-start">
     <safe-button
       icon="add"
       category="secondary"

--- a/projects/safe/src/lib/components/roles/components/group-list/group-list.component.html
+++ b/projects/safe/src/lib/components/roles/components/group-list/group-list.component.html
@@ -1,8 +1,13 @@
-<div class="flex gap-8 justify-between mb-8">
+<div
+  class="flex gap-2 sm:items-center flex-col sm:flex-row mb-8 sm:justify-between"
+>
   <!-- Filters -->
   <div class="flex flex-col gap-4">
     <div class="flex flex-wrap gap-2 items-center">
-      <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
+      <mat-form-field
+        appearance="outline"
+        class="mat-form-field-sm p-0 w-full sm:w-auto"
+      >
         <mat-icon matPrefix>search</mat-icon>
         <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
         <input matInput (keyup)="applyFilter($event)" type="search" />
@@ -10,7 +15,7 @@
     </div>
   </div>
   <!-- Actions -->
-  <div class="flex items-center">
+  <div class="flex items-center self-end sm:self-start">
     <safe-button
       [disabled]="loading || loadingFetch"
       [icon]="manualCreation ? 'add' : 'cloud_download'"

--- a/projects/safe/src/lib/components/roles/components/role-list/role-list.component.html
+++ b/projects/safe/src/lib/components/roles/components/role-list/role-list.component.html
@@ -1,8 +1,13 @@
-<div class="flex gap-8 justify-between mb-8">
+<div
+  class="flex gap-2 sm:items-center flex-col sm:flex-row mb-8 sm:justify-between"
+>
   <!-- Filters -->
   <div class="flex flex-col gap-4">
     <div class="flex flex-wrap gap-2 items-center">
-      <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
+      <mat-form-field
+        appearance="outline"
+        class="mat-form-field-sm p-0 w-full sm:w-auto"
+      >
         <mat-icon matPrefix>search</mat-icon>
         <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
         <input
@@ -15,7 +20,7 @@
     </div>
   </div>
   <!-- Actions -->
-  <div class="flex items-center">
+  <div class="flex items-center self-end sm:self-start">
     <safe-button
       icon="add"
       category="secondary"

--- a/projects/safe/src/lib/components/ui/button/button.component.html
+++ b/projects/safe/src/lib/components/ui/button/button.component.html
@@ -1,8 +1,9 @@
 <button
   mat-button
+  [class]="blockBreakpoint ? 'w-full ' + blockBreakpoint + ':w-fit' : ''"
   [class.mat-flat-button]="category === 'secondary'"
   [class.mat-stroked-button]="category === 'tertiary'"
-  [class.safe-btn-block]="block"
+  [class.safe-btn-block]="block && !blockBreakpoint"
   [class.safe-btn-small]="size === 'small'"
   [class.safe-btn-success]="variant === 'success'"
   [class.safe-btn-grey]="variant === 'grey'"

--- a/projects/safe/src/lib/components/ui/button/button.component.ts
+++ b/projects/safe/src/lib/components/ui/button/button.component.ts
@@ -22,7 +22,14 @@ export class SafeButtonComponent implements OnInit {
 
   @Input() isIcon = false;
 
+  /**
+   *  Whether the button will take all available width
+   *  Ignored if blockBreakpoint is provided
+   */
   @Input() block = false;
+
+  /** Specifies at which breakpoint the button will take full available width */
+  @Input() blockBreakpoint?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' = undefined;
 
   @HostBinding('class.disabled')
   @Input()

--- a/projects/safe/src/lib/components/users/users.component.html
+++ b/projects/safe/src/lib/components/users/users.component.html
@@ -1,7 +1,7 @@
-<div class="flex gap-8 justify-between mb-8">
+<div class="flex flex-col sm:flex-row gap-8 justify-between mb-8">
   <!-- Filters -->
   <div class="flex flex-col gap-4">
-    <div class="flex flex-wrap gap-2 items-center">
+    <div class="flex flex-wrap gap-2 flex-col sm:flex-row sm:items-center">
       <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
         <mat-icon matPrefix>search</mat-icon>
         <mat-label>{{ 'common.placeholder.search' | translate }}</mat-label>
@@ -18,6 +18,7 @@
         variant="primary"
         (click)="showFilters = !showFilters"
         class="filters-toggle"
+        blockBreakpoint="sm"
       >
         {{
           showFilters
@@ -30,7 +31,10 @@
       class="flex flex-wrap gap-2 items-center"
       [style.display]="!showFilters ? 'none' : ''"
     >
-      <mat-form-field appearance="outline" class="mat-form-field-sm p-0">
+      <mat-form-field
+        appearance="outline"
+        class="mat-form-field-sm p-0 grow sm:grow-0"
+      >
         <mat-label>{{ 'common.title' | translate }}</mat-label>
         <mat-select
           [ngModel]="roleFilter"
@@ -48,7 +52,7 @@
     </div>
   </div>
   <!-- Actions -->
-  <div class="flex gap-2 items-center">
+  <div class="flex gap-2 items-center self-end sm:self-start">
     <safe-button
       class="export-users"
       icon="file_download"

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -683,6 +683,10 @@ mat-tab-group[vertical] {
   }
 }
 
+.mat-tab-body-content {
+  overflow: hidden !important;
+}
+
 // === TINYMCE ===
 .tox-editor-header *,
 .tox-tinymce-aux * {


### PR DESCRIPTION
# Description

This PR makes it so that all the filters are responsive.
I also added another input to the safe-button to facilitate this name `blockBreakpoint` that gives the button 100% width till a specific breakpoint (defined in [tailwind](https://tailwindcss.com/docs/responsive-design)). 


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By resizing the screen for tabs that have filters

## Sreenshots
![Peek 2022-11-01 00-35](https://user-images.githubusercontent.com/102038450/199386808-244a6cd6-6d72-43e7-b927-5053227c06c7.gif)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
