### PR TITLE
feat/AB#21954_Improvement_inline_edition

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard-routing.module.ts
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard-routing.module.ts
@@ -1,12 +1,14 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { DashboardComponent } from './dashboard.component';
+import { CanDeactivateGuard } from '../../../guards/can-deactivate.guard';
 
 /** List of routes of dashboard module */
 const routes: Routes = [
   {
     path: '',
     component: DashboardComponent,
+    canDeactivate: [CanDeactivateGuard],
   },
 ];
 
@@ -14,5 +16,6 @@ const routes: Routes = [
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],
+  providers: [CanDeactivateGuard],
 })
 export class DashboardRoutingModule {}

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -139,6 +139,7 @@ export class SafeGridComponent implements OnInit, AfterViewInit, OnChanges {
   @Input() hasChanges = false;
   @Output() edit: EventEmitter<any> = new EventEmitter();
   public formGroup: UntypedFormGroup = new UntypedFormGroup({});
+  public timeoutId: any;
   private currentEditedRow = 0;
   private currentEditedItem: any;
   public gradientSettings = GRADIENT_SETTINGS;
@@ -566,6 +567,24 @@ export class SafeGridComponent implements OnInit, AfterViewInit, OnChanges {
     this.currentEditedItem = dataItem;
     this.currentEditedRow = rowIndex;
     this.grid?.editRow(rowIndex, this.formGroup);
+
+    this.fields.forEach((field) => {
+      this.formGroup.get(field.name)?.valueChanges.subscribe(() =>{
+        if (this.timeoutId) {
+          clearTimeout(this.timeoutId);
+        }
+        this.timeoutId = setTimeout(() => {
+          if (this.formGroup.dirty) {
+            this.action.emit({
+              action: 'edit',
+              item: this.currentEditedItem,
+              value: this.formGroup.value,
+            });
+          }
+          this.closeEditor();
+        }, 1000);
+      })
+    })
   }
 
   /**

--- a/libs/safe/src/lib/services/dashboard/dashboard.service.ts
+++ b/libs/safe/src/lib/services/dashboard/dashboard.service.ts
@@ -24,6 +24,9 @@ export class SafeDashboardService {
   get dashboard$(): Observable<Dashboard | null> {
     return this.dashboard.asObservable();
   }
+  
+  private inlineChange?: BehaviorSubject<boolean[]> = new BehaviorSubject<boolean[]>([]);
+  public inlineChangeObserver?: Observable<boolean[]> = this.inlineChange?.asObservable();
 
   /**
    * Shared dashboard service. Handles dashboard events.
@@ -37,6 +40,24 @@ export class SafeDashboardService {
       get(environment, 'availableWidgets', []).includes(widget.component)
     );
   }
+
+  /**
+   * Set that Inline has changed
+   *
+   * @param value if changed the inline edition
+   */
+  setInlineChange(value: boolean){
+    this.inlineChange?.next([...this.inlineChange.getValue(), value]);
+  }
+
+  /**
+   * Clear checker of inline edition
+   *
+   */
+  clearInlineChange(){
+    this.inlineChange?.next([]);
+  }
+
 
   /**
    * Opens a new dashboard.


### PR DESCRIPTION
# Description

Solved the problem of not intuitive use of inline edition listening the changes on the FormGroup and closing it if after 1 second no chages were done and creating prevent navigation while grid is not saved.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested verifying if the inline edition worked properly, that is if the FormGroup is closed if after 1 second no changes were done and if prevent navigation is displayed while grid is not saved.

## Screenshots
![Captura de tela de 2023-03-07 11-21-48](https://user-images.githubusercontent.com/56398308/223451389-b71faabb-a5a2-4fd0-917b-4268ed7f5fda.png)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
