### PR TITLE
feat: add empty components in resources tabs

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.html
@@ -69,8 +69,10 @@
       >
       </safe-skeleton-table>
     </div>
+    <!-- Pagination -->
     <mat-paginator
       *ngIf="!empty"
+      [disabled]="loading"
       [pageIndex]="pageInfo.pageIndex"
       [pageSize]="pageInfo.pageSize"
       [pageSizeOptions]="[10, 25, 50]"
@@ -78,6 +80,7 @@
       (page)="onPage($event)"
     >
     </mat-paginator>
+    <!-- Empty indicator -->
     <safe-empty
       class="m-auto py-6 px-0 bg-white"
       *ngIf="empty"

--- a/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.html
@@ -70,7 +70,7 @@
       </safe-skeleton-table>
     </div>
     <mat-paginator
-      [disabled]="loading"
+      *ngIf="!empty"
       [pageIndex]="pageInfo.pageIndex"
       [pageSize]="pageInfo.pageSize"
       [pageSizeOptions]="[10, 25, 50]"
@@ -79,8 +79,8 @@
     >
     </mat-paginator>
     <safe-empty
-      class="m-auto py-6 px-0"
-      *ngIf="aggregations.length === 0"
+      class="m-auto py-6 px-0 bg-white"
+      *ngIf="empty"
       [title]="'components.resource.empty.aggregations' | translate"
     ></safe-empty>
   </div>

--- a/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.html
@@ -78,5 +78,10 @@
       (page)="onPage($event)"
     >
     </mat-paginator>
+    <safe-empty
+      class="m-auto py-6 px-0"
+      *ngIf="aggregations.length === 0"
+      [title]="'components.resource.empty.aggregations' | translate"
+    ></safe-empty>
   </div>
 </div>

--- a/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.ts
@@ -44,9 +44,7 @@ export class AggregationsTabComponent implements OnInit {
     endCursor: '',
   };
 
-  /**
-   * Getter to know if the aggregations tab is empty.
-   */
+  /** @returns True if the aggregations tab is empty */
   get empty(): boolean {
     return this.loading || this.aggregations.length === 0;
   }

--- a/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.ts
@@ -45,6 +45,13 @@ export class AggregationsTabComponent implements OnInit {
   };
 
   /**
+   * Getter to know if the aggregations tab is empty.
+   */
+  get empty(): boolean {
+    return this.loading || this.aggregations.length === 0;
+  }
+
+  /**
    * Aggregations tab of resource page
    *
    * @param apollo Apollo service

--- a/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.module.ts
@@ -12,6 +12,7 @@ import {
   SafeAggregationBuilderModule,
   SafeDateModule,
   SafeSkeletonTableModule,
+  SafeEmptyModule,
 } from '@safe/builder';
 import { AggregationsTabComponent } from './aggregations-tab.component';
 import { MatPaginatorModule } from '@angular/material/paginator';
@@ -35,6 +36,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
     SafeDateModule,
     SafeSkeletonTableModule,
     MatPaginatorModule,
+    SafeEmptyModule,
   ],
 })
 export class AggregationsTabModule {}

--- a/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.html
@@ -61,8 +61,10 @@
       >
       </safe-skeleton-table>
     </div>
+    <!-- Pagination -->
     <mat-paginator
       *ngIf="!empty"
+      [disabled]="loading"
       [pageIndex]="pageInfo.pageIndex"
       [pageSize]="pageInfo.pageSize"
       [pageSizeOptions]="[10, 25, 50]"
@@ -70,6 +72,7 @@
       (page)="onPage($event)"
     >
     </mat-paginator>
+    <!-- Empty indicator -->
     <safe-empty
       class="m-auto py-6 px-0 bg-white"
       *ngIf="empty"

--- a/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.html
@@ -70,5 +70,10 @@
       (page)="onPage($event)"
     >
     </mat-paginator>
+    <safe-empty
+      class="m-auto py-6 px-0"
+      *ngIf="layouts.length === 0"
+      [title]="'components.resource.empty.layouts' | translate"
+    ></safe-empty>
   </div>
 </div>

--- a/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.html
@@ -62,7 +62,7 @@
       </safe-skeleton-table>
     </div>
     <mat-paginator
-      [disabled]="loading"
+      *ngIf="!empty"
       [pageIndex]="pageInfo.pageIndex"
       [pageSize]="pageInfo.pageSize"
       [pageSizeOptions]="[10, 25, 50]"
@@ -71,8 +71,8 @@
     >
     </mat-paginator>
     <safe-empty
-      class="m-auto py-6 px-0"
-      *ngIf="layouts.length === 0"
+      class="m-auto py-6 px-0 bg-white"
+      *ngIf="empty"
       [title]="'components.resource.empty.layouts' | translate"
     ></safe-empty>
   </div>

--- a/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.ts
@@ -41,6 +41,13 @@ export class LayoutsTabComponent implements OnInit {
   };
 
   /**
+   * Getter to know if the layouts tab is empty.
+   */
+  get empty(): boolean {
+    return this.loading || this.layouts.length === 0;
+  }
+
+  /**
    * Layouts tab of resource page
    *
    * @param apollo Apollo service

--- a/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.ts
@@ -40,9 +40,7 @@ export class LayoutsTabComponent implements OnInit {
     endCursor: '',
   };
 
-  /**
-   * Getter to know if the layouts tab is empty.
-   */
+  /** @returns True if the layouts tab is empty */
   get empty(): boolean {
     return this.loading || this.layouts.length === 0;
   }

--- a/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.module.ts
@@ -12,6 +12,7 @@ import {
   SafeEditLayoutModalModule,
   SafeDateModule,
   SafeSkeletonTableModule,
+  SafeEmptyModule,
 } from '@safe/builder';
 import { LayoutsTabComponent } from './layouts-tab.component';
 import { MatPaginatorModule } from '@angular/material/paginator';
@@ -35,6 +36,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
     SafeDateModule,
     SafeSkeletonTableModule,
     MatPaginatorModule,
+    SafeEmptyModule,
   ],
 })
 export class LayoutsTabModule {}

--- a/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
@@ -174,4 +174,9 @@
     aria-label="Select page of records"
     (page)="onPage($event)"
   ></mat-paginator>
+  <safe-empty
+    class="m-auto py-6 px-0"
+    *ngIf="dataSource.filteredData.length === 0"
+    [title]="'components.resource.empty.records' | translate"
+  ></safe-empty>
 </div>

--- a/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
@@ -166,14 +166,17 @@
     >
     </safe-skeleton-table>
   </div>
+  <!-- Pagination -->
   <mat-paginator
     *ngIf="!empty"
+    [disabled]="loading"
     [pageIndex]="pageInfo.pageIndex"
     [pageSize]="pageInfo.pageSize"
     [length]="pageInfo.length"
     aria-label="Select page of records"
     (page)="onPage($event)"
   ></mat-paginator>
+  <!-- Empty indicator -->
   <safe-empty
     class="m-auto py-6 px-0 bg-white"
     *ngIf="empty"

--- a/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
@@ -167,7 +167,7 @@
     </safe-skeleton-table>
   </div>
   <mat-paginator
-    [disabled]="loading"
+    *ngIf="!empty"
     [pageIndex]="pageInfo.pageIndex"
     [pageSize]="pageInfo.pageSize"
     [length]="pageInfo.length"
@@ -175,8 +175,8 @@
     (page)="onPage($event)"
   ></mat-paginator>
   <safe-empty
-    class="m-auto py-6 px-0"
-    *ngIf="dataSource.filteredData.length === 0"
+    class="m-auto py-6 px-0 bg-white"
+    *ngIf="empty"
     [title]="'components.resource.empty.records' | translate"
   ></safe-empty>
 </div>

--- a/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
@@ -56,9 +56,7 @@ export class RecordsTabComponent implements OnInit {
   public loading = true;
   public showUpload = false;
 
-  /**
-   * Getter to know if the records tab is empty.
-   */
+  /** @returns True if the records tab is empty */
   get empty(): boolean {
     return this.loading || this.dataSource.filteredData.length === 0;
   }

--- a/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
@@ -57,6 +57,13 @@ export class RecordsTabComponent implements OnInit {
   public showUpload = false;
 
   /**
+   * Getter to know if the records tab is empty.
+   */
+  get empty(): boolean {
+    return this.loading || this.dataSource.filteredData.length === 0;
+  }
+
+  /**
    * Records tab of resource page
    *
    * @param apollo Apollo service

--- a/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.module.ts
@@ -9,7 +9,11 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
-import { SafeButtonModule, SafeSkeletonTableModule } from '@safe/builder';
+import {
+  SafeButtonModule,
+  SafeSkeletonTableModule,
+  SafeEmptyModule,
+} from '@safe/builder';
 import { UploadMenuModule } from 'projects/back-office/src/app/components/upload-menu/upload-menu.module';
 
 /**
@@ -30,6 +34,7 @@ import { UploadMenuModule } from 'projects/back-office/src/app/components/upload
     OverlayModule,
     UploadMenuModule,
     SafeSkeletonTableModule,
+    SafeEmptyModule,
   ],
 })
 export class RecordsTabModule {}

--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -746,6 +746,11 @@
 			},
 			"dropdown": {
 				"select": "From resource"
+			},
+			"empty": {
+				"aggregations": "No aggregation detected",
+				"layouts": "No layout detected",
+				"records": "No record detected"
 			}
 		},
 		"role": {

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -746,6 +746,11 @@
 			},
 			"dropdown": {
 				"select": "Depuis la ressource"
+			},
+			"empty": {
+				"aggregations": "Aucune agrégation détectée",
+				"layouts": "Aucune mise en page détectée",
+				"records": "Aucun enregistrement détecté"
 			}
 		},
 		"role": {

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -746,6 +746,11 @@
 			},
 			"dropdown": {
 				"select": "******"
+			},
+			"empty": {
+				"aggregations": "******",
+				"layouts": "******",
+				"records": "******"
 			}
 		},
 		"role": {


### PR DESCRIPTION
# Description

Add SafeEmpty components in back-office resources tabs

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Create or open an empty resource. Go in Records / Layouts / Aggregations tabs. A message, showing that the content of the tab is empty, is displayed.
- [x] Open a resource with these tabs non-empty. The message is not displayed.

## Sreenshots

![empty_records](https://user-images.githubusercontent.com/59767527/211348627-1d6bb4b8-64b5-4e71-86aa-03f36409d343.png)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
