### PR TITLE
Fix/ab#60342 wrong styling on summary cards

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1112,6 +1112,9 @@
 					"axes": "Axes",
 					"hideLegend": "Hide legend",
 					"labels": {
+						"categoryPosition": "Choose where the labels should be displayed",
+						"inside": "Inside",
+						"outside": "Outside",
 						"percentage": "Percentage",
 						"showCategory": "Show category labels",
 						"showValue": "Show value labels",

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1119,6 +1119,9 @@
 					"axes": "Axes",
 					"hideLegend": "Masquer la légende",
 					"labels": {
+						"categoryPosition": "Choisissez où afficher les labels",
+						"inside": "A l'intérieur",
+						"outside": "A l'extérieur",
 						"percentage": "Pourcentage",
 						"showCategory": "Afficher la catégorie",
 						"showValue": "Afficher la valeur",

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1112,6 +1112,9 @@
 					"axes": "******",
 					"hideLegend": "******",
 					"labels": {
+						"categoryPosition": "******",
+						"inside": "******",
+						"outside": "******",
 						"percentage": "******",
 						"showCategory": "******",
 						"showValue": "******",

--- a/libs/safe/src/lib/components/widgets/chart-settings/charts/chart.ts
+++ b/libs/safe/src/lib/components/widgets/chart-settings/charts/chart.ts
@@ -45,7 +45,7 @@ export class Chart {
     const legend = get(settings, 'legend', null);
     const title = get(settings, 'title', null);
     const labels = get(settings, 'labels', null);
-    const palette: string[] = get(settings, 'palette.value', []);
+    const palette: string[] = get(settings, 'palette.value', DEFAULT_PALETTE);
     const axes = get(settings, 'axes', null);
     const stack = get(settings, 'stack', null);
 
@@ -89,6 +89,7 @@ export class Chart {
       }),
       labels: this.fb.group({
         showCategory: [get(labels, 'showCategory', false)],
+        categoryPosition: [get(labels, 'categoryPosition', 'inside')],
         showValue: [get(labels, 'showValue', false)],
         valueType: [
           {

--- a/libs/safe/src/lib/components/widgets/chart-settings/tab-display/tab-display.component.html
+++ b/libs/safe/src/lib/components/widgets/chart-settings/tab-display/tab-display.component.html
@@ -168,6 +168,17 @@
               'components.widget.settings.chart.labels.showCategory' | translate
             }}</mat-slide-toggle
           >
+          <div *ngIf="chartForm.value.labels.showCategory">
+            <mat-radio-group formControlName="categoryPosition">
+              <mat-radio-button value="inside">{{
+                'components.widget.settings.chart.labels.inside' | translate
+              }}</mat-radio-button>
+              <br>
+              <mat-radio-button value="outside">{{
+                'components.widget.settings.chart.labels.outside' | translate
+              }}</mat-radio-button>
+            </mat-radio-group>
+          </div>
           <mat-slide-toggle formControlName="showValue">{{
             'components.widget.settings.chart.labels.showValue' | translate
           }}</mat-slide-toggle>

--- a/libs/safe/src/lib/components/widgets/chart/chart.component.ts
+++ b/libs/safe/src/lib/components/widgets/chart/chart.component.ts
@@ -149,6 +149,11 @@ export class SafeChartComponent
       },
       labels: {
         showCategory: get(this.settings, 'chart.labels.showCategory', false),
+        categoryPosition: get(
+          this.settings,
+          'chart.labels.categoryPosition',
+          'inside'
+        ),
         showValue: get(this.settings, 'chart.labels.showValue', false),
         valueType: get(this.settings, 'chart.labels.valueType', 'value'),
       },

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.ts
@@ -135,7 +135,7 @@ export class SummaryCardItemComponent implements OnInit, OnChanges {
       }
     } else if (typeof this.card.layout === 'object') {
       this.layout = this.card.layout;
-      this.styles = get(this.card.layout, 'style', []);
+      this.styles = get(this.card.layout, 'query.style', []);
     }
     this.loading = false;
   }

--- a/libs/safe/src/lib/utils/graphs/plugins/outsideLabels.plugin.ts
+++ b/libs/safe/src/lib/utils/graphs/plugins/outsideLabels.plugin.ts
@@ -1,0 +1,159 @@
+import { Plugin } from 'chart.js';
+
+/**
+ * Basic interface for a point
+ */
+interface Point {
+  x: number;
+  y: number;
+}
+
+type DrawOutsideLabelsPluginType = {
+  display: boolean;
+};
+
+/**
+ * Gets a suitable Y coordinate for a label based on existing label coordinates and label direction
+ *
+ * @param {number} y - The Y coordinate to be checked and adjusted if necessary
+ * @param {number[]} yArray - An array of existing Y coordinates of labels
+ * @param {'left' | 'right'} direction - The direction of the label relative to the chart center
+ * @returns {number} - A suitable Y coordinate for the label
+ */
+const getSuitableY = (
+  y: number,
+  yArray: number[] = [],
+  direction: 'left' | 'right'
+): number => {
+  let result = y;
+  yArray.forEach((existedY) => {
+    if (existedY - 14 < result && existedY + 14 > result) {
+      if (direction === 'right') {
+        result = existedY + 14;
+      } else {
+        result = existedY - 14;
+      }
+    }
+  });
+  return result;
+};
+
+/**
+ * Calculates the origin point of a line from a source point to a center point at a given length
+ *
+ * @param {Point} source - The source point of the line
+ * @param {Point} center - The center point of the chart
+ * @param {number} l - The length of the line
+ * @returns {Point} - The origin point of the line
+ */
+const getOriginPoints = (source: Point, center: Point, l: number): Point => {
+  const a = {
+    x: 0,
+    y: 0,
+  };
+  const dx = (center.x - source.x) / l;
+  const dy = (center.y - source.y) / l;
+  a.x = center.x + l * dx;
+  a.y = center.y + l * dy;
+  return a;
+};
+
+/**
+ * A plugin to draw outside labels for a chart's data points
+ */
+const outsideLabelsPlugin: Plugin = {
+  id: 'customOutsideDataLabels',
+  afterDraw: (chart: any, _: any, opt: DrawOutsideLabelsPluginType) => {
+    if (!opt.display) return;
+    const ctx = chart.ctx;
+    ctx.save();
+    const leftLabelCoordinates: number[] = [];
+    const rightLabelCoordinates: number[] = [];
+    const chartCenterPoint = {
+      x:
+        (chart.chartArea.right - chart.chartArea.left) / 2 +
+        chart.chartArea.left,
+      y:
+        (chart.chartArea.bottom - chart.chartArea.top) / 2 +
+        chart.chartArea.top,
+    };
+    chart.config.data.labels.forEach((label: any, i: any) => {
+      const meta = chart.getDatasetMeta(0);
+      const arc = meta.data[i];
+      // Prepare data to draw
+      const centerPoint = arc.getCenterPoint();
+      const color = chart.config._config.data.datasets[0].backgroundColor[i]
+        ? chart.config._config.data.datasets[0].backgroundColor[i]
+        : null; //does not work as palette seems undefined
+      const angle = Math.atan2(
+        centerPoint.y - chartCenterPoint.y,
+        centerPoint.x - chartCenterPoint.x
+      );
+      const originPoint = getOriginPoints(
+        chartCenterPoint,
+        centerPoint,
+        arc.outerRadius
+      );
+      const point2X =
+        chartCenterPoint.x +
+        Math.cos(angle) *
+          (centerPoint.x < chartCenterPoint.x
+            ? arc.outerRadius + 10
+            : arc.outerRadius + 10);
+      let point2Y =
+        chartCenterPoint.y +
+        Math.sin(angle) *
+          (centerPoint.y < chartCenterPoint.y
+            ? arc.outerRadius + 15
+            : arc.outerRadius + 15);
+
+      let suitableY;
+      if (point2X < chartCenterPoint.x) {
+        suitableY = getSuitableY(point2Y, leftLabelCoordinates, 'left');
+      } else {
+        suitableY = getSuitableY(point2Y, rightLabelCoordinates, 'right');
+      }
+
+      point2Y = suitableY;
+
+      const value = label;
+      const edgePointX =
+        point2X < chartCenterPoint.x
+          ? chartCenterPoint.x - arc.outerRadius - 10
+          : chartCenterPoint.x + arc.outerRadius + 10;
+
+      if (point2X < chartCenterPoint.x) {
+        leftLabelCoordinates.push(point2Y);
+      } else {
+        rightLabelCoordinates.push(point2Y);
+      }
+
+      //DRAW CODE
+      // first line: connect between arc's center point and outside point
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(originPoint.x, originPoint.y);
+      ctx.lineTo(point2X, point2Y);
+      ctx.stroke();
+      // second line: connect between outside point and chart's edge
+      ctx.beginPath();
+      ctx.moveTo(point2X, point2Y);
+      ctx.lineTo(edgePointX, point2Y);
+      ctx.stroke();
+      //fill custom label
+      const labelAlignStyle =
+        edgePointX < chartCenterPoint.x ? 'right' : 'left';
+      const labelX =
+        edgePointX < chartCenterPoint.x ? edgePointX : edgePointX + 0;
+      const labelY = point2Y + 7;
+      ctx.textAlign = labelAlignStyle;
+      ctx.textBaseline = 'bottom';
+      ctx.font = 'bold';
+      ctx.fillText(value, labelX, labelY);
+    });
+    ctx.restore();
+  },
+};
+
+export default outsideLabelsPlugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@apollo/client": "^3.7.4",
         "@casl/ability": "^6.3.3",
         "@casl/angular": "^8.2.0",
+        "@energiency/chartjs-plugin-piechart-outlabels": "^1.3.2",
         "@esri/arcgis-rest-auth": "^3.4.3",
         "@esri/arcgis-rest-request": "^3.4.3",
         "@ngx-translate/core": "^14.0.0",
@@ -3831,6 +3832,14 @@
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@energiency/chartjs-plugin-piechart-outlabels": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@energiency/chartjs-plugin-piechart-outlabels/-/chartjs-plugin-piechart-outlabels-1.3.2.tgz",
+      "integrity": "sha512-yGcVdVI66jiudclvHsUIzuNvffcRnvrrFKRjQEhJpog/PgbfGfha5RTNQzyEQcXTOLadZAlmHVVCPdQcy+EevQ==",
+      "peerDependencies": {
+        "chart.js": "> 3"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@apollo/client": "^3.7.4",
         "@casl/ability": "^6.3.3",
         "@casl/angular": "^8.2.0",
-        "@energiency/chartjs-plugin-piechart-outlabels": "^1.3.2",
         "@esri/arcgis-rest-auth": "^3.4.3",
         "@esri/arcgis-rest-request": "^3.4.3",
         "@ngx-translate/core": "^14.0.0",
@@ -3832,14 +3831,6 @@
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@energiency/chartjs-plugin-piechart-outlabels": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@energiency/chartjs-plugin-piechart-outlabels/-/chartjs-plugin-piechart-outlabels-1.3.2.tgz",
-      "integrity": "sha512-yGcVdVI66jiudclvHsUIzuNvffcRnvrrFKRjQEhJpog/PgbfGfha5RTNQzyEQcXTOLadZAlmHVVCPdQcy+EevQ==",
-      "peerDependencies": {
-        "chart.js": "> 3"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {


### PR DESCRIPTION
# Description

Summary cards styling sometimes did not apply. Fixed it (Just changed get(this.card.layout, 'style' to get(this.card.layout, 'query.style')

## Ticket

[Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/60342/)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

On a static summary card, set up a layout with a style. Go in preview, and on the widget. The styles should appear.

## Sreenshots

![image](https://user-images.githubusercontent.com/59645813/229082102-a3474e24-f5c7-4b7d-a647-ce46a65f3ca7.png)
![image](https://user-images.githubusercontent.com/59645813/229082154-da377d5e-c3f6-4d2f-98ee-2e880abf2e48.png)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
