### PR TITLE
fix/OORT-539_icon-margin-bug

### DIFF
--- a/projects/safe/src/lib/components/ui/icon/icon.component.html
+++ b/projects/safe/src/lib/components/ui/icon/icon.component.html
@@ -9,5 +9,6 @@
   [style.width]="fontSize"
   [style.height]="fontSize"
   [style.line-height]="fontSize"
-  >{{ icon }}</mat-icon
 >
+  {{ icon }}
+</mat-icon>

--- a/projects/safe/src/lib/components/ui/icon/icon.component.scss
+++ b/projects/safe/src/lib/components/ui/icon/icon.component.scss
@@ -9,3 +9,7 @@
 .safe-icon-grey {
   color: #a9a9a9;
 }
+
+.material-icons-outlined {
+  overflow: hidden;
+}


### PR DESCRIPTION
# Description

I fixed the problem by simply adding the `overflow: auto` property in the `material-icons-outlined` class. It works as intended and I don't think this could ever be an issue, since we're already setting the expected width for the icon

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with all the problematic icons and a few others:
* `visibility_outline`
* `change_circle_outline`
* `edit_outline`

## Sreenshots

![image](https://user-images.githubusercontent.com/102038450/206948513-3f551901-49a3-4699-b931-fd6d0b61d6f8.png)


# Checklist:

( * == Mandatory ) 

- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
