### PR TITLE
fix/AB#61701-edit-label-of-fields

### DIFF
--- a/libs/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
+++ b/libs/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
@@ -140,47 +140,47 @@
     </div>
   </div>
 
-  <!-- Edited field -->
-  <div class="flex-1" *ngIf="fieldForm">
-    <ng-container *ngIf="fieldForm.value.kind === 'SCALAR'">
-      <form
-        [formGroup]="fieldForm"
-        class="p-4 rounded-lg border border-gray-300"
-      >
-        <div class="flex gap-2">
-          <safe-button
-            [isIcon]="true"
-            icon="arrow_back"
-            (click)="onCloseField()"
-          >
-          </safe-button>
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'models.form.field.name' | translate }}</mat-label>
-            <input
-              matInput
-              formControlName="name"
-              type="text"
-              [disabled]="true"
-            />
-          </mat-form-field>
-          <mat-form-field appearance="outline">
-            <mat-label>{{ 'models.form.field.label' | translate }}</mat-label>
-            <input matInput formControlName="label" type="text" />
-          </mat-form-field>
-        </div>
-        <h3 style="margin: 0">
-          {{ 'components.queryBuilder.fields.format.title' | translate }}
-        </h3>
-        <div class="info-text" style="margin-bottom: 10px">
-          {{ 'components.queryBuilder.fields.format.info' | translate }}
-        </div>
-        <editor [init]="editor" formControlName="format"></editor>
-      </form>
-    </ng-container>
-    <ng-container
-      *ngIf="fieldForm.value.kind !== 'SCALAR'"
-      [ngTemplateOutlet]="childTemplate"
-    ></ng-container>
-  </div>
+</div>
+<!-- Edited field -->
+<div class="flex-1" *ngIf="fieldForm">
+  <ng-container *ngIf="fieldForm.value.kind === 'SCALAR'">
+    <form
+      [formGroup]="fieldForm"
+      class="p-4 rounded-lg border border-gray-300"
+    >
+      <div class="flex gap-2">
+        <safe-button
+          [isIcon]="true"
+          icon="arrow_back"
+          (click)="onCloseField()"
+        >
+        </safe-button>
+        <mat-form-field appearance="outline">
+          <mat-label>{{ 'models.form.field.name' | translate }}</mat-label>
+          <input
+            matInput
+            formControlName="name"
+            type="text"
+            [disabled]="true"
+          />
+        </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>{{ 'models.form.field.label' | translate }}</mat-label>
+          <input matInput formControlName="label" type="text" />
+        </mat-form-field>
+      </div>
+      <h3 style="margin: 0">
+        {{ 'components.queryBuilder.fields.format.title' | translate }}
+      </h3>
+      <div class="info-text" style="margin-bottom: 10px">
+        {{ 'components.queryBuilder.fields.format.info' | translate }}
+      </div>
+      <editor [init]="editor" formControlName="format"></editor>
+    </form>
+  </ng-container>
+  <ng-container
+    *ngIf="fieldForm.value.kind !== 'SCALAR'"
+    [ngTemplateOutlet]="childTemplate"
+  ></ng-container>
 </div>
 <ng-template #childTemplate></ng-template>


### PR DESCRIPTION
# Description
When editing a layout or an email action is possible edit the label of the fields, but the HTML template was being hidden along with the template that listed the available and selected fields, so that's why we see a white screen.

## Ticket
[ABC - Cannot edit label of fields in layout / email](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/61701)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Editing label of fields or subfields when clicking on the pencil in the Layout configuration modal and when editing an email action.

## Sreenshots
![edit-label](https://user-images.githubusercontent.com/28535394/231782997-66d6cbb3-e519-442b-a7b3-a2ab7072a4dc.gif)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
