### PR TITLE
feat/AB#11698_date-expression-grid-filters

### DIFF
--- a/projects/safe/src/lib/components/ui/core-grid/date-filter/date-filter.component.html
+++ b/projects/safe/src/lib/components/ui/core-grid/date-filter/date-filter.component.html
@@ -1,0 +1,85 @@
+<ng-container *ngIf="form">
+  <div class="k-form" [formGroup]="form">
+    <!-- First Date -->
+    <ng-container [formGroup]="$any(filters.at(0))">
+      <kendo-dropdownlist
+        [data]="operatorsList"
+        [valuePrimitive]="true"
+        textField="text"
+        valueField="value"
+        formControlName="operator">
+      </kendo-dropdownlist>
+  
+      <div class="flex">
+        <kendo-textbox
+          *ngIf="firstDateMode === 'expression'"
+          [style.width.px]="300"
+          [clearButton]="true"
+          formControlName="value"
+        ></kendo-textbox>
+        <kendo-datepicker
+          *ngIf="firstDateMode === 'date'"
+          formControlName="value"
+        ></kendo-datepicker>
+    
+        <button
+          kendoButton
+          icon="refresh"
+          [title]="
+            (firstDateMode === 'expression'
+              ? 'components.queryBuilder.tooltip.filter.date.usePicker'
+              : 'components.queryBuilder.tooltip.filter.date.useExpression'
+            ) | translate
+          "
+          (click)="firstDateMode = firstDateMode === 'expression' ? 'date' : 'expression'"
+        ></button>
+      </div>
+    </ng-container>
+
+    <kendo-dropdownlist
+      formControlName="logic"
+      [data]="logics"
+      [valuePrimitive]="true"
+      textField="text"
+      valueField="value"
+      class="k-filter-and"
+    ></kendo-dropdownlist>
+
+    <!-- Second Date -->
+    <ng-container [formGroup]="$any(filters.at(1))">
+      <kendo-dropdownlist
+        [data]="operatorsList"
+        [valuePrimitive]="true"
+        textField="text"
+        valueField="value"
+        formControlName="operator">
+      </kendo-dropdownlist>
+  
+      <div class="flex">
+        <kendo-textbox
+          *ngIf="secondDateMode === 'expression'"
+          [style.width.px]="300"
+          [clearButton]="true"
+          formControlName="value"
+        ></kendo-textbox>
+        <kendo-datepicker
+          *ngIf="secondDateMode === 'date'"
+          formControlName="value"
+        ></kendo-datepicker>
+  
+        <button
+          kendoButton
+          icon="refresh"
+          [title]="
+            (secondDateMode === 'expression'
+              ? 'components.queryBuilder.tooltip.filter.date.usePicker'
+              : 'components.queryBuilder.tooltip.filter.date.useExpression'
+            ) | translate
+          "
+          (click)="secondDateMode = secondDateMode === 'expression' ? 'date' : 'expression'"
+        ></button>
+      </div>
+    </ng-container>
+
+  </div>
+</ng-container>

--- a/projects/safe/src/lib/components/ui/core-grid/date-filter/date-filter.component.spec.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/date-filter/date-filter.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SafeDateFilterComponent } from './date-filter.component';
+
+describe('SafeDateFilterComponent', () => {
+  let component: SafeDateFilterComponent;
+  let fixture: ComponentFixture<SafeDateFilterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SafeDateFilterComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SafeDateFilterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/safe/src/lib/components/ui/core-grid/date-filter/date-filter.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/date-filter/date-filter.component.ts
@@ -1,0 +1,110 @@
+import { Component, Input, OnInit } from '@angular/core';
+import {
+  UntypedFormArray,
+  UntypedFormBuilder,
+  UntypedFormGroup,
+} from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { FilterService } from '@progress/kendo-angular-grid';
+import { FIELD_TYPES, FILTER_OPERATORS } from '../../../filter/filter.const';
+
+/**
+ * Date Filter Component allows to use expressions or to select a date.
+ */
+@Component({
+  selector: 'safe-date-filter',
+  templateUrl: './date-filter.component.html',
+  styleUrls: ['./date-filter.component.scss'],
+})
+export class SafeDateFilterComponent implements OnInit {
+  @Input() public field = '';
+  @Input() public filter: any;
+  @Input() public valueField = '';
+  @Input() public filterService?: FilterService;
+
+  public form?: UntypedFormGroup;
+  public firstDateMode = 'expression';
+  public secondDateMode = 'date';
+
+  public operatorsList: any[] = [];
+  public logics = [
+    {
+      text: this.translate.instant('kendo.grid.filterOrLogic'),
+      value: 'or',
+    },
+    {
+      text: this.translate.instant('kendo.grid.filterAndLogic'),
+      value: 'and',
+    },
+  ];
+
+  /** @returns The filters */
+  public get filters(): UntypedFormArray {
+    return this.form?.get('filters') as UntypedFormArray;
+  }
+
+  /**
+   * Constructor for date filter component
+   *
+   * @param formBuilder This is the service used to build forms.
+   * @param translate The translation service
+   */
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    public translate: TranslateService
+  ) {
+    const type = FIELD_TYPES.find((x) => x.editor === 'datetime');
+    this.operatorsList = FILTER_OPERATORS.filter((x) =>
+      type?.operators?.includes(x.value)
+    );
+    this.operatorsList.forEach((o) => {
+      o.text = this.translate.instant(o.label);
+    });
+  }
+
+  ngOnInit(): void {
+    this.form = this.formBuilder.group({
+      logic: this.filter.logic,
+      filters: this.formBuilder.array([
+        this.formBuilder.group({
+          field: this.field,
+          operator: this.filter.filters[0]
+            ? this.filter.filters[0].operator
+            : 'eq',
+          value: this.formBuilder.control(
+            this.filter.filters[0] ? this.filter.filters[0].value : ''
+          ),
+        }),
+        this.formBuilder.group({
+          field: this.field,
+          operator: this.filter.filters[1]
+            ? this.filter.filters[1].operator
+            : 'eq',
+          value: this.formBuilder.control(
+            this.filter.filters[1] ? this.filter.filters[1].value : ''
+          ),
+        }),
+      ]),
+    });
+
+    this.translate.onLangChange.subscribe(() => {
+      this.logics = [
+        {
+          text: this.translate.instant('kendo.grid.filterEqOperator'),
+          value: 'eq',
+        },
+        {
+          text: this.translate.instant('kendo.grid.filterNotEqOperator'),
+          value: 'neq',
+        },
+      ];
+      this.operatorsList.forEach((o) => {
+        o.text = this.translate.instant(o.text);
+      });
+    });
+
+    this.form.valueChanges.subscribe((value) => {
+      this.filterService?.filter(value);
+    });
+  }
+}

--- a/projects/safe/src/lib/components/ui/core-grid/date-filter/date-filter.module.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/date-filter/date-filter.module.ts
@@ -1,0 +1,28 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ButtonModule } from '@progress/kendo-angular-buttons';
+import { ButtonsModule } from '@progress/kendo-angular-buttons';
+import { TranslateModule } from '@ngx-translate/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SafeDateFilterComponent } from './date-filter.component';
+import { DropDownsModule } from '@progress/kendo-angular-dropdowns';
+import { DateInputsModule } from '@progress/kendo-angular-dateinputs';
+import { InputsModule } from '@progress/kendo-angular-inputs';
+
+/** DateFilterComponent module. */
+@NgModule({
+  declarations: [SafeDateFilterComponent],
+  imports: [
+    CommonModule,
+    ButtonModule,
+    ButtonsModule,
+    TranslateModule,
+    FormsModule,
+    ReactiveFormsModule,
+    DropDownsModule,
+    InputsModule,
+    DateInputsModule,
+  ],
+  exports: [SafeDateFilterComponent],
+})
+export class SafeDateFilterModule {}

--- a/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -130,6 +130,25 @@
       >
         <!-- FILTER -->
         <ng-container *ngIf="field.meta">
+          <!-- FILTER ( datetime / date ) -->
+          <ng-container
+            *ngIf="['datetime', 'date'].includes(field.meta.type)"
+          >
+            <ng-template
+              kendoGridFilterMenuTemplate
+              let-filter
+              let-column="column"
+              let-filterService="filterService"
+              >
+              <safe-date-filter
+                [filter]="filter"
+                [field]="field.name"
+                [filterService]="filterService"
+                valueField="value"
+              >
+              </safe-date-filter>
+            </ng-template>
+          </ng-container>
           <!-- FILTER ( dropdown / radiogroup ) -->
           <ng-container
             *ngIf="['dropdown', 'radiogroup'].includes(field.meta.type)"

--- a/projects/safe/src/lib/components/ui/core-grid/grid/grid.module.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/grid/grid.module.ts
@@ -7,6 +7,7 @@ import { SafeArrayFilterModule } from '../array-filter/array-filter.module';
 import { SafeArrayFilterMenuModule } from '../array-filter-menu/array-filter-menu.module';
 import { SafeDropdownFilterModule } from '../dropdown-filter/dropdown-filter.module';
 import { SafeDropdownFilterMenuModule } from '../dropdown-filter-menu/dropdown-filter-menu.module';
+import { SafeDateFilterModule } from '../date-filter/date-filter.module';
 import { SafeExpandedCommentModule } from '../expanded-comment/expanded-comment.module';
 import { SafeErrorsModalModule } from '../errors-modal/errors-modal.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -50,6 +51,7 @@ import { SafeButtonModule } from '../../button/button.module';
     SafeArrayFilterMenuModule,
     SafeDropdownFilterModule,
     SafeDropdownFilterMenuModule,
+    SafeDateFilterModule,
     // === ROW ===
     SafeGridRowActionsModule,
     // === TOOLBAR ===


### PR DESCRIPTION
# Description
Updated `SafeGridComponent`: changed the default kendo filter for fields with  date or datetime type and created a custom filter (`SafeDateFilterComponent`) that allows using expressions (such as `{{today}}`) or the date picker 

## Type of change
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Changing the filter of date fields on the table in the Grids Widget.

## Sreenshots
![filter1](https://user-images.githubusercontent.com/28535394/218852405-1fcb9d1f-b7fb-471b-987d-c95cd481e6a8.gif)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
