### PR TITLE
Feat/oort 594/translated saving survey in the form builder

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/form-builder/form-builder.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/form-builder/form-builder.component.ts
@@ -215,7 +215,7 @@ export class FormBuilderComponent implements OnInit {
       const statusModal = this.dialog.open(SafeStatusModalComponent, {
         disableClose: true,
         data: {
-          title: 'Saving survey',
+          title: this.translate.instant('components.formBuilder.saveSurvey'),
           showSpinner: true,
         },
       });

--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -554,6 +554,7 @@
 			}
 		},
 		"formBuilder": {
+			"saveSurvey": "SavingSurvey",
 			"errors": {
 				"missingGridField": "Missing an available field grid for question {{question}} on page {{page}}. Please select a least one in Custom Question Properties to save the form.",
 				"missingRelatedName": "Missing related name for question {{question}} on page {{page}}. Please provide a valid data value name (snake case format) to save the form.",

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -554,6 +554,7 @@
 			}
 		},
 		"formBuilder": {
+			"saveSurvey": "Sauvegarde du questionnaire",
 			"errors": {
 				"missingGridField": "Champs disponible de table de données manquant pour la question {{question}} à la page {{page}}. Veuillez en sélectionner au moins un dans la propriété Custom Question pour sauvegarder le formulaire.",
 				"missingRelatedName": "Nom lié manquant pour la question {{question}} à la page {{page}}. Veuillez entrer un nom valide pour la valeur de la donnée (au format snake_case) pour sauvegarder le formulaire.",


### PR DESCRIPTION
# Description

Saving the survey in the form builder while in french version now displays 'Sauvegarde du questionnaire' instead of 'Saving survey'.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Set your oort to french. Open a survey and edit it. Click on "Sauvegarder le questionnaire".

## Sreenshots

![Screenshot from 2023-02-09 10-05-25](https://user-images.githubusercontent.com/59645813/217769592-4c5d7411-58a0-472f-94a9-5a9c131fc2b8.png)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
