### PR TITLE
refactor/AB#51567_table-styling-with-tailwind

### DIFF
--- a/projects/back-office/src/app/application/pages/channels/channels.component.html
+++ b/projects/back-office/src/app/application/pages/channels/channels.component.html
@@ -19,7 +19,9 @@
           <th mat-header-cell *matHeaderCellDef>
             {{ 'common.title' | translate }}
           </th>
-          <td mat-cell *matCellDef="let element">{{ element.title }}</td>
+          <td mat-cell *matCellDef="let element" class="font-bold">
+            {{ element.title }}
+          </td>
         </ng-container>
         <ng-container matColumnDef="subscribedRoles">
           <th mat-header-cell *matHeaderCellDef>

--- a/projects/back-office/src/app/application/pages/position/position.component.html
+++ b/projects/back-office/src/app/application/pages/position/position.component.html
@@ -19,7 +19,9 @@
           <th mat-header-cell *matHeaderCellDef>
             {{ 'common.title' | translate }}
           </th>
-          <td mat-cell *matCellDef="let element">{{ element.title }}</td>
+          <td mat-cell *matCellDef="let element" class="font-bold">
+            {{ element.title }}
+          </td>
         </ng-container>
 
         <ng-container matColumnDef="actions" [stickyEnd]="true">

--- a/projects/back-office/src/app/application/pages/subscriptions/subscriptions.component.html
+++ b/projects/back-office/src/app/application/pages/subscriptions/subscriptions.component.html
@@ -19,7 +19,9 @@
           <th mat-header-cell *matHeaderCellDef>
             {{ 'common.title' | translate }}
           </th>
-          <td mat-cell *matCellDef="let element">{{ element.title }}</td>
+          <td mat-cell *matCellDef="let element" class="font-bold">
+            {{ element.title }}
+          </td>
         </ng-container>
         <ng-container matColumnDef="convertTo">
           <th mat-header-cell *matHeaderCellDef>

--- a/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.html
+++ b/projects/back-office/src/app/dashboard/pages/api-configurations/api-configurations.component.html
@@ -87,7 +87,9 @@
             {{ 'common.name' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="status">

--- a/projects/back-office/src/app/dashboard/pages/applications/applications.component.html
+++ b/projects/back-office/src/app/dashboard/pages/applications/applications.component.html
@@ -39,7 +39,9 @@
               {{ 'common.name' | translate }}
             </span>
           </th>
-          <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+          <td mat-cell *matCellDef="let element" class="font-bold">
+            {{ element.name }}
+          </td>
         </ng-container>
 
         <ng-container matColumnDef="createdAt">

--- a/projects/back-office/src/app/dashboard/pages/forms/forms.component.html
+++ b/projects/back-office/src/app/dashboard/pages/forms/forms.component.html
@@ -31,7 +31,9 @@
             {{ 'common.name' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="createdAt">

--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.component.html
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.component.html
@@ -18,7 +18,9 @@
         <th mat-header-cell *matHeaderCellDef>
           {{ 'common.name' | translate }}
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef>

--- a/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.html
+++ b/projects/back-office/src/app/dashboard/pages/reference-datas/reference-datas.component.html
@@ -41,7 +41,9 @@
             {{ 'common.name' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="type">

--- a/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/aggregations-tab/aggregations-tab.component.html
@@ -20,7 +20,9 @@
           <th mat-header-cell *matHeaderCellDef>
             {{ 'common.name' | translate }}
           </th>
-          <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+          <td mat-cell *matCellDef="let element" class="font-bold">
+            {{ element.name }}
+          </td>
         </ng-container>
 
         <ng-container matColumnDef="createdAt">

--- a/projects/back-office/src/app/dashboard/pages/resource/forms-tab/forms-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/forms-tab/forms-tab.component.html
@@ -7,7 +7,9 @@
         <th mat-header-cell *matHeaderCellDef>
           {{ 'common.name' | translate }}
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="createdAt">

--- a/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resource/layouts-tab/layouts-tab.component.html
@@ -15,7 +15,9 @@
           <th mat-header-cell *matHeaderCellDef>
             {{ 'common.name' | translate }}
           </th>
-          <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+          <td mat-cell *matCellDef="let element" class="font-bold">
+            {{ element.name }}
+          </td>
         </ng-container>
 
         <ng-container matColumnDef="createdAt">

--- a/projects/back-office/src/app/dashboard/pages/resources/resources.component.html
+++ b/projects/back-office/src/app/dashboard/pages/resources/resources.component.html
@@ -34,7 +34,9 @@
             {{ 'common.name' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="createdAt">

--- a/projects/safe/src/lib/components/aggregation/aggregation-table/aggregation-table.component.html
+++ b/projects/safe/src/lib/components/aggregation/aggregation-table/aggregation-table.component.html
@@ -13,7 +13,9 @@
         <th mat-header-cell *matHeaderCellDef>
           {{ 'common.name' | translate }}
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="createdAt">

--- a/projects/safe/src/lib/components/distribution-lists/distribution-lists.component.html
+++ b/projects/safe/src/lib/components/distribution-lists/distribution-lists.component.html
@@ -23,7 +23,9 @@
             {{ 'common.name' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="actions">

--- a/projects/safe/src/lib/components/grid-layout/layout-table/layout-table.component.html
+++ b/projects/safe/src/lib/components/grid-layout/layout-table/layout-table.component.html
@@ -13,7 +13,9 @@
         <th mat-header-cell *matHeaderCellDef>
           {{ 'common.name' | translate }}
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="createdAt">

--- a/projects/safe/src/lib/components/query-builder/tab-style/query-style-list/query-style-list.component.html
+++ b/projects/safe/src/lib/components/query-builder/tab-style/query-style-list/query-style-list.component.html
@@ -13,7 +13,9 @@
         <th mat-header-cell *matHeaderCellDef>
           {{ 'common.name' | translate }}
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="preview">

--- a/projects/safe/src/lib/components/role-summary/role-features/role-dashboards/role-dashboards.component.html
+++ b/projects/safe/src/lib/components/role-summary/role-features/role-dashboards/role-dashboards.component.html
@@ -9,7 +9,9 @@
           <th mat-header-cell *matHeaderCellDef>
             {{ 'common.name' | translate }}
           </th>
-          <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+          <td mat-cell *matCellDef="let element" class="font-bold">
+            {{ element.name }}
+          </td>
         </ng-container>
 
         <ng-container matColumnDef="actions" [stickyEnd]="true">

--- a/projects/safe/src/lib/components/role-summary/role-features/role-forms/role-forms.component.html
+++ b/projects/safe/src/lib/components/role-summary/role-features/role-forms/role-forms.component.html
@@ -9,7 +9,9 @@
           <th mat-header-cell *matHeaderCellDef>
             {{ 'common.name' | translate }}
           </th>
-          <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+          <td mat-cell *matCellDef="let element" class="font-bold">
+            {{ element.name }}
+          </td>
         </ng-container>
 
         <ng-container matColumnDef="actions" [stickyEnd]="true">

--- a/projects/safe/src/lib/components/role-summary/role-features/role-workflows/role-workflows.component.html
+++ b/projects/safe/src/lib/components/role-summary/role-features/role-workflows/role-workflows.component.html
@@ -5,7 +5,9 @@
       <th mat-header-cell *matHeaderCellDef>
         {{ 'common.name' | translate }}
       </th>
-      <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+      <td mat-cell *matCellDef="let element" class="font-bold">
+        {{ element.name }}
+      </td>
     </ng-container>
 
     <ng-container matColumnDef="actions">
@@ -69,7 +71,9 @@
               <th mat-header-cell *matHeaderCellDef>
                 {{ 'common.step.one' | translate }}
               </th>
-              <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+              <td mat-cell *matCellDef="let element" class="font-bold">
+                {{ element.name }}
+              </td>
             </ng-container>
             <ng-container matColumnDef="actions">
               <th mat-header-cell *matHeaderCellDef></th>

--- a/projects/safe/src/lib/components/role-summary/role-resources/resource-fields/resource-fields.component.html
+++ b/projects/safe/src/lib/components/role-summary/role-resources/resource-fields/resource-fields.component.html
@@ -10,7 +10,9 @@
         <th mat-header-cell *matHeaderCellDef>
           {{ 'common.field.one' | translate }}
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
       <ng-container matColumnDef="actions" [stickyEnd]="true">
         <th mat-header-cell *matHeaderCellDef></th>

--- a/projects/safe/src/lib/components/role-summary/role-resources/role-resources.component.html
+++ b/projects/safe/src/lib/components/role-summary/role-resources/role-resources.component.html
@@ -20,7 +20,9 @@
         <th mat-header-cell *matHeaderCellDef>
           {{ 'common.name' | translate }}
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.resource.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.resource.name }}
+        </td>
       </ng-container>
       <!-- Resource Actions & Permissions -->
       <ng-container matColumnDef="actions" [stickyEnd]="true">

--- a/projects/safe/src/lib/components/role-summary/role-users/role-users.component.html
+++ b/projects/safe/src/lib/components/role-summary/role-users/role-users.component.html
@@ -9,7 +9,9 @@
             {{ 'common.name' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-black bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="username">

--- a/projects/safe/src/lib/components/roles/components/group-list/group-list.component.html
+++ b/projects/safe/src/lib/components/roles/components/group-list/group-list.component.html
@@ -38,7 +38,9 @@
             {{ 'common.title' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.title }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.title }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="usersCount">

--- a/projects/safe/src/lib/components/roles/components/role-list/role-list.component.html
+++ b/projects/safe/src/lib/components/roles/components/role-list/role-list.component.html
@@ -40,7 +40,9 @@
             {{ 'common.title' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.title }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.title }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="usersCount">

--- a/projects/safe/src/lib/components/skeleton/skeleton-table/skeleton-table.component.html
+++ b/projects/safe/src/lib/components/skeleton/skeleton-table/skeleton-table.component.html
@@ -1,10 +1,10 @@
 <table mat-table [dataSource]="dataSource" matSort>
   <ng-container matColumnDef="select" *ngIf="checkbox">
-    <th mat-header-cell *matHeaderCellDef class="w-16">
-      <mat-checkbox></mat-checkbox>
+    <th mat-header-cell *matHeaderCellDef>
+      <mat-checkbox class="mr-2"></mat-checkbox>
     </th>
-    <td mat-cell *matCellDef="let element" class="w-16">
-      <mat-checkbox></mat-checkbox>
+    <td mat-cell *matCellDef="let element">
+      <mat-checkbox class="mr-2"></mat-checkbox>
     </td>
   </ng-container>
 

--- a/projects/safe/src/lib/components/templates/templates.component.html
+++ b/projects/safe/src/lib/components/templates/templates.component.html
@@ -23,7 +23,9 @@
             {{ 'common.name' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="type">

--- a/projects/safe/src/lib/components/users/users.component.html
+++ b/projects/safe/src/lib/components/users/users.component.html
@@ -140,7 +140,9 @@
             {{ 'common.name' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="roles">

--- a/projects/safe/src/lib/components/users/users.component.html
+++ b/projects/safe/src/lib/components/users/users.component.html
@@ -108,6 +108,7 @@
       <ng-container matColumnDef="select">
         <th mat-header-cell *matHeaderCellDef>
           <mat-checkbox
+            class="mr-2"
             (change)="$event ? masterToggle() : null"
             [checked]="selection.hasValue() && isAllSelected()"
             [indeterminate]="selection.hasValue() && !isAllSelected()"
@@ -117,6 +118,7 @@
         </th>
         <td mat-cell *matCellDef="let row">
           <mat-checkbox
+            class="mr-2"
             (click)="$event.stopPropagation()"
             (change)="$event ? selection.toggle(row) : null"
             [checked]="selection.isSelected(row)"

--- a/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-clorophlets/map-clorophlets.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-clorophlets/map-clorophlets.component.html
@@ -15,7 +15,9 @@
         <th mat-header-cell *matHeaderCellDef>
           {{ 'common.name' | translate }}
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
       <ng-container matColumnDef="actions" [stickyEnd]="true">
         <th mat-header-cell *matHeaderCellDef></th>

--- a/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-online-layers/map-online-layers.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-layers/map-online-layers/map-online-layers.component.html
@@ -40,7 +40,9 @@
           <th mat-header-cell *matHeaderCellDef>
             {{ 'common.name' | translate }}
           </th>
-          <td mat-cell *matCellDef="let element">{{ element.title }}</td>
+          <td mat-cell *matCellDef="let element" class="font-bold">
+            {{ element.title }}
+          </td>
         </ng-container>
         <ng-container matColumnDef="actions" [stickyEnd]="true">
           <th mat-header-cell *matHeaderCellDef></th>

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -350,10 +350,6 @@ $safe-theme: mat.define-light-theme($safe-primary, $safe-accent, $safe-warn);
     border-bottom: 1px solid #f2f3f5 !important;
     color: #3f3c3c;
   }
-  .mat-cell:first-child {
-    color: #000000;
-    font-weight: 500;
-  }
 }
 
 .mat-spinner {

--- a/projects/safe/src/lib/views/application-users/components/user-list/user-list.component.html
+++ b/projects/safe/src/lib/views/application-users/components/user-list/user-list.component.html
@@ -23,6 +23,7 @@
       <ng-container *ngIf="!autoAssigned" matColumnDef="select">
         <th mat-header-cell *matHeaderCellDef>
           <mat-checkbox
+            class="mr-2"
             (change)="$event ? masterToggle() : null"
             [checked]="selection.hasValue() && isAllSelected()"
             [indeterminate]="selection.hasValue() && !isAllSelected()"
@@ -32,6 +33,7 @@
         </th>
         <td mat-cell *matCellDef="let row">
           <mat-checkbox
+            class="mr-2"
             (click)="$event.stopPropagation()"
             (change)="$event ? selection.toggle(row) : null"
             [checked]="selection.isSelected(row)"

--- a/projects/safe/src/lib/views/application-users/components/user-list/user-list.component.html
+++ b/projects/safe/src/lib/views/application-users/components/user-list/user-list.component.html
@@ -55,7 +55,9 @@
             {{ 'common.name' | translate }}
           </span>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+        <td mat-cell *matCellDef="let element" class="font-bold">
+          {{ element.name }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="roles">

--- a/projects/safe/src/lib/views/profile/profile.component.html
+++ b/projects/safe/src/lib/views/profile/profile.component.html
@@ -44,7 +44,7 @@
               }})
             </span>
           </th>
-          <td mat-cell *matCellDef="let element">
+          <td mat-cell *matCellDef="let element" class="font-bold">
             {{ element.name
             }}<span *ngIf="user.favoriteApp === element.id">
               <mat-icon inline="true" color="primary">star</mat-icon>


### PR DESCRIPTION
# Description

This PR removes the global styling for the first cell of each mat-table row and adds it on the relevant tables only using tailwind

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By checking if the styles on some of the targeted tables were being applied

## Sreenshots
![image](https://user-images.githubusercontent.com/102038450/213053998-ba801fb4-3080-45d1-a4d7-b743dbe58f90.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
