### PR TITLE
Clean drop and drag styling

### DIFF
--- a/projects/back-office/src/app/application/pages/workflow/workflow.component.scss
+++ b/projects/back-office/src/app/application/pages/workflow/workflow.component.scss
@@ -1,12 +1,3 @@
-.cdk-drag-preview {
-  background-color: rgba(0, 0, 0, 0.2);
-  border-radius: 0;
-}
-
-.cdk-drag-animating {
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
-
 .step-list.cdk-drop-list-dragging .step-box:not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }

--- a/projects/back-office/src/app/application/pages/workflow/workflow.component.scss
+++ b/projects/back-office/src/app/application/pages/workflow/workflow.component.scss
@@ -1,3 +1,0 @@
-.step-list.cdk-drop-list-dragging .step-box:not(.cdk-drag-placeholder) {
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}

--- a/projects/safe/src/lib/components/aggregation/aggregation-table/aggregation-table.component.html
+++ b/projects/safe/src/lib/components/aggregation/aggregation-table/aggregation-table.component.html
@@ -2,34 +2,33 @@
 <div class="overflow-x-hidden shadow-2lg" *ngIf="aggregations.length > 0">
   <!-- Table scroll container -->
   <div class="overflow-x-auto">
-    <table
-      mat-table
+    <mat-table
       [dataSource]="aggregations"
       cdkDropList
       (cdkDropListDropped)="drop($event)"
       [cdkDropListData]="aggregations"
     >
       <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef>
+        <mat-header-cell *matHeaderCellDef>
           {{ 'common.name' | translate }}
-        </th>
-        <td mat-cell *matCellDef="let element" class="font-bold">
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element" class="font-bold">
           {{ element.name }}
-        </td>
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="createdAt">
-        <th mat-header-cell *matHeaderCellDef>
+        <mat-header-cell *matHeaderCellDef>
           {{ 'common.createdOn' | translate }}
-        </th>
-        <td mat-cell *matCellDef="let element">
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element">
           {{ element.createdAt | safeDate }}
-        </td>
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="_actions" [stickyEnd]="true">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let element">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let element">
           <safe-button
             [isIcon]="true"
             icon="more_vert"
@@ -47,17 +46,16 @@
               {{ 'common.delete' | translate }}
             </button>
           </mat-menu>
-        </td>
+        </mat-cell>
       </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="columns"></tr>
-      <tr
-        mat-row
+      <mat-header-row *matHeaderRowDef="columns"></mat-header-row>
+      <mat-row
         *matRowDef="let row; columns: columns"
         cdkDrag
         [cdkDragData]="row"
-      ></tr>
-    </table>
+      ></mat-row>
+    </mat-table>
   </div>
 </div>
 <div class="flex mt-4 justify-center">

--- a/projects/safe/src/lib/components/aggregation/aggregation-table/aggregation-table.component.scss
+++ b/projects/safe/src/lib/components/aggregation/aggregation-table/aggregation-table.component.scss
@@ -1,6 +1,1 @@
-.cdk-drag-preview {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background-color: white;
-}
+

--- a/projects/safe/src/lib/components/grid-layout/layout-table/layout-table.component.html
+++ b/projects/safe/src/lib/components/grid-layout/layout-table/layout-table.component.html
@@ -2,34 +2,33 @@
 <div class="overflow-x-hidden shadow-2lg" *ngIf="layouts.length > 0">
   <!-- Table scroll container -->
   <div class="overflow-x-auto">
-    <table
-      mat-table
+    <mat-table
       [dataSource]="layouts"
       cdkDropList
       (cdkDropListDropped)="drop($event)"
       [cdkDropListData]="layouts"
     >
       <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef>
+        <mat-header-cell *matHeaderCellDef>
           {{ 'common.name' | translate }}
-        </th>
-        <td mat-cell *matCellDef="let element" class="font-bold">
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element" class="font-bold">
           {{ element.name }}
-        </td>
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="createdAt">
-        <th mat-header-cell *matHeaderCellDef>
+        <mat-header-cell *matHeaderCellDef>
           {{ 'common.createdOn' | translate }}
-        </th>
-        <td mat-cell *matCellDef="let element">
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element">
           {{ element.createdAt | safeDate }}
-        </td>
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="_actions" [stickyEnd]="true">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let element">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let element">
           <safe-button
             [isIcon]="true"
             icon="more_vert"
@@ -47,17 +46,16 @@
               {{ 'common.delete' | translate }}
             </button>
           </mat-menu>
-        </td>
+        </mat-cell>
       </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="columns"></tr>
-      <tr
-        mat-row
+      <mat-header-row *matHeaderRowDef="columns"></mat-header-row>
+      <mat-row
         *matRowDef="let row; columns: columns"
         cdkDrag
         [cdkDragData]="row"
-      ></tr>
-    </table>
+      ></mat-row>
+    </mat-table>
   </div>
 </div>
 <div class="flex justify-center mt-4">

--- a/projects/safe/src/lib/components/grid-layout/layout-table/layout-table.component.scss
+++ b/projects/safe/src/lib/components/grid-layout/layout-table/layout-table.component.scss
@@ -1,6 +1,0 @@
-.cdk-drag-preview {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background-color: white;
-}

--- a/projects/safe/src/lib/components/layout/layout.component.scss
+++ b/projects/safe/src/lib/components/layout/layout.component.scss
@@ -51,14 +51,6 @@
   }
 }
 
-.cdk-drag-placeholder {
-  opacity: 0;
-}
-
-.cdk-drag-animating {
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
-
 .notification-menu {
   display: flex;
   align-items: flex-end;

--- a/projects/safe/src/lib/components/left-sidenav/left-sidenav.component.html
+++ b/projects/safe/src/lib/components/left-sidenav/left-sidenav.component.html
@@ -74,18 +74,15 @@
               </button>
             </div>
           </mat-list-item>
-          <mat-list *cdkDragPreview>
-            <a
-              mat-list-item
-              class="nav-item"
-              [class]="item.class ? item.class : ''"
-            >
+          <!-- Preview when dragging element -->
+          <mat-list-item *cdkDragPreview class="nav-item">
+            <a [class]="item.class ? item.class : ''">
               <mat-icon mat-list-icon class="nav-icon">
                 {{ item.icon }}
               </mat-icon>
               <div mat-line>{{ item.name }}</div>
             </a>
-          </mat-list>
+          </mat-list-item>
         </div>
       </ng-container>
     </div>

--- a/projects/safe/src/lib/components/left-sidenav/left-sidenav.component.scss
+++ b/projects/safe/src/lib/components/left-sidenav/left-sidenav.component.scss
@@ -53,10 +53,6 @@
   }
 }
 
-.nav-items-list.cdk-drop-list-dragging .nav-item:not(.cdk-drag-placeholder) {
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
-
 .nav-item-handle {
   cursor: move;
 }

--- a/projects/safe/src/lib/components/left-sidenav/left-sidenav.component.scss
+++ b/projects/safe/src/lib/components/left-sidenav/left-sidenav.component.scss
@@ -53,14 +53,6 @@
   }
 }
 
-.cdk-drag-placeholder {
-  opacity: 0;
-}
-
-.cdk-drag-animating {
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
-
 .nav-items-list.cdk-drop-list-dragging .nav-item:not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }

--- a/projects/safe/src/lib/components/palette-control/palette-control.component.scss
+++ b/projects/safe/src/lib/components/palette-control/palette-control.component.scss
@@ -1,11 +1,3 @@
 :host {
   display: block;
-
-  .cdk-drag-placeholder {
-    opacity: 0;
-  }
-
-  .cdk-drag-animating {
-    transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-  }
 }

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
@@ -91,7 +91,8 @@
             "
             cdkDrag
           >
-            <div>
+            <!-- Field name and errors -->
+            <div class="flex items-center">
               <span>{{ field.name }}</span>
               <safe-button
                 [isIcon]="true"
@@ -113,6 +114,7 @@
               >
               </safe-button>
             </div>
+            <!-- Field type -->
             <div *ngIf="field.type" class="flex items-center">
               <span
                 class="text-gray-500"

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.scss
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.scss
@@ -23,14 +23,6 @@
   font-size: 14px;
 }
 
-.cdk-drag-placeholder {
-  opacity: 0;
-}
-
-.cdk-drag-animating {
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
-
 .field-box:last-child {
   border: none;
 }

--- a/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.scss
+++ b/projects/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.scss
@@ -27,10 +27,6 @@
   border: none;
 }
 
-.field-list.cdk-drop-list-dragging .field-box:not(.cdk-drag-placeholder) {
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
-
 .floating-info {
   position: absolute;
   bottom: 52px;

--- a/projects/safe/src/lib/components/query-builder/tab-style/query-style-list/query-style-list.component.html
+++ b/projects/safe/src/lib/components/query-builder/tab-style/query-style-list/query-style-list.component.html
@@ -2,36 +2,35 @@
 <div class="overflow-x-hidden shadow-2lg">
   <!-- Table scroll container -->
   <div class="overflow-x-auto">
-    <table
-      mat-table
+    <mat-table
       [dataSource]="styles"
       cdkDropList
       (cdkDropListDropped)="drop($event)"
       [cdkDropListData]="styles"
     >
       <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef>
+        <mat-header-cell *matHeaderCellDef>
           {{ 'common.name' | translate }}
-        </th>
-        <td mat-cell *matCellDef="let element" class="font-bold">
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element" class="font-bold">
           {{ element.name }}
-        </td>
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="preview">
-        <th mat-header-cell *matHeaderCellDef>
+        <mat-header-cell *matHeaderCellDef>
           {{ 'common.preview' | translate }}
-        </th>
-        <td mat-cell *matCellDef="let element">
+        </mat-header-cell>
+        <mat-cell *matCellDef="let element">
           <safe-query-style-preview
             [style]="element"
           ></safe-query-style-preview>
-        </td>
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="_actions" [stickyEnd]="true">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let element; let i = index">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let element; let i = index">
           <safe-button
             [isIcon]="true"
             icon="more_vert"
@@ -49,16 +48,15 @@
               {{ 'common.delete' | translate }}
             </button>
           </mat-menu>
-        </td>
+        </mat-cell>
       </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="columns"></tr>
-      <tr
-        mat-row
+      <mat-header-row *matHeaderRowDef="columns"></mat-header-row>
+      <mat-row
         *matRowDef="let row; columns: columns"
         cdkDrag
         [cdkDragData]="row"
-      ></tr>
-    </table>
+      ></mat-row>
+    </mat-table>
   </div>
 </div>

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -703,9 +703,18 @@ mat-tab-group[vertical] {
 // Allow to use @apply in not visible by default elements
 @layer components {
   .cdk-drag-preview {
-    @apply box-border rounded shadow-xl;
+    @apply box-border rounded shadow-xl bg-white flex items-center justify-between;
     // previous shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12),
   }
+}
+
+//drag and drop
+.cdk-drag-animating{
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0;
 }
 
 // Define new colors

--- a/projects/safe/src/lib/style/styles.scss
+++ b/projects/safe/src/lib/style/styles.scss
@@ -364,6 +364,11 @@ $safe-theme: mat.define-light-theme(
   background: mat.get-color-from-palette($safe-warn) !important;
 }
 
+// Mat table
+mat-header-row {
+  border-bottom: none !important;
+}
+
 .mat-header-cell {
   border-bottom: 1px solid #d8d8d8 !important;
   color: #767373;
@@ -410,7 +415,7 @@ $safe-theme: mat.define-light-theme(
 
 .mat-column-_actions,
 .mat-column-actions {
-  width: 64px;
+  max-width: 64px;
 }
 
 .mat-chip {
@@ -702,19 +707,24 @@ mat-tab-group[vertical] {
 /* === Tailwindcss === */
 // Allow to use @apply in not visible by default elements
 @layer components {
+  // Drag & Drop
   .cdk-drag-preview {
-    @apply box-border rounded shadow-xl bg-white flex items-center justify-between;
-    // previous shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12),
+    @apply box-border rounded shadow-xl flex items-center justify-between bg-white;
   }
-}
 
-//drag and drop
-.cdk-drag-animating{
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
+  .cdk-drag-animating {
+    @apply transition-transform;
+  }
 
-.cdk-drag-placeholder {
-  opacity: 0;
+  .cdk-drag-placeholder {
+    @apply opacity-0;
+  }
+
+  .cdk-drop-list-dragging {
+    .cdk-drag:not(.cdk-drag-placeholder) {
+      @apply transition-transform;
+    }
+  }
 }
 
 // Define new colors


### PR DESCRIPTION
# Description

Removed multiple places that styled the classes cdk-drag-preview, cdk-drag-animating, cdk-drag-placeholder and put just one main style in styles.scss

## Type of change

-  [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
It has been tested by checking the functionality of css classes.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
