### PR TITLE
fix/OORT-555_remove-irrelevant-elements-graphqlselect

### DIFF
--- a/projects/safe/src/lib/components/graphql-select/graphql-select.component.html
+++ b/projects/safe/src/lib/components/graphql-select/graphql-select.component.html
@@ -1,6 +1,7 @@
 <mat-select
   [formControl]="ngControl && $any(ngControl.control)"
   (openedChange)="onOpenSelect($event)"
+  (closed)="onCloseSelect()"
   [required]="required"
   (focusin)="onFocusIn()"
   (focusout)="onFocusOut($event)"

--- a/projects/safe/src/lib/components/graphql-select/graphql-select.component.ts
+++ b/projects/safe/src/lib/components/graphql-select/graphql-select.component.ts
@@ -247,6 +247,7 @@ export class SafeGraphQLSelectComponent
   @Input() selectedElements: any[] = [];
   public elements = new BehaviorSubject<any[]>([]);
   public elements$!: Observable<any[]>;
+  private queryElements: any[] = [];
   private pageInfo = {
     endCursor: '',
     hasNextPage: true,
@@ -291,6 +292,7 @@ export class SafeGraphQLSelectComponent
           )
       );
       this.elements.next([...selectedElements, ...elements]);
+      this.queryElements = elements;
       this.pageInfo = get(res.data, path).pageInfo;
       this.loading = res.loading;
     });
@@ -337,21 +339,6 @@ export class SafeGraphQLSelectComponent
         )
     );
     this.elements.next([...selectedElements, ...elements]);
-
-    /**
-     * This is needed in order to display previously selected elements
-     * when the selectedElements input changes, due to how displayWith works
-     */
-    // if (
-    //   changes.selectedElements &&
-    //   changes.selectedElements.currentValue.length > 0
-    // ) {
-    //   this.searchText = '';
-    //   this.searchText =
-    //     this.elements
-    //       .getValue()
-    //       .find((x) => x[this.valueField] === this.value) || '';
-    // }
   }
 
   ngOnDestroy(): void {
@@ -452,5 +439,26 @@ export class SafeGraphQLSelectComponent
    */
   public onSelectionChange(event: MatSelectChange) {
     this.value = event.value;
+  }
+
+  /** Triggers on close of select */
+  onCloseSelect() {
+    // filter out from the elements the ones that are
+    // not in the queryElements array or the selectedElements array
+    const elements = this.elements
+      .getValue()
+      .filter(
+        (element) =>
+          this.queryElements.find(
+            (queryElement) =>
+              queryElement[this.valueField] === element[this.valueField]
+          ) ||
+          this.selectedElements.find(
+            (selectedElement) =>
+              selectedElement[this.valueField] === element[this.valueField]
+          )
+      );
+
+    this.elements.next(elements);
   }
 }


### PR DESCRIPTION
# Description

Fixes bug where old selected options would remain when they shouldn't

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* First, search for items that are far in the list ( not in first 10 items of query ), and select them.
* They should be “cached”, so even if we filter, they still appear
* Then, search for other elements ( at start of query is fine ), and close the select, then reopen it
* You should see that the first selected elements no longer appears

## Sreenshots

![Peek 2022-12-22 02-03](https://user-images.githubusercontent.com/102038450/209061075-29b6ab90-c12e-4618-8e2c-4e24a307eb97.gif)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
