### PR TITLE
Fix 1.3.0/oort 563 reload history

### DIFF
--- a/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -567,6 +567,7 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
           // if no error, reload the grid
           this.reloadData();
         }
+        this.reloadHistory.next(true);
       });
     }
   }

--- a/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -22,7 +22,7 @@ import {
   SortDescriptor,
 } from '@progress/kendo-data-query';
 import { Apollo, QueryRef } from 'apollo-angular';
-import { Subscription } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 import { SafeAuthService } from '../../../services/auth/auth.service';
 import { SafeDownloadService } from '../../../services/download/download.service';
 import { SafeLayoutService } from '../../../services/layout/layout.service';
@@ -142,6 +142,9 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
   private dataQuery!: QueryRef<QueryResponse>;
   private metaQuery: any;
   private dataSubscription?: Subscription;
+  public reloadHistory: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
+    false
+  );
 
   // === PAGINATION ===
   public pageSize = 10;
@@ -901,6 +904,7 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
       if (value) {
         this.validateRecords(ids);
         this.reloadData();
+        this.reloadHistory.next(true);
       }
     });
   }
@@ -1012,6 +1016,7 @@ export class SafeCoreGridComponent implements OnInit, OnChanges, OnDestroy {
         id: item.id,
         revert: (version: any) => this.confirmRevertDialog(item, version),
         template: this.settings.template || null,
+        reload: this.reloadHistory.asObservable(),
       },
     });
   }


### PR DESCRIPTION
# Description

Reload open history when updating related record in grid.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Create a dashboard then create a grid with some records. After that open history of a record and update the record by inlining or using the ‘update’ button. History is also updae

## Sreenshots

![reload_history](https://user-images.githubusercontent.com/59767527/210787886-66e51f75-fa58-4dc6-a309-72d70d12b3c3.png)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
