### PR TITLE
refactor/AB#51566_show-user-groups-in-FO

### DIFF
--- a/projects/safe/src/lib/components/user-summary/user-roles/user-groups/user-groups.component.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-groups/user-groups.component.ts
@@ -17,9 +17,11 @@ export class UserGroupsComponent implements OnInit {
   @Input() user!: User;
   selectedGroups!: FormControl;
   @Output() edit = new EventEmitter();
+  @Input() canEdit = false;
 
   /** Setter for the loading state */
   @Input() set loading(loading: boolean) {
+    if (!this.canEdit) return;
     if (loading) {
       this.selectedGroups?.disable({ emitEvent: false });
     } else {
@@ -41,9 +43,10 @@ export class UserGroupsComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.selectedGroups = this.fb.control(
-      get(this.user, 'groups', []).map((x) => x.id)
-    );
+    this.selectedGroups = this.fb.control({
+      value: get(this.user, 'groups', []).map((x) => x.id),
+      disabled: !this.canEdit,
+    });
     this.selectedGroups.valueChanges.subscribe((value) => {
       this.edit.emit({ groups: value });
     });

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-roles.component.html
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-roles.component.html
@@ -1,5 +1,6 @@
 <safe-user-groups
   *ngIf="canSeeGroups"
+  [canEdit]="!application"
   [user]="user"
   (edit)="edit.emit($event)"
   [loading]="loading"

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-roles.component.html
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-roles.component.html
@@ -1,5 +1,5 @@
 <safe-user-groups
-  *ngIf="!application"
+  *ngIf="canSeeGroups"
   [user]="user"
   (edit)="edit.emit($event)"
   [loading]="loading"

--- a/projects/safe/src/lib/components/user-summary/user-roles/user-roles.component.ts
+++ b/projects/safe/src/lib/components/user-summary/user-roles/user-roles.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Application } from '../../../models/application.model';
 import { User } from '../../../models/user.model';
+import { SafeAuthService } from '../../../services/auth/auth.service';
 
 /** Component for the roles tab of the user summary */
 @Component({
@@ -15,6 +16,24 @@ export class UserRolesComponent implements OnInit {
   @Output() edit = new EventEmitter();
 
   @Input() loading = false;
+  public canSeeGroups = false;
 
-  ngOnInit(): void {}
+  /**
+   * Component for the roles tab of the user summary
+   *
+   * @param authService Shared auth service
+   */
+  constructor(private authService: SafeAuthService) {}
+
+  async ngOnInit(): Promise<void> {
+    this.canSeeGroups = await new Promise<boolean>((resolve) => {
+      this.authService.user$.subscribe((user) => {
+        // can_see_groups is a permission that is only available globally
+        // therefore no need to check against the current application
+        resolve(
+          user?.permissions?.some((p) => p.type === 'can_see_groups') ?? false
+        );
+      });
+    });
+  }
 }


### PR DESCRIPTION
# Description

This PR changes the condition for rendering the groups section in the role tab of the user settings. Before, it was rendered outside applications. Now, it's rendered whenever the user has the can_see_groups permission.

I thought it would also make sense to disable the edition when in an application. For example, a manager of an application that isn't an admin could remove or add groups of users that are used in another app they are not aware of.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By accessing the roles tab in the user summary with and without the required permission

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
