### PR TITLE
feat/AB#61579_DB-see-if-possible-to-have-different-instances-of-surve…

### DIFF
--- a/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
+++ b/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
@@ -91,7 +91,7 @@
         <safe-button (click)="onEditFilter()">
           {{ 'components.application.dashboard.editFilter' | translate }}
         </safe-button>
-        <div #surveyCreatorContainer></div>
+        <div #dashboardSurveyCreatorContainer></div>
       </form>
     </div>
   </div>

--- a/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.scss
+++ b/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.scss
@@ -69,5 +69,6 @@
 ::ng-deep .edit-filters-modal {
   mat-dialog-container {
     margin: auto;
+    padding-top: 0;
   }
 }

--- a/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -53,7 +53,8 @@ export class SafeDashboardFilterComponent
   public filterFormGroup: FormGroup = new FormGroup({});
   public survey: Survey.Model = new Survey.Model();
   public surveyStructure: any = {};
-  @ViewChild('surveyCreatorContainer') surveyCreatorContainer!: ElementRef;
+  @ViewChild('dashboardSurveyCreatorContainer')
+  dashboardSurveyCreatorContainer!: ElementRef;
 
   public applicationId?: string;
 
@@ -141,7 +142,8 @@ export class SafeDashboardFilterComponent
    * Opens the modal to edit filters
    */
   public onEditFilter() {
-    const surveyStructure = this.surveyStructure.text ?? this.surveyStructure;
+    const surveyStructure =
+      this.surveyStructure.text ?? JSON.stringify(this.surveyStructure);
     const dialogRef = this.dialog.open(SafeFilterBuilderComponent, {
       height: '90%',
       width: '100%',
@@ -194,6 +196,6 @@ export class SafeDashboardFilterComponent
     this.survey = new Survey.Model(surveyStructure);
     this.survey.showCompletedPage = false;
     this.survey.showNavigationButtons = false;
-    this.survey.render(this.surveyCreatorContainer.nativeElement);
+    this.survey.render(this.dashboardSurveyCreatorContainer.nativeElement);
   }
 }

--- a/libs/safe/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder.component.html
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder.component.html
@@ -1,1 +1,12 @@
-<div class="w-full h-full" id="surveyCreatorContainer"></div>
+<div class="sticky top-0 z-10 bg-white">
+  <safe-button
+    class="ml-auto"
+    [isIcon]="true"
+    icon="close"
+    variant="danger"
+    [matTooltip]="'common.close' | translate"
+    (click)="cancelSurveyCreation()"
+  >
+  </safe-button>
+</div>
+<div class="w-full h-full" id="dashboardSurveyCreatorContainer"></div>

--- a/libs/safe/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder.component.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder.component.ts
@@ -134,7 +134,7 @@ export class SafeFilterBuilderComponent
     );
     this.surveyCreator.text = this.data?.surveyStructure;
     this.surveyCreator.showToolbox = 'right';
-    this.surveyCreator.showPropertyGrid = 'none';
+    this.surveyCreator.showPropertyGrid = 'right';
     this.surveyCreator.haveCommercialLicense = true;
     this.surveyCreator.survey.showQuestionNumbers = 'off';
     this.surveyCreator.saveSurveyFunc = this.saveMySurvey;

--- a/libs/safe/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder.component.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder.component.ts
@@ -1,10 +1,17 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  Inject,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
 import * as SurveyCreator from 'survey-creator';
 import * as Survey from 'survey-angular';
 import {
   MatLegacyDialogRef as MatDialogRef,
   MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
 } from '@angular/material/legacy-dialog';
+import { SafeFormService } from '../../../services/form/form.service';
 
 /**
  * Data passed to initialize the filter builder
@@ -82,21 +89,30 @@ const CORE_QUESTION_ALLOWED_PROPERTIES = [
   templateUrl: './filter-builder.component.html',
   styleUrls: ['./filter-builder.component.scss'],
 })
-export class SafeFilterBuilderComponent implements OnInit {
+export class SafeFilterBuilderComponent
+  implements OnInit, AfterViewInit, OnDestroy
+{
   surveyCreator!: SurveyCreator.SurveyCreator;
 
   /**
    * Dialog component to build the filter
    *
+   * @param formService Shared form service
    * @param dialogRef reference to the dialog component
    * @param data data passed to initialize the filter builder
    */
   constructor(
+    private formService: SafeFormService,
     private dialogRef: MatDialogRef<SafeFilterBuilderComponent>,
     @Inject(MAT_DIALOG_DATA) public data: DialogData
   ) {}
 
   ngOnInit(): void {
+    // Initialize survey creator instance without custom questions
+    this.formService.setSurveyCreatorInstance({ customQuestions: false });
+  }
+
+  ngAfterViewInit(): void {
     this.setFormBuilder();
   }
 
@@ -110,11 +126,10 @@ export class SafeFilterBuilderComponent implements OnInit {
       generateValidJSON: true,
       showTranslationTab: false,
       questionTypes: QUESTION_TYPES,
-      customQuestionTypes: [], // doesn't work to remove the custom questions
     };
     this.setCustomTheme();
     this.surveyCreator = new SurveyCreator.SurveyCreator(
-      'surveyCreatorContainer',
+      'dashboardSurveyCreatorContainer',
       creatorOptions
     );
     this.surveyCreator.text = this.data?.surveyStructure;
@@ -151,4 +166,16 @@ export class SafeFilterBuilderComponent implements OnInit {
   saveMySurvey = () => {
     this.dialogRef.close(this.surveyCreator);
   };
+
+  /**
+   * Close modal
+   */
+  cancelSurveyCreation() {
+    this.dialogRef.close();
+  }
+
+  ngOnDestroy(): void {
+    //Once we destroy the dashboard filter survey, set the survey creator with the custom questions config
+    this.formService.setSurveyCreatorInstance();
+  }
 }

--- a/libs/safe/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder.module.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder.module.ts
@@ -2,13 +2,22 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SafeFormBuilderModule } from '../../form-builder/form-builder.module';
 import { SafeFilterBuilderComponent } from './filter-builder.component';
+import { SafeButtonModule } from '../../ui/button/button.module';
+import { TranslateModule } from '@ngx-translate/core';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 /**
  *
  */
 @NgModule({
   declarations: [SafeFilterBuilderComponent],
-  imports: [CommonModule, SafeFormBuilderModule],
+  imports: [
+    CommonModule,
+    SafeFormBuilderModule,
+    SafeButtonModule,
+    TranslateModule,
+    MatTooltipModule,
+  ],
   exports: [SafeFilterBuilderComponent],
 })
 export class SafeFilterBuilderModule {}

--- a/libs/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -54,7 +54,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { SafeModalModule } from '../ui/modal/modal.module';
 import { SafeSpinnerModule } from '../ui/spinner/spinner.module';
 import { SafeUnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component';
-import { SafeFormService } from '../../services/form/form.service';
+import { SafeFormHelpersService } from '../../services/form-helper/form-helper.service';
 
 /**
  * Interface of Dialog data.
@@ -137,7 +137,7 @@ export class SafeFormModalComponent
    * @param snackBar This is the service that allows you to display a snackbar.
    * @param authService This is the service that handles authentication.
    * @param formBuilderService This is the service that will be used to build forms.
-   * @param formService This is the service that will handle forms.
+   * @param formHelpersService This is the service that will handle forms.
    * @param confirmService This is the service that will be used to display confirm window.
    * @param translate This is the service that allows us to translate the text in our application.
    * @param ngZone Angular Service to execute code inside Angular environment
@@ -150,7 +150,7 @@ export class SafeFormModalComponent
     private snackBar: SafeSnackBarService,
     private authService: SafeAuthService,
     private formBuilderService: SafeFormBuilderService,
-    private formService: SafeFormService,
+    private formHelpersService: SafeFormHelpersService,
     private confirmService: SafeConfirmService,
     private translate: TranslateService,
     private ngZone: NgZone
@@ -303,7 +303,7 @@ export class SafeFormModalComponent
       : 1;
 
     /** we can send to backend empty data if they are not required */
-    this.formService.setEmptyQuestions(survey);
+    this.formHelpersService.setEmptyQuestions(survey);
     // Displays confirmation modal.
     if (this.data.askForConfirm) {
       const dialogRef = this.confirmService.openConfirmModal(
@@ -350,7 +350,7 @@ export class SafeFormModalComponent
    * @param survey current survey
    */
   public async onUpdate(survey: any): Promise<void> {
-    await this.formService.uploadFiles(
+    await this.formHelpersService.uploadFiles(
       survey,
       this.temporaryFilesStorage,
       this.form?.id
@@ -626,7 +626,7 @@ export class SafeFormModalComponent
    * @param version The version to recover
    */
   private confirmRevertDialog(record: any, version: any) {
-    const dialogRef = this.formService.createRevertDialog(version);
+    const dialogRef = this.formHelpersService.createRevertDialog(version);
     dialogRef.afterClosed().subscribe((value) => {
       if (value) {
         this.apollo

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -29,7 +29,7 @@ import { SafeFormBuilderService } from '../../services/form-builder/form-builder
 import { SafeRecordHistoryComponent } from '../record-history/record-history.component';
 import { TranslateService } from '@ngx-translate/core';
 import { SafeUnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component';
-import { SafeFormService } from '../../services/form/form.service';
+import { SafeFormHelpersService } from '../../services/form-helper/form-helper.service';
 
 /**
  * This component is used to display forms
@@ -86,7 +86,7 @@ export class SafeFormComponent
    * @param authService This is the service that handles authentication.
    * @param layoutService Shared layout service
    * @param formBuilderService This is the service that will be used to build forms.
-   * @param formService This is the service that will handle forms.
+   * @param formHelpersService This is the service that will handle forms.
    * @param translate This is the service used to translate text
    */
   constructor(
@@ -96,7 +96,7 @@ export class SafeFormComponent
     private authService: SafeAuthService,
     private layoutService: SafeLayoutService,
     private formBuilderService: SafeFormBuilderService,
-    private formService: SafeFormService,
+    private formHelpersService: SafeFormHelpersService,
     private translate: TranslateService
   ) {
     super();
@@ -261,12 +261,12 @@ export class SafeFormComponent
   public onComplete = async () => {
     let mutation: any;
     this.surveyActive = false;
-    await this.formService.uploadFiles(
+    await this.formHelpersService.uploadFiles(
       this.survey,
       this.temporaryFilesStorage,
       this.form?.id
     );
-    this.formService.setEmptyQuestions(this.survey);
+    this.formHelpersService.setEmptyQuestions(this.survey);
     // If is an already saved record, edit it
     if (this.record || this.form.uniqueRecord) {
       const recordId = this.record
@@ -375,7 +375,7 @@ export class SafeFormComponent
    * @param version The version to recover
    */
   private confirmRevertDialog(record: any, version: any) {
-    const dialogRef = this.formService.createRevertDialog(version);
+    const dialogRef = this.formHelpersService.createRevertDialog(version);
     dialogRef.afterClosed().subscribe((value) => {
       if (value) {
         this.apollo

--- a/libs/safe/src/lib/components/record-modal/record-modal.component.ts
+++ b/libs/safe/src/lib/components/record-modal/record-modal.component.ts
@@ -31,7 +31,7 @@ import { BehaviorSubject, firstValueFrom, Observable, takeUntil } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import isEqual from 'lodash/isEqual';
 import { SafeUnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component';
-import { SafeFormService } from '../../services/form/form.service';
+import { SafeFormHelpersService } from '../../services/form-helper/form-helper.service';
 
 /**
  * Interface that describes the structure of the data that will be shown in the dialog
@@ -93,7 +93,7 @@ export class SafeRecordModalComponent
    * @param authService This is the service that handles the authentication of the user
    * @param snackBar This is the service that allows you to display a snackbar message to the user.
    * @param formBuilderService This is the service that will be used to build forms.
-   * @param formService This is the service to handle forms.
+   * @param formHelpersService This is the service to handle forms.
    * @param translate This is the service that allows us to translate the text in the modal.
    */
   constructor(
@@ -104,7 +104,7 @@ export class SafeRecordModalComponent
     private authService: SafeAuthService,
     private snackBar: SafeSnackBarService,
     private formBuilderService: SafeFormBuilderService,
-    private formService: SafeFormService,
+    private formHelpersService: SafeFormHelpersService,
     private translate: TranslateService
   ) {
     super();
@@ -275,7 +275,7 @@ export class SafeRecordModalComponent
    * @param version The version to recover
    */
   private confirmRevertDialog(record: any, version: any) {
-    const dialogRef = this.formService.createRevertDialog(version);
+    const dialogRef = this.formHelpersService.createRevertDialog(version);
     dialogRef.afterClosed().subscribe((value) => {
       if (value) {
         this.apollo

--- a/libs/safe/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/safe/src/lib/services/form-helper/form-helper.service.ts
@@ -1,0 +1,125 @@
+import { Injectable } from '@angular/core';
+import * as Survey from 'survey-angular';
+import { MatLegacyDialogRef } from '@angular/material/legacy-dialog';
+import { Apollo } from 'apollo-angular';
+import { SafeSnackBarService } from '../snackbar/snackbar.service';
+import { TranslateService } from '@ngx-translate/core';
+import { SafeConfirmService } from '../confirm/confirm.service';
+import { firstValueFrom } from 'rxjs';
+import {
+  UPLOAD_FILE,
+  UploadFileMutationResponse,
+} from '../../components/form/graphql/mutations';
+
+/**
+ * Shared survey helper service.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SafeFormHelpersService {
+  /**
+   * Shared survey helper service.
+   *
+   * @param apollo Apollo client
+   * @param snackBar This is the service that allows you to display a snackbar.
+   * @param confirmService This is the service that will be used to display confirm window.
+   * @param translate This is the service that allows us to translate the text in our application.
+   */
+  constructor(
+    public apollo: Apollo,
+    private snackBar: SafeSnackBarService,
+    private confirmService: SafeConfirmService,
+    private translate: TranslateService
+  ) {}
+
+  /**
+   * Create a dialog modal to confirm the recovery of survey data
+   *
+   * @param version The version to recover
+   * @returns dialogRef
+   */
+  createRevertDialog(version: any): MatLegacyDialogRef<any> {
+    // eslint-disable-next-line radix
+    const date = new Date(parseInt(version.createdAt, 0));
+    const formatDate = `${date.getDate()}/${
+      date.getMonth() + 1
+    }/${date.getFullYear()}`;
+    const dialogRef = this.confirmService.openConfirmModal({
+      title: this.translate.instant('components.record.recovery.title'),
+      content: this.translate.instant(
+        'components.record.recovery.confirmationMessage',
+        { date: formatDate }
+      ),
+      confirmText: this.translate.instant('components.confirmModal.confirm'),
+      confirmColor: 'primary',
+    });
+    return dialogRef;
+  }
+
+  /**
+   * Set data from survey empty questions
+   *
+   * @param survey Current survey to set up empty questions
+   */
+  setEmptyQuestions(survey: Survey.SurveyModel): void {
+    // We get all the questions from the survey and check which ones contains values
+    const questions = survey.getAllQuestions();
+    for (const field in questions) {
+      if (questions[field]) {
+        const key = questions[field].getValueName();
+        // If there is no value for this question
+        if (!survey.data[key]) {
+          // And is not boolean(false by default, we want to save that), we nullify it
+          if (questions[field].getType() !== 'boolean') {
+            survey.data[key] = null;
+          }
+          // Or if is not visible or not actionable by the user, we don't want to save it, just delete the field from the data
+          if (questions[field].readOnly || !questions[field].visible) {
+            delete survey.data[key];
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Upload asynchronously files to create questions in the form
+   *
+   * @param survey The form in which the files will be updated
+   * @param temporaryFilesStorage Temporary files saved while executing the survey
+   * @param formId Form where to upload the files
+   */
+  async uploadFiles(
+    survey: any,
+    temporaryFilesStorage: any,
+    formId: string | undefined
+  ): Promise<void> {
+    const data = survey.data;
+    const questionsToUpload = Object.keys(temporaryFilesStorage);
+    for (const name of questionsToUpload) {
+      const files = temporaryFilesStorage[name];
+      for (const [index, file] of files.entries()) {
+        const res = await firstValueFrom(
+          this.apollo.mutate<UploadFileMutationResponse>({
+            mutation: UPLOAD_FILE,
+            variables: {
+              file,
+              form: formId,
+            },
+            context: {
+              useMultipart: true,
+            },
+          })
+        );
+        if (res.errors) {
+          this.snackBar.openSnackBar(res.errors[0].message, { error: true });
+          return;
+        } else {
+          data[name][index].content = res.data?.uploadFile;
+        }
+      }
+    }
+    survey.data = data;
+  }
+}

--- a/libs/safe/src/lib/services/form/form.service.ts
+++ b/libs/safe/src/lib/services/form/form.service.ts
@@ -4,32 +4,20 @@ import * as Survey from 'survey-angular';
 import { initCreatorSettings } from '../../survey/creator';
 import { initCustomSurvey } from '../../survey/init';
 import { DomService } from '../dom/dom.service';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogRef,
-} from '@angular/material/legacy-dialog';
+import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { Apollo } from 'apollo-angular';
 import { UntypedFormBuilder } from '@angular/forms';
 import { SafeAuthService } from '../auth/auth.service';
 import { SafeReferenceDataService } from '../reference-data/reference-data.service';
-import { SafeSnackBarService } from '../snackbar/snackbar.service';
-import { TranslateService } from '@ngx-translate/core';
-import { SafeConfirmService } from '../confirm/confirm.service';
-import { firstValueFrom } from 'rxjs';
-import {
-  UPLOAD_FILE,
-  UploadFileMutationResponse,
-} from '../../components/form/graphql/mutations';
 
 /**
  * Shared survey service.
  * Initializes the additional code we made on top of the default logic of the library.
  * Must be initialized at some point in the applications.
  */
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable({ providedIn: 'root' })
 export class SafeFormService {
+  private environment: any;
   /**
    * Shared survey service.
    * Initializes the additional code we made on top of the default logic of the library.
@@ -42,9 +30,6 @@ export class SafeFormService {
    * @param formBuilder Angular form builder
    * @param authService Shared authentication service
    * @param referenceDataService Reference data service
-   * @param snackBar This is the service that allows you to display a snackbar.
-   * @param confirmService This is the service that will be used to display confirm window.
-   * @param translate This is the service that allows us to translate the text in our application.
    */
   constructor(
     @Inject('environment') environment: any,
@@ -53,124 +38,48 @@ export class SafeFormService {
     public apollo: Apollo,
     public formBuilder: UntypedFormBuilder,
     public authService: SafeAuthService,
-    public referenceDataService: SafeReferenceDataService,
-    private snackBar: SafeSnackBarService,
-    private confirmService: SafeConfirmService,
-    private translate: TranslateService
+    public referenceDataService: SafeReferenceDataService
+  ) {
+    this.environment = environment;
+    this.setSurveyCreatorInstance();
+  }
+
+  /**
+   * Set any custom components needed for our survey creator instance
+   *
+   * @param additionalQuestions Object narrowing the question types that the survey has to have
+   * @param additionalQuestions.customQuestions If the survey creator should contain custom questions
+   */
+  setSurveyCreatorInstance(
+    additionalQuestions: { customQuestions: boolean } = {
+      customQuestions: true,
+    }
   ) {
     // === CUSTOM WIDGETS / COMPONENTS ===
     initCustomSurvey(
       SurveyKo,
-      domService,
-      dialog,
-      apollo,
-      formBuilder,
-      authService,
-      environment,
-      referenceDataService
+      this.domService,
+      this.dialog,
+      this.apollo,
+      this.formBuilder,
+      this.authService,
+      this.environment,
+      this.referenceDataService,
+      additionalQuestions.customQuestions
     );
     // === CREATOR SETTINGS ===
     initCreatorSettings(SurveyKo);
     // === CUSTOM WIDGETS / COMPONENTS ===
     initCustomSurvey(
       Survey,
-      domService,
-      dialog,
-      apollo,
-      formBuilder,
-      authService,
-      environment,
-      referenceDataService
+      this.domService,
+      this.dialog,
+      this.apollo,
+      this.formBuilder,
+      this.authService,
+      this.environment,
+      this.referenceDataService,
+      additionalQuestions.customQuestions
     );
-  }
-
-  /**
-   * Create a dialog modal to confirm the recovery of survey data
-   *
-   * @param version The version to recover
-   * @returns dialogRef
-   */
-  createRevertDialog(version: any): MatLegacyDialogRef<any> {
-    // eslint-disable-next-line radix
-    const date = new Date(parseInt(version.createdAt, 0));
-    const formatDate = `${date.getDate()}/${
-      date.getMonth() + 1
-    }/${date.getFullYear()}`;
-    const dialogRef = this.confirmService.openConfirmModal({
-      title: this.translate.instant('components.record.recovery.title'),
-      content: this.translate.instant(
-        'components.record.recovery.confirmationMessage',
-        { date: formatDate }
-      ),
-      confirmText: this.translate.instant('components.confirmModal.confirm'),
-      confirmColor: 'primary',
-    });
-    return dialogRef;
-  }
-
-  /**
-   * Set data from survey empty questions
-   *
-   * @param survey Current survey to set up empty questions
-   */
-  setEmptyQuestions(survey: Survey.SurveyModel): void {
-    // We get all the questions from the survey and check which ones contains values
-    const questions = survey.getAllQuestions();
-    for (const field in questions) {
-      if (questions[field]) {
-        const key = questions[field].getValueName();
-        // If there is no value for this question
-        if (!survey.data[key]) {
-          // And is not boolean(false by default, we want to save that), we nullify it
-          if (questions[field].getType() !== 'boolean') {
-            survey.data[key] = null;
-          }
-          // Or if is not visible or not actionable by the user, we don't want to save it, just delete the field from the data
-          if (questions[field].readOnly || !questions[field].visible) {
-            delete survey.data[key];
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * Upload asynchronously files to create questions in the form
-   *
-   * @param survey The form in which the files will be updated
-   * @param temporaryFilesStorage Temporary files saved while executing the survey
-   * @param formId Form where to upload the files
-   */
-  async uploadFiles(
-    survey: any,
-    temporaryFilesStorage: any,
-    formId: string | undefined
-  ): Promise<void> {
-    const data = survey.data;
-    const questionsToUpload = Object.keys(temporaryFilesStorage);
-    for (const name of questionsToUpload) {
-      const files = temporaryFilesStorage[name];
-      for (const [index, file] of files.entries()) {
-        const res = await firstValueFrom(
-          this.apollo.mutate<UploadFileMutationResponse>({
-            mutation: UPLOAD_FILE,
-            variables: {
-              file,
-              form: formId,
-            },
-            context: {
-              useMultipart: true,
-            },
-          })
-        );
-        if (res.errors) {
-          this.snackBar.openSnackBar(res.errors[0].message, { error: true });
-          return;
-        } else {
-          data[name][index].content = res.data?.uploadFile;
-        }
-      }
-    }
-    survey.data = data;
   }
 }

--- a/libs/safe/src/lib/survey/init.ts
+++ b/libs/safe/src/lib/survey/init.ts
@@ -34,6 +34,7 @@ import { initLocalization } from './localization';
  * @param authService custom auth service
  * @param environment injected environment
  * @param referenceDataService Reference data service
+ * @param containsCustomQuestions If survey contains custom questions or not
  */
 export const initCustomSurvey = (
   Survey: any,
@@ -43,19 +44,27 @@ export const initCustomSurvey = (
   formBuilder: UntypedFormBuilder,
   authService: SafeAuthService,
   environment: any,
-  referenceDataService: SafeReferenceDataService
+  referenceDataService: SafeReferenceDataService,
+  containsCustomQuestions: boolean
 ): void => {
-  // load widgets (aka custom questions)
-  SurveyJSWidgets.select2tagbox(Survey);
-  CommentWidget.init(Survey);
-  TextWidget.init(Survey, domService);
-  // load components (same as widgets, but with less configuration options)
-  ResourceComponent.init(Survey, domService, apollo, dialog, formBuilder);
-  ResourcesComponent.init(Survey, domService, apollo, dialog, formBuilder);
-  OwnerComponent.init(Survey, domService, apollo);
-  UsersComponent.init(Survey, domService, apollo);
-  // load global properties
-  ReferenceDataProperties.init(Survey, domService, referenceDataService);
+  // If the survey created does not contain custom questions, we destroy previously set custom questions if so
+  if (!containsCustomQuestions) {
+    Survey.CustomWidgetCollection.Instance.clear();
+    Survey.ComponentCollection.Instance.clear();
+  } else {
+    // load widgets (aka custom questions)
+    SurveyJSWidgets.select2tagbox(Survey);
+    CommentWidget.init(Survey);
+    TextWidget.init(Survey, domService);
+    // load components (same as widgets, but with less configuration options)
+    ResourceComponent.init(Survey, domService, apollo, dialog, formBuilder);
+    ResourcesComponent.init(Survey, domService, apollo, dialog, formBuilder);
+    OwnerComponent.init(Survey, domService, apollo);
+    UsersComponent.init(Survey, domService, apollo);
+    // load global properties
+    ReferenceDataProperties.init(Survey, domService, referenceDataService);
+  }
+
   TooltipProperty.init(Survey);
   OtherProperties.init(Survey, environment);
   // set localization


### PR DESCRIPTION
…yjs fix: same id for dashboard form survey and dashboard filter survey fix: initialize survey structure of dashboard filter with no text feat: add a sticky close button to dashboard filter survey modal for a more user friendly experience feat: add setSurveyCreatorInstance is form.service to update the current survey creator instance with the needed question configuration refactor: add survey helpers to a new service to have a clean overview of the survey data/work flow in the code

# Description

Add the possibility to update the current Survey Creator instance with the question configuration needed for each survey.
Custom question config deleted from the creation of the dashboard filter survey

Fixed error when creating a new dashboard filter survey with no text in the suveryStructure stringifying the `{}` default value 

Refactor the survey creator methods with a new service to have a clean overview of the survey data/work flow in the code

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/61579)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please refer to the screenshots below

## Sreenshots

Default configuration for the survey creator:
![default survey](https://user-images.githubusercontent.com/123092672/231778572-d7330ea0-b669-4874-bfa3-40f427f6da2b.png)

Simplified survey creator for dashboard filter:
![simple survey](https://user-images.githubusercontent.com/123092672/231778643-06ca56c0-eb83-4416-ad86-6fb85986a67c.png)

Property grid:
![image](https://user-images.githubusercontent.com/123092672/231788798-f5487b8d-b375-4dd9-a096-fa97e17e8906.png)


Improved user experience by adding a simple sticky close button
![user-friendly](https://user-images.githubusercontent.com/123092672/231778847-3b2aeeb2-3330-4b54-82fa-22db595bcf44.png)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
