### PR TITLE
feat/AB#57440_remove-records-questions-resources-grid

### DIFF
--- a/projects/safe/src/i18n/en.json
+++ b/projects/safe/src/i18n/en.json
@@ -1123,6 +1123,7 @@
 						"delete": "Delete records",
 						"export": "Export records",
 						"inline": "Inline edition",
+						"remove": "Remove",
 						"show": "Show history",
 						"showDetails": "Show record details",
 						"title": "Enabled actions",
@@ -1180,6 +1181,7 @@
 							"delete": "If authorized, user can delete visible records",
 							"export": "User can export selected columns of visible records",
 							"inline": "If authorized, user can edit records in the grid",
+							"remove": "Remove (not deleting) the selected records",
 							"show": "User can see full history of visible records",
 							"showDetails": "User can see full details of visible records",
 							"update": "If authorized, user can update visible records"

--- a/projects/safe/src/i18n/fr.json
+++ b/projects/safe/src/i18n/fr.json
@@ -1130,6 +1130,7 @@
 						"delete": "Supprimer les enregistrements",
 						"export": "Exporter les enregistrements",
 						"inline": "Modifier par ligne",
+						"remove": "Retirer",
 						"show": "Voir l'historique",
 						"showDetails": "Afficher les détails des enregistrements",
 						"title": "Actions activées",
@@ -1187,6 +1188,7 @@
 							"delete": "L'utilisateur peut supprimer les enregistrements affichés, s'il en a la permission",
 							"export": "L'utilisateur peut exporter les enregistrements affichés",
 							"inline": "L'utilisateur peut éditer dans la grille les enregistrements affichés, s'il en a la permission",
+							"remove": "Retirer (sans exclure) les enregistrements affichés",
 							"show": "L'utilisateur peut afficher l'historique complet des enregistrements affichés",
 							"showDetails": "L'utilisateur peut afficher les informations des enregistrements affichés",
 							"update": "L'utilisateur peut mettre à jour les enregistrements affichés"

--- a/projects/safe/src/i18n/test.json
+++ b/projects/safe/src/i18n/test.json
@@ -1123,6 +1123,7 @@
 						"delete": "******",
 						"export": "******",
 						"inline": "******",
+						"remove": "******",
 						"show": "******",
 						"showDetails": "******",
 						"title": "******",
@@ -1180,6 +1181,7 @@
 							"delete": "******",
 							"export": "******",
 							"inline": "******",
+							"remove": "******",
 							"show": "******",
 							"showDetails": "******",
 							"update": "******"

--- a/projects/safe/src/lib/components/choose-record-modal/choose-record-modal.component.ts
+++ b/projects/safe/src/lib/components/choose-record-modal/choose-record-modal.component.ts
@@ -145,6 +145,7 @@ export class SafeChooseRecordModalComponent
         convert: false,
         update: false,
         inlineEdition: false,
+        remove: false,
       },
     };
   }

--- a/projects/safe/src/lib/components/query-builder/tab-layout-preview/tab-layout-preview.component.ts
+++ b/projects/safe/src/lib/components/query-builder/tab-layout-preview/tab-layout-preview.component.ts
@@ -17,6 +17,7 @@ const DEFAULT_GRID_SETTINGS = {
     convert: false,
     update: false,
     inlineEdition: false,
+    remove: false,
   },
 };
 

--- a/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.ts
+++ b/projects/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.ts
@@ -65,6 +65,7 @@ export class SafeResourceGridModalComponent implements OnInit {
         convert: false,
         update: false,
         inlineEdition: false,
+        remove: false,
       },
     };
     this.ref.tick();

--- a/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -259,6 +259,7 @@ export class SafeCoreGridComponent
     convert: false,
     export: this.showExport,
     showDetails: true,
+    remove: false,
   };
 
   public editable = false;
@@ -332,6 +333,7 @@ export class SafeCoreGridComponent
       convert: get(this.settings, 'actions.convert', false),
       export: get(this.settings, 'actions.export', false),
       showDetails: get(this.settings, 'actions.showDetails', true),
+      remove: get(this.settings, 'actions.remove', false),
     };
     this.editable = this.settings.actions?.inlineEdition;
     // this.selectableSettings = { ...this.selectableSettings, mode: this.multiSelect ? 'multiple' : 'single' };
@@ -802,6 +804,15 @@ export class SafeCoreGridComponent
         }
         break;
       }
+      case 'remove': {
+        if (event.item) {
+          this.onRemoveRow([event.item]);
+        }
+        if (event.items && event.items.length > 0) {
+          this.onRemoveRow(event.items);
+        }
+        break;
+      }
       case 'resetLayout': {
         this.resetDefaultLayout();
         break;
@@ -1264,5 +1275,18 @@ export class SafeCoreGridComponent
    */
   resetDefaultLayout(): void {
     this.defaultLayoutReset.emit();
+  }
+
+  /**
+   * Remove (not deleting) the selected records from the grid
+   *
+   * @param items  items to remove
+   */
+  private onRemoveRow(items: any[]): void {
+    const selected: string[] = items.map((x) => x.id);
+    this.gridData.data = this.gridData.data.filter(
+      (x) => !selected.includes(x.id)
+    );
+    this.items = [...this.gridData.data];
   }
 }

--- a/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -156,6 +156,7 @@ export class SafeGridComponent implements OnInit, AfterViewInit, OnChanges {
     convert: false,
     export: false,
     showDetails: false,
+    remove: false,
   };
   @Input() hasDetails = true;
   @Output() action = new EventEmitter();

--- a/projects/safe/src/lib/components/ui/core-grid/models/grid-settings.model.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/models/grid-settings.model.ts
@@ -21,6 +21,7 @@ export interface GridSettings {
     convert?: boolean;
     update?: boolean;
     inlineEdition?: boolean;
+    remove?: boolean;
   };
   // showDetails?: boolean;
   // showExport?: boolean;

--- a/projects/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.html
+++ b/projects/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.html
@@ -39,4 +39,12 @@
   >
     {{ 'common.delete' | translate }}
   </button>
+  <button
+    *ngIf="actions.remove && item.canUpdate"
+    mat-menu-item
+    color="warn"
+    (click)="action.emit({ action: 'remove', item: item })"
+  >
+    {{ 'components.widget.settings.grid.actions.remove' | translate }}
+  </button>
 </mat-menu>

--- a/projects/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.ts
@@ -16,6 +16,7 @@ export class SafeGridRowActionsComponent implements OnInit {
     delete: false,
     history: false,
     convert: false,
+    remove: false,
   };
   @Output() action = new EventEmitter();
 
@@ -24,7 +25,8 @@ export class SafeGridRowActionsComponent implements OnInit {
     return (
       this.actions.history ||
       (this.item.canDelete && this.actions.delete) ||
-      (this.item.canUpdate && (this.actions.update || this.actions.convert))
+      (this.item.canUpdate &&
+        (this.actions.update || this.actions.convert || this.actions.remove))
     );
   }
 

--- a/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.component.html
+++ b/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.component.html
@@ -7,13 +7,21 @@
     kendoButton
     (click)="action.emit({ action: 'convert', items: items })"
   >
-    Convert
+    {{ 'models.record.convert' | translate }}
   </button>
   <button
     *ngIf="actions.delete && canDelete"
     kendoButton
     (click)="action.emit({ action: 'delete', items: items })"
   >
-    Delete
+    {{ 'common.delete' | translate }}
+  </button>
+
+  <button
+    *ngIf="actions.remove && canUpdate"
+    kendoButton
+    (click)="action.emit({ action: 'remove', items: items })"
+  >
+    {{ 'components.widget.settings.grid.actions.remove' | translate }}
   </button>
 </ng-container>

--- a/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.component.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.component.ts
@@ -20,6 +20,7 @@ export class SafeGridToolbarComponent implements OnInit {
     delete: false,
     history: false,
     convert: false,
+    remove: false,
   };
   @Output() action = new EventEmitter();
 

--- a/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.module.ts
+++ b/projects/safe/src/lib/components/ui/core-grid/toolbar/toolbar.module.ts
@@ -2,13 +2,14 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SafeGridToolbarComponent } from './toolbar.component';
 import { ButtonModule } from '@progress/kendo-angular-buttons';
+import { TranslateModule } from '@ngx-translate/core';
 
 /**
  * Module declaration for grid toolbar component
  */
 @NgModule({
   declarations: [SafeGridToolbarComponent],
-  imports: [CommonModule, ButtonModule],
+  imports: [CommonModule, ButtonModule, TranslateModule],
   exports: [SafeGridToolbarComponent],
 })
 export class SafeGridToolbarModule {}

--- a/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -123,6 +123,7 @@ export const createGridWidgetFormGroup = (
       addRecord: [get(configuration, 'actions.addRecord', false)],
       export: [get(configuration, 'actions.export', true)],
       showDetails: [get(configuration, 'actions.showDetails', true)],
+      remove: [get(configuration, 'actions.remove', true)],
     }),
     floatingButtons: fb.array(
       configuration.floatingButtons && configuration.floatingButtons.length

--- a/projects/safe/src/lib/components/widgets/grid-settings/tab-actions/tab-actions.component.ts
+++ b/projects/safe/src/lib/components/widgets/grid-settings/tab-actions/tab-actions.component.ts
@@ -53,5 +53,10 @@ export class TabActionsComponent {
       text: 'components.widget.settings.grid.actions.showDetails',
       tooltip: 'components.widget.settings.grid.hint.actions.showDetails',
     },
+    {
+      name: 'remove',
+      text: 'components.widget.settings.grid.actions.remove',
+      tooltip: 'components.widget.settings.grid.hint.actions.remove',
+    },
   ];
 }

--- a/projects/safe/src/lib/survey/components/resources.ts
+++ b/projects/safe/src/lib/survey/components/resources.ts
@@ -267,6 +267,20 @@ export const init = (
         visibleIndex: 3,
       });
       Survey.Serializer.addProperty('resources', {
+        name: 'remove:boolean',
+        displayName: 'Allow Remove Records',
+        category: 'Custom Questions',
+        dependsOn: ['resource', 'displayAsGrid'],
+        visibleIf: (obj: any) => {
+          if (!obj || !obj.resource || !obj.displayAsGrid) {
+            return false;
+          } else {
+            return true;
+          }
+        },
+        visibleIndex: 3,
+      });
+      Survey.Serializer.addProperty('resources', {
         name: 'addRecord:boolean',
         displayName: 'Add new records',
         category: 'Custom Questions',
@@ -878,6 +892,7 @@ export const init = (
           convert: question.convert,
           update: question.update,
           inlineEdition: question.inlineEdition,
+          remove: question.remove,
         },
       });
     }

--- a/projects/safe/src/lib/survey/types.ts
+++ b/projects/safe/src/lib/survey/types.ts
@@ -68,4 +68,5 @@ export interface QuestionResource
   staticValue: string;
   customFilter: string;
   displayAsGrid: boolean;
+  remove?: boolean;
 }


### PR DESCRIPTION
# Description
Added `remove` boolean option to resources question: if the "Display as grid" option is selected, the "Allow remove records" can be selected as well. This way, the remove option is available to resources questions but not to the regular grids by default.

Added "Remove" option resources questions displayed as a grid: 
- In the action menu at the end of the row
- As a button at the top right corner of the grid to bulk remove selected records

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Removing records of the grid without deleting them.

## Sreenshots
![remove2](https://user-images.githubusercontent.com/28535394/221300459-ddb91fa6-5108-4749-9637-e037b2691cfb.gif)
![remove](https://user-images.githubusercontent.com/28535394/221300464-6676ae0c-37d0-44e8-bb9a-29d77d66591f.gif)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
