### PR TITLE
feat/AB#57612_integrate-cron-scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "leaflet.markercluster": "^1.4.1",
     "localforage": "^1.10.0",
     "ng2-charts": "^4.1.1",
+    "ngx-cron-editor": "^0.7.6",
     "rxjs": "^7.8.0",
     "subscriptions-transport-ws": "^0.9.18",
     "survey-angular": "1.9.71",

--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/components/edit-pull-job-modal/edit-pull-job-modal.component.html
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/components/edit-pull-job-modal/edit-pull-job-modal.component.html
@@ -46,15 +46,6 @@
             </mat-select>
           </mat-form-field>
         </div>
-        <!-- Show readable value of the schedule -->
-        <safe-alert
-          *ngIf="formGroup.get('schedule')?.valid"
-          variant="primary"
-          class="mb-6"
-        >
-          <safe-icon icon="schedule"></safe-icon>
-          {{ formGroup.value.schedule | safeReadableCron }}
-        </safe-alert>
         <div class="flex gap-x-2 flex-wrap">
           <!-- Schedule -->
           <mat-form-field appearance="outline" class="flex-1">
@@ -65,13 +56,18 @@
                 'components.pullJob.modal.placeholder.schedule' | translate
               "
               matInput
-              formControlName="schedule"
+              readonly
+              value="{{ formGroup.get('schedule')?.invalid 
+                ? ('components.pullJob.modal.placeholder.schedule' | translate)
+                : (formGroup.value.schedule | safeReadableCron)
+              }}"
             />
             <safe-icon
-              icon="info"
+              icon="edit"
               class="cursor-pointer"
               variant="grey"
               matSuffix
+              (click)="onEditCronExpression()"
               [matTooltip]="
                 'components.pullJob.modal.hint.schedule' | translate
               "

--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/components/edit-pull-job-modal/edit-pull-job-modal.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/components/edit-pull-job-modal/edit-pull-job-modal.component.ts
@@ -8,6 +8,7 @@ import {
 import {
   MatLegacyDialogRef as MatDialogRef,
   MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
+  MatLegacyDialog as MatDialog,
 } from '@angular/material/legacy-dialog';
 import { MatLegacySelect as MatSelect } from '@angular/material/legacy-select';
 import {
@@ -19,6 +20,7 @@ import {
   status,
   authType,
   cronValidator,
+  SafeCronExpressionControlComponent,
 } from '@safe/builder';
 import { Apollo, QueryRef } from 'apollo-angular';
 import {
@@ -107,6 +109,7 @@ export class EditPullJobModalComponent implements OnInit {
    *
    * @param formBuilder Angular form builder
    * @param dialogRef Material dialog ref
+   * @param dialog Material dialog service
    * @param apollo Apollo service
    * @param data Modal injected data
    * @param data.channels list of available channels
@@ -115,6 +118,7 @@ export class EditPullJobModalComponent implements OnInit {
   constructor(
     private formBuilder: UntypedFormBuilder,
     public dialogRef: MatDialogRef<EditPullJobModalComponent>,
+    public dialog: MatDialog,
     private apollo: Apollo,
     @Inject(MAT_DIALOG_DATA)
     public data: {
@@ -424,5 +428,15 @@ export class EditPullJobModalComponent implements OnInit {
     this.applications.next(this.cachedApplications);
     this.applicationsPageInfo = data.applications.pageInfo;
     this.applicationsLoading = loading;
+  }
+
+  /** Opens the cron expression component modal */
+  public onEditCronExpression(): void {
+    this.dialog.open(SafeCronExpressionControlComponent, {
+      autoFocus: false,
+      data: {
+        form: this.formGroup.controls.schedule,
+      },
+    });
   }
 }

--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/components/edit-pull-job-modal/edit-pull-job-modal.module.ts
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/components/edit-pull-job-modal/edit-pull-job-modal.module.ts
@@ -4,7 +4,6 @@ import { EditPullJobModalComponent } from './edit-pull-job-modal.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import {
-  SafeAlertModule,
   SafeGraphQLSelectModule,
   SafeModalModule,
   SafeReadableCronModule,
@@ -29,7 +28,6 @@ import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy
     SafeModalModule,
     SafeGraphQLSelectModule,
     SafeReadableCronModule,
-    SafeAlertModule,
     MatTooltipModule,
     MatInputModule,
     MatSelectModule,

--- a/projects/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.component.ts
+++ b/projects/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.component.ts
@@ -386,8 +386,9 @@ export class PullJobsComponent
                         this.translate.instant(
                           'common.notifications.objectUpdated',
                           {
-                            type: this.translate.instant('common.pullJob.one')
-                              .toLowerCase,
+                            type: this.translate
+                              .instant('common.pullJob.one')
+                              .toLowerCase(),
                             value: value.name,
                           }
                         )

--- a/projects/safe/src/lib/components/cron-expression-control/cron-expression-control.component.html
+++ b/projects/safe/src/lib/components/cron-expression-control/cron-expression-control.component.html
@@ -1,0 +1,16 @@
+<safe-modal size="medium">
+    <cron-editor [formControl]="form" [options]="cronOptions"></cron-editor>
+    <!-- Show readable value of the schedule -->
+    <safe-alert *ngIf="form.valid" variant="primary" class="mb-6">
+        <safe-icon icon="schedule"></safe-icon>
+        {{ form.value | safeReadableCron }}
+    </safe-alert>
+    <!-- Modal actions -->
+    <div mat-dialog-actions align="end">
+        <safe-button mat-dialog-close>{{ 'common.close' | translate }}</safe-button>
+        <safe-button category="secondary" variant="primary" mat-dialog-close
+            [disabled]="!form.valid">
+            {{ 'common.save' | translate }}
+        </safe-button>
+    </div>
+</safe-modal>

--- a/projects/safe/src/lib/components/cron-expression-control/cron-expression-control.component.spec.ts
+++ b/projects/safe/src/lib/components/cron-expression-control/cron-expression-control.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SafeCronExpressionControlComponent } from './cron-expression-control.component';
+
+describe('SafeCronExpressionControlComponent', () => {
+  let component: SafeCronExpressionControlComponent;
+  let fixture: ComponentFixture<SafeCronExpressionControlComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SafeCronExpressionControlComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SafeCronExpressionControlComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/safe/src/lib/components/cron-expression-control/cron-expression-control.component.ts
+++ b/projects/safe/src/lib/components/cron-expression-control/cron-expression-control.component.ts
@@ -1,0 +1,108 @@
+import { Component, forwardRef, Inject, Provider } from '@angular/core';
+import {
+  ControlValueAccessor,
+  NG_VALUE_ACCESSOR,
+  UntypedFormControl,
+} from '@angular/forms';
+import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { CronOptions } from 'ngx-cron-editor';
+
+/**
+ * Control value accessor
+ */
+const CONTROL_VALUE_ACCESSOR: Provider = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => SafeCronExpressionControlComponent),
+  multi: true,
+};
+
+/**
+ * Cron expression form control
+ */
+@Component({
+  selector: 'safe-cron-expression-control',
+  templateUrl: './cron-expression-control.component.html',
+  styleUrls: ['./cron-expression-control.component.scss'],
+  providers: [CONTROL_VALUE_ACCESSOR],
+})
+export class SafeCronExpressionControlComponent
+  implements ControlValueAccessor
+{
+  public form: UntypedFormControl = new UntypedFormControl({});
+
+  public cronOptions: CronOptions = {
+    defaultTime: '00:00:00',
+    // Cron Tab Options
+    hideMinutesTab: false,
+    hideHourlyTab: false,
+    hideDailyTab: false,
+    hideWeeklyTab: false,
+    hideMonthlyTab: false,
+    hideYearlyTab: false,
+    hideAdvancedTab: true,
+    hideSpecificWeekDayTab: false,
+    hideSpecificMonthWeekTab: false,
+    // Time options
+    use24HourTime: true,
+    hideSeconds: false,
+    // standard or quartz
+    cronFlavor: 'standard',
+  };
+
+  private onTouched!: any;
+  private onChanged!: any;
+  public disabled = false;
+
+  /**
+   *  Cron expression form control
+   *
+   * @param data Injected dialog data
+   * @param data.form is the cron form control
+   */
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    public data: {
+      form: UntypedFormControl;
+    }
+  ) {
+    if (this.data) {
+      this.form = this.data.form;
+    }
+  }
+
+  /**
+   * Write new value
+   *
+   * @param value cron expression
+   */
+  writeValue(value: any): void {
+    this.form.setValue(value);
+  }
+
+  /**
+   * Register change of the control
+   *
+   * @param fn callback
+   */
+  registerOnChange(fn: any): void {
+    this.onChanged = fn;
+  }
+
+  /**
+   * Register touch event
+   *
+   * @param fn callback
+   */
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+
+  /**
+   * Set disabled state
+   *
+   * @param isDisabled is control disabled
+   */
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+}

--- a/projects/safe/src/lib/components/cron-expression-control/cron-expression-control.module.ts
+++ b/projects/safe/src/lib/components/cron-expression-control/cron-expression-control.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SafeCronExpressionControlComponent } from './cron-expression-control.component';
+import { CronEditorModule } from 'ngx-cron-editor';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SafeModalModule } from '../ui/modal/modal.module';
+import { SafeReadableCronModule } from '../../pipes/readable-cron/readable-cron.module';
+import { SafeAlertModule } from '../ui/alert/alert.module';
+
+/** Cron expression control module. */
+@NgModule({
+  declarations: [SafeCronExpressionControlComponent],
+  imports: [
+    CommonModule,
+    CronEditorModule,
+    SafeModalModule,
+    FormsModule,
+    ReactiveFormsModule,
+    SafeReadableCronModule,
+    SafeAlertModule,
+  ],
+})
+export class SafeCronExpressionControlModule {}

--- a/projects/safe/src/lib/components/cron-expression-control/public-api.ts
+++ b/projects/safe/src/lib/components/cron-expression-control/public-api.ts
@@ -1,0 +1,2 @@
+export * from './cron-expression-control.component';
+export * from './cron-expression-control.module';

--- a/projects/safe/src/lib/safe.module.ts
+++ b/projects/safe/src/lib/safe.module.ts
@@ -39,6 +39,7 @@ import { SafeLeftSidenavModule } from './components/left-sidenav/left-sidenav.mo
 import { SafeReadableCronModule } from './pipes/readable-cron/readable-cron.module';
 import { SafeCronParserModule } from './pipes/cron-parser/cron-parser.module';
 import { SafeUnsubscribeModule } from './components/utils/unsubscribe/unsubscribe.module';
+import { SafeCronExpressionControlModule } from './components/cron-expression-control/cron-expression-control.module';
 import { SafeViewsModule } from './views/views.module';
 
 /** Main module for the safe project */
@@ -72,6 +73,7 @@ import { SafeViewsModule } from './views/views.module';
     SafeSkeletonTableModule,
     SafeSkeletonModule,
     SafeUserSummaryModule,
+    SafeCronExpressionControlModule,
     // === Pipes ===
     SafeDateModule,
     SafeReadableCronModule,

--- a/projects/safe/src/public-api.ts
+++ b/projects/safe/src/public-api.ts
@@ -90,6 +90,7 @@ export * from './lib/components/ui/empty/public-api';
 export * from './lib/components/ui/divider/public-api';
 export * from './lib/components/edit-calculated-field-modal/public-api';
 export * from './lib/components/utils/unsubscribe/public-api';
+export * from './lib/components/cron-expression-control/public-api';
 
 /** Grid Layouts */
 export * from './lib/components/grid-layout/edit-layout-modal/public-api';


### PR DESCRIPTION
# Description
Created the `SafeCronExpressionControlComponent` (that uses the `ngx-cron-editor` package) to use as a cron editor instead of the text field from "schedule" in EditPullJobModalComponent.

when clicking on 'edit' icon, the corn expression modal is open and the input field only shows the readable cron expression.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Using the new control component to add and change cron expression in the pull job modal.

## Sree
![cron1](https://user-images.githubusercontent.com/28535394/221666037-e969057d-afa6-43a6-8801-025c5c6bde3a.gif)
nshots


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
