### PR TITLE
Refactor/OORT-587 replace vertical mat tabs with mat drawer

### DIFF
--- a/projects/safe/src/lib/components/preferences-modal/enums/tab-types.ts
+++ b/projects/safe/src/lib/components/preferences-modal/enums/tab-types.ts
@@ -1,0 +1,4 @@
+/** Enum for the current tabs in the preferences modal settings */
+export enum PreferencesModalTabTypes {
+  LANGUAGE,
+}

--- a/projects/safe/src/lib/components/preferences-modal/preferences-modal.component.html
+++ b/projects/safe/src/lib/components/preferences-modal/preferences-modal.component.html
@@ -2,17 +2,8 @@
   <h1 mat-dialog-title>{{ 'components.preferences.title' | translate }}</h1>
   <mat-dialog-content>
     <form [formGroup]="preferencesForm">
-      <mat-tab-group vertical animationDuration="0ms">
-        <mat-tab>
-          <ng-template mat-tab-label>
-            <safe-icon
-              icon="language"
-              [size]="18"
-              matTooltip="{{ 'components.preferences.language' | translate }}"
-              matTooltipPosition="right"
-            ></safe-icon>
-            <span>{{ 'components.preferences.language' | translate }}</span>
-          </ng-template>
+      <safe-tab-settings-options [tabOptionsConfig]="tabSettingsConfig">
+        <ng-container ngProjectAs="[selectedTabTemplate]">
           <div class="flex flex-col">
             <!-- LANGUAGE SELECTION -->
             <mat-form-field appearance="outline">
@@ -40,8 +31,8 @@
               </mat-select>
             </mat-form-field>
           </div>
-        </mat-tab>
-      </mat-tab-group>
+        </ng-container>
+      </safe-tab-settings-options>
     </form>
   </mat-dialog-content>
   <mat-dialog-actions align="end">

--- a/projects/safe/src/lib/components/preferences-modal/preferences-modal.component.ts
+++ b/projects/safe/src/lib/components/preferences-modal/preferences-modal.component.ts
@@ -5,6 +5,8 @@ import { TranslateService } from '@ngx-translate/core';
 import { DatePipe } from '@angular/common';
 import { SafeDateTranslateService } from '../../services/date-translate/date-translate.service';
 import { getLanguageNativeName } from '../../utils/languages';
+import { TabSettingsOptionConfig } from '../ui/tab-settings-options/tab-settings-options.interface';
+import { PreferencesModalTabTypes } from './enums/tab-types';
 
 /** Preferences Dialog Data */
 interface PreferencesDialogData {
@@ -28,6 +30,17 @@ export class SafePreferencesModalComponent implements OnInit {
   currLang: string;
   dateFormats: { name: string | null; value: string }[] = [];
   currDateFormat: string;
+  /**Config object to load the tabs in preferences modal */
+  public tabSettingsConfig: TabSettingsOptionConfig<PreferencesModalTabTypes>[] =
+    [
+      {
+        tab: PreferencesModalTabTypes.LANGUAGE,
+        icon: 'language',
+        iconSize: 18,
+        translation: 'components.preferences.language',
+        tooltipPosition: 'right',
+      },
+    ];
 
   /**
    * Preferences Modal constructor

--- a/projects/safe/src/lib/components/preferences-modal/preferences-modal.module.ts
+++ b/projects/safe/src/lib/components/preferences-modal/preferences-modal.module.ts
@@ -4,8 +4,8 @@ import { SafePreferencesModalComponent } from './preferences-modal.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
-import { MatTabsModule } from '@angular/material/tabs';
 import { SafeModalModule } from '../ui/modal/modal.module';
+import { SafeTabSettingsOptionsModule } from '../ui/tab-settings-options/tab-settings-options.module';
 
 /**
  * SafePreferencesModalModule is a class used to manage all the modules and components
@@ -19,7 +19,7 @@ import { SafeModalModule } from '../ui/modal/modal.module';
     ReactiveFormsModule,
     MatFormFieldModule,
     MatSelectModule,
-    MatTabsModule,
+    SafeTabSettingsOptionsModule,
     SafeModalModule,
   ],
   exports: [SafePreferencesModalComponent],

--- a/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.component.html
+++ b/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.component.html
@@ -1,0 +1,29 @@
+<mat-drawer-container class="h-full w-full flex">
+  <mat-drawer class="h-full mb-3 border-none" mode="side" opened>
+    <div
+      *ngFor="let option of tabOptionsConfig"
+      role="button"
+      option
+      [ngClass]="{
+        'active-status': selectedTab === option.tab,
+        'disable-status': option.disabled
+      }"
+      class="flex items-center font-medium h-12 gap-1.5 px-6 w-full"
+      (click)="handleTabChange(option)"
+    >
+      <safe-icon
+        icon="{{ option.icon }}"
+        [size]="option.iconSize"
+        matTooltip="{{ option.translation | translate }}"
+        [matTooltipPosition]="option.tooltipPosition"
+      ></safe-icon>
+      <span>{{ option.translation | translate }}</span>
+    </div>
+  </mat-drawer>
+  <mat-drawer-content
+    [@tabContentDisplay]="triggerAnimation"
+    class="flex-1 pl-8"
+  >
+    <ng-content select="[selectedTabTemplate]"></ng-content>
+  </mat-drawer-content>
+</mat-drawer-container>

--- a/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.component.scss
+++ b/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.component.scss
@@ -1,0 +1,34 @@
+mat-drawer {
+  width: 240px;
+
+  & div[option] {
+    border-radius: 7px;
+    &.active-status {
+      background-color: #f5f5f5;
+    }
+    &.disable-status {
+      opacity: 0.38;
+      cursor: default;
+    }
+    & > safe-icon {
+      pointer-events: none;
+    }
+  }
+}
+
+.mat-drawer-container {
+  background: none;
+}
+
+@media (max-width: 598px) {
+  mat-drawer {
+    width: unset;
+
+    & div[option] > span {
+      display: none;
+    }
+    & div[option] > safe-icon {
+      pointer-events: all !important;
+    }
+  }
+}

--- a/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.component.spec.ts
+++ b/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SafeTabSettingsOptionsComponent } from './tab-settings-options.component';
+
+describe('SettingsOptionsComponent', () => {
+  let component: SafeTabSettingsOptionsComponent<any>;
+  let fixture: ComponentFixture<SafeTabSettingsOptionsComponent<any>>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SafeTabSettingsOptionsComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SafeTabSettingsOptionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.component.ts
+++ b/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.component.ts
@@ -1,0 +1,73 @@
+import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
+import {
+  trigger,
+  style,
+  animate,
+  transition,
+  query,
+  state,
+} from '@angular/animations';
+import { TabSettingsOptionConfig } from './tab-settings-options.interface';
+
+@Component({
+  selector: 'safe-tab-settings-options',
+  templateUrl: './tab-settings-options.component.html',
+  styleUrls: ['./tab-settings-options.component.scss'],
+  animations: [
+    trigger('tabContentDisplay', [
+      // Initial state of content when loading component is visible(no animation)
+      state('initial', style({ opacity: 1, transform: 'translateY(0%)' })),
+      // Load content state is hidden when we load another tab that is not the default one
+      state(
+        'loadContent',
+        style({ opacity: 0, transform: 'translateY(100%)' })
+      ),
+      // From the load content to content-in we would trigger the animation that loads the content in from bottom to top
+      transition('loadContent => contentIn', [
+        query(':self', [
+          animate(
+            '.3s ease-in-out',
+            style({ opacity: 1, transform: 'translateY(0)' })
+          ),
+        ]),
+      ]),
+    ]),
+  ],
+})
+export class SafeTabSettingsOptionsComponent<T> implements OnInit {
+  @Input() tabOptionsConfig: TabSettingsOptionConfig<T>[] = [];
+  @Output() selectedTabEvent: EventEmitter<T> = new EventEmitter<T>();
+  selectedTab!: T;
+  triggerAnimation = 'initial';
+
+  ngOnInit(): void {
+    /**Default selected tab would be the first one */
+    this.handleTabChange(this.tabOptionsConfig[0], true);
+  }
+
+  /**
+   * Emits the selected tab to the parent component
+   */
+  public handleTabChange(
+    selectedTab: TabSettingsOptionConfig<T>,
+    isDefaultTab = false
+  ): void {
+    /** If the tab selected is disabled or the tab number is just one we won't trigger any action*/
+    if (
+      selectedTab.disabled ||
+      (this.tabOptionsConfig.length === 1 && !isDefaultTab)
+    ) {
+      return;
+    }
+    this.selectedTab = selectedTab.tab;
+    /** If is not the default tab we trigger the content animation
+     */
+    if (!isDefaultTab) {
+      this.triggerAnimation = 'loadContent';
+      setTimeout(() => {
+        this.triggerAnimation = 'contentIn';
+      }, 0);
+    }
+    this.selectedTabEvent.emit(selectedTab.tab);
+  }
+}

--- a/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.interface.ts
+++ b/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.interface.ts
@@ -1,0 +1,10 @@
+import { TooltipPosition } from '@angular/material/tooltip';
+
+export interface TabSettingsOptionConfig<T> {
+  tab: T;
+  icon: string;
+  iconSize: number;
+  translation: string;
+  tooltipPosition: TooltipPosition;
+  disabled?: boolean;
+}

--- a/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.module.ts
+++ b/projects/safe/src/lib/components/ui/tab-settings-options/tab-settings-options.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { TranslateModule } from '@ngx-translate/core';
+import { SafeIconModule } from '../icon/icon.module';
+import { SafeTabSettingsOptionsComponent } from './tab-settings-options.component';
+
+@NgModule({
+  declarations: [SafeTabSettingsOptionsComponent],
+  imports: [
+    CommonModule,
+    MatSidenavModule,
+    SafeIconModule,
+    TranslateModule,
+    MatTooltipModule,
+  ],
+  exports: [SafeTabSettingsOptionsComponent],
+})
+export class SafeTabSettingsOptionsModule {}

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.html
@@ -1,55 +1,25 @@
-<mat-tab-group
-  class="grow"
-  vertical
-  animationDuration="0ms"
-  (selectedTabChange)="handleTabChange($event)"
+<safe-tab-settings-options
+  class="w-full"
+  (selectedTabEvent)="handleTabChange($event)"
+  [tabOptionsConfig]="tabSettingsConfig"
 >
-  <!-- Main Parameters -->
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <safe-icon
-        icon="settings"
-        [size]="24"
-        matTooltip="{{ 'common.general' | translate }}"
-        matTooltipPosition="right"
-      ></safe-icon>
-      <span>{{ 'common.general' | translate }}</span>
-    </ng-template>
-    <ng-template matTabContent>
-      <safe-tab-main [formGroup]="formGroup" [type]="type"></safe-tab-main>
-    </ng-template>
-  </mat-tab>
-  <!-- Display options -->
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <safe-icon
-        icon="tune"
-        [size]="24"
-        matTooltip="{{ 'common.display' | translate }}"
-        matTooltipPosition="right"
-      ></safe-icon>
-      <span>{{ 'common.display' | translate }}</span>
-    </ng-template>
-    <ng-template matTabContent>
-      <safe-tab-display
-        [formGroup]="formGroup"
-        [type]="type"
-      ></safe-tab-display>
-    </ng-template>
-  </mat-tab>
-  <!-- Preview -->
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <safe-icon
-        icon="preview"
-        [size]="24"
-        matTooltip="{{ 'common.preview' | translate }}"
-        matTooltipPosition="right"
-      ></safe-icon>
-      <span>{{ 'common.preview' | translate }}</span>
-    </ng-template>
-    <ng-template matTabContent>
-      <safe-tab-preview [formGroup]="formGroup"></safe-tab-preview>
-    </ng-template>
-  </mat-tab>
-</mat-tab-group>
+  <ng-container ngProjectAs="[selectedTabTemplate]">
+    <div [ngSwitch]="selectedTab">
+      <!-- Display options -->
+      <ng-container *ngSwitchCase="chartSettingsTabTypes.DISPLAY">
+        <safe-tab-display
+          [formGroup]="formGroup"
+          [type]="type"
+        ></safe-tab-display>
+      </ng-container>
+      <!-- Preview -->
+      <ng-container *ngSwitchCase="chartSettingsTabTypes.PREVIEW">
+        <safe-tab-preview [formGroup]="formGroup"></safe-tab-preview>
+      </ng-container>
+      <!-- Main Parameters -->
+      <ng-container *ngSwitchDefault>
+        <safe-tab-main [formGroup]="formGroup" [type]="type"></safe-tab-main>
+      </ng-container>
+    </div>
+  </ng-container>
+</safe-tab-settings-options>

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.component.ts
@@ -3,12 +3,13 @@ import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { MAT_AUTOCOMPLETE_SCROLL_STRATEGY } from '@angular/material/autocomplete';
 import { MAT_CHIPS_DEFAULT_OPTIONS } from '@angular/material/chips';
-import { MatTabChangeEvent } from '@angular/material/tabs';
 import get from 'lodash/get';
 import { scrollFactory } from '../../../utils/scroll-factory';
 import { codesFactory } from '../../distribution-lists/components/edit-distribution-list-modal/edit-distribution-list-modal.component';
+import { TabSettingsOptionConfig } from '../../ui/tab-settings-options/tab-settings-options.interface';
 import { Chart } from './charts/chart';
 import { CHART_TYPES } from './constants';
+import { ChartSettingsTabTypes } from './enums/tab-types';
 
 /**
  * Chart settings component
@@ -42,6 +43,30 @@ export class SafeChartSettingsComponent implements OnInit {
   public types = CHART_TYPES;
   public chart?: Chart;
   public type: any;
+  /**Config object to load the tabs in chart settings modal */
+  public tabSettingsConfig: TabSettingsOptionConfig<ChartSettingsTabTypes>[] = [
+    {
+      tab: ChartSettingsTabTypes.MAIN,
+      icon: 'settings',
+      iconSize: 24,
+      translation: 'common.general',
+      tooltipPosition: 'right',
+    },
+    {
+      tab: ChartSettingsTabTypes.DISPLAY,
+      icon: 'tune',
+      iconSize: 24,
+      translation: 'common.display',
+      tooltipPosition: 'right',
+    },
+    {
+      tab: ChartSettingsTabTypes.PREVIEW,
+      icon: 'preview',
+      iconSize: 24,
+      translation: 'common.preview',
+      tooltipPosition: 'right',
+    },
+  ];
 
   // === DISPLAY PREVIEW ===
   public settings: any;
@@ -53,7 +78,9 @@ export class SafeChartSettingsComponent implements OnInit {
   }
 
   /** Stores the selected tab */
-  public selectedTab = 0;
+  public selectedTab!: ChartSettingsTabTypes;
+  /** Chart tab types to use in the components html template */
+  public chartSettingsTabTypes = ChartSettingsTabTypes;
 
   /**
    * Constructor for the chart settings component
@@ -96,11 +123,11 @@ export class SafeChartSettingsComponent implements OnInit {
   }
 
   /**
-   *  Handles the a tab change event
+   *  Handles the tab change event
    *
    * @param event Event triggered on tab switch
    */
-  handleTabChange(event: MatTabChangeEvent): void {
-    this.selectedTab = event.index;
+  handleTabChange(event: ChartSettingsTabTypes): void {
+    this.selectedTab = event;
   }
 }

--- a/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.module.ts
+++ b/projects/safe/src/lib/components/widgets/chart-settings/chart-settings.module.ts
@@ -13,7 +13,6 @@ import { SafeQueryBuilderModule } from '../../query-builder/query-builder.module
 import { SafeChartModule } from '../chart/chart.module';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatTabsModule } from '@angular/material/tabs';
 import { SafeButtonModule } from '../../ui/button/button.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { SafeAggregationBuilderModule } from '../../ui/aggregation-builder/aggregation-builder.module';
@@ -26,6 +25,7 @@ import { TabMainModule } from './tab-main/tab-main.module';
 import { TabDisplayModule } from './tab-display/tab-display.module';
 import { TabPreviewModule } from './tab-preview/tab-preview.module';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { SafeTabSettingsOptionsModule } from '../../ui/tab-settings-options/tab-settings-options.module';
 
 /** Module for the chart settings component */
 @NgModule({
@@ -45,7 +45,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     SafeChartModule,
     MatExpansionModule,
     MatSlideToggleModule,
-    MatTabsModule,
+    SafeTabSettingsOptionsModule,
     SafeButtonModule,
     TranslateModule,
     SafeAggregationBuilderModule,

--- a/projects/safe/src/lib/components/widgets/chart-settings/enums/tab-types.ts
+++ b/projects/safe/src/lib/components/widgets/chart-settings/enums/tab-types.ts
@@ -1,0 +1,6 @@
+/** Enum for the current tabs in the chart settings */
+export enum ChartSettingsTabTypes {
+  MAIN,
+  DISPLAY,
+  PREVIEW,
+}

--- a/projects/safe/src/lib/components/widgets/grid-settings/enums/tab-types.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/enums/tab-types.ts
@@ -1,0 +1,6 @@
+/** Enum for the current tabs in the grid settings */
+export enum GridSettingsTabTypes {
+  MAIN,
+  ACTIONS,
+  BUTTONS,
+}

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -1,72 +1,34 @@
-<mat-tab-group
-  class="grow"
-  vertical
-  animationDuration="0ms"
-  (selectedTabChange)="handleTabChange($event)"
+<safe-tab-settings-options
+  class="w-full"
+  (selectedTabEvent)="handleTabChange($event)"
+  [tabOptionsConfig]="tabSettingsConfig"
 >
-  <!-- MAIN PARAMETERS / SELECTION OF LAYOUTS -->
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <safe-icon
-        icon="preview"
-        [size]="24"
-        matTooltip="{{ 'common.general' | translate }}"
-        matTooltipPosition="right"
-      ></safe-icon>
-      <span>{{ 'common.general' | translate }}</span>
-    </ng-template>
-    <ng-template matTabContent>
-      <safe-tab-main
-        [formGroup]="formGroup"
-        [resource]="resource"
-        [queries]="filteredQueries"
-        [templates]="templates"
-      ></safe-tab-main>
-    </ng-template>
-  </mat-tab>
-  <!-- AVAILABLE ACTIONS -->
-  <mat-tab [disabled]="formGroup.value.aggregations.length > 0">
-    <ng-template mat-tab-label>
-      <safe-icon
-        icon="toggle_on"
-        [size]="24"
-        matTooltip="{{
-          'components.widget.settings.grid.actions.title' | translate
-        }}"
-        matTooltipPosition="right"
-      ></safe-icon>
-      <span>{{
-        'components.widget.settings.grid.actions.title' | translate
-      }}</span>
-    </ng-template>
-    <ng-template matTabContent>
-      <safe-tab-actions [formGroup]="formGroup"></safe-tab-actions>
-    </ng-template>
-  </mat-tab>
-  <!-- BUTTONS -->
-  <mat-tab [disabled]="formGroup.value.aggregations.length > 0">
-    <ng-template mat-tab-label>
-      <safe-icon
-        icon="bolt"
-        [size]="24"
-        matTooltip="{{
-          'components.widget.settings.grid.buttons.title' | translate
-        }}"
-        matTooltipPosition="right"
-      ></safe-icon>
-      <span>{{
-        'components.widget.settings.grid.buttons.title' | translate
-      }}</span>
-    </ng-template>
-    <ng-template matTabContent>
-      <safe-tab-buttons
-        [formGroup]="formGroup"
-        [fields]="fields"
-        [templates]="appTemplates"
-        [distributionLists]="distributionLists"
-        [relatedForms]="relatedForms"
-        [channels]="channels"
-      ></safe-tab-buttons>
-    </ng-template>
-  </mat-tab>
-</mat-tab-group>
+  <ng-container ngProjectAs="[selectedTabTemplate]">
+    <div [ngSwitch]="selectedTab">
+      <!-- BUTTONS -->
+      <ng-container *ngSwitchCase="gridSettingsTabTypes.BUTTONS">
+        <safe-tab-buttons
+          [formGroup]="formGroup"
+          [fields]="fields"
+          [templates]="appTemplates"
+          [distributionLists]="distributionLists"
+          [relatedForms]="relatedForms"
+          [channels]="channels"
+        ></safe-tab-buttons>
+      </ng-container>
+      <!-- AVAILABLE ACTIONS -->
+      <ng-container *ngSwitchCase="gridSettingsTabTypes.ACTIONS">
+        <safe-tab-actions [formGroup]="formGroup"></safe-tab-actions>
+      </ng-container>
+      <!-- MAIN PARAMETERS / SELECTION OF LAYOUTS -->
+      <ng-container *ngSwitchDefault>
+        <safe-tab-main
+          [formGroup]="formGroup"
+          [resource]="resource"
+          [queries]="filteredQueries"
+          [templates]="templates"
+        ></safe-tab-main>
+      </ng-container>
+    </div>
+  </ng-container>
+</safe-tab-settings-options>

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -23,11 +23,12 @@ import { Overlay } from '@angular/cdk/overlay';
 import { MAT_AUTOCOMPLETE_SCROLL_STRATEGY } from '@angular/material/autocomplete';
 import { scrollFactory } from '../../../utils/scroll-factory';
 import { Resource } from '../../../models/resource.model';
-import { MatTabChangeEvent } from '@angular/material/tabs';
 import { createGridWidgetFormGroup } from './grid-settings.forms';
 import { DistributionList } from '../../../models/distribution-list.model';
 import { SafeUnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.component';
 import { takeUntil } from 'rxjs/operators';
+import { GridSettingsTabTypes } from './enums/tab-types';
+import { TabSettingsOptionConfig } from '../../ui/tab-settings-options/tab-settings-options.interface';
 
 /**
  * Modal content for the settings of the grid widgets.
@@ -70,9 +71,39 @@ export class SafeGridSettingsComponent
   private allQueries: any[] = [];
   public filteredQueries: any[] = [];
   public resource: Resource | null = null;
+  /**Config object to load the tabs in grid settings modal */
+  public tabSettingsConfig: TabSettingsOptionConfig<GridSettingsTabTypes>[] = [
+    {
+      tab: GridSettingsTabTypes.MAIN,
+      icon: 'preview',
+      iconSize: 24,
+      translation: 'common.general',
+      tooltipPosition: 'right',
+      disabled: false,
+    },
+    {
+      tab: GridSettingsTabTypes.ACTIONS,
+      icon: 'toggle_on',
+      iconSize: 24,
+      translation: 'components.widget.settings.grid.actions.title',
+      tooltipPosition: 'right',
+      disabled: true,
+    },
+    {
+      tab: GridSettingsTabTypes.BUTTONS,
+      icon: 'preview',
+      iconSize: 24,
+      translation: 'common.preview',
+      tooltipPosition: 'right',
+      disabled: false,
+    },
+  ];
 
   /** Stores the selected tab */
-  public selectedTab = 0;
+  public selectedTab!: GridSettingsTabTypes;
+  /** Grid tab types to use in the components html template */
+  public gridSettingsTabTypes = GridSettingsTabTypes;
+
   /** @returns application templates */
   get appTemplates(): any[] {
     return this.applicationService.templates || [];
@@ -224,6 +255,7 @@ export class SafeGridSettingsComponent
 
   ngAfterViewInit(): void {
     if (this.formGroup) {
+      this.updateGridSettingsTabsAvailability();
       this.formGroup.valueChanges
         .pipe(takeUntil(this.destroy$))
         .subscribe(() => {
@@ -318,7 +350,21 @@ export class SafeGridSettingsComponent
    *
    * @param event Event triggered on tab switch
    */
-  handleTabChange(event: MatTabChangeEvent): void {
-    this.selectedTab = event.index;
+  handleTabChange(event: GridSettingsTabTypes): void {
+    this.selectedTab = event;
+  }
+
+  /**
+   *  Updates the availability of each needed tab of the grid settings
+   *
+   */
+  private updateGridSettingsTabsAvailability(): void {
+    this.tabSettingsConfig.forEach(
+      (config: TabSettingsOptionConfig<GridSettingsTabTypes>) => {
+        if (config.tab !== GridSettingsTabTypes.MAIN) {
+          config.disabled = this.formGroup.value.aggregations.length > 0;
+        }
+      }
+    );
   }
 }

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.module.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { SafeGridSettingsComponent } from './grid-settings.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatTabsModule } from '@angular/material/tabs';
 import { SafeButtonModule } from '../../ui/button/button.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { SafeIconModule } from '../../ui/icon/icon.module';
@@ -11,6 +10,7 @@ import { TabActionsModule } from './tab-actions/tab-actions.module';
 import { TabButtonsModule } from './tab-buttons/tab-buttons.module';
 import { TabMainModule } from './tab-main/tab-main.module';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { SafeTabSettingsOptionsModule } from '../../ui/tab-settings-options/tab-settings-options.module';
 
 /** Module for the grid widget settings component */
 @NgModule({
@@ -20,10 +20,10 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     FormsModule,
     ReactiveFormsModule,
     MatFormFieldModule,
-    MatTabsModule,
     SafeButtonModule,
     TranslateModule,
     SafeIconModule,
+    SafeTabSettingsOptionsModule,
     TabActionsModule,
     TabButtonsModule,
     TabMainModule,

--- a/projects/safe/src/lib/components/widgets/map-settings/enums/tab-types.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/enums/tab-types.ts
@@ -1,0 +1,6 @@
+/** Enum for the current tabs in the map settings */
+export enum MapSettingsTabTypes {
+  GENERAL,
+  LAYERS,
+  PROPERTIES,
+}

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -1,62 +1,28 @@
 <ng-container *ngIf="tileForm">
-  <mat-tab-group
-    mat-align-tabs="start"
-    animationDuration="0ms"
-    vertical
-    class="grow"
+  <safe-tab-settings-options
+    class="w-full"
+    (selectedTabEvent)="handleTabChange($event)"
+    [tabOptionsConfig]="tabSettingsConfig"
   >
-    <!-- GENERAL SETTINGS -->
-    <mat-tab>
-      <ng-template mat-tab-label>
-        <safe-icon
-          icon="preview"
-          [size]="24"
-          matTooltip="{{ 'common.general' | translate }}"
-          matTooltipPosition="right"
-        ></safe-icon>
-        <span>{{ 'common.general' | translate }}</span>
-      </ng-template>
-      <ng-template matTabContent>
-        <safe-map-general *ngIf="tileForm" [form]="tileForm"></safe-map-general>
-      </ng-template>
-    </mat-tab>
-    <!-- LAYERS CONFIGURATION -->
-    <mat-tab>
-      <ng-template mat-tab-label>
-        <safe-icon
-          icon="layers"
-          [size]="24"
-          matTooltip="{{ 'common.layers' | translate }}"
-          matTooltipPosition="right"
-        ></safe-icon>
-        <span>{{ 'common.layers' | translate }}</span>
-      </ng-template>
-      <ng-template matTabContent>
-        <safe-map-layers
-          [form]="tileForm"
-          [selectedFields]="selectedFields"
-          [formattedSelectedFields]="formattedSelectedFields"
-        ></safe-map-layers>
-      </ng-template>
-    </mat-tab>
-    <!-- MAP PARAMETERS -->
-    <mat-tab>
-      <ng-template mat-tab-label>
-        <safe-icon
-          icon="map"
-          [size]="24"
-          matTooltip="{{
-            'components.widget.settings.map.properties.title' | translate
-          }}"
-          matTooltipPosition="right"
-        ></safe-icon>
-        <span>{{
-          'components.widget.settings.map.properties.title' | translate
-        }}</span>
-      </ng-template>
-      <ng-template matTabContent>
-        <safe-map-properties [form]="tileForm"></safe-map-properties>
-      </ng-template>
-    </mat-tab>
-  </mat-tab-group>
+    <ng-container ngProjectAs="[selectedTabTemplate]">
+      <div [ngSwitch]="selectedTab">
+        <!-- LAYERS CONFIGURATION -->
+        <ng-container *ngSwitchCase="mapSettingsTabTypes.LAYERS">
+          <safe-map-layers
+            [form]="tileForm"
+            [selectedFields]="selectedFields"
+            [formattedSelectedFields]="formattedSelectedFields"
+          ></safe-map-layers>
+        </ng-container>
+        <!-- MAP PARAMETERS -->
+        <ng-container *ngSwitchCase="mapSettingsTabTypes.PROPERTIES">
+          <safe-map-properties [form]="tileForm"></safe-map-properties>
+        </ng-container>
+        <!-- GENERAL SETTINGS -->
+        <ng-container *ngSwitchDefault>
+          <safe-map-general [form]="tileForm"></safe-map-general>
+        </ng-container>
+      </div>
+    </ng-container>
+  </safe-tab-settings-options>
 </ng-container>

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -4,6 +4,8 @@ import { FormGroup, FormArray } from '@angular/forms';
 import { QueryBuilderService } from '../../../services/query-builder/query-builder.service';
 import { debounceTime } from 'rxjs/operators';
 import { cloneDeep } from 'lodash';
+import { TabSettingsOptionConfig } from '../../ui/tab-settings-options/tab-settings-options.interface';
+import { MapSettingsTabTypes } from './enums/tab-types';
 
 /**
  * Filters an array of fields to only include fields that match the given paths.
@@ -94,6 +96,35 @@ export class SafeMapSettingsComponent implements OnInit {
 
   public selectedFields: (string | undefined)[] = [];
   public formattedSelectedFields: any[] = [];
+  /**Config object to load the tabs in map settings modal */
+  public tabSettingsConfig: TabSettingsOptionConfig<MapSettingsTabTypes>[] = [
+    {
+      tab: MapSettingsTabTypes.GENERAL,
+      icon: 'preview',
+      iconSize: 24,
+      translation: 'common.general',
+      tooltipPosition: 'right',
+    },
+    {
+      tab: MapSettingsTabTypes.LAYERS,
+      icon: 'layers',
+      iconSize: 24,
+      translation: 'common.layers',
+      tooltipPosition: 'right',
+    },
+    {
+      tab: MapSettingsTabTypes.PROPERTIES,
+      icon: 'map',
+      iconSize: 24,
+      translation: 'components.widget.settings.map.properties.title',
+      tooltipPosition: 'right',
+    },
+  ];
+
+  /** Stores the selected tab */
+  public selectedTab!: MapSettingsTabTypes;
+  /** Map tab types to use in the components html template */
+  public mapSettingsTabTypes = MapSettingsTabTypes;
 
   /**
    * Get marker rules as form array
@@ -226,4 +257,13 @@ export class SafeMapSettingsComponent implements OnInit {
   //       };
   //     });
   // }
+
+  /**
+   *  Handles the a tab change event
+   *
+   * @param event Event triggered on tab switch
+   */
+  handleTabChange(event: MapSettingsTabTypes): void {
+    this.selectedTab = event;
+  }
 }

--- a/projects/safe/src/lib/components/widgets/map-settings/map-settings.module.ts
+++ b/projects/safe/src/lib/components/widgets/map-settings/map-settings.module.ts
@@ -4,11 +4,11 @@ import { SafeMapSettingsComponent } from './map-settings.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { SafeIconModule } from '../../ui/icon/icon.module';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MapGeneralModule } from './map-general/map-general.module';
 import { MapLayersModule } from './map-layers/map-layers.module';
 import { MapPropertiesModule } from './map-properties/map-properties.module';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { SafeTabSettingsOptionsModule } from '../../ui/tab-settings-options/tab-settings-options.module';
 
 /** Module for map settings component */
 @NgModule({
@@ -19,7 +19,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     ReactiveFormsModule,
     SafeIconModule,
     TranslateModule,
-    MatTabsModule,
+    SafeTabSettingsOptionsModule,
     MapGeneralModule,
     MapLayersModule,
     MapPropertiesModule,

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/card-modal.component.html
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/card-modal.component.html
@@ -3,97 +3,55 @@
     {{ 'components.widget.settings.summaryCard.card.title' | translate }}
   </h1>
   <mat-dialog-content>
-    <form [formGroup]="form">
-      <mat-tab-group
-        vertical
-        animationDuration="0ms"
-        #tabGroup
-        (selectedTabChange)="handleTabChange($event)"
-        [selectedIndex]="0"
+    <form class="h-full" [formGroup]="form">
+      <safe-tab-settings-options
+        class="w-full"
+        (selectedTabEvent)="handleTabChange($event)"
+        [tabOptionsConfig]="tabSettingsConfig"
       >
-        <!-- Selection of data source -->
-        <mat-tab>
-          <ng-template mat-tab-label>
-            <safe-icon icon="settings" [size]="24"></safe-icon>
-            <span>{{
-              'components.widget.settings.summaryCard.card.dataSource.title'
-                | translate
-            }}</span>
-          </ng-template>
-          <ng-template matTabContent>
-            <safe-data-source-tab
-              [form]="form"
-              [selectedResource]="selectedResource"
-              [selectedLayout]="selectedLayout"
-              [selectedAggregation]="selectedAggregation"
-              (layoutChange)="handleLayoutChange($event)"
-              (aggregationChange)="handleAggregationChange($event)"
-            ></safe-data-source-tab>
-          </ng-template>
-        </mat-tab>
-        <!-- Selection of record -->
-        <mat-tab
-          *ngIf="
-            !form.get('isDynamic')?.value && !form.get('isAggregation')?.value
-          "
-        >
-          <ng-template mat-tab-label>
-            <safe-icon icon="list" [size]="24"></safe-icon>
-            <span>{{
-              'components.widget.settings.summaryCard.card.valueSelector.title'
-                | translate
-            }}</span>
-          </ng-template>
-          <ng-template matTabContent>
-            <safe-value-selector-tab
-              [form]="form"
-              [settings]="selectedLayout"
-            ></safe-value-selector-tab>
-          </ng-template>
-        </mat-tab>
-        <!-- Card display settings -->
-        <mat-tab>
-          <ng-template mat-tab-label>
-            <safe-icon icon="display_settings" [size]="24"></safe-icon>
-            <span>{{ 'common.display' | translate }}</span>
-          </ng-template>
-          <ng-template matTabContent>
-            <safe-display-tab [form]="form"></safe-display-tab>
-          </ng-template>
-        </mat-tab>
-        <!-- Card text editor -->
-        <mat-tab>
-          <ng-template mat-tab-label>
-            <safe-icon icon="article" [size]="24"></safe-icon>
-            <span>{{
-              'components.widget.settings.summaryCard.card.textEditor.title'
-                | translate
-            }}</span>
-          </ng-template>
-          <ng-template matTabContent>
-            <safe-text-editor-tab
-              *ngIf="isEditorTab()"
-              [form]="form"
-              [fields]="fields"
-            ></safe-text-editor-tab>
-          </ng-template>
-        </mat-tab>
-        <!-- Preview of card -->
-        <mat-tab [label]="'common.preview' | translate">
-          <ng-template mat-tab-label>
-            <safe-icon icon="preview" [size]="24"></safe-icon>
-            <span>{{ 'common.preview' | translate }}</span>
-          </ng-template>
-          <ng-template matTabContent>
-            <safe-preview-tab
-              [form]="form"
-              [record]="selectedRecord"
-              [fields]="fields"
-              [layout]="form.value.isAggregation ? null : selectedLayout"
-            ></safe-preview-tab>
-          </ng-template>
-        </mat-tab>
-      </mat-tab-group>
+        <ng-container ngProjectAs="[selectedTabTemplate]">
+          <div [ngSwitch]="selectedTab">
+            <!-- Selection of record -->
+            <ng-container *ngSwitchCase="summaryCardSettingsTabTypes.RECORD">
+              <safe-value-selector-tab
+                [form]="form"
+                [settings]="selectedLayout"
+              ></safe-value-selector-tab>
+            </ng-container>
+            <!-- Card display settings -->
+            <ng-container *ngSwitchCase="summaryCardSettingsTabTypes.SETTINGS">
+              <safe-display-tab [form]="form"></safe-display-tab>
+            </ng-container>
+            <!-- Card text editor -->
+            <ng-container *ngSwitchCase="summaryCardSettingsTabTypes.EDITOR">
+              <safe-text-editor-tab
+                [form]="form"
+                [fields]="fields"
+              ></safe-text-editor-tab>
+            </ng-container>
+            <!-- Preview of card -->
+            <ng-container *ngSwitchCase="summaryCardSettingsTabTypes.PREVIEW">
+              <safe-preview-tab
+                [form]="form"
+                [record]="selectedRecord"
+                [fields]="fields"
+                [layout]="form.value.isAggregation ? null : selectedLayout"
+              ></safe-preview-tab>
+            </ng-container>
+            <!-- Selection of data source -->
+            <ng-container *ngSwitchDefault>
+              <safe-data-source-tab
+                [form]="form"
+                [selectedResource]="selectedResource"
+                [selectedLayout]="selectedLayout"
+                [selectedAggregation]="selectedAggregation"
+                (layoutChange)="handleLayoutChange($event)"
+                (aggregationChange)="handleAggregationChange($event)"
+              ></safe-data-source-tab>
+            </ng-container>
+          </div>
+        </ng-container>
+      </safe-tab-settings-options>
     </form>
   </mat-dialog-content>
   <!-- Modal actions ( close / save ) -->

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/card-modal.component.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/card-modal.component.ts
@@ -333,19 +333,7 @@ export class SafeCardModalComponent implements OnInit {
   }
 
   /**
-   * Checks if the user is in the editor tab before loading it.
-   *
-   * @returns Returns a boolean.
-   */
-  isEditorTab(): boolean {
-    return this.form.get('isDynamic')?.value ||
-      this.form.get('isAggregation')?.value
-      ? this.selectedTab === SummaryCardSettingsTabTypes.PREVIEW
-      : this.selectedTab === SummaryCardSettingsTabTypes.RECORD;
-  }
-
-  /**
-   *  Handles the a tab change event
+   *  Handles the tab change event
    *
    * @param event Event triggered on tab switch
    */

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/card-modal.component.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/card-modal.component.ts
@@ -1,14 +1,6 @@
-import {
-  Component,
-  OnInit,
-  Inject,
-  ChangeDetectorRef,
-  ViewChild,
-  AfterViewInit,
-} from '@angular/core';
+import { Component, OnInit, Inject } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { MatTabChangeEvent } from '@angular/material/tabs';
 import { Apollo } from 'apollo-angular';
 import {
   GET_RESOURCE,
@@ -25,6 +17,8 @@ import { Aggregation } from '../../../../models/aggregation.model';
 import { Resource } from '../../../../models/resource.model';
 import get from 'lodash/get';
 import { SafeAggregationService } from '../../../../services/aggregation/aggregation.service';
+import { SummaryCardSettingsTabTypes } from './enums/tab-types';
+import { TabSettingsOptionConfig } from '../../../ui/tab-settings-options/tab-settings-options.interface';
 
 /**
  * Card modal component.
@@ -35,14 +29,57 @@ import { SafeAggregationService } from '../../../../services/aggregation/aggrega
   templateUrl: './card-modal.component.html',
   styleUrls: ['./card-modal.component.scss'],
 })
-export class SafeCardModalComponent implements OnInit, AfterViewInit {
-  @ViewChild('tabGroup') tabGroup: any;
-
+export class SafeCardModalComponent implements OnInit {
   public form!: FormGroup;
   public fields: any[] = [];
 
-  // === CURRENT TAB ===
-  private activeTabIndex: number | undefined;
+  /**Config object to load the tabs in summary card settings modal */
+  public tabSettingsConfig: TabSettingsOptionConfig<SummaryCardSettingsTabTypes>[] =
+    [
+      {
+        tab: SummaryCardSettingsTabTypes.DATA_SOURCE,
+        icon: 'settings',
+        iconSize: 24,
+        translation:
+          'components.widget.settings.summaryCard.card.dataSource.title',
+        tooltipPosition: 'right',
+      },
+      {
+        tab: SummaryCardSettingsTabTypes.RECORD,
+        icon: 'list',
+        iconSize: 24,
+        translation:
+          'components.widget.settings.summaryCard.card.valueSelector.title',
+        tooltipPosition: 'right',
+      },
+      {
+        tab: SummaryCardSettingsTabTypes.SETTINGS,
+        icon: 'display_settings',
+        iconSize: 24,
+        translation: 'common.display',
+        tooltipPosition: 'right',
+      },
+      {
+        tab: SummaryCardSettingsTabTypes.EDITOR,
+        icon: 'article',
+        iconSize: 24,
+        translation:
+          'components.widget.settings.summaryCard.card.textEditor.title',
+        tooltipPosition: 'right',
+      },
+      {
+        tab: SummaryCardSettingsTabTypes.PREVIEW,
+        icon: 'preview',
+        iconSize: 24,
+        translation: 'common.preview',
+        tooltipPosition: 'right',
+      },
+    ];
+
+  /** Stores the selected tab */
+  public selectedTab!: SummaryCardSettingsTabTypes;
+  /** Summary card tab types to use in the components html template */
+  public summaryCardSettingsTabTypes = SummaryCardSettingsTabTypes;
 
   // === RECORD DATA ===
   public selectedRecord: any;
@@ -72,7 +109,6 @@ export class SafeCardModalComponent implements OnInit, AfterViewInit {
     @Inject(MAT_DIALOG_DATA) public data: any,
     public dialogRef: MatDialogRef<SafeCardModalComponent>,
     public fb: FormBuilder,
-    private cdRef: ChangeDetectorRef,
     private apollo: Apollo,
     private aggregationService: SafeAggregationService
   ) {}
@@ -304,17 +340,17 @@ export class SafeCardModalComponent implements OnInit, AfterViewInit {
   isEditorTab(): boolean {
     return this.form.get('isDynamic')?.value ||
       this.form.get('isAggregation')?.value
-      ? this.activeTabIndex === 2
-      : this.activeTabIndex === 3;
+      ? this.selectedTab === SummaryCardSettingsTabTypes.PREVIEW
+      : this.selectedTab === SummaryCardSettingsTabTypes.RECORD;
   }
 
   /**
-   * Sets an internal variable with the current tab.
+   *  Handles the a tab change event
    *
-   * @param e Change tab event.
+   * @param event Event triggered on tab switch
    */
-  handleTabChange(e: MatTabChangeEvent) {
-    this.activeTabIndex = e.index;
+  handleTabChange(event: SummaryCardSettingsTabTypes): void {
+    this.selectedTab = event;
   }
 
   /**
@@ -334,13 +370,5 @@ export class SafeCardModalComponent implements OnInit, AfterViewInit {
   handleAggregationChange(aggregation: Aggregation | null) {
     this.selectedAggregation = aggregation;
     this.getCustomAggregation();
-  }
-
-  /**
-   * Initializes the active tab variable.
-   */
-  ngAfterViewInit() {
-    this.activeTabIndex = this.tabGroup.selectedIndex;
-    this.cdRef.detectChanges();
   }
 }

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/card-modal.module.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/card-modal.module.ts
@@ -6,7 +6,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MatRadioModule } from '@angular/material/radio';
 import { SafeCardModalComponent } from './card-modal.component';
 import { SafeDataSourceTabModule } from './data-source-tab/data-source.module';
@@ -15,6 +14,7 @@ import { SafeDisplayTabModule } from './display-tab/display.module';
 import { SafeTextEditorTabModule } from './text-editor-tab/text-editor.module';
 import { SafePreviewTabModule } from './preview-tab/preview.module';
 import { SafeModalModule } from '../../../ui/modal/modal.module';
+import { SafeTabSettingsOptionsModule } from '../../../ui/tab-settings-options/tab-settings-options.module';
 
 /** Card Modal Module */
 @NgModule({
@@ -28,7 +28,7 @@ import { SafeModalModule } from '../../../ui/modal/modal.module';
     ReactiveFormsModule,
     MatFormFieldModule,
     MatInputModule,
-    MatTabsModule,
+    SafeTabSettingsOptionsModule,
     MatRadioModule,
     SafeDataSourceTabModule,
     SafeValueSelectorTabModule,

--- a/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/enums/tab-types.ts
+++ b/projects/safe/src/lib/components/widgets/summary-card-settings/card-modal/enums/tab-types.ts
@@ -1,0 +1,8 @@
+/** Enum for the current tabs in the summary card settings */
+export enum SummaryCardSettingsTabTypes {
+  DATA_SOURCE,
+  RECORD,
+  SETTINGS,
+  EDITOR,
+  PREVIEW,
+}


### PR DESCRIPTION
refactor[safe]: Replace all the vertical mat tabs for mat drawers in components using them 
Create a generic tab settings option component which is used in all the components aforementioned 
Preserve all the previous stylings and functionalities

# Description

Vertical mat tabs have been replaced for a custom component relying in mat-drawer component to avoid excesive customization of mat tabs for our UX needs.
The new component would handle the tabs configuration given to it and display the projected content from the parent component
New interface TabSettingsOptionConfig<T: TabEnum> created to narrow the configuration of the tabs given to the new component(base on the current use, could be extended)


## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Projects involving the affected components where served and manually tested as user

## Sreenshots

Styling of components and functionality remains the same, but we have all the features and styling narrowed to a shared component
preferences modal
![preferences-modalpng](https://user-images.githubusercontent.com/123092672/214353053-2b4c92cf-fef8-43e3-a5f1-7f2703cc82b8.png)
preferences modal collapse
![preferences-modal-collapse](https://user-images.githubusercontent.com/123092672/214353090-ffeb1726-df59-4925-a663-a07fc6e8b1ee.png)
chart settings
![chart-settings](https://user-images.githubusercontent.com/123092672/214353145-27c0a773-1c91-45f1-8507-f0dc082d7531.png)
chart settings collapse
![chart-settings-collapse](https://user-images.githubusercontent.com/123092672/214353196-b4b22597-f45a-4a1d-8a0a-7fd0c3865ed8.png)
maps settings
![maps-settings](https://user-images.githubusercontent.com/123092672/214353254-48679c68-1486-4478-990c-f08ef34b93b3.png)
maps settings collapse
![map-settings-collapse](https://user-images.githubusercontent.com/123092672/214353312-3cd8c575-6f3e-4251-afa9-d209fdc99e6f.png)

And so on

# Checklist:

( * == Mandatory ) 

- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
