### PR TITLE
fix-2.0.x/AB#60045_fix_NaN_value_recorded_date_sum_card

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
@@ -135,7 +135,7 @@ const replaceRecordFields = (
                 new Date(value).toLocaleString().split(',')[0],
                 field
               ) +
-              +'</span>';
+              '</span>';
             break;
           case 'datetime':
             const date = new Date(parseInt(value, 10));


### PR DESCRIPTION
# Description

Fix the display of NaN for recorded date on summary card. A "+" symbol had been added and avoided the close of the span element.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories/?workitem=60045

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. login to dev environment 

2. Navigate to any application->dashboard 

3. Created summary card 

4. Navigated to settings and selection static/dynamic type and click on add new card 

5. Navigated to settings page of new card 

6. Click on 'start from blank' 

7. Provided resource and layout and navigated to text editor page 

8. Added date type of field on text editor by choosing {{..

9. Verified the data on summary widget

## Sreenshots

![image](https://user-images.githubusercontent.com/65243509/228888654-481d0fd9-6a5f-4832-9b4a-8d9d054d6c5d.png)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
