### PR TITLE
feat/AB#61054-consistent-styling-for-layer-tabs

### DIFF
--- a/libs/safe/src/lib/components/widgets/map-settings/map-layer/map-layer.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-layer/map-layer.component.html
@@ -1,68 +1,70 @@
 <ng-template #layerNavigationTemplate>
-  <safe-button
-    icon="map"
-    [attr.data-selected]="currentTab === 'parameters'"
-    (click)="currentTab = 'parameters'"
-  >
-    {{ 'components.widget.settings.map.edit.layerProperties' | translate }}
-  </safe-button>
-  <safe-button
-    icon="storage"
-    [attr.data-selected]="currentTab === 'datasource'"
-    (click)="currentTab = 'datasource'"
-  >
-    {{ 'components.widget.settings.map.edit.layerDatasource' | translate }}
-  </safe-button>
-  <safe-button
-    icon="storage"
-    [attr.data-selected]="currentTab === 'styling'"
-    (click)="currentTab = 'styling'"
-  >
-    {{ 'components.widget.settings.map.edit.layerStyling' | translate }}
-  </safe-button>
-  <!-- <safe-button
-    icon="map"
-    [attr.data-selected]="currentTab === 'filter'"
-    (click)="currentTab = 'filter'"
-  >
-    {{ 'components.widget.settings.map.edit.filter' | translate }}
-  </safe-button> -->
-  <!-- <safe-button
-    icon="map"
-    [attr.data-selected]="currentTab === 'cluster'"
-    (click)="currentTab = 'cluster'"
-  >
-    {{ 'components.widget.settings.map.edit.cluster.cluster' | translate }}
-  </safe-button> -->
-  <safe-button
-    *ngIf="form.get('layerDefinition.featureReduction')?.enabled"
-    icon="map"
-    [attr.data-selected]="currentTab === 'aggregation'"
-    (click)="currentTab = 'aggregation'"
-  >
-    {{ 'components.widget.settings.map.edit.aggregation' | translate }}
-  </safe-button>
-  <safe-button
-    icon="map"
-    [attr.data-selected]="currentTab === 'popup'"
-    (click)="currentTab = 'popup'"
-  >
-    {{ 'components.widget.settings.map.edit.popup' | translate }}
-  </safe-button>
-  <safe-button
-    icon="map"
-    [attr.data-selected]="currentTab === 'fields'"
-    (click)="currentTab = 'fields'"
-  >
-    {{ 'components.widget.settings.map.edit.fields' | translate }}
-  </safe-button>
-  <!-- <safe-button
-    icon="map"
-    [attr.data-selected]="currentTab === 'labels'"
-    (click)="currentTab = 'labels'"
-  >
-    {{ 'components.widget.settings.map.edit.labels' | translate }}
-  </safe-button> -->
+  <div class="tabs">
+    <safe-button
+      icon="map"
+      [attr.data-selected]="currentTab === 'parameters'"
+      (click)="currentTab = 'parameters'"
+    >
+      {{ 'components.widget.settings.map.edit.layerProperties' | translate }}
+    </safe-button>
+    <safe-button
+      icon="storage"
+      [attr.data-selected]="currentTab === 'datasource'"
+      (click)="currentTab = 'datasource'"
+    >
+      {{ 'components.widget.settings.map.edit.layerDatasource' | translate }}
+    </safe-button>
+    <safe-button
+      icon="storage"
+      [attr.data-selected]="currentTab === 'styling'"
+      (click)="currentTab = 'styling'"
+    >
+      {{ 'components.widget.settings.map.edit.layerStyling' | translate }}
+    </safe-button>
+    <!-- <safe-button
+      icon="map"
+      [attr.data-selected]="currentTab === 'filter'"
+      (click)="currentTab = 'filter'"
+    >
+      {{ 'components.widget.settings.map.edit.filter' | translate }}
+    </safe-button> -->
+    <!-- <safe-button
+      icon="map"
+      [attr.data-selected]="currentTab === 'cluster'"
+      (click)="currentTab = 'cluster'"
+    >
+      {{ 'components.widget.settings.map.edit.cluster.cluster' | translate }}
+    </safe-button> -->
+    <safe-button
+      *ngIf="form.get('layerDefinition.featureReduction')?.enabled"
+      icon="map"
+      [attr.data-selected]="currentTab === 'aggregation'"
+      (click)="currentTab = 'aggregation'"
+    >
+      {{ 'components.widget.settings.map.edit.aggregation' | translate }}
+    </safe-button>
+    <safe-button
+      icon="map"
+      [attr.data-selected]="currentTab === 'popup'"
+      (click)="currentTab = 'popup'"
+    >
+      {{ 'components.widget.settings.map.edit.popup' | translate }}
+    </safe-button>
+    <safe-button
+      icon="map"
+      [attr.data-selected]="currentTab === 'fields'"
+      (click)="currentTab = 'fields'"
+    >
+      {{ 'components.widget.settings.map.edit.fields' | translate }}
+    </safe-button>
+    <!-- <safe-button
+      icon="map"
+      [attr.data-selected]="currentTab === 'labels'"
+      (click)="currentTab = 'labels'"
+    >
+      {{ 'components.widget.settings.map.edit.labels' | translate }}
+    </safe-button> -->
+  </div>
 </ng-template>
 
 <ng-template #layerSettingsTemplate>

--- a/libs/safe/src/lib/components/widgets/map-settings/map-layer/map-layer.component.scss
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-layer/map-layer.component.scss
@@ -1,0 +1,11 @@
+.tabs {
+  @apply flex flex-col max-w-full;
+
+  ::ng-deep safe-button {
+    @apply w-full rounded-sm text-neutral-500;
+  }
+
+  ::ng-deep safe-button[data-selected='true'] {
+    @apply text-black bg-neutral-100;
+  }
+}

--- a/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.scss
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.scss
@@ -4,6 +4,7 @@
   mat-drawer {
     ::ng-deep safe-button {
       @apply w-full rounded-sm text-neutral-500;
+      text-align-last: start;
       ::ng-deep {
         .mat-button-wrapper {
           @apply flex items-center p-1.5;


### PR DESCRIPTION
# Description
Edited map tabs buttons to have a consistent style.

## Ticket
[DB - Consistent styling for layer tabs](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/61054)

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Changing the tabs of the layer tabs options.

## Sreenshots
![image](https://user-images.githubusercontent.com/28535394/230096301-93a18200-f930-41be-9cb2-6d3aba904f5b.png)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
