### PR TITLE
Fix/ab#56907 map layers groups can now check uncheck their children

### DIFF
--- a/projects/safe/src/lib/components/ui/map/map.component.ts
+++ b/projects/safe/src/lib/components/ui/map/map.component.ts
@@ -20,7 +20,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { takeUntil } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 import {
-  BaseLayerTree,
+  OverlayLayerTree,
   LayerActionOnMap,
 } from './interfaces/map-layers.interface';
 import {
@@ -488,7 +488,7 @@ export class SafeMapComponent
     const parseTreeNode = (
       layer: Layer,
       leafletLayer?: L.Layer
-    ): BaseLayerTree => {
+    ): OverlayLayerTree => {
       // Add to the layers array
       this.layers.push(layer);
 
@@ -502,14 +502,23 @@ export class SafeMapComponent
       if (!this.map.hasLayer(featureLayer)) this.map.addLayer(featureLayer);
 
       const children = layer.getChildren();
-      return {
-        label: layer.name,
-        layer: featureLayer,
-        children:
-          children.length > 0
-            ? children.map((c) => parseTreeNode(c.object, c.layer))
-            : undefined,
-      };
+      if (layer.type === 'group') {
+        // It is a group, it should not have any layer but it should be able to check/uncheck its children
+        return {
+          label: layer.name,
+          selectAllCheckbox: true,
+          children:
+            children.length > 0
+              ? children.map((c) => parseTreeNode(c.object, c.layer))
+              : undefined,
+        };
+      } else {
+        // It is a node, it does not have any children but it displays a layer
+        return {
+          label: layer.name,
+          layer: featureLayer,
+        };
+      }
     };
 
     const layers = [new Layer(MOCK_LAYER_SETTINGS)];


### PR DESCRIPTION
# Description

In maps, when you would create a layers group, it could not check/uncheck its children. I fixed it by changing the parseTreeNode function. It now returns an OverlayLayerTree instead of a BaseLayerTree. This allows to take into account the 'selectAllCheckbox' parameter.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Pull related branch, an example layers tree already exists (thanks Matheus). When clicking on 'test group', it should check/uncheck all its children.

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
