### PR TITLE
fix/AB#56991_api-configuration-fix

### DIFF
--- a/projects/back-office/src/app/dashboard/pages/api-configuration/api-configuration.component.html
+++ b/projects/back-office/src/app/dashboard/pages/api-configuration/api-configuration.component.html
@@ -73,16 +73,28 @@
       <h2>
         {{ 'pages.apiConfiguration.host' | translate }}
       </h2>
-      <!-- Send ping request -->
-      <safe-button
-        icon="online_prediction"
-        category="secondary"
-        variant="primary"
-        (click)="onPing()"
-        [disabled]="!apiForm.value.pingUrl || !apiForm.value.endpoint"
-      >
-        {{ 'pages.apiConfiguration.ping' | translate }}
-      </safe-button>
+      <div class="flex flex-wrap gap-2 justify-end">
+        <!-- Send ping request using saved settings-->
+        <safe-button
+          icon="online_prediction"
+          category="secondary"
+          variant="primary"
+          (click)="onPing('saved')"
+          [disabled]="!apiForm.value.pingUrl || !apiForm.value.endpoint"
+        >
+          {{ 'pages.apiConfiguration.ping' | translate: { type: 'pages.apiConfiguration.saved' | translate } }}
+        </safe-button>
+        <!-- Send ping request using unsaved settings-->
+        <safe-button
+          icon="online_prediction"
+          category="secondary"
+          variant="primary"
+          (click)="onPing('unsaved')"
+          [disabled]="!apiForm.value.pingUrl || !apiForm.value.endpoint || !apiForm.dirty"
+        >
+          {{ 'pages.apiConfiguration.ping' | translate: { type: '' } }}
+        </safe-button>
+      </div>
     </div>
     <div class="flex gap-x-2">
       <!-- Endpoint -->

--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -1603,7 +1603,7 @@
 				"pingFailed": "Ping request failed.",
 				"pingReceived": "Received positive response from ping request."
 			},
-			"ping": "Try settings",
+			"ping": "Try {{type}} settings",
 			"pingUrl": "Ping extension",
 			"placeholder": {
 				"baseUrl": "Base URL for the API",
@@ -1615,6 +1615,7 @@
 				"token": "Enter token for authentication",
 				"tokenUrl": "Enter access token URL"
 			},
+			"saved": "saved",
 			"scope": "Scope",
 			"secret": "Client Secret",
 			"token": "Token",

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -1611,7 +1611,7 @@
 				"pingFailed": "La requête ping a échoué.",
 				"pingReceived": "La requête ping a reçu une réponse positive."
 			},
-			"ping": "Essayer avec ces paramètres",
+			"ping": "Essayer avec ces {{type}} paramètres",
 			"pingUrl": "Extension ping",
 			"placeholder": {
 				"baseUrl": "URL de base pour l'API",
@@ -1623,6 +1623,7 @@
 				"token": "Entrez le jeton d'accès pour l'authentification",
 				"tokenUrl": "Entrez l'URL du jeton d'accès"
 			},
+			"saved": "sauvegardés",
 			"scope": "Scope",
 			"secret": "Client Secret",
 			"token": "Jeton d'accès",

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -1603,7 +1603,7 @@
 				"pingFailed": "******",
 				"pingReceived": "******"
 			},
-			"ping": "******",
+			"ping": "****** {{type}} ******",
 			"pingUrl": "******",
 			"placeholder": {
 				"baseUrl": "******",
@@ -1615,6 +1615,7 @@
 				"token": "******",
 				"tokenUrl": "******"
 			},
+			"saved": "******",
 			"scope": "******",
 			"secret": "******",
 			"token": "******",

--- a/projects/safe/src/lib/services/api-proxy/api-proxy.service.ts
+++ b/projects/safe/src/lib/services/api-proxy/api-proxy.service.ts
@@ -40,14 +40,23 @@ export class SafeApiProxyService {
    *
    * @param name - The name of the API
    * @param pingUrl - The url to ping
+   * @param body - Optional: The body to the POST request
    * @returns An observable with results of the request, or null if name is
    * undefined or empty
    */
-  public buildPingRequest(name: string | undefined, pingUrl: string): any {
+  public buildPingRequest(
+    name: string | undefined,
+    pingUrl: string,
+    body?: any
+  ): any {
     if (name) {
-      const url = `${this.baseUrl}${name}${pingUrl}`;
+      const url = this.buildPingUrl(name, pingUrl);
       const headers = this.buildHeaders();
-      return this.restService.get(url, { headers });
+      if (body) {
+        return this.restService.post(this.baseUrl, body, { headers });
+      } else {
+        return this.restService.get(url, { headers });
+      }
     }
     return null;
   }
@@ -80,5 +89,19 @@ export class SafeApiProxyService {
     return firstValueFrom(
       this.restService.post(url, body, { ...options, headers })
     );
+  }
+
+  /**
+   * Builds the ping url to call the backend
+   *
+   * @param {string} apiConfigName name of the Api Configuration
+   * @param {string} pingUrl ping extension url
+   * @returns string ping url
+   */
+  private buildPingUrl(apiConfigName: string, pingUrl: string): string {
+    if (!apiConfigName.endsWith('/') && !pingUrl.startsWith('/')) {
+      apiConfigName = apiConfigName + '/';
+    }
+    return `${this.baseUrl}${apiConfigName}${pingUrl}`;
   }
 }


### PR DESCRIPTION
# Description
Is no more necessary to add a ''/"  to the end of the url or start of the ping. The backend already handles this, but the problem was when building the url in the front-end to call the backend endpoint.

Test the ping if the API configuration is not saved now works: previously, the backend only worked using the API configurations saved in the db. The router endpoint was divided to handle the GETs and POSTs request: the old way is the GET request, and a POST was created to send the API configurations not saved in the body of the request

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Calling the proxy router with GETs and POSTs requests.

## Sreenshots
![api1](https://user-images.githubusercontent.com/28535394/221019488-14694b5d-eda9-4ad0-93aa-99eca5d1d680.gif)
![api2](https://user-images.githubusercontent.com/28535394/221019499-48237054-673e-4dc6-b5ca-63401b2a2fa4.gif)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
