### PR TITLE
fix: put mat-tab-body-wrapper out of mat-tab-group to be taken into a…

### DIFF
--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -591,23 +591,27 @@ mat-tab-group[vertical] {
       display: none;
     }
   }
+}
 
-  & > .mat-tab-body-wrapper {
-    width: 100%;
+.mat-tab-body-wrapper {
+  width: 100%;
+  overflow: visible !important;
 
-    & > .mat-tab-body {
-      & > .mat-tab-body-content {
-        transition: all ease 200ms;
-        padding-left: 32px;
-      }
-      &
-        > .mat-tab-body-content[style*='transform: translate3d(100%, 0px, 0px)'] {
-        transform: translate3d(0px, 100%, 0px) !important;
-      }
-      &
-        > .mat-tab-body-content[style*='transform: translate3d(-100%, 0px, 0px)'] {
-        transform: translate3d(0px, -100%, 0px) !important;
-      }
+  .mat-tab-body {
+    overflow: visible !important;
+
+    .mat-tab-body-content {
+      transition: all ease 200ms;
+      padding-left: 32px;
+      overflow: visible !important;
+    }
+    &
+      > .mat-tab-body-content[style*='transform: translate3d(100%, 0px, 0px)'] {
+      transform: translate3d(0px, 100%, 0px) !important;
+    }
+    &
+      > .mat-tab-body-content[style*='transform: translate3d(-100%, 0px, 0px)'] {
+      transform: translate3d(0px, -100%, 0px) !important;
     }
   }
 }


### PR DESCRIPTION
# Description

Add overflow visible to mat-body-wrapper and its children to avoid to hide shadows.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Open pages where a table is in a mat-tag-group (for example roles page) and check that the overflow of the table's shadow is visible.

## Sreenshots

![overflow_mat-tab](https://user-images.githubusercontent.com/59767527/211518840-8440e5e0-ef24-4cd0-afd3-0bb8e3dc291a.png)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
