### PR TITLE
feat-1.3.0/OORT-513_rotate_long_labels

### DIFF
--- a/projects/safe/src/lib/components/ui/bar-chart/bar-chart.component.ts
+++ b/projects/safe/src/lib/components/ui/bar-chart/bar-chart.component.ts
@@ -119,6 +119,11 @@ export class SafeBarChartComponent implements OnChanges {
           stacked: get(this.options, 'stack', false),
           min: isBar ? get(this.options, 'axes.x.min', undefined) : undefined,
           max: isBar ? get(this.options, 'axes.x.max', undefined) : undefined,
+          ticks: {
+            autoSkip: false,
+            maxRotation: !isBar && this.shouldRotateLabels() ? 90 : 0,
+            minRotation: !isBar && this.shouldRotateLabels() ? 90 : 0,
+          },
         },
         y: {
           stacked: get(this.options, 'stack', false),
@@ -223,6 +228,30 @@ export class SafeBarChartComponent implements OnChanges {
         actualField: d.field,
       })),
     }));
+  }
+
+  /**
+   * Gets whether or not the labels should be rotated
+   *
+   * @returns true if the labels should be rotated, false otherwise
+   */
+  private shouldRotateLabels() {
+    if (this.orientation === 'horizontal') return false;
+
+    const ctx = this.chart?.chart?.ctx;
+    if (!ctx) return false;
+
+    const labels = new Set<string>();
+    this.series.forEach((s) =>
+      s.data.forEach((d: any) => labels.add(d.category))
+    );
+
+    const totalLabelWidth = Array.from(labels).reduce(
+      (acc, label) => acc + ctx.measureText(label).width + 10,
+      0
+    );
+
+    return ctx.canvas.width < totalLabelWidth;
   }
 
   /** Exports chart as an image */

--- a/projects/safe/src/lib/components/ui/bar-chart/bar-chart.component.ts
+++ b/projects/safe/src/lib/components/ui/bar-chart/bar-chart.component.ts
@@ -120,9 +120,9 @@ export class SafeBarChartComponent implements OnChanges {
           min: isBar ? get(this.options, 'axes.x.min', undefined) : undefined,
           max: isBar ? get(this.options, 'axes.x.max', undefined) : undefined,
           ticks: {
-            autoSkip: false,
-            maxRotation: !isBar && this.shouldRotateLabels() ? 90 : 0,
-            minRotation: !isBar && this.shouldRotateLabels() ? 90 : 0,
+            autoSkip: isBar,
+            maxRotation: 90,
+            minRotation: 0,
           },
         },
         y: {
@@ -230,30 +230,6 @@ export class SafeBarChartComponent implements OnChanges {
         actualField: d.field,
       })),
     }));
-  }
-
-  /**
-   * Gets whether or not the labels should be rotated
-   *
-   * @returns true if the labels should be rotated, false otherwise
-   */
-  private shouldRotateLabels() {
-    if (this.orientation === 'horizontal') return false;
-
-    const ctx = this.chart?.chart?.ctx;
-    if (!ctx) return false;
-
-    const labels = new Set<string>();
-    this.series.forEach((s) =>
-      s.data.forEach((d: any) => labels.add(d.category))
-    );
-
-    const totalLabelWidth = Array.from(labels).reduce(
-      (acc, label) => acc + ctx.measureText(label).width + 10,
-      0
-    );
-
-    return ctx.canvas.width < totalLabelWidth;
   }
 
   /** Exports chart as an image */

--- a/projects/safe/src/lib/components/ui/line-chart/line-chart.component.ts
+++ b/projects/safe/src/lib/components/ui/line-chart/line-chart.component.ts
@@ -118,6 +118,13 @@ export class SafeLineChartComponent implements OnChanges {
     this.chartOptions = {
       ...this.chartOptions,
       scales: {
+        x: {
+          ticks: {
+            autoSkip: false,
+            maxRotation: this.shouldRotateLabels() ? 90 : 0,
+            minRotation: this.shouldRotateLabels() ? 90 : 0,
+          },
+        },
         y: {
           min: this.min - 0.1 * this.min,
           max: this.max + 0.1 * this.max,
@@ -172,6 +179,28 @@ export class SafeLineChartComponent implements OnChanges {
         },
       });
     }
+  }
+
+  /**
+   * Gets whether or not the labels should be rotated
+   *
+   * @returns true if the labels should be rotated, false otherwise
+   */
+  private shouldRotateLabels() {
+    const ctx = this.chart?.chart?.ctx;
+    if (!ctx) return false;
+
+    const labels = new Set<string>();
+    this.series.forEach((s) =>
+      s.data.forEach((d: any) => labels.add(d.category))
+    );
+
+    const totalLabelWidth = Array.from(labels).reduce(
+      (acc, label) => acc + ctx.measureText(label).width + 10,
+      0
+    );
+
+    return ctx.canvas.width < totalLabelWidth;
   }
 
   /** Exports chart as an image */

--- a/projects/safe/src/lib/components/ui/line-chart/line-chart.component.ts
+++ b/projects/safe/src/lib/components/ui/line-chart/line-chart.component.ts
@@ -121,8 +121,8 @@ export class SafeLineChartComponent implements OnChanges {
         x: {
           ticks: {
             autoSkip: false,
-            maxRotation: this.shouldRotateLabels() ? 90 : 0,
-            minRotation: this.shouldRotateLabels() ? 90 : 0,
+            maxRotation: 90,
+            minRotation: 0,
           },
         },
         y: {
@@ -181,28 +181,6 @@ export class SafeLineChartComponent implements OnChanges {
         },
       });
     }
-  }
-
-  /**
-   * Gets whether or not the labels should be rotated
-   *
-   * @returns true if the labels should be rotated, false otherwise
-   */
-  private shouldRotateLabels() {
-    const ctx = this.chart?.chart?.ctx;
-    if (!ctx) return false;
-
-    const labels = new Set<string>();
-    this.series.forEach((s) =>
-      s.data.forEach((d: any) => labels.add(d.category))
-    );
-
-    const totalLabelWidth = Array.from(labels).reduce(
-      (acc, label) => acc + ctx.measureText(label).width + 10,
-      0
-    );
-
-    return ctx.canvas.width < totalLabelWidth;
   }
 
   /** Exports chart as an image */


### PR DESCRIPTION
# Description

This PR adds responsivity to the labels on bar and line charts
The label will be rotated if it doesn't fit in the x axis

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By resizing the graphs until the labels don't fit

## Sreenshots
![Peek 2022-12-01 11-18](https://user-images.githubusercontent.com/102038450/205083264-684cd7e3-54e9-4f98-9682-3320ca26f739.gif)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
