### PR TITLE
Fix 1.3.x/AB#22069 multilevel dropdown on tagbox

### DIFF
--- a/projects/safe/src/lib/components/reference-data-dropdown/reference-data-dropdown.component.html
+++ b/projects/safe/src/lib/components/reference-data-dropdown/reference-data-dropdown.component.html
@@ -9,6 +9,7 @@
     (openedChange)="onOpenSelect($event)"
     (selectionChange)="onSelect($event)"
   >
+    <mat-option>{{'common.input.none' | translate}}</mat-option>
     <mat-option
       *ngIf="selectedReferenceData"
       [value]="selectedReferenceData.id"

--- a/projects/safe/src/lib/survey/global-properties/reference-data.ts
+++ b/projects/safe/src/lib/survey/global-properties/reference-data.ts
@@ -244,15 +244,25 @@ export const render = (
       updateChoices();
     }
     // look on changes
-    question.registerFunctionOnPropertyValueChanged('referenceData', () => {
-      question.referenceDataDisplayField = undefined;
-    });
+    question.registerFunctionOnPropertyValueChanged(
+      'referenceData',
+      (value: string) => {
+        question.referenceDataDisplayField = undefined;
+        if (!value) {
+          question.referenceDataDisplayField = undefined;
+          question.referenceDataFilterFilterFromQuestion = undefined;
+          question.referenceDataFilterForeignField = undefined;
+          question.referenceDataFilterFilterCondition = undefined;
+          question.referenceDataFilterLocalField = undefined;
+        }
+      }
+    );
     question.registerFunctionOnPropertyValueChanged(
       'referenceDataDisplayField',
       updateChoices
     );
 
-    // logic for filters
+    // Look for foreign question changes if needed for filter
     const foreignQuestion = (question.survey as SurveyModel)
       .getAllQuestions()
       .find(

--- a/projects/safe/src/lib/survey/global-properties/reference-data.ts
+++ b/projects/safe/src/lib/survey/global-properties/reference-data.ts
@@ -236,12 +236,14 @@ export const render = (
       } else {
         question.choices = [];
       }
-      question.referenceDataChoicesLoaded = true;
     };
 
     // init the choices
     if (!question.referenceDataChoicesLoaded && question.referenceData) {
-      updateChoices();
+      referenceDataService
+        .cacheItems(question.referenceData)
+        .then(() => updateChoices());
+      question.referenceDataChoicesLoaded = true;
     }
     // look on changes
     question.registerFunctionOnPropertyValueChanged(


### PR DESCRIPTION
# Description

- Allow to use RefData filters properties for multiselect questions
- Prevent sending too much requests by caching the full list of choices once at the beginning
- Allow to unselect refData properties in the form builder

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested it with a form with the following questions:
- Region dropdown
- Country dropdown filter by above
- Regions tagbox
- Countries tagbox filtered by above

## Sreenshots

Tagbox
<img width="1171" alt="image" src="https://user-images.githubusercontent.com/37704336/208628312-2bf794bf-9f18-43ad-bda1-116e1b6c16f8.png">
Dropdown
<img width="825" alt="image" src="https://user-images.githubusercontent.com/37704336/208628620-820a91bb-2008-4e60-a136-8a1cdf8dff91.png">

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
