### PR TITLE
fix/AB#60593/OORT-611_prevent-storing-choices-in-the-form-structure fix: destr…

### DIFF
--- a/projects/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/projects/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -247,7 +247,7 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
       this.addCustomClassToCoreFields(coreFields);
     }
 
-    // Scroll to question when adde
+    // Scroll to question when added
     this.surveyCreator.onQuestionAdded.add((sender, opt) => {
       const name = opt.question.name;
       setTimeout(() => {
@@ -403,20 +403,26 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
     }
     // if choices object exists, checks for duplicate values
     if (element.choices) {
-      const values = element.choices.map(
-        (choice: { value: string; text: string }) => choice.value || choice
-      );
-      const distinctValues = [...new Set(values)];
-
-      if (values.length > distinctValues.length) {
-        throw new Error(
-          this.translate.instant(
-            'pages.formBuilder.errors.choices.valueDuplicated',
-            {
-              question: element.valueName,
-            }
-          )
+      // If choices do not come from a reference data, we would make the duplication check as we want to save the choices in the form
+      if (!element.referenceData) {
+        const values = element.choices.map(
+          (choice: { value: string; text: string }) => choice.value || choice
         );
+        const distinctValues = [...new Set(values)];
+
+        if (values.length > distinctValues.length) {
+          throw new Error(
+            this.translate.instant(
+              'pages.formBuilder.errors.choices.valueDuplicated',
+              {
+                question: element.valueName,
+              }
+            )
+          );
+        }
+        // As we already have the reference data value to get the choices, we dont want to save them again with the form structure
+      } else {
+        element.choices = [];
       }
     }
     if (element.getType() === 'multipletext') {

--- a/projects/safe/src/lib/services/reference-data/reference-data.service.ts
+++ b/projects/safe/src/lib/services/reference-data/reference-data.service.ts
@@ -120,9 +120,14 @@ export class SafeReferenceDataService {
       a[displayField] > b[displayField] ? 1 : -1;
 
     // get items
-    const { items: items_, valueField } = (await localForage.getItem(
+    const referenceDataObj = (await localForage.getItem(
       referenceDataID
     )) as CachedItems;
+
+    if (!referenceDataObj) {
+      return [];
+    }
+    const { items: items_, valueField } = referenceDataObj;
     // sort items by displayField
     const items = items_.sort(sortByDisplayField);
     const foreignIsMultiselect = Array.isArray(filter?.foreignValue);


### PR DESCRIPTION
…ucture of referenceData object to set choices when first loading it from the survey properties feat: use reference data ID to load needed choices in the surveys and avoid saving choices in the survey structure for those cases

# FYI
If one of the choices loaded from the reference data is manually deleted, as we are using the reference data id to set the choices, is not taking in account when loading the form later on. That can be added in another task or in this one

# Description

We now check if any question with choices from the survey contains a reference data as it's source, if so, we will just send the reference data id in the survey instead of the choices.

We will load the needed choices with just the saved reference data id

Also fixed reference data object destructure if reference data is undefined

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/60593)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to the screenshots below

## Sreenshots

JSON data sent when survey is saved:
![choices](https://user-images.githubusercontent.com/123092672/230887224-798c532f-2a36-4ed5-852a-bbecfc79b16e.png)
Form containing choices when loading it:
![form with choices](https://user-images.githubusercontent.com/123092672/230887264-41a61d35-1362-442c-89a7-fc365c80cd77.png)
Data sent correctly when creating a new record:
![sent data](https://user-images.githubusercontent.com/123092672/230887337-9a4035eb-b5cd-4d78-a7d8-6cec467ccc23.png)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
