### PR TITLE
fix/AB#60147-grid-widget-layout-selection-width

### DIFF
--- a/libs/safe/src/lib/components/widgets/grid/grid.component.html
+++ b/libs/safe/src/lib/components/widgets/grid/grid.component.html
@@ -75,7 +75,7 @@
 <ng-template #layoutsTemplate>
   <ng-container *ngIf="layouts.length > 1">
     <kendo-dropdownlist
-      class="m-auto"
+      class="m-auto w-auto"
       [data]="layouts"
       textField="name"
       valueField="id"


### PR DESCRIPTION
# Description
in the grid widget, the layout selection in the header no longer takes the hole header.

## Ticket
[Layout selection display on a grid widget takes the whole header](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/60147)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots
![grid](https://user-images.githubusercontent.com/28535394/227628397-6fae7ad1-1a32-4d99-9aa9-4218793c0b0d.png)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
