### PR TITLE
feat/AB#58739-remove-basemap-selection-use-default

### DIFF
--- a/libs/safe/src/lib/components/ui/map/interfaces/map.interface.ts
+++ b/libs/safe/src/lib/components/ui/map/interfaces/map.interface.ts
@@ -8,7 +8,6 @@ export interface MapConstructorSettings {
   // maxBounds array of two points [[southWest], [northEast]]
   // e.g. [[-90, -180], [90, 180]]
   maxBounds?: number[][];
-  basemap?: string;
   zoomControl?: boolean;
   minZoom?: number;
   maxZoom?: number;

--- a/libs/safe/src/lib/components/ui/map/map.component.ts
+++ b/libs/safe/src/lib/components/ui/map/map.component.ts
@@ -16,7 +16,7 @@ import 'leaflet.markercluster';
 import 'leaflet.control.layers.tree';
 import 'leaflet-fullscreen';
 import 'esri-leaflet';
-import * as Vector from 'esri-leaflet-vector';
+// import * as Vector from 'esri-leaflet-vector';
 import { TranslateService } from '@ngx-translate/core';
 import { takeUntil } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
@@ -29,7 +29,6 @@ import {
   MapEvent,
   MapEventType,
 } from './interfaces/map.interface';
-import { BASEMAP_LAYERS } from './const/baseMaps';
 import { merge } from 'lodash';
 import { timeDimensionGeoJSON } from './test/timedimension-test';
 import { SafeMapControlsService } from '../../../services/maps/map-controls.service';
@@ -125,7 +124,6 @@ export class MapComponent
   private basemap: any;
   private esriApiKey!: string;
   public settingsConfig: MapConstructorSettings = {
-    basemap: 'OSM',
     centerLat: 0,
     centerLong: 0,
   };
@@ -302,7 +300,6 @@ export class MapComponent
       [-90, -180],
       [90, 180],
     ]);
-    const basemap = get(this.settingsConfig, 'basemap', 'OSM');
     const maxZoom = get(this.settingsConfig, 'maxZoom', 18);
     const minZoom = get(this.settingsConfig, 'minZoom', 2);
     const worldCopyJump = get(this.settingsConfig, 'worldCopyJump', true);
@@ -328,7 +325,6 @@ export class MapComponent
       centerLong,
       centerLat,
       maxBounds,
-      basemap,
       maxZoom,
       minZoom,
       worldCopyJump,
@@ -345,7 +341,6 @@ export class MapComponent
       centerLong,
       centerLat,
       maxBounds: maxBoundArray,
-      basemap,
       maxZoom,
       minZoom,
       worldCopyJump,
@@ -371,8 +366,13 @@ export class MapComponent
       timeDimension,
     } as any).setView(L.latLng(centerLat, centerLong), zoom);
 
-    // TODO: see if fixable, issue is that it does not work if leaflet not put in html imports
-    this.setBasemap(basemap);
+    this.basemap = L.tileLayer(
+      'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      {
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      }
+    ).addTo(this.map);
 
     // Add zoom control
     L.control.zoom({ position: 'bottomleft' }).addTo(this.map);
@@ -417,7 +417,6 @@ export class MapComponent
         centerLong,
         centerLat,
         maxBounds,
-        basemap,
         maxZoom,
         minZoom,
         zoom,
@@ -436,14 +435,6 @@ export class MapComponent
 
       if (this.map.getZoom() !== zoom) {
         this.map.setZoom(zoom);
-      }
-
-      if (basemap) {
-        const currentBasemap = this.basemap?.options?.key;
-        const newBaseMap = get(BASEMAP_LAYERS, basemap);
-        if (newBaseMap !== currentBasemap) {
-          this.setBasemap(basemap);
-        }
       }
 
       const center = this.map.getCenter();
@@ -759,18 +750,18 @@ export class MapComponent
   // }
 
   /**
-   * Set the basemap.
+   * Set the basemap. NOT BEING USED.
    *
    * @param basemap String containing the id (name) of the basemap
    */
-  public setBasemap(basemap: any) {
-    // @TODO when switching between basemaps the related layers and controls to the previous map are there
-    if (this.basemap) {
-      this.basemap.remove();
-    }
-    const basemapName = get(BASEMAP_LAYERS, basemap, BASEMAP_LAYERS.OSM);
-    this.basemap = Vector.vectorBasemapLayer(basemapName, {
-      apiKey: this.esriApiKey,
-    }).addTo(this.map);
-  }
+  // public setBasemap(basemap: any) {
+  //   // @TODO when switching between basemaps the related layers and controls to the previous map are there
+  //   if (this.basemap) {
+  //     this.basemap.remove();
+  //   }
+  //   const basemapName = get(BASEMAP_LAYERS, basemap, BASEMAP_LAYERS.OSM);
+  //   this.basemap = Vector.vectorBasemapLayer(basemapName, {
+  //     apiKey: this.esriApiKey,
+  //   }).addTo(this.map);
+  // }
 }

--- a/libs/safe/src/lib/components/widgets/map-settings/map-layers/edit-layer-modal/edit-layer-modal.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-layers/edit-layer-modal/edit-layer-modal.component.ts
@@ -144,7 +144,6 @@ export class SafeEditLayerModalComponent
         [-90, -1000],
         [90, 1000],
       ],
-      basemap: 'OSM',
       zoomControl: false,
       minZoom: 2,
       maxZoom: 18,

--- a/libs/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -11,18 +11,6 @@
         <input matInput formControlName="title" type="string" />
       </mat-form-field>
       <safe-divider></safe-divider>
-      <!-- Basemap -->
-      <mat-form-field appearance="outline" class="p-0">
-        <mat-label>{{
-          'components.widget.settings.map.properties.basemap' | translate
-        }}</mat-label>
-        <mat-select formControlName="basemap" placeholder="OSM">
-          <mat-option *ngFor="let map of baseMaps" [value]="map">
-            {{ map }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-      <safe-divider></safe-divider>
       <!-- Default view -->
       <!-- Default zoom -->
       <mat-label>

--- a/libs/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
@@ -7,7 +7,6 @@ import {
   MapEvent,
   MapEventType,
 } from '../../../ui/map/interfaces/map.interface';
-import { BASEMAPS } from '../../../ui/map/const/baseMaps';
 
 /**
  * Map Properties of Map widget.
@@ -24,7 +23,6 @@ export class MapPropertiesComponent
   @Input() form!: UntypedFormGroup;
 
   public mapSettings!: MapConstructorSettings;
-  public baseMaps = BASEMAPS;
 
   /**
    * Map Properties of Map widget.
@@ -38,7 +36,6 @@ export class MapPropertiesComponent
    */
   ngOnInit(): void {
     const defaultMapSettings = {
-      basemap: this.form.value.basemap,
       zoom: this.form.value.zoom,
       centerLat: this.form.value.centerLat,
       centerLong: this.form.value.centerLong,
@@ -69,12 +66,6 @@ export class MapPropertiesComponent
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((value) =>
         this.updateMapSettings({ centerLong: value } as MapConstructorSettings)
-      );
-    this.form
-      .get('basemap')
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe((value) =>
-        this.updateMapSettings({ basemap: value } as MapConstructorSettings)
       );
     this.form
       .get('timeDimension')


### PR DESCRIPTION
# Description
Removed the basemap selection on the map settings, now the default leaflet basemap is loaded instead.

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Making sure that the new default basemap appears in the leaflet layer control and in the map correctly.

## Sreenshots
![image](https://user-images.githubusercontent.com/28535394/224351838-c4f361b5-1b11-44ec-afdf-559fd1ca3c7e.png)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
