### PR TITLE
Feat/ab#56474 added basemap to the top right button and fixed padding

### DIFF
--- a/projects/safe/src/lib/components/ui/map/map.component.scss
+++ b/projects/safe/src/lib/components/ui/map/map.component.scss
@@ -37,3 +37,7 @@
 ::ng-deep .leaflet-layerstree-expand-collapse {
   cursor: pointer;
 }
+
+::ng-deep .leaflet-layerstree-children {
+  padding-left: 20px;
+}

--- a/projects/safe/src/lib/components/ui/map/map.component.scss
+++ b/projects/safe/src/lib/components/ui/map/map.component.scss
@@ -19,11 +19,9 @@
 }
 
 ::ng-deep .leaflet-layerstree-children {
-  padding-left: 10px;
-}
-
-::ng-deep .leaflet-layerstree-children-nopad {
-  padding-left: 0px;
+  &:not(.leaflet-layerstree-children-nopad) {
+    padding-left: 20px;
+  }
 }
 
 ::ng-deep .leaflet-layerstree-hide {
@@ -36,8 +34,4 @@
 
 ::ng-deep .leaflet-layerstree-expand-collapse {
   cursor: pointer;
-}
-
-::ng-deep .leaflet-layerstree-children {
-  padding-left: 20px;
 }

--- a/projects/safe/src/lib/components/ui/map/map.component.ts
+++ b/projects/safe/src/lib/components/ui/map/map.component.ts
@@ -91,7 +91,7 @@ export class SafeMapComponent
     if (layerData) {
       // When using geoman tools no layer control is shown
       if (!this.useGeomanTools) {
-        L.control.layers.tree(undefined, layerData).addTo(this.map);
+        L.control.layers.tree(this.baseTree, layerData).addTo(this.map);
       }
       this.map.addLayer(layerData.layer);
     }
@@ -134,6 +134,7 @@ export class SafeMapComponent
 
   // === MARKERS ===
   private popupMarker: any;
+  private baseTree: any;
   private layers: LayerTree[] = [];
   private layerControl: any;
   private layerTreeCloned!: any;
@@ -411,9 +412,13 @@ export class SafeMapComponent
     }
   }
   /**
-   * Draw layers on map.
+   * Draw layers on map and sets the baseTree.
    */
   private drawLayers(): void {
+    this.baseTree = {
+      label: this.basemap.options.key,
+      layer: this.basemap,
+    };
     const options1 = {
       style: {
         opacity: 0.2,
@@ -480,7 +485,7 @@ export class SafeMapComponent
       drawLayer(layer);
     }
     this.layerControl = L.control.layers
-      .tree(undefined, this.layers)
+      .tree(this.baseTree, this.layers)
       .addTo(this.map);
   }
 


### PR DESCRIPTION
# Description

Added a base tree to the top right button. The base tree displays the current basemap. Fixed a padding parent-children problem.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Go to a map widget. Open top right button. It should show the basemap and a padded version of the options.

## Sreenshots
![Screenshot from 2023-02-14 11-45-52](https://user-images.githubusercontent.com/59645813/218713261-3ccba0ec-f094-4ed1-b503-7d88e1df68f4.png)

# Checklist:

( * == Mandatory ) 


- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
