### PR TITLE
fix/AB#59926-summary-card-widget-scroll

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.scss
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.scss
@@ -3,10 +3,10 @@
   grid-auto-rows: 200px;
   gap: 16px;
   padding: 16px;
-  min-height: 100%;
   grid-auto-flow: row;
   background-color: unset;
   overflow: auto;
+  max-height: 80vh;
 
   .k-card {
     border: none;


### PR DESCRIPTION
# Description
In the summary card widget, fixed scroll bar logic to be possible to see all the data.

## Ticket
[Unable to see the data displaying on the bottom of summary card widget, scroll bar is missing to see the data](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/59926)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Creating summary cards widget with more than 3 records data to observe the scrollbar behavior.

## Sreenshots
![scroll](https://user-images.githubusercontent.com/28535394/227591361-1228b080-ff22-4aa7-8cfe-c8f232b59f55.gif)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
