### PR TITLE
Fix/ab#60033 unable to drag scrollbar reedit

### DIFF
--- a/libs/safe/src/lib/services/editor/editor.service.ts
+++ b/libs/safe/src/lib/services/editor/editor.service.ts
@@ -72,6 +72,7 @@ export class SafeEditorService {
    * @param keys list of keys
    */
   addCalcAndKeysAutoCompleter(editor: RawEditorSettings, keys: string[]) {
+    this.allowScrolling();
     editor.setup = (e: Editor) => {
       e.ui.registry.addAutocompleter('keys_data_and_calc', {
         ch: '{',
@@ -87,5 +88,20 @@ export class SafeEditorService {
             .map((key) => ({ value: key, text: key })),
       });
     };
+  }
+
+  /**
+   * Allows scrolling within the TinyMCE autocompleter container, and prevents the autocompleter from closing when clicking on the scrollbar.
+   *  This function sets a timeout to give TinyMCE some time to render its elements before trying to access them.
+   * The editor still closes when a value is successfully selected.
+   */
+  private allowScrolling() {
+    setTimeout(function () {
+      const autoCompleterContainer = document.querySelector('.tox-tinymce-aux');
+      if (!autoCompleterContainer) return;
+      autoCompleterContainer.addEventListener('mousedown', function (event) {
+        event.stopPropagation();
+      });
+    }, 500);
   }
 }


### PR DESCRIPTION
# Description

Fixed a bug on summary cards, clicking on scrollbar would make the div disappear. This is a known problem for tinyMCE https://github.com/tinymce/tinymce/issues/6580. Fixed inspired by [devinizetic](https://github.com/devinizetic)'s answer.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/60033/

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

On a summary card, go in the text editor, type '{' and try to scroll with the click.

## Sreenshots

![image](https://user-images.githubusercontent.com/59645813/229095212-a087337a-9468-420f-8c05-bd16a34b3047.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
