### PR TITLE
fix/OORT-546_map-legend-overflow

### DIFF
--- a/projects/safe/src/lib/components/widgets/map/map.component.ts
+++ b/projects/safe/src/lib/components/widgets/map/map.component.ts
@@ -477,6 +477,10 @@ export class SafeMapComponent implements AfterViewInit, OnDestroy {
       L.DomEvent.on(div, 'dblclick', (e: any) => {
         e.stopPropagation();
       });
+      // Prevent scroll on legend panel to zoom
+      L.DomEvent.on(div, 'mousewheel', (e: any) => {
+        e.stopPropagation();
+      });
       // Creates legend for clorophlets
       data.clorophlets?.map((clorophlet: any) => {
         const layer = overlays[clorophlet.name];

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -679,6 +679,8 @@ mat-tab-group[vertical] {
 
 // === LEAFLET ===
 .map-legend-container {
+  max-height: 320px;
+  overflow-y: auto;
   padding: 6px 8px;
   font: 14px/16px Arial, Helvetica, sans-serif;
   background: white;


### PR DESCRIPTION
# Description

This PR fixes the issue with overflowing map legends

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By setting up a map with a multiple choropleth divisions

## Sreenshots
![Peek 2022-12-14 14-47](https://user-images.githubusercontent.com/102038450/207670924-7182b61e-ebb9-48cd-b299-0a43d3198bbf.gif)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
