### PR TITLE
feat/AB#60921-custom-styling-active-between-pages

### DIFF
--- a/apps/back-office/src/app/application/application-routing.module.ts
+++ b/apps/back-office/src/app/application/application-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { CanDeactivateGuard } from '../guards/can-deactivate.guard';
 import { ApplicationComponent } from './application.component';
 
 /** Routes of application module */
@@ -7,6 +8,7 @@ const routes: Routes = [
   {
     path: '',
     component: ApplicationComponent,
+    canDeactivate: [CanDeactivateGuard],
     children: [
       {
         path: '',
@@ -211,6 +213,7 @@ const routes: Routes = [
  */
 @NgModule({
   imports: [RouterModule.forChild(routes)],
+  providers: [CanDeactivateGuard],
   exports: [RouterModule],
 })
 export class ApplicationRoutingModule {}

--- a/apps/back-office/src/app/application/application.component.ts
+++ b/apps/back-office/src/app/application/application.component.ts
@@ -9,7 +9,8 @@ import {
   SafeUnsubscribeComponent,
 } from '@oort-front/safe';
 import get from 'lodash/get';
-import { takeUntil } from 'rxjs/operators';
+import { takeUntil, map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
 /**
  * Main component of Application view.
@@ -219,6 +220,33 @@ export class ApplicationComponent
     this.applicationService.reorderPages(
       event.filter((x: any) => x.id).map((x: any) => x.id)
     );
+  }
+
+  /**
+   * Show modal confirmation before leave the page if has changes on custom styling
+   *
+   * @returns boolean of observable of boolean
+   */
+  canDeactivate(): Observable<boolean> | boolean {
+    if (this.applicationService.customStyleEdited) {
+      const dialogRef = this.confirmService.openConfirmModal({
+        title: this.translate.instant('components.form.update.exit'),
+        content: this.translate.instant(
+          'components.widget.settings.close.confirmationMessage'
+        ),
+        confirmText: this.translate.instant('components.confirmModal.confirm'),
+        confirmColor: 'primary',
+      });
+      return dialogRef.afterClosed().pipe(
+        map((confirm) => {
+          if (confirm) {
+            return true;
+          }
+          return false;
+        })
+      );
+    }
+    return true;
   }
 
   override ngOnDestroy(): void {

--- a/apps/back-office/src/app/application/pages/settings/settings.component.ts
+++ b/apps/back-office/src/app/application/pages/settings/settings.component.ts
@@ -195,5 +195,6 @@ export class SettingsComponent
     this.layoutService.setRightSidenav({
       component: CustomStyleComponent,
     });
+    this.layoutService.closeRightSidenav = false;
   }
 }

--- a/libs/safe/src/lib/services/application/application.service.ts
+++ b/libs/safe/src/lib/services/application/application.service.ts
@@ -86,6 +86,7 @@ import {
   UPDATE_CUSTOM_NOTIFICATION,
 } from '../application-notifications/graphql/mutations';
 import { SafeRestService } from '../rest/rest.service';
+import { SafeLayoutService } from '../layout/layout.service';
 
 /**
  * Shared application service. Handles events of opened application.
@@ -112,6 +113,7 @@ export class SafeApplicationService {
 
   /** Application custom style */
   public customStyle?: HTMLStyleElement;
+  public customStyleEdited = false;
 
   /** @returns Path to download application users */
   get usersDownloadPath(): string {
@@ -175,7 +177,8 @@ export class SafeApplicationService {
     private router: Router,
     private translate: TranslateService,
     private restService: SafeRestService,
-    private downloadService: SafeDownloadService
+    private downloadService: SafeDownloadService,
+    private layoutService: SafeLayoutService
   ) {
     this.environment = environment;
   }
@@ -202,6 +205,7 @@ export class SafeApplicationService {
         this.application.next(data.application);
         const application = this.application.getValue();
         this.getCustomStyle();
+        this.customStyleEdited = false;
         if (data.application.locked) {
           if (!application?.lockedByUser) {
             this.snackBar.openSnackBar(
@@ -256,6 +260,7 @@ export class SafeApplicationService {
     if (this.customStyle) {
       document.getElementsByTagName('body')[0].removeChild(this.customStyle);
       this.customStyle = undefined;
+      this.layoutService.closeRightSidenav = true;
     }
     const application = this.application.getValue();
     this.application.next(null);

--- a/libs/safe/src/lib/services/layout/layout.service.ts
+++ b/libs/safe/src/lib/services/layout/layout.service.ts
@@ -10,6 +10,8 @@ import { BehaviorSubject, Observable } from 'rxjs';
   providedIn: 'root',
 })
 export class SafeLayoutService {
+  /** Close right sidenav opened when navigating */
+  public closeRightSidenav = true;
   /** Current right sidenav */
   private rightSidenav = new BehaviorSubject<any>(null);
   /** @returns Current right sidenav as observable */
@@ -26,7 +28,9 @@ export class SafeLayoutService {
   constructor(private router: Router) {
     // If the router detects a change, we close the sidenav
     this.router.events.subscribe(() => {
-      this.rightSidenav.next(null);
+      if (this.closeRightSidenav) {
+        this.rightSidenav.next(null);
+      }
     });
   }
 


### PR DESCRIPTION
# Description
- Keep custom styling active while navigating between pages, but if we close the application, we close the panel
-  when opening the custom styling of an application, the form isn't considered 'edited' after the  code prettify
- if the panel is active & updated, but the changes wasn't saved, show confirm modal when clicking in the close button and using the CanDeactivateGuard  if trying to leave the active route (the application route)

## Ticket
[DB - Keep styling active when navigating between application pages](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/60921)

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Opening the custom styling to see the save button disabled because the pristine status of the form is true, closing the settings and changing the application page and keeping the custom style sidenav open and testing closing the sidnav or exiting the application by changing the navigation to see the confirm modal alert.

## Sreenshots
![cs](https://user-images.githubusercontent.com/28535394/229578976-fd8e5e3a-7a89-458f-aab5-b2bb7f1e8bf0.gif)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
