### PR TITLE
Fix 2.0.x/oort 614 grey bg forms

### DIFF
--- a/libs/safe/src/lib/style/styles.scss
+++ b/libs/safe/src/lib/style/styles.scss
@@ -23,6 +23,7 @@
   --primary-color: #{rgb($primary_500)};
   --secondary-color: #{rgb($primary_500)};
   --progress-buttons-color: #{rgb($primary_500)};
+  --header-background-color: transparent;
   // --primary-text-color: #676a6c;
   // --secondary-text-color: #a7a7a7;
   // --inverted-text-color: #ffffff;


### PR DESCRIPTION
# Description

Changed the property value of header background color from style.scss to avoid the grey background on forms.

## Ticket

https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/3?selectedIssue=OORT-614

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I checked that the grey background has disappeared on forms.

## Sreenshots

![image](https://user-images.githubusercontent.com/65243509/231206008-5cc2493e-8703-4f56-89c8-f2777a97cfe6.png)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
