### PR TITLE
the size of tabs icon is updated with the size of the window

### DIFF
--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
@@ -6,8 +6,12 @@
   <!-- Main Parameters -->
   <mat-tab>
     <ng-template mat-tab-label>
-      <safe-icon icon="settings" [size]="24"></safe-icon>
-      <span>{{ 'common.general' | translate }}</span>
+      <safe-icon
+        icon="settings"
+        [size]="24"
+        [matTooltip]="!largeDevice ? ('common.general' | translate) : ''"
+      ></safe-icon>
+      <span *ngIf="largeDevice">{{ 'common.general' | translate }}</span>
     </ng-template>
     <ng-template matTabContent>
       <safe-tab-main [formGroup]="formGroup" [type]="type"></safe-tab-main>
@@ -16,8 +20,12 @@
   <!-- Display options -->
   <mat-tab>
     <ng-template mat-tab-label>
-      <safe-icon icon="tune" [size]="24"></safe-icon>
-      <span>{{ 'common.display' | translate }}</span>
+      <safe-icon
+        icon="tune"
+        [size]="24"
+        [matTooltip]="!largeDevice ? ('common.display' | translate) : ''"
+      ></safe-icon>
+      <span *ngIf="largeDevice">{{ 'common.display' | translate }}</span>
     </ng-template>
     <ng-template matTabContent>
       <safe-tab-display
@@ -29,8 +37,12 @@
   <!-- Preview -->
   <mat-tab>
     <ng-template mat-tab-label>
-      <safe-icon icon="preview" [size]="24"></safe-icon>
-      <span>{{ 'common.preview' | translate }}</span>
+      <safe-icon
+        icon="preview"
+        [size]="24"
+        [matTooltip]="!largeDevice ? ('common.preview' | translate) : ''"
+      ></safe-icon>
+      <span *ngIf="largeDevice">{{ 'common.preview' | translate }}</span>
     </ng-template>
     <ng-template matTabContent>
       <safe-tab-preview [formGroup]="formGroup"></safe-tab-preview>

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.scss
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.scss
@@ -1,8 +1,21 @@
 :host {
   flex: 1;
   display: flex;
+  --tab-width: 240px;
 }
 
 mat-tab-group {
   flex: 1;
+
+  ::ng-deep .mat-tab-header {
+    width: fit-content !important;
+  }
+
+  ::ng-deep .mat-tab-label {
+    min-width: var(--tab-width) !important;
+  }
+
+  ::ng-deep .mat-tab-body-wrapper {
+    padding-left: var(--tab-width) !important;
+  }
 }

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.ts
@@ -1,5 +1,13 @@
 import { Overlay } from '@angular/cdk/overlay';
-import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  Input,
+  EventEmitter,
+  Output,
+  HostListener,
+  ElementRef,
+} from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { MAT_AUTOCOMPLETE_SCROLL_STRATEGY } from '@angular/material/autocomplete';
 import { MAT_CHIPS_DEFAULT_OPTIONS } from '@angular/material/chips';
@@ -47,6 +55,9 @@ export class SafeChartSettingsComponent implements OnInit {
   public settings: any;
   public grid: any;
 
+  // === DISPLAY ===
+  public largeDevice = true;
+
   /** @returns the form for the chart */
   public get chartForm(): FormGroup {
     return (this.formGroup?.controls.chart as FormGroup) || null;
@@ -59,11 +70,13 @@ export class SafeChartSettingsComponent implements OnInit {
    * Constructor for the chart settings component
    *
    * @param formBuilder The formBuilder service
+   * @param elRef The element reference.
    */
-  constructor(private formBuilder: FormBuilder) {}
+  constructor(private formBuilder: FormBuilder, private elRef: ElementRef) {}
 
   /** Build the settings form, using the widget saved parameters. */
   ngOnInit(): void {
+    this.resizeTab(window.innerWidth);
     const tileSettings = this.tile.settings;
     const chartSettings = tileSettings.chart;
     if (chartSettings.type) {
@@ -102,5 +115,32 @@ export class SafeChartSettingsComponent implements OnInit {
    */
   handleTabChange(event: MatTabChangeEvent): void {
     this.selectedTab = event.index;
+  }
+
+  /**
+   * Listen the window size and call the resizeTab function.
+   *
+   * @param event Event that implies a change in window size
+   */
+  @HostListener('window:resize', ['$event'])
+  onResize(event: any): void {
+    this.resizeTab(event.target.innerWidth);
+  }
+
+  /**
+   * Change the tab display depending on windows size.
+   *
+   * @param width The width of the window.
+   */
+  private resizeTab(width: any): void {
+    const oldValue = this.largeDevice;
+    this.largeDevice = width > 1024;
+    if (this.largeDevice !== oldValue) {
+      if (this.largeDevice) {
+        this.elRef.nativeElement.style.setProperty('--tab-width', '240px');
+      } else {
+        this.elRef.nativeElement.style.setProperty('--tab-width', '80px');
+      }
+    }
   }
 }

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.module.ts
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.module.ts
@@ -25,6 +25,7 @@ import { SafePaletteControlModule } from '../../palette-control/palette-control.
 import { TabMainModule } from './tab-main/tab-main.module';
 import { TabDisplayModule } from './tab-display/tab-display.module';
 import { TabPreviewModule } from './tab-preview/tab-preview.module';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 /** Module for the chart settings component */
 @NgModule({
@@ -56,6 +57,7 @@ import { TabPreviewModule } from './tab-preview/tab-preview.module';
     TabMainModule,
     TabDisplayModule,
     TabPreviewModule,
+    MatTooltipModule,
   ],
   exports: [SafeChartSettingsComponent],
 })

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -6,8 +6,12 @@
   <!-- MAIN PARAMETERS / SELECTION OF LAYOUTS -->
   <mat-tab>
     <ng-template mat-tab-label>
-      <safe-icon icon="preview" [size]="24"></safe-icon>
-      <span>{{ 'common.general' | translate }}</span>
+      <safe-icon
+        icon="preview"
+        [size]="24"
+        [matTooltip]="!largeDevice ? ('common.general' | translate) : ''"
+      ></safe-icon>
+      <span *ngIf="largeDevice">{{ 'common.general' | translate }}</span>
     </ng-template>
     <ng-template matTabContent>
       <safe-tab-main
@@ -21,8 +25,12 @@
   <!-- AVAILABLE ACTIONS -->
   <mat-tab>
     <ng-template mat-tab-label>
-      <safe-icon icon="toggle_on" [size]="24"></safe-icon>
-      <span>{{
+      <safe-icon
+        icon="toggle_on"
+        [size]="24"
+        [matTooltip]="!largeDevice ? ('components.widget.settings.grid.actions.title' | translate) : ''"
+      ></safe-icon>
+      <span *ngIf="largeDevice">{{
         'components.widget.settings.grid.actions.title' | translate
       }}</span>
     </ng-template>
@@ -33,8 +41,12 @@
   <!-- BUTTONS -->
   <mat-tab>
     <ng-template mat-tab-label>
-      <safe-icon icon="bolt" [size]="24"></safe-icon>
-      <span>{{
+      <safe-icon
+        icon="bolt"
+        [size]="24"
+        [matTooltip]="!largeDevice ? ('components.widget.settings.grid.buttons.title' | translate) : ''"
+      ></safe-icon>
+      <span *ngIf="largeDevice">{{
         'components.widget.settings.grid.buttons.title' | translate
       }}</span>
     </ng-template>

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.scss
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.scss
@@ -1,10 +1,23 @@
 :host {
   flex: 1;
   display: flex;
+  --tab-width: 240px
 }
 
 mat-tab-group {
   flex: 1;
+
+  ::ng-deep .mat-tab-header {
+    width: fit-content !important;
+  }
+
+  ::ng-deep .mat-tab-label {
+    min-width: var(--tab-width) !important;
+  }
+
+  ::ng-deep .mat-tab-body-wrapper {
+    padding-left: var(--tab-width) !important;
+  }
 }
 
 .add-button {

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -6,6 +6,8 @@ import {
   Output,
   EventEmitter,
   AfterViewInit,
+  HostListener,
+  ElementRef,
 } from '@angular/core';
 import { FormGroup, FormArray } from '@angular/forms';
 import { QueryBuilderService } from '../../../services/query-builder/query-builder.service';
@@ -66,6 +68,9 @@ export class SafeGridSettingsComponent implements OnInit, AfterViewInit {
   public filteredQueries: any[] = [];
   public resource: Resource | null = null;
 
+  // === DISPLAY ===
+  public largeDevice = true;
+
   /** Stores the selected tab */
   public selectedTab = 0;
 
@@ -75,15 +80,18 @@ export class SafeGridSettingsComponent implements OnInit, AfterViewInit {
    * @param apollo The apollo client
    * @param applicationService The application service
    * @param queryBuilder The query builder service
+   * @param elRef The element reference
    */
   constructor(
     private apollo: Apollo,
     private applicationService: SafeApplicationService,
-    private queryBuilder: QueryBuilderService
+    private queryBuilder: QueryBuilderService,
+    private elRef: ElementRef
   ) {}
 
   /** Build the settings form, using the widget saved parameters. */
   ngOnInit(): void {
+    this.resizeTab(window.innerWidth);
     const tileSettings = this.tile.settings;
     this.formGroup = createGridWidgetFormGroup(this.tile.id, tileSettings);
     this.change.emit(this.formGroup);
@@ -214,5 +222,32 @@ export class SafeGridSettingsComponent implements OnInit, AfterViewInit {
    */
   handleTabChange(event: MatTabChangeEvent): void {
     this.selectedTab = event.index;
+  }
+
+  /**
+   * Listen the window size and call the resizeTab function.
+   *
+   * @param event Event that implies a change in window size
+   */
+  @HostListener('window:resize', ['$event'])
+  onResize(event: any): void {
+    this.resizeTab(event.target.innerWidth);
+  }
+
+  /**
+   * Change the tab display depending on windows size.
+   *
+   * @param width The width of the window.
+   */
+  private resizeTab(width: any): void {
+    const oldValue = this.largeDevice;
+    this.largeDevice = width > 1024;
+    if (this.largeDevice !== oldValue) {
+      if (this.largeDevice) {
+        this.elRef.nativeElement.style.setProperty('--tab-width', '240px');
+      } else {
+        this.elRef.nativeElement.style.setProperty('--tab-width', '80px');
+      }
+    }
   }
 }

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.module.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.module.ts
@@ -10,6 +10,7 @@ import { SafeIconModule } from '../../ui/icon/icon.module';
 import { TabActionsModule } from './tab-actions/tab-actions.module';
 import { TabButtonsModule } from './tab-buttons/tab-buttons.module';
 import { TabMainModule } from './tab-main/tab-main.module';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 /** Module for the grid widget settings component */
 @NgModule({
@@ -26,6 +27,7 @@ import { TabMainModule } from './tab-main/tab-main.module';
     TabActionsModule,
     TabButtonsModule,
     TabMainModule,
+    MatTooltipModule,
   ],
   exports: [SafeGridSettingsComponent],
 })

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -3,8 +3,12 @@
     <!-- GENERAL SETTINGS -->
     <mat-tab>
       <ng-template mat-tab-label>
-        <safe-icon icon="preview" [size]="24"></safe-icon>
-        <span>{{ 'common.general' | translate }}</span>
+        <safe-icon
+          icon="preview"
+          [size]="24"
+          [matTooltip]="!largeDevice ? ('common.general' | translate) : ''"
+        ></safe-icon>
+        <span *ngIf="largeDevice">{{ 'common.general' | translate }}</span>
       </ng-template>
       <ng-template matTabContent>
         <safe-map-general [form]="tileForm"></safe-map-general>
@@ -13,8 +17,12 @@
     <!-- LAYERS CONFIGURATION -->
     <mat-tab>
       <ng-template mat-tab-label>
-        <safe-icon icon="layers" [size]="24"></safe-icon>
-        <span>{{ 'common.layers' | translate }}</span>
+        <safe-icon
+          icon="layers"
+          [size]="24"
+          [matTooltip]="!largeDevice ? ('common.layers' | translate) : ''"
+        ></safe-icon>
+        <span *ngIf="largeDevice">{{ 'common.layers' | translate }}</span>
       </ng-template>
       <ng-template matTabContent>
         <safe-map-layers
@@ -27,8 +35,12 @@
     <!-- MAP PARAMETERS -->
     <mat-tab>
       <ng-template mat-tab-label>
-        <safe-icon icon="map" [size]="24"></safe-icon>
-        <span>{{
+        <safe-icon
+          icon="map"
+          [size]="24"
+          [matTooltip]="!largeDevice ? ('components.widget.settings.map.properties.title' | translate) : ''"
+        ></safe-icon>
+        <span *ngIf="largeDevice">{{
           'components.widget.settings.map.properties.title' | translate
         }}</span>
       </ng-template>

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.scss
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.scss
@@ -1,10 +1,23 @@
 :host {
   flex: 1;
   display: flex;
+  --tab-width: 240px;
 }
 
 mat-tab-group {
   flex: 1;
+
+  ::ng-deep .mat-tab-header {
+    width: fit-content !important;
+  }
+
+  ::ng-deep .mat-tab-label {
+    min-width: var(--tab-width) !important;
+  }
+
+  ::ng-deep .mat-tab-body-wrapper {
+    padding-left: var(--tab-width) !important;
+  }
 }
 
 .map-default-settings {

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  Input,
+  Output,
+  EventEmitter,
+  HostListener,
+  ElementRef,
+} from '@angular/core';
 import { mapform } from './map-forms';
 import { FormGroup, FormArray } from '@angular/forms';
 import { QueryBuilderService } from '../../../services/query-builder/query-builder.service';
@@ -15,6 +23,9 @@ export class SafeMapSettingsComponent implements OnInit {
 
   // === WIDGET ===
   @Input() tile: any;
+
+  // === DISPLAY ===
+  public largeDevice = true;
 
   // === EMIT THE CHANGES APPLIED ===
   // eslint-disable-next-line @angular-eslint/no-output-native
@@ -36,11 +47,16 @@ export class SafeMapSettingsComponent implements OnInit {
    * Component for the map widget settings
    *
    * @param queryBuilder Shared query builder service
+   * @param elRef The element reference.
    */
-  constructor(private queryBuilder: QueryBuilderService) {}
+  constructor(
+    private queryBuilder: QueryBuilderService,
+    private elRef: ElementRef
+  ) {}
 
   /** Build the settings form, using the widget saved parameters. */
   ngOnInit(): void {
+    this.resizeTab(window.innerWidth);
     this.tileForm = mapform(this.tile.id, this.tile.settings);
 
     this.change.emit(this.tileForm);
@@ -141,5 +157,32 @@ export class SafeMapSettingsComponent implements OnInit {
           ...(formatedFields ? { fields: formatedFields } : {}),
         };
       });
+  }
+
+  /**
+   * Listen the window size and call the resizeTab function.
+   *
+   * @param event Event that implies a change in window size
+   */
+  @HostListener('window:resize', ['$event'])
+  onResize(event: any): void {
+    this.resizeTab(event.target.innerWidth);
+  }
+
+  /**
+   * Change the tab display depending on windows size.
+   *
+   * @param width The width of the window.
+   */
+  private resizeTab(width: any): void {
+    const oldValue = this.largeDevice;
+    this.largeDevice = width > 1024;
+    if (this.largeDevice !== oldValue) {
+      if (this.largeDevice) {
+        this.elRef.nativeElement.style.setProperty('--tab-width', '240px');
+      } else {
+        this.elRef.nativeElement.style.setProperty('--tab-width', '80px');
+      }
+    }
   }
 }

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.module.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.module.ts
@@ -8,6 +8,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MapGeneralModule } from './map-general/map-general.module';
 import { MapLayersModule } from './map-layers/map-layers.module';
 import { MapPropertiesModule } from './map-properties/map-properties.module';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 /** Module for map settings component */
 @NgModule({
@@ -22,6 +23,7 @@ import { MapPropertiesModule } from './map-properties/map-properties.module';
     MapGeneralModule,
     MapLayersModule,
     MapPropertiesModule,
+    MatTooltipModule,
   ],
   exports: [SafeMapSettingsComponent],
 })


### PR DESCRIPTION
# Description

Resize tabs icon in widgets settings with the size of the screen.

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Reduce the size of the screen, check that the tabs is resized, the text disappeared and the tootip functionnality.
- [x] Open settings when the screen is already small, check it is the right size. Enlarge the window and check that the size of the tabs becomes the original one.  

## Sreenshots

![resize_tabs_button](https://user-images.githubusercontent.com/59767527/199760871-d9dafa14-4617-4699-8f1a-150c2d8d36d8.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
