### PR TITLE
AB#60045 fix wrong displayed value date_time sum_card

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
@@ -138,7 +138,7 @@ const replaceRecordFields = (
               '</span>';
             break;
           case 'datetime':
-            const date = new Date(parseInt(value, 10));
+            const date = new Date(value);
             const hour =
               date.getHours() >= 12 ? date.getHours() - 12 : date.getHours();
             const minutes =
@@ -146,6 +146,7 @@ const replaceRecordFields = (
                 ? '0' + date.getMinutes()
                 : date.getMinutes();
             const time = date.getHours() >= 12 ? 'PM' : 'AM';
+
             convertedValue =
               `<span style='${style}'>` +
               applyLayoutFormat(


### PR DESCRIPTION
# Description

Fix the display of the wrong recorded date / time on summary card. The string was parsing to int before date/time format and was preventing the value from being properly read, a default date/time value was displayed. 

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories/?workitem=60045

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. login to dev environment 

2. Navigate to any application->dashboard 

3. Created summary card 

4. Navigated to settings and selection static/dynamic type and click on add new card 

5. Navigated to settings page of new card 

6. Click on 'start from blank' 

7. Provided resource and layout and navigated to text editor page 

8. Added date type of field on text editor by choosing {{..

9. Verified the data on summary widget

## Sreenshots

Bug
![image](https://user-images.githubusercontent.com/65243509/229085533-92bd0289-8442-4e5d-9419-64166a7c4174.png)

Fix
![image](https://user-images.githubusercontent.com/65243509/229085883-9100c2c7-c122-4f82-9e39-185cbc9f0609.png)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
