### PR TITLE
Fix/ab#56269 resources question create records even when question is dropped

### DIFF
--- a/libs/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -76,7 +76,7 @@ export class SafeFormModalComponent implements OnInit {
 
   public modifiedAt: Date | null = null;
 
-  private isMultiEdition = false;
+  protected isMultiEdition = false;
   private storedMergedData: any;
 
   public survey!: Survey.SurveyModel;
@@ -116,13 +116,13 @@ export class SafeFormModalComponent implements OnInit {
     public dialog: MatDialog,
     public dialogRef: MatDialogRef<SafeFormModalComponent>,
     private apollo: Apollo,
-    private snackBar: SafeSnackBarService,
+    protected snackBar: SafeSnackBarService,
     private restService: SafeRestService,
     private authService: SafeAuthService,
     private formBuilderService: SafeFormBuilderService,
-    private confirmService: SafeConfirmService,
-    private translate: TranslateService,
-    private ngZone: NgZone
+    protected confirmService: SafeConfirmService,
+    protected translate: TranslateService,
+    protected ngZone: NgZone
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -478,7 +478,7 @@ export class SafeFormModalComponent implements OnInit {
    *
    * @param survey The form in which the files will be updated
    */
-  private async uploadFiles(survey: any): Promise<void> {
+  protected async uploadFiles(survey: any): Promise<void> {
     const data = survey.data;
     const questionsToUpload = Object.keys(this.temporaryFilesStorage);
     for (const name of questionsToUpload) {

--- a/libs/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -4,6 +4,7 @@ import {
   ElementRef,
   Inject,
   NgZone,
+  OnDestroy,
   OnInit,
   ViewChild,
 } from '@angular/core';
@@ -68,7 +69,7 @@ const DEFAULT_DIALOG_DATA = { askForConfirm: true };
   templateUrl: './form-modal.component.html',
   styleUrls: ['./form-modal.component.scss'],
 })
-export class SafeFormModalComponent implements OnInit {
+export class SafeFormModalComponent implements OnInit, OnDestroy {
   // === DATA ===
   public loading = true;
   public saving = false;
@@ -645,6 +646,19 @@ export class SafeFormModalComponent implements OnInit {
       this.survey.currentPageNo = i;
     }
     this.selectedTabIndex = i;
+  }
+
+  /**
+   * Clears the cache for the records created by resource questions
+   */
+  ngOnDestroy(): void {
+    this.survey.getAllQuestions().forEach((question) => {
+      if (['resources', 'resource'].includes(question.getType())) {
+        question.value.forEach((recordId: any) =>
+          localForage.removeItem(recordId)
+        );
+      }
+    });
   }
 
   /**

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -375,7 +375,6 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
     Promise.allSettled(promises).then(() => {
       //We wait for the resources questions to update their ids
       this.survey.data = surveyData;
-      console.log(surveyData);
       if (this.record || this.form.uniqueRecord) {
         const recordId = this.record
           ? this.record.id
@@ -390,7 +389,6 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
           },
         });
       } else {
-        console.log('mutating');
         mutation = this.apollo.mutate<AddRecordMutationResponse>({
           mutation: ADD_RECORD,
           variables: {

--- a/libs/safe/src/lib/components/resource-modal/resource-modal.component.spec.ts
+++ b/libs/safe/src/lib/components/resource-modal/resource-modal.component.spec.ts
@@ -1,0 +1,62 @@
+import { HttpClientModule } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  MatLegacyDialogModule as MatDialogModule,
+  MatLegacyDialogRef as MatDialogRef,
+  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
+} from '@angular/material/legacy-dialog';
+import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
+import { SafeResourceModalComponent } from './resource-modal.component';
+import {
+  DateTimeProvider,
+  OAuthLogger,
+  OAuthService,
+  UrlHelperService,
+} from 'angular-oauth2-oidc';
+import {
+  TranslateModule,
+  TranslateService,
+  TranslateFakeLoader,
+  TranslateLoader,
+} from '@ngx-translate/core';
+
+describe('SafeResourceModalComponent', () => {
+  let component: SafeResourceModalComponent;
+  let fixture: ComponentFixture<SafeResourceModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        OAuthService,
+        UrlHelperService,
+        OAuthLogger,
+        DateTimeProvider,
+        TranslateService,
+      ],
+      declarations: [SafeResourceModalComponent],
+      imports: [
+        MatDialogModule,
+        MatSnackBarModule,
+        HttpClientModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: TranslateFakeLoader,
+          },
+        }),
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SafeResourceModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/safe/src/lib/components/resource-modal/resource-modal.component.ts
+++ b/libs/safe/src/lib/components/resource-modal/resource-modal.component.ts
@@ -1,0 +1,83 @@
+import { Component } from '@angular/core';
+import { SafeFormModalComponent } from '../form-modal/form-modal.component';
+import { v4 as uuidv4 } from 'uuid';
+import localForage from 'localforage';
+import { MAT_TOOLTIP_SCROLL_STRATEGY } from '@angular/material/tooltip';
+import { BlockScrollStrategy, Overlay } from '@angular/cdk/overlay';
+
+/**
+ * Factory for creating scroll strategy
+ *
+ * @param overlay The overlay
+ * @returns A function that returns a block scroll strategy
+ */
+export function scrollFactory(overlay: Overlay): () => BlockScrollStrategy {
+  const block = () => overlay.scrollStrategies.block();
+  return block;
+}
+
+/**
+ * Dev phase, à la cool
+ */
+@Component({
+  selector: 'safe-resource-modal',
+  templateUrl: '../form-modal/form-modal.component.html',
+  styleUrls: ['../form-modal/form-modal.component.scss'],
+  providers: [
+    {
+      provide: MAT_TOOLTIP_SCROLL_STRATEGY,
+      useFactory: scrollFactory,
+      deps: [Overlay],
+    },
+  ],
+})
+export class SafeResourceModalComponent extends SafeFormModalComponent {
+  /**
+   * Calls the complete method of the survey if no error.
+   */
+  public override submit(): void {
+    this.saving = true;
+    if (!this.survey?.hasErrors()) {
+      this.survey?.completeLastPage();
+    } else {
+      this.snackBar.openSnackBar(
+        this.translate.instant('models.form.notifications.savingFailed'),
+        { error: true }
+      );
+      this.saving = false;
+    }
+  }
+
+  /**
+   * We override this method to not directly save new records
+   *
+   * @param survey current survey
+   */
+  public override async onUpdate(survey: any): Promise<void> {
+    if (this.data.recordId) {
+      await this.uploadFiles(survey);
+      if (this.isMultiEdition) {
+        this.updateMultipleData(this.data.recordId, survey);
+      } else {
+        this.updateData(this.data.recordId, survey);
+      }
+    } else {
+      await this.uploadFiles(survey);
+      const temporaryId = uuidv4();
+      await localForage.setItem(
+        temporaryId.toString(),
+        JSON.stringify({ data: survey.data, template: this.data.template })
+      ); //We save the question temporarily before applying the mutation.
+      this.ngZone.run(() => {
+        this.dialogRef.close({
+          template: this.data.template,
+          data: {
+            id: temporaryId,
+            data: survey.data,
+          },
+        });
+      });
+    }
+    survey.showCompletedPage = true;
+  }
+}

--- a/libs/safe/src/lib/components/resource-modal/resource-modal.component.ts
+++ b/libs/safe/src/lib/components/resource-modal/resource-modal.component.ts
@@ -17,7 +17,7 @@ export function scrollFactory(overlay: Overlay): () => BlockScrollStrategy {
 }
 
 /**
- * Dev phase, à la cool
+ * Component to create a record for a resource question without directly saving it
  */
 @Component({
   selector: 'safe-resource-modal',

--- a/libs/safe/src/lib/components/resource-modal/resource-modal.module.ts
+++ b/libs/safe/src/lib/components/resource-modal/resource-modal.module.ts
@@ -1,0 +1,38 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SafeResourceModalComponent } from './resource-modal.component';
+import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import { SafeButtonModule } from '../ui/button/button.module';
+import { MatLegacyTabsModule as MatTabsModule } from '@angular/material/legacy-tabs';
+import { SafeIconModule } from '../ui/icon/icon.module';
+import { SafeRecordSummaryModule } from '../record-summary/record-summary.module';
+import { SafeRecordHistoryModalModule } from '../record-history-modal/record-history-modal.module';
+import { SafeFormActionsModule } from '../form-actions/form-actions.module';
+import { TranslateModule } from '@ngx-translate/core';
+import { SafeModalModule } from '../ui/modal/modal.module';
+
+/**
+ * SafeResourceModalModule is a class used to manage all the modules and components
+ * related to modals containing forms.
+ */
+@NgModule({
+  declarations: [SafeResourceModalComponent],
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatIconModule,
+    MatButtonModule,
+    MatTabsModule,
+    SafeButtonModule,
+    SafeIconModule,
+    SafeRecordHistoryModalModule,
+    SafeRecordSummaryModule,
+    SafeFormActionsModule,
+    TranslateModule,
+    SafeModalModule,
+  ],
+  exports: [SafeResourceModalComponent],
+})
+export class SafeResourceModalModule {}

--- a/libs/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -625,7 +625,6 @@ export class SafeCoreGridComponent
           this.status = {
             error: false,
           };
-          console.log(data, 'data', this.settings.query);
           for (const field in data) {
             try {
               if (Object.prototype.hasOwnProperty.call(data, field)) {
@@ -636,7 +635,7 @@ export class SafeCoreGridComponent
                       style: x.meta.style,
                     },
                   })) || [];
-                this.totalCount = data[field]?.totalCount;
+                this.totalCount = data[field] ? data[field].totalCount : 0;
                 this.items = cloneData(nodes);
                 this.convertDateFields(this.items);
                 this.originalItems = cloneData(this.items);
@@ -655,7 +654,7 @@ export class SafeCoreGridComponent
                 // }
               }
             } catch (error) {
-              console.error(error, 'dats why');
+              console.error(error);
             }
           }
           if (this.settings.query.temporaryRecords) {
@@ -705,11 +704,6 @@ export class SafeCoreGridComponent
       data: this.items,
       total: this.totalCount,
     };
-    console.log(
-      'load items',
-      this.gridData,
-      this.settings?.query?.temporaryRecords
-    );
   }
 
   /**
@@ -884,6 +878,20 @@ export class SafeCoreGridComponent
             name: this.queryBuilder.getQueryNameFromResourceName(field.type),
             template: null,
           },
+        },
+      });
+    } else if (
+      (!isArray && items.isTemporary) ||
+      (isArray && items[0].isTemporary)
+    ) {
+      //case for temporary records
+      this.dialog.open(SafeRecordModalComponent, {
+        data: {
+          isTemporary: true,
+          template: isArray ? items[0].template : items.template,
+          canUpdate: false,
+          compareTo: false,
+          temporaryRecordData: isArray ? items[0] : items,
         },
       });
     } else {

--- a/libs/safe/src/lib/safe.module.ts
+++ b/libs/safe/src/lib/safe.module.ts
@@ -41,6 +41,7 @@ import { SafeCronParserModule } from './pipes/cron-parser/cron-parser.module';
 import { SafeUnsubscribeModule } from './components/utils/unsubscribe/unsubscribe.module';
 import { SafeViewsModule } from './views/views.module';
 import { SafeEditableTextModule } from './components/editable-text/editable-text.module';
+import { SafeResourceModalModule } from './components/resource-modal/resource-modal.module';
 
 /** Main module for the safe project */
 @NgModule({
@@ -49,6 +50,7 @@ import { SafeEditableTextModule } from './components/editable-text/editable-text
     SafeAccessModule,
     SafeFormModule,
     SafeFormBuilderModule,
+    SafeResourceModalModule,
     SafeChartSettingsModule,
     SafeEditorSettingsModule,
     SafeGridSettingsModule,

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -890,7 +890,10 @@ export const init = (
       promises.push(promise);
     });
     const uuidRegExpr =
-      /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+      /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+    console.log(
+      question.value.filter((id: string) => !uuidRegExpr.test(id.toString()))
+    );
     const settings = {
       query: {
         ...query,

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -891,9 +891,6 @@ export const init = (
     });
     const uuidRegExpr =
       /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
-    console.log(
-      question.value.filter((id: string) => !uuidRegExpr.test(id.toString()))
-    );
     const settings = {
       query: {
         ...query,

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -872,7 +872,13 @@ export const init = (
           .then((data: any) => {
             if (data != null) {
               // We ensure to make it only if such a record is found
-              temporaryRecords.push({ id: recordId, ...JSON.parse(data).data });
+              const parsedData = JSON.parse(data);
+              temporaryRecords.push({
+                id: recordId,
+                template: parsedData.template,
+                ...parsedData.data,
+                isTemporary: true,
+              });
             }
             resolve();
           })

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -889,7 +889,8 @@ export const init = (
       });
       promises.push(promise);
     });
-
+    const uuidRegExpr =
+      /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
     const settings = {
       query: {
         ...query,
@@ -900,7 +901,9 @@ export const init = (
             {
               field: 'ids',
               operator: 'eq',
-              value: question.value || [],
+              value:
+                question.value.filter((id: string) => !uuidRegExpr.test(id)) ||
+                [], //We exclude the temporary records by excluding id in UUID format
             },
           ],
         },

--- a/libs/safe/src/lib/survey/components/utils.ts
+++ b/libs/safe/src/lib/survey/components/utils.ts
@@ -3,6 +3,7 @@ import { SafeResourceGridModalComponent } from '../../components/search-resource
 import { UntypedFormGroup } from '@angular/forms';
 import { surveyLocalization } from 'survey-angular';
 import { SafeResourceModalComponent } from '../../components/resource-modal/resource-modal.component';
+import localForage from 'localforage';
 
 /**
  * Build the search button for resource and resources components
@@ -27,28 +28,56 @@ export const buildSearchButton = (
   searchButton.style.marginRight = '8px';
   if (fieldsSettingsForm) {
     searchButton.onclick = () => {
-      const dialogRef = dialog.open(SafeResourceGridModalComponent, {
-        data: {
-          multiselect,
-          gridSettings: fieldsSettingsForm,
-          selectedRows: Array.isArray(question.value)
-            ? question.value
-            : question.value
-            ? [question.value]
-            : [],
-          selectable: true,
-        },
-        panelClass: 'closable-dialog',
+      const temporaryRecords: any[] = [];
+      const promises: any[] = [];
+      question.newCreatedRecords?.forEach((recordId: string) => {
+        const promise = new Promise<void>((resolve, reject) => {
+          localForage
+            .getItem(recordId)
+            .then((data: any) => {
+              if (data != null) {
+                // We ensure to make it only if such a record is found
+                temporaryRecords.push({
+                  id: recordId,
+                  ...JSON.parse(data).data,
+                });
+              }
+              resolve();
+            })
+            .catch((error: any) => {
+              console.error(error); // Handle any errors that occur while getting the item
+              reject(error);
+            });
+        });
+        promises.push(promise);
       });
-      dialogRef.afterClosed().subscribe((rows: any[]) => {
-        if (!rows) {
-          return;
-        }
-        if (rows.length > 0) {
-          question.value = multiselect ? rows : rows[0];
-        } else {
-          question.value = null;
-        }
+      Promise.allSettled(promises).then(() => {
+        const dialogRef = dialog.open(SafeResourceGridModalComponent, {
+          data: {
+            multiselect,
+            gridSettings: {
+              ...fieldsSettingsForm,
+              temporaryRecords: temporaryRecords,
+            },
+            selectedRows: Array.isArray(question.value)
+              ? question.value
+              : question.value
+              ? [question.value]
+              : [],
+            selectable: true,
+          },
+          panelClass: 'closable-dialog',
+        });
+        dialogRef.afterClosed().subscribe((rows: any[]) => {
+          if (!rows) {
+            return;
+          }
+          if (rows.length > 0) {
+            question.value = multiselect ? rows : rows[0];
+          } else {
+            question.value = null;
+          }
+        });
       });
     };
   }
@@ -94,13 +123,6 @@ export const buildAddButton = (
       });
       dialogRef.afterClosed().subscribe(({ data }: any) => {
         if (data) {
-          // TODO: call reload method
-          // if (question.displayAsGrid && gridComponent) {
-          //   gridComponent.availableRecords.push({
-          //     value: data.id,
-          //     text: data.data[question.displayField]
-          //   });
-          // }
           if (multiselect) {
             const newItem = {
               value: data.id,

--- a/libs/safe/src/lib/survey/components/utils.ts
+++ b/libs/safe/src/lib/survey/components/utils.ts
@@ -1,8 +1,8 @@
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
-import { SafeFormModalComponent } from '../../components/form-modal/form-modal.component';
 import { SafeResourceGridModalComponent } from '../../components/search-resource-grid-modal/search-resource-grid-modal.component';
 import { UntypedFormGroup } from '@angular/forms';
 import { surveyLocalization } from 'survey-angular';
+import { SafeResourceModalComponent } from '../../components/resource-modal/resource-modal.component';
 
 /**
  * Build the search button for resource and resources components
@@ -77,7 +77,7 @@ export const buildAddButton = (
   );
   if (question.addRecord && question.addTemplate) {
     addButton.onclick = () => {
-      const dialogRef = dialog.open(SafeFormModalComponent, {
+      const dialogRef = dialog.open(SafeResourceModalComponent, {
         disableClose: true,
         data: {
           template: question.addTemplate,


### PR DESCRIPTION
# Description

Upon creating records from a resource question in a form, the record was instantly saved even though the form record was cancelled. Changed the logic, to instead save the resource record in the local storage and only save it when the parent record is saved. There is still a question for nested forms: if A has a resource question B that has a resource question C, the records from C will be saved when B is saved, and not when A is saved. I guess this should not happen too much and you can still cancel from B.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Try to add record B while creating a new record A from a form page
Try to add record B while creating a new record A from a add record on a grid widget
Try to add record B while updating a record A from a grid widget
Try to add record B while updating a record A from the view records view (Forms > Form A action button > View record)
Set up a form C with a resource question (with add record) targeting resource A
    -> While creating a record C, try to add record A and record B in nested form

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
