### PR TITLE
refactor: empty page when no content

### DIFF
--- a/apps/front-office/src/app/dashboard/dashboard.component.html
+++ b/apps/front-office/src/app/dashboard/dashboard.component.html
@@ -10,6 +10,13 @@
     [title]="title"
     [settings]="adminNavItems"
   ></safe-app-application-toolbar>
+  <!-- Empty indicator -->
+  <safe-empty
+    class="m-auto py-6 px-0 bg-white"
+    *ngIf="empty"
+    icon="dashboard"
+    [title]="'components.application.dashboard.empty' | translate"
+  ></safe-empty>
 </ng-template>
 <!--Need the nav variable, don't remove let-nav, used in layout-->
 <ng-template #leftSidenav let-nav>

--- a/apps/front-office/src/app/dashboard/dashboard.component.ts
+++ b/apps/front-office/src/app/dashboard/dashboard.component.ts
@@ -48,6 +48,10 @@ export class DashboardComponent
   /** Roles of the user */
   private roles: Role[] = [];
 
+  /** @returns True if applications is empty */
+  get empty(): boolean {
+    return this.applications.length === 0;
+  }
   /**
    * Main component of Front-Office navigation.
    *
@@ -105,13 +109,6 @@ export class DashboardComponent
             this.applicationService.loadApplication(this.appID);
             this.roles = user.roles || [];
             this.permissions = user.permissions || [];
-          } else {
-            this.snackBar.openSnackBar(
-              this.translate.instant(
-                'common.notifications.platformAccessNotGranted'
-              ),
-              { error: true }
-            );
           }
         }
       });

--- a/apps/front-office/src/app/dashboard/dashboard.module.ts
+++ b/apps/front-office/src/app/dashboard/dashboard.module.ts
@@ -6,7 +6,9 @@ import {
   SafeApplicationToolbarModule,
   SafeLayoutModule,
   SafeLeftSidenavModule,
+  SafeEmptyModule,
 } from '@oort-front/safe';
+import { TranslateModule } from '@ngx-translate/core';
 
 /**
  * Front-Office Dashboard module.
@@ -21,6 +23,8 @@ import {
     SafeLeftSidenavModule,
     DashboardRoutingModule,
     SafeApplicationToolbarModule,
+    SafeEmptyModule,
+    TranslateModule,
   ],
 })
 export class DashboardModule {}

--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -396,6 +396,9 @@
 			}
 		},
 		"application": {
+			"dashboard": {
+				"empty": "No content available. Wait for your administrator to build some."
+			},
 			"delete": {
 				"confirmationMessage": "Do you confirm the deletion of the application {{name}}?"
 			},

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -396,6 +396,9 @@
 			}
 		},
 		"application": {
+			"dashboard": {
+				"empty": "Aucun contenu n'est disponible. Veuillez attendre que votre administrateur en crée."
+			},
 			"delete": {
 				"confirmationMessage": "Voulez-vous vraiment supprimer cette application ?"
 			},

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -396,6 +396,9 @@
 			}
 		},
 		"application": {
+			"dashboard": {
+				"empty": "******"
+			},
 			"delete": {
 				"confirmationMessage": "****** {{name}} ******"
 			},


### PR DESCRIPTION
# Description

Add an empty page in front-office, when no content is available

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

The page properly displays the error message when the user has no access to any application 

## Sreenshots

![screencapture-localhost-4200-2023-03-14-15_22_00](https://user-images.githubusercontent.com/9751045/225031235-30409367-b35c-4e73-ae19-327780aab7e3.png)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
