### PR TITLE
AB#54822 - updated map properties tab

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -1183,14 +1183,15 @@
 						"latitude": "Map center latitude",
 						"longitude": "Map center longitude",
 						"title": "Map Parameters",
-						"zoom": "Default zoom"
+						"zoom": "Default zoom",
+						"setByMap": "Set By Map"
 					},
 					"tooltip": {
 						"category": "Selecting a field will separate your records into different layers, accessible on top right corner of the map",
 						"dataset": "Select data points below and drag them to 'selected fields' on the right. They will be displayed in the pop-up when clicking on a marker",
 						"default": {
-							"latitude": "Select a default latitude to center the map around",
-							"longitude": "Select a default longitude to center the map around",
+							"latitude": "Set the default latitude of the center of the map. You can use 'Set By Map' to use the latitude of the preview map.",
+							"longitude": "Set the default longitude of the center of the map. You can use 'Set By Map' to use the longitude of the preview map.",
 							"zoom": "Select a default zoom for the map display"
 						}
 					}

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -1185,14 +1185,15 @@
 						"latitude": "Latitude du centre de la carte",
 						"longitude": "Longitude du centre de la carte",
 						"title": "Affichage par défaut",
-						"zoom": "Zoom par défaut"
+						"zoom": "Zoom par défaut",
+						"setByMap": "Définir par carte"
 					},
 					"tooltip": {
 						"category": "Sélectionnez un champ pour séparer vos enregistrements en différentes catégories",
 						"dataset": "Sélectionnez des champs ci-dessous et déplacez-les vers 'champs sélectionnés' sur la droite. Ils seront présents dans le pop-up affiché en cliquant sur les marqueurs",
 						"default": {
-							"latitude": "Sélectionnez une latitude par défaut autour de laquelle vous souhaitez centrer la carte",
-							"longitude": "Sélectionnez une longitude par défaut autour de laquelle vous souhaitez centrer la carte",
+							"latitude": "Définissez la latitude par défaut du centre de la carte. Vous pouvez utiliser 'Définir par carte' pour utiliser la latitude de la carte d'aperçu.",
+							"longitude": "Définissez la longitude par défaut du centre de la carte. Vous pouvez utiliser 'Définir par carte' pour utiliser la longitude de la carte d'aperçu.",
 							"zoom": "Sélectionnez un zoom par défaut"
 						}
 					}

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -1184,7 +1184,7 @@
 						"basemap": "Fond de carte",
 						"latitude": "Latitude du centre de la carte",
 						"longitude": "Longitude du centre de la carte",
-						"setByMap": "Définir par carte",
+						"setByMap": "Utiliser la vue actuelle",
 						"title": "Affichage par défaut",
 						"zoom": "Zoom par défaut"
 					},
@@ -1192,8 +1192,8 @@
 						"category": "Sélectionnez un champ pour séparer vos enregistrements en différentes catégories",
 						"dataset": "Sélectionnez des champs ci-dessous et déplacez-les vers 'champs sélectionnés' sur la droite. Ils seront présents dans le pop-up affiché en cliquant sur les marqueurs",
 						"default": {
-							"latitude": "Définissez la latitude par défaut du centre de la carte. Vous pouvez utiliser 'Définir par carte' pour utiliser la latitude de la carte d'aperçu.",
-							"longitude": "Définissez la longitude par défaut du centre de la carte. Vous pouvez utiliser 'Définir par carte' pour utiliser la longitude de la carte d'aperçu.",
+							"latitude": "Définissez la latitude par défaut du centre de la carte. 'Utiliser la vue actuelle' sauvegardera la latitude de la carte d'aperçu.",
+							"longitude": "Définissez la longitude par défaut du centre de la carte. 'Utiliser la vue actuelle' sauvegardera la longitude de la carte d'aperçu.",
 							"zoom": "Sélectionnez un zoom par défaut"
 						}
 					}

--- a/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -1,99 +1,116 @@
-<form [formGroup]="form" class="overflow-hidden">
-  <div class="flex flex-col last:mb-0">
-    <h2>
-      {{ 'components.widget.settings.map.properties.title' | translate }}
-    </h2>
-    <div class="flex flex-wrap justify-evenly">
-      <div class="flex flex-col basis-1/1 md:basis-1/3 self-center">
-        <mat-form-field appearance="outline">
-          <mat-label>{{
-            'components.widget.settings.map.properties.basemap' | translate
-          }}</mat-label>
-          <mat-select formControlName="basemap" placeholder="OSM">
-            <mat-option *ngFor="let map of basemaps" [value]="map">
-              {{ map }}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-label>
-          {{ 'components.widget.settings.map.properties.zoom' | translate }}
+<form [formGroup]="form" class="overflow-hidden h-full">
+  <div class="flex flex-wrap gap-4 flex-col lg:flex-row lg:h-full">
+    <!-- Map properties -->
+    <div class="flex flex-col flex-1">
+      <h2>
+        {{ 'components.widget.settings.map.properties.title' | translate }}
+      </h2>
+      <!-- Widget ( map ) name -->
+      <mat-form-field appearance="outline" class="p-0">
+        <mat-label>{{ 'common.name' | translate }}</mat-label>
+        <input matInput formControlName="title" type="string" />
+      </mat-form-field>
+      <safe-divider></safe-divider>
+      <!-- Basemap -->
+      <mat-form-field appearance="outline" class="p-0">
+        <mat-label>{{
+          'components.widget.settings.map.properties.basemap' | translate
+        }}</mat-label>
+        <mat-select formControlName="basemap" placeholder="OSM">
+          <mat-option *ngFor="let map of basemaps" [value]="map">
+            {{ map }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <safe-divider></safe-divider>
+      <!-- Default view -->
+      <!-- Default zoom -->
+      <mat-label>
+        {{ 'components.widget.settings.map.properties.zoom' | translate }}
+        <safe-icon
+          icon="info_outline"
+          class="cursor-pointer"
+          [matTooltip]="
+            'components.widget.settings.map.properties.zoom' | translate
+          "
+          [inline]="true"
+          [size]="18"
+          variant="grey"
+        ></safe-icon>
+      </mat-label>
+      <mat-slider
+        thumbLabel
+        tickInterval="1"
+        formControlName="zoom"
+        [min]="2"
+        [max]="18"
+      ></mat-slider>
+      <div class="flex flex-wrap gap-2">
+        <!-- Default latitude -->
+        <mat-form-field appearance="outline" class="flex-1">
+          <mat-label>
+            {{
+              'components.widget.settings.map.properties.latitude' | translate
+            }}
+          </mat-label>
+          <input type="number" matInput formControlName="centerLat" />
           <safe-icon
-            icon="info_outline"
+            matSuffix
+            icon="info"
             class="cursor-pointer"
-            [matTooltip]="
-              'components.widget.settings.map.properties.zoom' | translate
-            "
-            [inline]="true"
-            [size]="18"
             variant="grey"
+            [matTooltip]="
+              'components.widget.settings.map.tooltip.default.latitude'
+                | translate
+            "
           ></safe-icon>
-        </mat-label>
-        <mat-slider
-          thumbLabel
-          tickInterval="1"
-          formControlName="zoom"
-          [min]="2"
-          [max]="18"
-        ></mat-slider>
-        <div class="flex flex-wrap gap-2">
-          <mat-form-field appearance="outline" class="flex-1">
-            <mat-label>{{ 'common.name' | translate }}</mat-label>
-            <input matInput formControlName="title" type="string" />
-          </mat-form-field>
-          <mat-form-field appearance="outline" class="flex-1">
-            <mat-label>
-              {{ 'components.widget.settings.map.properties.latitude' | translate }}
-            </mat-label>
-            <input type="number" matInput formControlName="centerLat" />
-            <safe-icon
-              matSuffix
-              icon="info"
-              class="cursor-pointer"
-              variant="grey"
-              [matTooltip]="
-                'components.widget.settings.map.tooltip.default.latitude'
-                  | translate
-              "
-            ></safe-icon>
-            <mat-error *ngIf="form.controls.centerLat.errors">
-              {{ 'components.widget.settings.map.errors.latitude' | translate }}
-            </mat-error>
-          </mat-form-field>
-          <mat-form-field appearance="outline" class="flex-1">
-            <mat-label>
-              {{
-                'components.widget.settings.map.properties.longitude' | translate
-              }}
-            </mat-label>
-            <input type="number" matInput formControlName="centerLong" />
-            <safe-icon
-              matSuffix
-              icon="info"
-              class="cursor-pointer"
-              variant="grey"
-              [matTooltip]="
-                'components.widget.settings.map.tooltip.default.longitude'
-                  | translate
-              "
-            ></safe-icon>
-            <mat-error *ngIf="form.controls.centerLat.errors">
-              {{ 'components.widget.settings.map.errors.longitude' | translate }}
-            </mat-error>
-          </mat-form-field>
-        </div>
-        <safe-button
-          class="mb-4 self-end flex-1"
-          (click)="onSetByMap()"
-          category="secondary"
-          variant="primary"
-        >
-          {{ 'components.widget.settings.map.properties.setByMap' | translate }}
-        </safe-button>
+          <mat-error *ngIf="form.controls.centerLat.errors">
+            {{ 'components.widget.settings.map.errors.latitude' | translate }}
+          </mat-error>
+        </mat-form-field>
+        <!-- Default longitude -->
+        <mat-form-field appearance="outline" class="flex-1">
+          <mat-label>
+            {{
+              'components.widget.settings.map.properties.longitude'
+                | translate
+            }}
+          </mat-label>
+          <input type="number" matInput formControlName="centerLong" />
+          <safe-icon
+            matSuffix
+            icon="info"
+            class="cursor-pointer"
+            variant="grey"
+            [matTooltip]="
+              'components.widget.settings.map.tooltip.default.longitude'
+                | translate
+            "
+          ></safe-icon>
+          <mat-error *ngIf="form.controls.centerLat.errors">
+            {{
+              'components.widget.settings.map.errors.longitude' | translate
+            }}
+          </mat-error>
+        </mat-form-field>
       </div>
-
-      <div class="basis-1/1 md:basis-1/2 map-container">
-        <safe-map [header]="false" [settings]="mapSettings"></safe-map>
-      </div>
+      <!-- Use map to set properties -->
+      <safe-button
+        class="mb-4 self-end flex-1"
+        (click)="onSetByMap()"
+        category="secondary"
+        variant="primary"
+      >
+        {{ 'components.widget.settings.map.properties.setByMap' | translate }}
+      </safe-button>
+    </div>
+    <!-- Map preview -->
+    <div class="lg:flex-1 max-lg:min-w-full h-80 lg:min-h-full">
+      <safe-map
+        class="w-full h-full"
+        [header]="false"
+        [settings]="mapSettings"
+      ></safe-map>
     </div>
   </div>
 </form>

--- a/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -3,78 +3,97 @@
     <h2>
       {{ 'components.widget.settings.map.properties.title' | translate }}
     </h2>
-    <mat-form-field appearance="outline">
-      <mat-label>{{
-        'components.widget.settings.map.properties.basemap' | translate
-      }}</mat-label>
-      <mat-select formControlName="basemap" placeholder="OSM">
-        <mat-option *ngFor="let map of basemaps" [value]="map">
-          {{ map }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-label>
-      {{ 'components.widget.settings.map.properties.zoom' | translate }}
-      <safe-icon
-        icon="info_outline"
-        class="cursor-pointer"
-        [matTooltip]="
-          'components.widget.settings.map.properties.zoom' | translate
-        "
-        [inline]="true"
-        [size]="18"
-        variant="grey"
-      ></safe-icon>
-    </mat-label>
-    <mat-slider
-      thumbLabel
-      tickInterval="1"
-      formControlName="zoom"
-      [min]="2"
-      [max]="18"
-    ></mat-slider>
-    <div class="flex flex-wrap gap-2">
-      <mat-form-field appearance="outline" class="flex-1">
+    <div class="flex flex-wrap justify-evenly">
+      <div class="flex flex-col basis-1/1 md:basis-1/3 self-center">
+        <mat-form-field appearance="outline">
+          <mat-label>{{
+            'components.widget.settings.map.properties.basemap' | translate
+          }}</mat-label>
+          <mat-select formControlName="basemap" placeholder="OSM">
+            <mat-option *ngFor="let map of basemaps" [value]="map">
+              {{ map }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
         <mat-label>
-          {{ 'components.widget.settings.map.properties.latitude' | translate }}
+          {{ 'components.widget.settings.map.properties.zoom' | translate }}
+          <safe-icon
+            icon="info_outline"
+            class="cursor-pointer"
+            [matTooltip]="
+              'components.widget.settings.map.properties.zoom' | translate
+            "
+            [inline]="true"
+            [size]="18"
+            variant="grey"
+          ></safe-icon>
         </mat-label>
-        <input type="number" matInput formControlName="centerLat" />
-        <safe-icon
-          matSuffix
-          icon="info"
-          class="cursor-pointer"
-          variant="grey"
-          [matTooltip]="
-            'components.widget.settings.map.tooltip.default.latitude'
-              | translate
-          "
-        ></safe-icon>
-        <mat-error *ngIf="form.controls.centerLat.errors">
-          {{ 'components.widget.settings.map.errors.latitude' | translate }}
-        </mat-error>
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="flex-1">
-        <mat-label>
-          {{
-            'components.widget.settings.map.properties.longitude' | translate
-          }}
-        </mat-label>
-        <input type="number" matInput formControlName="centerLong" />
-        <safe-icon
-          matSuffix
-          icon="info"
-          class="cursor-pointer"
-          variant="grey"
-          [matTooltip]="
-            'components.widget.settings.map.tooltip.default.longitude'
-              | translate
-          "
-        ></safe-icon>
-        <mat-error *ngIf="form.controls.centerLat.errors">
-          {{ 'components.widget.settings.map.errors.longitude' | translate }}
-        </mat-error>
-      </mat-form-field>
+        <mat-slider
+          thumbLabel
+          tickInterval="1"
+          formControlName="zoom"
+          [min]="2"
+          [max]="18"
+        ></mat-slider>
+        <div class="flex flex-wrap gap-2">
+          <mat-form-field appearance="outline" class="flex-1">
+            <mat-label>{{ 'common.name' | translate }}</mat-label>
+            <input matInput formControlName="title" type="string" />
+          </mat-form-field>
+          <mat-form-field appearance="outline" class="flex-1">
+            <mat-label>
+              {{ 'components.widget.settings.map.properties.latitude' | translate }}
+            </mat-label>
+            <input type="number" matInput formControlName="centerLat" />
+            <safe-icon
+              matSuffix
+              icon="info"
+              class="cursor-pointer"
+              variant="grey"
+              [matTooltip]="
+                'components.widget.settings.map.tooltip.default.latitude'
+                  | translate
+              "
+            ></safe-icon>
+            <mat-error *ngIf="form.controls.centerLat.errors">
+              {{ 'components.widget.settings.map.errors.latitude' | translate }}
+            </mat-error>
+          </mat-form-field>
+          <mat-form-field appearance="outline" class="flex-1">
+            <mat-label>
+              {{
+                'components.widget.settings.map.properties.longitude' | translate
+              }}
+            </mat-label>
+            <input type="number" matInput formControlName="centerLong" />
+            <safe-icon
+              matSuffix
+              icon="info"
+              class="cursor-pointer"
+              variant="grey"
+              [matTooltip]="
+                'components.widget.settings.map.tooltip.default.longitude'
+                  | translate
+              "
+            ></safe-icon>
+            <mat-error *ngIf="form.controls.centerLat.errors">
+              {{ 'components.widget.settings.map.errors.longitude' | translate }}
+            </mat-error>
+          </mat-form-field>
+        </div>
+        <safe-button
+          class="mb-4 self-end flex-1"
+          (click)="onSetByMap()"
+          category="secondary"
+          variant="primary"
+        >
+          {{ 'components.widget.settings.map.properties.setByMap' | translate }}
+        </safe-button>
+      </div>
+
+      <div class="basis-1/1 md:basis-1/2 map-container">
+        <safe-map [header]="false" [settings]="mapSettings"></safe-map>
+      </div>
     </div>
-    <safe-map [header]="false" [settings]="mapSettings"></safe-map>
   </div>
 </form>

--- a/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.scss
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.scss
@@ -1,4 +1,10 @@
-safe-map {
-  height: 500px;
+safe-map, .map-container {
+  height: 450px;
   width: 100%;
+}
+
+@media (max-width: 779px) {
+  .map-container{
+    height: 300px !important;
+  }
 }

--- a/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
@@ -44,6 +44,7 @@ export class MapPropertiesComponent
   @ViewChild(SafeMapComponent) previewMap!: SafeMapComponent;
 
   public basemaps = BASEMAPS;
+  public map: any;
 
   public mapSettings!: {
     basemap: string;
@@ -101,14 +102,18 @@ export class MapPropertiesComponent
    * Subscribe to map events to update settings
    */
   ngAfterViewInit(): void {
-    const map = this.previewMap.map;
-    map.on('zoomend', () => {
-      this.form.get('zoom')?.setValue(map.getZoom(), { emitEvent: false });
+    this.map = this.previewMap.map;
+    this.map.on('zoomend', () => {
+      this.form.get('zoom')?.setValue(this.map.getZoom(), { emitEvent: false });
     });
-    map.on('moveend', () => {
-      const center = map.getCenter();
-      this.form.get('centerLat')?.setValue(center.lat, { emitEvent: false });
-      this.form.get('centerLong')?.setValue(center.lng, { emitEvent: false });
-    });
+  }
+
+  /**
+   * Set the latitude and longitude of the center of the map using the one in the preview map.
+   */
+  onSetByMap(): void {
+    const center = this.map.getCenter();
+    this.form.get('centerLat')?.setValue(center.lat, { emitEvent: false });
+    this.form.get('centerLong')?.setValue(center.lng, { emitEvent: false });
   }
 }

--- a/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
@@ -103,9 +103,6 @@ export class MapPropertiesComponent
    */
   ngAfterViewInit(): void {
     this.map = this.previewMap.map;
-    this.map.on('zoomend', () => {
-      this.form.get('zoom')?.setValue(this.map.getZoom(), { emitEvent: false });
-    });
   }
 
   /**
@@ -115,5 +112,6 @@ export class MapPropertiesComponent
     const center = this.map.getCenter();
     this.form.get('centerLat')?.setValue(center.lat, { emitEvent: false });
     this.form.get('centerLong')?.setValue(center.lng, { emitEvent: false });
+    this.form.get('zoom')?.setValue(this.map.getZoom(), { emitEvent: false });
   }
 }

--- a/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.module.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.module.ts
@@ -10,6 +10,7 @@ import { SafeIconModule } from '../../../ui/icon/icon.module';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSelectModule } from '@angular/material/select';
 import { SafeMapModule } from '../../map/map.module';
+import { SafeButtonModule } from '../../../ui/button/button.module';
 
 /**
  * Module of Map Properties of Map Widget.
@@ -28,6 +29,7 @@ import { SafeMapModule } from '../../map/map.module';
     MatSelectModule,
     SafeIconModule,
     SafeMapModule,
+    SafeButtonModule,
   ],
   exports: [MapPropertiesComponent],
 })

--- a/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.module.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.module.ts
@@ -11,6 +11,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSelectModule } from '@angular/material/select';
 import { SafeMapModule } from '../../map/map.module';
 import { SafeButtonModule } from '../../../ui/button/button.module';
+import { SafeDividerModule } from '../../../ui/divider/divider.module';
 
 /**
  * Module of Map Properties of Map Widget.
@@ -30,6 +31,7 @@ import { SafeButtonModule } from '../../../ui/button/button.module';
     SafeIconModule,
     SafeMapModule,
     SafeButtonModule,
+    SafeDividerModule,
   ],
   exports: [MapPropertiesComponent],
 })

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -5,38 +5,6 @@
     vertical
     class="grow"
   >
-    <!-- GENERAL SETTINGS -->
-    <mat-tab>
-      <ng-template mat-tab-label>
-        <safe-icon
-          icon="preview"
-          [size]="24"
-          matTooltip="{{ 'common.general' | translate }}"
-          matTooltipPosition="right"
-        ></safe-icon>
-        <span>{{ 'common.general' | translate }}</span>
-      </ng-template>
-      <ng-template matTabContent>
-        <safe-map-general *ngIf="tileForm" [form]="tileForm"></safe-map-general>
-      </ng-template>
-    </mat-tab>
-
-    <!-- LAYERS CONFIGURATION -->
-    <mat-tab>
-      <ng-template mat-tab-label>
-        <safe-icon
-          icon="layers"
-          [size]="24"
-          matTooltip="{{ 'common.layers' | translate }}"
-          matTooltipPosition="right"
-        ></safe-icon>
-        <span>{{ 'common.layers' | translate }}</span>
-      </ng-template>
-      <ng-template matTabContent>
-        <safe-map-layers [form]="tileForm"></safe-map-layers>
-      </ng-template>
-    </mat-tab>
-
     <!-- MAP PARAMETERS -->
     <mat-tab>
       <ng-template mat-tab-label>
@@ -54,6 +22,22 @@
       </ng-template>
       <ng-template matTabContent>
         <safe-map-properties [form]="tileForm"></safe-map-properties>
+      </ng-template>
+    </mat-tab>
+
+    <!-- LAYERS CONFIGURATION -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <safe-icon
+          icon="layers"
+          [size]="24"
+          matTooltip="{{ 'common.layers' | translate }}"
+          matTooltipPosition="right"
+        ></safe-icon>
+        <span>{{ 'common.layers' | translate }}</span>
+      </ng-template>
+      <ng-template matTabContent>
+        <safe-map-layers [form]="tileForm"></safe-map-layers>
       </ng-template>
     </mat-tab>
   </mat-tab-group>


### PR DESCRIPTION
# Description

Updated 'Map Parameters' tab in the map settings in dashboard:
- Removed general tab and moved the name form for this tab
- Latitude and longitude are no longer automatically set
- Added 'Set By Map' button to update the latitude and longitude of the center of the map using the one in the preview map
- Updated info display: left column with all proprieties and right column with the map

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Accessing, editing and updating map properties in the properties tab.

## Sreenshots

![map](https://user-images.githubusercontent.com/28535394/214138836-caaa1794-4956-4d52-9f69-cbf8b38d27b9.gif)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
