### PR TITLE
fix/AB#55074_copy-dashboard-from-workflow

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
@@ -399,13 +399,14 @@ export class DashboardComponent
   }
 
   /**
-   * Duplicate page, in a new ( or same ) application
+   * Duplicate page (or step), in a new ( or same ) application
    *
-   * @param event duplication event
+   * @param event duplication event, contains the chosen application id
    */
   public onDuplicate(event: any): void {
-    if (this.dashboard?.page?.id) {
-      this.applicationService.duplicatePage(this.dashboard?.page?.id, event.id);
+    const id = this.dashboard?.page?.id ?? this.dashboard?.step?.id;
+    if (id) {
+      this.applicationService.duplicatePage(id, event.id, this.applicationId);
     }
   }
 

--- a/projects/safe/src/lib/services/application/application.service.ts
+++ b/projects/safe/src/lib/services/application/application.service.ts
@@ -541,14 +541,20 @@ export class SafeApplicationService {
    *
    * @param pageId page id which will be duplicated
    * @param applicationId id of the application where it should be duplicated
+   * @param baseApplicationId id of the application the page originally belongs to
    */
-  duplicatePage(pageId: string, applicationId: string): void {
+  duplicatePage(
+    pageId: string,
+    applicationId: string,
+    baseApplicationId?: string
+  ): void {
     this.apollo
       .mutate<duplicatePageMutationResponse>({
         mutation: DUPLICATE_PAGE,
         variables: {
           id: pageId,
           application: applicationId,
+          baseApplication: baseApplicationId,
         },
       })
       .subscribe(({ errors, data }) => {

--- a/projects/safe/src/lib/services/application/graphql/mutations.ts
+++ b/projects/safe/src/lib/services/application/graphql/mutations.ts
@@ -35,8 +35,12 @@ export interface AddPageMutationResponse {
 
 /** Duplicate page mutation, used by Application service. */
 export const DUPLICATE_PAGE = gql`
-  mutation duplicatePage($id: ID!, $application: ID!) {
-    duplicatePage(id: $id, application: $application) {
+  mutation duplicatePage($id: ID!, $application: ID!, $baseApplication: ID) {
+    duplicatePage(
+      id: $id
+      application: $application
+      baseApplication: $baseApplication
+    ) {
       id
       name
       type


### PR DESCRIPTION
# Description

It's possible to make a copy of a Dashboard, however if the Dashboard in question was inside a Workflow it's a Step and when clicking on the 'Duplicate' button nothing happens.

The mutation needed to be updated to also duplicate Dashboards that are Steps, and not only duplicate Pages.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Copying Dashboards from inside and outside Workflows.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
