### PR TITLE
fix: add a save error message when display as grid is selected witout…

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -519,6 +519,7 @@
 		},
 		"formBuilder": {
 			"errors": {
+				"missingGridField": "Missing an available field grid for question {{question}} on page {{page}}. Please select a least one in Custom Question Properties to save the form.",
 				"missingRelatedName": "Missing related name for question {{question}} on page {{page}}. Please provide a valid data value name (snake case format) to save the form.",
 				"missingTemplate": "Missing related resource template for question {{question}} on page {{page}}. Please select a template to save the form."
 			}

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -519,6 +519,7 @@
 		},
 		"formBuilder": {
 			"errors": {
+				"missingGridField": "Champs disponible de table de données manquant pour la question {{question}} à la page {{page}}. Veuillez en sélectionner au moins un dans la propriété Custom Question pour sauvegarder le formulaire.",
 				"missingRelatedName": "Nom lié manquant pour la question {{question}} à la page {{page}}. Veuillez entrer un nom valide pour la valeur de la donnée (au format snake_case) pour sauvegarder le formulaire.",
 				"missingTemplate": "Ressource liée manquante pour la question {{question}} à la page {{page}}. Veuillez sélectionner un modèle pour sauvegarder le formulaire."
 			}

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -519,6 +519,7 @@
 		},
 		"formBuilder": {
 			"errors": {
+				"missingGridField": "****** {{question}} ****** {{page}} ******",
 				"missingRelatedName": "****** {{question}} ****** {{page}} ******",
 				"missingTemplate": "****** {{question}} ****** {{page}} ******"
 			}

--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -477,6 +477,19 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
           )
         );
       }
+
+      // Error if the user selected Display As Grid without adding an available field.
+      if (element.displayAsGrid && !element.gridFieldsSettings) {
+        throw new Error(
+          this.translate.instant(
+            'components.formBuilder.errors.missingGridField',
+            {
+              question: element.name,
+              page: page.name,
+            }
+          )
+        );
+      }
     }
     // Check that at least an application is selected in the properties of users and owner question
     if (['users', 'owner'].includes(element.getType())) {

--- a/projects/safe/src/lib/survey/types.ts
+++ b/projects/safe/src/lib/survey/types.ts
@@ -63,6 +63,7 @@ export interface QuestionResource
   filterBy: string;
   staticValue: string;
   customFilter: string;
+  displayAsGrid: boolean;
 }
 
 /** Type for any questions, which allows to use all properties of different question types */


### PR DESCRIPTION
# Description

Add a save error message when display as grid is selected witout an available field in custom question resources

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Select ‘display as grid' of a resources question in a form without selecting an available field, and save. An error is shown.

## Sreenshots

![missing_available_field](https://user-images.githubusercontent.com/59767527/212295131-842429b7-fcc4-47bc-80b8-4a33c4ec263e.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
