### PR TITLE
fix/AB#56185_application-users-table

### DIFF
--- a/projects/safe/src/lib/views/application-users/components/user-list/user-list.component.html
+++ b/projects/safe/src/lib/views/application-users/components/user-list/user-list.component.html
@@ -106,7 +106,7 @@
           >
           </safe-button>
           <mat-menu #menu="matMenu">
-            <button mat-menu-item>
+            <button mat-menu-item (click)="onDelete([element])">
               <mat-icon>delete</mat-icon>
               {{ 'common.delete' | translate }}
             </button>


### PR DESCRIPTION
# Description
Subtask [AB#56186 Cannot use the delete button on a user row](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/56186)

The delete button at the end of the row in the applications users table wasn't assigned to any function, that's why it didn't do anything.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Deleting users in the application user page table using the button at the end of the row.

## Sreenshots
![delete](https://user-images.githubusercontent.com/28535394/219385991-d623d127-f44a-490c-81da-443209bf56be.gif)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
