### PR TITLE
Feat/ab#61944 abc implement breadcrumbs component

### DIFF
--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -7,3 +7,4 @@ export * from './lib/checkbox/checkbox.module';
 export * from './lib/flyout-menu/flyout-menu.module';
 export * from './lib/icon/icon.module';
 export * from './lib/select/select.module';
+export * from './lib/breadcrumbs/breadcrumbs.module';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -1,3 +1,5 @@
+import { from } from 'rxjs';
+
 export * from './lib/ui.module';
 
 // === TAILWIND COMPONENTS === //
@@ -8,3 +10,10 @@ export * from './lib/flyout-menu/flyout-menu.module';
 export * from './lib/icon/icon.module';
 export * from './lib/select/select.module';
 export * from './lib/breadcrumbs/breadcrumbs.module';
+
+// === ENUMS === //
+export * from './lib/breadcrumbs/enums/breadcrumb-display.enum';
+export * from './lib/breadcrumbs/enums/breadcrumb-separator.enum';
+
+// === INTERFACES === //
+export * from './lib/breadcrumbs/interfaces/breadcrumb.interface';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -1,5 +1,3 @@
-import { from } from 'rxjs';
-
 export * from './lib/ui.module';
 
 // === TAILWIND COMPONENTS === //

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -1,0 +1,1 @@
+<p>breadcrumbs works!</p>

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -1,9 +1,65 @@
+<ng-template #defineSep>
+  <!-- Check the display style and adapt accordingly -->
+    <div [ngSwitch]="display">
+      <div *ngSwitchCase="BreadcrumbsTypes.CONTAINED">
+          <svg
+            class="h-full w-6 flex-shrink-0 text-gray-200"
+            viewBox="0 0 24 44"
+            preserveAspectRatio="none"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+          </svg>
+      </div>
+      <div *ngSwitchCase="BreadcrumbsTypes.FULL">
+          <svg
+            class="h-full w-6 flex-shrink-0 text-gray-200"
+            viewBox="0 0 24 44"
+            preserveAspectRatio="none"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+          </svg>
+      </div>
+      <div *ngSwitchCase="BreadcrumbsTypes.SIMPLE">
+        <!-- Check the separator style and adapt accordingly -->
+        <div [ngSwitch]="separator">
+          <div *ngSwitchCase="BreadcrumbsSeparators.CHEVRON">
+              <svg
+                class="h-5 w-5 flex-shrink-0 text-gray-400"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+          </div>
+          <div *ngSwitchCase="BreadcrumbsSeparators.SLASH">
+              <svg
+                class="h-5 w-5 flex-shrink-0 text-gray-300"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                aria-hidden="true"
+              >
+                <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+              </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+</ng-template>
+
 <nav
   [ngClass]="{
-    'flex': display === BreadcrumbsTypes.SIMPLE,
-    'flex': display === BreadcrumbsTypes.CONTAINED,
-    'flex border-b border-gray-200 bg-white': display === BreadcrumbsTypes.FULL
+    'border-b border-gray-200 bg-white': display === BreadcrumbsTypes.FULL
   }"
+  class="flex"
   aria-label="Breadcrumb"
 >
   <ol
@@ -16,66 +72,11 @@
   >
     <!-- For each breadcrumb in the breadcrumbs list -->
     <li *ngFor="let breadcrumb of breadcrumbs; let f = first" class="flex">
+      <div *ngIf="!f">
+        <ng-template [ngTemplateOutlet]="defineSep"></ng-template>
+      </div>
+      <!-- Breadcrumb link -->
       <div class="flex items-center">
-        <!-- Check the display style and adapt accordingly -->
-        <div [ngSwitch]="display" class="flex">
-          <div *ngSwitchCase="BreadcrumbsTypes.CONTAINED">
-            <svg
-              *ngIf="!f"
-              class="h-full w-6 flex-shrink-0 text-gray-200"
-              viewBox="0 0 24 44"
-              preserveAspectRatio="none"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
-            </svg>
-          </div>
-          <div *ngSwitchCase="BreadcrumbsTypes.FULL">
-            <svg
-              *ngIf="!f"
-              class="h-full w-6 flex-shrink-0 text-gray-200"
-              viewBox="0 0 24 44"
-              preserveAspectRatio="none"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
-            </svg>
-          </div>
-          <div *ngSwitchCase="BreadcrumbsTypes.SIMPLE">
-            <!-- Check the separator style and adapt accordingly -->
-            <div [ngSwitch]="separator">
-              <div *ngSwitchCase="BreadcrumbsSeparators.CHEVRON">
-                <svg
-                  *ngIf="!f"
-                  class="h-5 w-5 flex-shrink-0 text-gray-400"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
-              </div>
-              <div *ngSwitchCase="BreadcrumbsSeparators.SLASH">
-                <svg
-                  *ngIf="!f"
-                  class="h-5 w-5 flex-shrink-0 text-gray-300"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                  aria-hidden="true"
-                >
-                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-                </svg>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Breadcrumb link -->
         <a
           *ngIf="breadcrumb.key || breadcrumb.text"
           href="{{ breadcrumb.uri }}"

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -1,56 +1,28 @@
-<ng-template #defineSep>
-  <!-- Check the display style and adapt accordingly -->
-  <div [ngSwitch]="display">
-    <div *ngSwitchCase="BreadcrumbsTypes.CONTAINED">
+<!-- Check the separator style and adapt accordingly -->
+<ng-template #separatorTmpl>
+  <ng-container [ngSwitch]="separator">
+    <ng-container *ngSwitchCase="BreadcrumbsSeparators.CHEVRON">
       <svg
-        class="h-full w-6 flex-shrink-0 text-gray-200"
-        viewBox="0 0 24 44"
-        preserveAspectRatio="none"
+        class="h-5 w-5 flex-shrink-0 text-gray-400"
+        viewBox="-5 0 60 60"
         fill="currentColor"
         aria-hidden="true"
       >
         <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
       </svg>
-    </div>
-    <div *ngSwitchCase="BreadcrumbsTypes.FULL">
+    </ng-container>
+    <ng-container *ngSwitchCase="BreadcrumbsSeparators.SLASH">
       <svg
-        class="h-full w-6 flex-shrink-0 text-gray-200"
-        viewBox="0 0 24 44"
-        preserveAspectRatio="none"
+        class="h-5 w-5 flex-shrink-0 text-gray-300"
         fill="currentColor"
+        viewBox="0 0 20 20"
         aria-hidden="true"
       >
-        <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+        <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
       </svg>
-    </div>
-    <div *ngSwitchCase="BreadcrumbsTypes.SIMPLE">
-      <!-- Check the separator style and adapt accordingly -->
-      <div [ngSwitch]="separator">
-        <div *ngSwitchCase="BreadcrumbsSeparators.CHEVRON">
-          <svg
-            class="h-5 w-5 flex-shrink-0 text-gray-400"
-            viewBox="-5 0 60 60"
-            fill="currentColor"
-            aria-hidden="true"
-          >
-            <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
-          </svg>
-        </div>
-        <div *ngSwitchCase="BreadcrumbsSeparators.SLASH">
-          <svg
-            class="h-5 w-5 flex-shrink-0 text-gray-300"
-            fill="currentColor"
-            viewBox="0 0 20 20"
-            aria-hidden="true"
-          >
-            <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-          </svg>
-        </div>
-      </div>
-    </div>
-  </div>
+    </ng-container>
+  </ng-container>
 </ng-template>
-
 <nav
   [ngClass]="{
     'border-b border-gray-200 bg-white': display === BreadcrumbsTypes.FULL
@@ -69,7 +41,7 @@
     <!-- For each breadcrumb in the breadcrumbs list -->
     <li *ngFor="let breadcrumb of breadcrumbs; let f = first" class="flex">
       <div *ngIf="!f">
-        <ng-template [ngTemplateOutlet]="defineSep"></ng-template>
+        <ng-container *ngTemplateOutlet="separatorTmpl"></ng-container>
       </div>
       <!-- Breadcrumb link -->
       <div class="flex items-center">

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -1,58 +1,54 @@
 <ng-template #defineSep>
   <!-- Check the display style and adapt accordingly -->
-    <div [ngSwitch]="display">
-      <div *ngSwitchCase="BreadcrumbsTypes.CONTAINED">
+  <div [ngSwitch]="display">
+    <div *ngSwitchCase="BreadcrumbsTypes.CONTAINED">
+      <svg
+        class="h-full w-6 flex-shrink-0 text-gray-200"
+        viewBox="0 0 24 44"
+        preserveAspectRatio="none"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+      </svg>
+    </div>
+    <div *ngSwitchCase="BreadcrumbsTypes.FULL">
+      <svg
+        class="h-full w-6 flex-shrink-0 text-gray-200"
+        viewBox="0 0 24 44"
+        preserveAspectRatio="none"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+      </svg>
+    </div>
+    <div *ngSwitchCase="BreadcrumbsTypes.SIMPLE">
+      <!-- Check the separator style and adapt accordingly -->
+      <div [ngSwitch]="separator">
+        <div *ngSwitchCase="BreadcrumbsSeparators.CHEVRON">
           <svg
-            class="h-full w-6 flex-shrink-0 text-gray-200"
-            viewBox="0 0 24 44"
-            preserveAspectRatio="none"
+            class="h-5 w-5 flex-shrink-0 text-gray-400"
+            viewBox="-5 0 60 60"
             fill="currentColor"
             aria-hidden="true"
           >
             <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
           </svg>
-      </div>
-      <div *ngSwitchCase="BreadcrumbsTypes.FULL">
+        </div>
+        <div *ngSwitchCase="BreadcrumbsSeparators.SLASH">
           <svg
-            class="h-full w-6 flex-shrink-0 text-gray-200"
-            viewBox="0 0 24 44"
-            preserveAspectRatio="none"
+            class="h-5 w-5 flex-shrink-0 text-gray-300"
             fill="currentColor"
+            viewBox="0 0 20 20"
             aria-hidden="true"
           >
-            <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+            <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
           </svg>
-      </div>
-      <div *ngSwitchCase="BreadcrumbsTypes.SIMPLE">
-        <!-- Check the separator style and adapt accordingly -->
-        <div [ngSwitch]="separator">
-          <div *ngSwitchCase="BreadcrumbsSeparators.CHEVRON">
-              <svg
-                class="h-5 w-5 flex-shrink-0 text-gray-400"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
-                  clip-rule="evenodd"
-                />
-              </svg>
-          </div>
-          <div *ngSwitchCase="BreadcrumbsSeparators.SLASH">
-              <svg
-                class="h-5 w-5 flex-shrink-0 text-gray-300"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-                aria-hidden="true"
-              >
-                <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-              </svg>
-          </div>
         </div>
       </div>
     </div>
+  </div>
 </ng-template>
 
 <nav

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -1,9 +1,13 @@
-<nav *ngIf="display === 'simple'" class="flex" aria-label="Breadcrumb">
+<nav
+  *ngIf="display === BreadcrumbsTypes.SIMPLE"
+  class="flex"
+  aria-label="Breadcrumb"
+>
   <ol role="list" class="flex items-center space-x-4">
     <li *ngFor="let pth of path">
       <div class="flex items-center">
         <svg
-          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === '>'"
+          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === BreadcrumbsSeperators.CHEVRON"
           class="h-5 w-5 flex-shrink-0 text-gray-400"
           viewBox="0 0 20 20"
           fill="currentColor"
@@ -16,7 +20,7 @@
           />
         </svg>
         <svg
-          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === '/'"
+          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === BreadcrumbsSeperators.SLASH"
           class="h-5 w-5 flex-shrink-0 text-gray-300"
           fill="currentColor"
           viewBox="0 0 20 20"
@@ -34,12 +38,16 @@
   </ol>
 </nav>
 
-<nav *ngIf="display === 'contained'" class="flex" aria-label="Breadcrumb">
+<nav
+  *ngIf="display === BreadcrumbsTypes.CONTAINED"
+  class="flex"
+  aria-label="Breadcrumb"
+>
   <ol role="list" class="flex space-x-4 rounded-md bg-white px-6 shadow">
     <li *ngFor="let pth of path" class="flex">
       <div class="flex items-center">
         <svg
-          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === '>'"
+          *ngIf="!(path.indexOf(pth, 0) === 0)"
           class="h-full w-6 flex-shrink-0 text-gray-200"
           viewBox="0 0 24 44"
           preserveAspectRatio="none"
@@ -48,15 +56,36 @@
         >
           <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
         </svg>
+        <a
+          href="#"
+          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
+          >{{ pth }}</a
+        >
+      </div>
+    </li>
+  </ol>
+</nav>
+
+<nav
+  *ngIf="display === BreadcrumbsTypes.FULL"
+  class="flex border-b border-gray-200 bg-white"
+  aria-label="Breadcrumb"
+>
+  <ol
+    role="list"
+    class="mx-auto flex w-full max-w-screen-xl space-x-4 px-4 sm:px-6 lg:px-8"
+  >
+    <li *ngFor="let pth of path" class="flex">
+      <div class="flex items-center">
         <svg
-          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === '/'"
-          class="h-full w-6 flex-shrink-0 items-center text-gray-200"
+          *ngIf="!(path.indexOf(pth, 0) === 0)"
+          class="h-full w-6 flex-shrink-0 text-gray-200"
           viewBox="0 0 24 44"
           preserveAspectRatio="none"
           fill="currentColor"
           aria-hidden="true"
         >
-          <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+          <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
         </svg>
         <a
           href="#"

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -1,1 +1,69 @@
-<p>breadcrumbs works!</p>
+<nav *ngIf="display === 'simple'" class="flex" aria-label="Breadcrumb">
+  <ol role="list" class="flex items-center space-x-4">
+    <li *ngFor="let pth of path">
+      <div class="flex items-center">
+        <svg
+          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === '>'"
+          class="h-5 w-5 flex-shrink-0 text-gray-400"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        <svg
+          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === '/'"
+          class="h-5 w-5 flex-shrink-0 text-gray-300"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          aria-hidden="true"
+        >
+          <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+        </svg>
+        <a
+          href="#"
+          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
+          >{{ pth }}</a
+        >
+      </div>
+    </li>
+  </ol>
+</nav>
+
+<nav *ngIf="display === 'contained'" class="flex" aria-label="Breadcrumb">
+  <ol role="list" class="flex space-x-4 rounded-md bg-white px-6 shadow">
+    <li *ngFor="let pth of path" class="flex">
+      <div class="flex items-center">
+        <svg
+          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === '>'"
+          class="h-full w-6 flex-shrink-0 text-gray-200"
+          viewBox="0 0 24 44"
+          preserveAspectRatio="none"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+        </svg>
+        <svg
+          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === '/'"
+          class="h-full w-6 flex-shrink-0 items-center text-gray-200"
+          viewBox="0 0 24 44"
+          preserveAspectRatio="none"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+        </svg>
+        <a
+          href="#"
+          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
+          >{{ pth }}</a
+        >
+      </div>
+    </li>
+  </ol>
+</nav>

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -1,177 +1,80 @@
-<!-- Defining the template -->
-<!-- <ng-template 
-   ngFor let-breadcrumb [ngForOf]="breadcrumbs" 
-   let-i="index" 
-   let-f="first"
-   #breadcrumbTemplate>
- 
-</ng-template> -->
-
-<!-- Separator switch cases -->
-<!-- <div [ngSwitch]="separator">
-  <ng-template [ngSwitchCase]="BreadcrumbsSeparators.CHEVRON" #separatorTemplate>
-    <svg
-      *ngIf="!f"
-      class="h-5 w-5 flex-shrink-0 text-gray-400"
-      viewBox="0 0 20 20"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        fill-rule="evenodd"
-        d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
-        clip-rule="evenodd"
-      />
-    </svg>
-  </ng-template>
-  <ng-template [ngSwitchCase]="BreadcrumbsSeparators.SLASH" #separatorTemplate>
-    <svg
-      *ngIf="!f"
-      class="h-5 w-5 flex-shrink-0 text-gray-300"
-      fill="currentColor"
-      viewBox="0 0 20 20"
-      aria-hidden="true"
-    >
-      <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-    </svg>
-  </ng-template>
-  <ng-template ngSwitchDefault #separatorTemplate>
-      <svg
-        *ngIf="!f"
-        class="h-5 w-5 flex-shrink-0 text-gray-400"
-        viewBox="0 0 20 20"
-        fill="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          fill-rule="evenodd"
-          d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
-          clip-rule="evenodd"
-        />
-      </svg>
-  </ng-template>
-</div> -->
-
-
-<!-- <div [ngSwitch]="display">
-  <ng-template [ngSwitchCase]="BreadcrumbsTypes.SIMPLE" #displayTemplate>
-    <div>One</div>
-  </ng-template>
-  <ng-template [ngSwitchCase]="BreadcrumbsTypes.CONTAINED" #displayTemplate>
-    <div>Two</div>
-  </ng-template>
-  <ng-template [ngSwitchCase]="BreadcrumbsTypes.FULL" #displayTemplate>
-    <div>Three</div>
-  </ng-template>
-  <ng-template ngSwitchDefault #displayTemplate>
-    <div>This is default</div>
-  </ng-template>
-</div> -->
-
-<!-- If display is simple -->
 <nav
-  *ngIf="display === BreadcrumbsTypes.SIMPLE"
-  class="flex"
-  aria-label="Breadcrumb"
->
-  <ol role="list" class="flex items-center space-x-4">
-    <!-- For each breadcrumb in the breadcrumbs list -->
-    <li *ngFor="let breadcrumb of breadcrumbs; let f = first">
-      <div class="flex items-center">
-        <!-- If it is not the first breadcrumb, display APPROPRIATE separator -->
-        <svg
-          *ngIf="!f && separator === BreadcrumbsSeparators.CHEVRON"
-          class="h-5 w-5 flex-shrink-0 text-gray-400"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
-            clip-rule="evenodd"
-          />
-        </svg>
-        <svg
-          *ngIf="!f&& separator === BreadcrumbsSeparators.SLASH"
-          class="h-5 w-5 flex-shrink-0 text-gray-300"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          aria-hidden="true"
-        >
-          <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-        </svg>
-        <!-- Breadcrumb link -->
-        <a
-          *ngIf="breadcrumb.key || breadcrumb.text"
-          href="{{ breadcrumb.uri }}"
-          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
-        >
-          <span>{{ breadcrumb.key ? breadcrumb.key : breadcrumb.text }}</span>
-        </a>
-      </div>
-    </li>
-  </ol>
-</nav>
-
-<!-- If display is contained -->
-<nav
-  *ngIf="display === BreadcrumbsTypes.CONTAINED"
-  class="flex"
-  aria-label="Breadcrumb"
->
-  <ol role="list" class="flex space-x-4 rounded-md bg-white px-6 shadow">
-    <!-- For each breadcrumb in the breadcrumbs list -->
-    <li *ngFor="let breadcrumb of breadcrumbs; let f = first" class="flex">
-      <div class="flex items-center">
-        <!-- If it is not the first breadcrumb, display separator -->
-        <svg
-          *ngIf="!f"
-          class="h-full w-6 flex-shrink-0 text-gray-200"
-          viewBox="0 0 24 44"
-          preserveAspectRatio="none"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
-        </svg>
-        <!-- Breadcrumb link -->
-        <a
-          *ngIf="breadcrumb.key || breadcrumb.text"
-          href="{{ breadcrumb.uri }}"
-          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
-        >
-          <span>{{ breadcrumb.key ? breadcrumb.key : breadcrumb.text }}</span>
-        </a>
-      </div>
-    </li>
-  </ol>
-</nav>
-
-<!-- If display is full -->
-<nav
-  *ngIf="display === BreadcrumbsTypes.FULL"
-  class="flex border-b border-gray-200 bg-white"
+  [ngClass]="{
+    flex: display === BreadcrumbsTypes.SIMPLE,
+    flex: display === BreadcrumbsTypes.CONTAINED,
+    'flex border-b border-gray-200 bg-white': display === BreadcrumbsTypes.FULL
+  }"
   aria-label="Breadcrumb"
 >
   <ol
     role="list"
-    class="mx-auto flex w-full max-w-screen-xl space-x-4 px-4 sm:px-6 lg:px-8"
+    [ngClass]="{
+      'ui-breadcrumbs__simple': display === BreadcrumbsTypes.SIMPLE,
+      'ui-breadcrumbs__contained': display === BreadcrumbsTypes.CONTAINED,
+      'ui-breadcrumbs__full': display === BreadcrumbsTypes.FULL
+    }"
   >
     <!-- For each breadcrumb in the breadcrumbs list -->
     <li *ngFor="let breadcrumb of breadcrumbs; let f = first" class="flex">
       <div class="flex items-center">
-        <!-- If it is not the first breadcrumb, display separator -->
-        <svg
-          *ngIf="!f"
-          class="h-full w-6 flex-shrink-0 text-gray-200"
-          viewBox="0 0 24 44"
-          preserveAspectRatio="none"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
-        </svg>
+        <!-- Check the display style and adapt accordingly -->
+        <div [ngSwitch]="display" class="flex">
+          <div *ngSwitchCase="BreadcrumbsTypes.CONTAINED">
+            <svg
+              *ngIf="!f"
+              class="h-full w-6 flex-shrink-0 text-gray-200"
+              viewBox="0 0 24 44"
+              preserveAspectRatio="none"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+            </svg>
+          </div>
+          <div *ngSwitchCase="BreadcrumbsTypes.FULL">
+            <svg
+              *ngIf="!f"
+              class="h-full w-6 flex-shrink-0 text-gray-200"
+              viewBox="0 0 24 44"
+              preserveAspectRatio="none"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
+            </svg>
+          </div>
+          <div *ngSwitchCase="BreadcrumbsTypes.SIMPLE">
+            <!-- Check the separator style and adapt accordingly -->
+            <div [ngSwitch]="separator">
+              <div *ngSwitchCase="BreadcrumbsSeparators.SLASH">
+                <svg
+                  *ngIf="!f"
+                  class="h-5 w-5 flex-shrink-0 text-gray-400"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+                    clip-rule="evenodd"
+                  />
+                </svg>
+              </div>
+              <div *ngSwitchCase="BreadcrumbsSeparators.CHEVRON">
+                <svg
+                  *ngIf="!f"
+                  class="h-5 w-5 flex-shrink-0 text-gray-300"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  aria-hidden="true"
+                >
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
         <!-- Breadcrumb link -->
         <a
           *ngIf="breadcrumb.key || breadcrumb.text"

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -1,11 +1,14 @@
+<!-- If display is simple -->
 <nav
   *ngIf="display === BreadcrumbsTypes.SIMPLE"
   class="flex"
   aria-label="Breadcrumb"
 >
   <ol role="list" class="flex items-center space-x-4">
+    <!-- For each breadcrumb in the breadcrumbs list -->
     <li *ngFor="let breadcrumb of breadcrumbs; let i = index">
       <div class="flex items-center">
+        <!-- If it is not the first breadcrump, display APPROPRIATE seperator -->
         <svg
           *ngIf="!(i === 0) && seperator === BreadcrumbsSeperators.CHEVRON"
           class="h-5 w-5 flex-shrink-0 text-gray-400"
@@ -28,39 +31,30 @@
         >
           <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
         </svg>
-        <!-- <a
-          href="#"
-          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
-          >{{ pth }}</a
-        > -->
         <!-- Breadcrumb link -->
         <a
           *ngIf="breadcrumb.key || breadcrumb.text"
-          href={{breadcrumb.uri}}
+          href="{{ breadcrumb.uri }}"
           class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
         >
-          <span>{{
-            breadcrumb.key ? (breadcrumb.key) : breadcrumb.text
-          }}</span>
+          <span>{{ breadcrumb.key ? breadcrumb.key : breadcrumb.text }}</span>
         </a>
-        <!-- Loading indicator if text not set
-  <kendo-skeleton
-    *ngIf="!breadcrumb.key && !breadcrumb.text"
-    width="3em"
-  ></kendo-skeleton> -->
       </div>
     </li>
   </ol>
 </nav>
 
+<!-- If display is contained -->
 <nav
   *ngIf="display === BreadcrumbsTypes.CONTAINED"
   class="flex"
   aria-label="Breadcrumb"
 >
   <ol role="list" class="flex space-x-4 rounded-md bg-white px-6 shadow">
+    <!-- For each breadcrumb in the breadcrumbs list -->
     <li *ngFor="let breadcrumb of breadcrumbs; let i = index" class="flex">
       <div class="flex items-center">
+        <!-- If it is not the first breadcrump, display seperator -->
         <svg
           *ngIf="!(i === 0)"
           class="h-full w-6 flex-shrink-0 text-gray-200"
@@ -71,26 +65,20 @@
         >
           <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
         </svg>
-        <!-- <a
-          href="#"
-          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
-          >{{ pth }}</a
-        > -->
         <!-- Breadcrumb link -->
         <a
           *ngIf="breadcrumb.key || breadcrumb.text"
-          href={{breadcrumb.uri}}
+          href="{{ breadcrumb.uri }}"
           class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
         >
-          <span>{{
-            breadcrumb.key ? (breadcrumb.key) : breadcrumb.text
-          }}</span>
+          <span>{{ breadcrumb.key ? breadcrumb.key : breadcrumb.text }}</span>
         </a>
       </div>
     </li>
   </ol>
 </nav>
 
+<!-- If display is full -->
 <nav
   *ngIf="display === BreadcrumbsTypes.FULL"
   class="flex border-b border-gray-200 bg-white"
@@ -100,8 +88,10 @@
     role="list"
     class="mx-auto flex w-full max-w-screen-xl space-x-4 px-4 sm:px-6 lg:px-8"
   >
+    <!-- For each breadcrumb in the breadcrumbs list -->
     <li *ngFor="let breadcrumb of breadcrumbs; let i = index" class="flex">
       <div class="flex items-center">
+        <!-- If it is not the first breadcrump, display seperator -->
         <svg
           *ngIf="!(i === 0)"
           class="h-full w-6 flex-shrink-0 text-gray-200"
@@ -112,20 +102,13 @@
         >
           <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
         </svg>
-        <!-- <a
-          href="#"
-          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
-          >{{ pth }}</a
-        > -->
         <!-- Breadcrumb link -->
         <a
           *ngIf="breadcrumb.key || breadcrumb.text"
-          href={{breadcrumb.uri}}
+          href="{{ breadcrumb.uri }}"
           class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
         >
-          <span>{{
-            breadcrumb.key ? (breadcrumb.key) : breadcrumb.text
-          }}</span>
+          <span>{{ breadcrumb.key ? breadcrumb.key : breadcrumb.text }}</span>
         </a>
       </div>
     </li>

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -4,10 +4,10 @@
   aria-label="Breadcrumb"
 >
   <ol role="list" class="flex items-center space-x-4">
-    <li *ngFor="let pth of path">
+    <li *ngFor="let breadcrumb of breadcrumbs; let i = index">
       <div class="flex items-center">
         <svg
-          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === BreadcrumbsSeperators.CHEVRON"
+          *ngIf="!(i === 0) && seperator === BreadcrumbsSeperators.CHEVRON"
           class="h-5 w-5 flex-shrink-0 text-gray-400"
           viewBox="0 0 20 20"
           fill="currentColor"
@@ -20,7 +20,7 @@
           />
         </svg>
         <svg
-          *ngIf="!(path.indexOf(pth, 0) === 0) && seperator === BreadcrumbsSeperators.SLASH"
+          *ngIf="!(i === 0) && seperator === BreadcrumbsSeperators.SLASH"
           class="h-5 w-5 flex-shrink-0 text-gray-300"
           fill="currentColor"
           viewBox="0 0 20 20"
@@ -28,11 +28,26 @@
         >
           <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
         </svg>
-        <a
+        <!-- <a
           href="#"
           class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
           >{{ pth }}</a
+        > -->
+        <!-- Breadcrumb link -->
+        <a
+          *ngIf="breadcrumb.key || breadcrumb.text"
+          href={{breadcrumb.uri}}
+          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
         >
+          <span>{{
+            breadcrumb.key ? (breadcrumb.key) : breadcrumb.text
+          }}</span>
+        </a>
+        <!-- Loading indicator if text not set
+  <kendo-skeleton
+    *ngIf="!breadcrumb.key && !breadcrumb.text"
+    width="3em"
+  ></kendo-skeleton> -->
       </div>
     </li>
   </ol>
@@ -44,10 +59,10 @@
   aria-label="Breadcrumb"
 >
   <ol role="list" class="flex space-x-4 rounded-md bg-white px-6 shadow">
-    <li *ngFor="let pth of path" class="flex">
+    <li *ngFor="let breadcrumb of breadcrumbs; let i = index" class="flex">
       <div class="flex items-center">
         <svg
-          *ngIf="!(path.indexOf(pth, 0) === 0)"
+          *ngIf="!(i === 0)"
           class="h-full w-6 flex-shrink-0 text-gray-200"
           viewBox="0 0 24 44"
           preserveAspectRatio="none"
@@ -56,11 +71,21 @@
         >
           <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
         </svg>
-        <a
+        <!-- <a
           href="#"
           class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
           >{{ pth }}</a
+        > -->
+        <!-- Breadcrumb link -->
+        <a
+          *ngIf="breadcrumb.key || breadcrumb.text"
+          href={{breadcrumb.uri}}
+          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
         >
+          <span>{{
+            breadcrumb.key ? (breadcrumb.key) : breadcrumb.text
+          }}</span>
+        </a>
       </div>
     </li>
   </ol>
@@ -75,10 +100,10 @@
     role="list"
     class="mx-auto flex w-full max-w-screen-xl space-x-4 px-4 sm:px-6 lg:px-8"
   >
-    <li *ngFor="let pth of path" class="flex">
+    <li *ngFor="let breadcrumb of breadcrumbs; let i = index" class="flex">
       <div class="flex items-center">
         <svg
-          *ngIf="!(path.indexOf(pth, 0) === 0)"
+          *ngIf="!(i === 0)"
           class="h-full w-6 flex-shrink-0 text-gray-200"
           viewBox="0 0 24 44"
           preserveAspectRatio="none"
@@ -87,11 +112,21 @@
         >
           <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
         </svg>
-        <a
+        <!-- <a
           href="#"
           class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
           >{{ pth }}</a
+        > -->
+        <!-- Breadcrumb link -->
+        <a
+          *ngIf="breadcrumb.key || breadcrumb.text"
+          href={{breadcrumb.uri}}
+          class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
         >
+          <span>{{
+            breadcrumb.key ? (breadcrumb.key) : breadcrumb.text
+          }}</span>
+        </a>
       </div>
     </li>
   </ol>

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -1,7 +1,7 @@
 <nav
   [ngClass]="{
-    flex: display === BreadcrumbsTypes.SIMPLE,
-    flex: display === BreadcrumbsTypes.CONTAINED,
+    'flex': display === BreadcrumbsTypes.SIMPLE,
+    'flex': display === BreadcrumbsTypes.CONTAINED,
     'flex border-b border-gray-200 bg-white': display === BreadcrumbsTypes.FULL
   }"
   aria-label="Breadcrumb"
@@ -46,7 +46,7 @@
           <div *ngSwitchCase="BreadcrumbsTypes.SIMPLE">
             <!-- Check the separator style and adapt accordingly -->
             <div [ngSwitch]="separator">
-              <div *ngSwitchCase="BreadcrumbsSeparators.SLASH">
+              <div *ngSwitchCase="BreadcrumbsSeparators.CHEVRON">
                 <svg
                   *ngIf="!f"
                   class="h-5 w-5 flex-shrink-0 text-gray-400"
@@ -61,7 +61,7 @@
                   />
                 </svg>
               </div>
-              <div *ngSwitchCase="BreadcrumbsSeparators.CHEVRON">
+              <div *ngSwitchCase="BreadcrumbsSeparators.SLASH">
                 <svg
                   *ngIf="!f"
                   class="h-5 w-5 flex-shrink-0 text-gray-300"

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -1,3 +1,73 @@
+<!-- Defining the template -->
+<!-- <ng-template 
+   ngFor let-breadcrumb [ngForOf]="breadcrumbs" 
+   let-i="index" 
+   let-f="first"
+   #breadcrumbTemplate>
+ 
+</ng-template> -->
+
+<!-- Separator switch cases -->
+<!-- <div [ngSwitch]="separator">
+  <ng-template [ngSwitchCase]="BreadcrumbsSeparators.CHEVRON" #separatorTemplate>
+    <svg
+      *ngIf="!f"
+      class="h-5 w-5 flex-shrink-0 text-gray-400"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+        clip-rule="evenodd"
+      />
+    </svg>
+  </ng-template>
+  <ng-template [ngSwitchCase]="BreadcrumbsSeparators.SLASH" #separatorTemplate>
+    <svg
+      *ngIf="!f"
+      class="h-5 w-5 flex-shrink-0 text-gray-300"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+      aria-hidden="true"
+    >
+      <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+    </svg>
+  </ng-template>
+  <ng-template ngSwitchDefault #separatorTemplate>
+      <svg
+        *ngIf="!f"
+        class="h-5 w-5 flex-shrink-0 text-gray-400"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+          clip-rule="evenodd"
+        />
+      </svg>
+  </ng-template>
+</div> -->
+
+
+<!-- <div [ngSwitch]="display">
+  <ng-template [ngSwitchCase]="BreadcrumbsTypes.SIMPLE" #displayTemplate>
+    <div>One</div>
+  </ng-template>
+  <ng-template [ngSwitchCase]="BreadcrumbsTypes.CONTAINED" #displayTemplate>
+    <div>Two</div>
+  </ng-template>
+  <ng-template [ngSwitchCase]="BreadcrumbsTypes.FULL" #displayTemplate>
+    <div>Three</div>
+  </ng-template>
+  <ng-template ngSwitchDefault #displayTemplate>
+    <div>This is default</div>
+  </ng-template>
+</div> -->
+
 <!-- If display is simple -->
 <nav
   *ngIf="display === BreadcrumbsTypes.SIMPLE"
@@ -6,11 +76,11 @@
 >
   <ol role="list" class="flex items-center space-x-4">
     <!-- For each breadcrumb in the breadcrumbs list -->
-    <li *ngFor="let breadcrumb of breadcrumbs; let i = index">
+    <li *ngFor="let breadcrumb of breadcrumbs; let f = first">
       <div class="flex items-center">
-        <!-- If it is not the first breadcrump, display APPROPRIATE seperator -->
+        <!-- If it is not the first breadcrumb, display APPROPRIATE separator -->
         <svg
-          *ngIf="!(i === 0) && seperator === BreadcrumbsSeperators.CHEVRON"
+          *ngIf="!f && separator === BreadcrumbsSeparators.CHEVRON"
           class="h-5 w-5 flex-shrink-0 text-gray-400"
           viewBox="0 0 20 20"
           fill="currentColor"
@@ -23,7 +93,7 @@
           />
         </svg>
         <svg
-          *ngIf="!(i === 0) && seperator === BreadcrumbsSeperators.SLASH"
+          *ngIf="!f&& separator === BreadcrumbsSeparators.SLASH"
           class="h-5 w-5 flex-shrink-0 text-gray-300"
           fill="currentColor"
           viewBox="0 0 20 20"
@@ -52,11 +122,11 @@
 >
   <ol role="list" class="flex space-x-4 rounded-md bg-white px-6 shadow">
     <!-- For each breadcrumb in the breadcrumbs list -->
-    <li *ngFor="let breadcrumb of breadcrumbs; let i = index" class="flex">
+    <li *ngFor="let breadcrumb of breadcrumbs; let f = first" class="flex">
       <div class="flex items-center">
-        <!-- If it is not the first breadcrump, display seperator -->
+        <!-- If it is not the first breadcrumb, display separator -->
         <svg
-          *ngIf="!(i === 0)"
+          *ngIf="!f"
           class="h-full w-6 flex-shrink-0 text-gray-200"
           viewBox="0 0 24 44"
           preserveAspectRatio="none"
@@ -89,11 +159,11 @@
     class="mx-auto flex w-full max-w-screen-xl space-x-4 px-4 sm:px-6 lg:px-8"
   >
     <!-- For each breadcrumb in the breadcrumbs list -->
-    <li *ngFor="let breadcrumb of breadcrumbs; let i = index" class="flex">
+    <li *ngFor="let breadcrumb of breadcrumbs; let f = first" class="flex">
       <div class="flex items-center">
-        <!-- If it is not the first breadcrump, display seperator -->
+        <!-- If it is not the first breadcrumb, display separator -->
         <svg
-          *ngIf="!(i === 0)"
+          *ngIf="!f"
           class="h-full w-6 flex-shrink-0 text-gray-200"
           viewBox="0 0 24 44"
           preserveAspectRatio="none"

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.scss
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.scss
@@ -1,0 +1,9 @@
+.ui-breadcrumbs__simple {
+    @apply flex items-center space-x-4;
+  }
+.ui-breadcrumbs__contained {
+    @apply flex space-x-4 rounded-md bg-white px-6 shadow;
+  }
+.ui-breadcrumbs__full {
+    @apply mx-auto flex w-full max-w-screen-xl space-x-4 px-4 sm:px-6 lg:px-8;
+  }

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BreadcrumbsComponent } from './breadcrumbs.component';
+
+describe('BreadcrumbsComponent', () => {
+  let component: BreadcrumbsComponent;
+  let fixture: ComponentFixture<BreadcrumbsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BreadcrumbsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BreadcrumbsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
@@ -1,9 +1,7 @@
 import { moduleMetadata, Story, Meta } from '@storybook/angular';
-import {
-  BreadcrumbDisplay,
-  BreadcrumbSeperator,
-  BreadcrumbsComponent,
-} from './breadcrumbs.component';
+import { BreadcrumbsComponent } from './breadcrumbs.component';
+import { BreadcrumbDisplay } from './enums/breadcrumb-display.enum';
+import { BreadcrumbSeparator } from './enums/breadcrumb-separator.enum';
 
 export default {
   title: 'BreadcrumbsComponent',
@@ -35,6 +33,6 @@ Primary.args = {
       uri: '#',
     },
   ],
-  seperator: BreadcrumbSeperator.CHEVRON,
+  separator: BreadcrumbSeparator.CHEVRON,
   display: BreadcrumbDisplay.SIMPLE,
 };

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
@@ -1,98 +1,113 @@
-import { moduleMetadata, Story, Meta } from '@storybook/angular';
+import { moduleMetadata, Meta, StoryObj } from '@storybook/angular';
 import { BreadcrumbsComponent } from './breadcrumbs.component';
 import { BreadcrumbDisplay } from './enums/breadcrumb-display.enum';
 import { BreadcrumbSeparator } from './enums/breadcrumb-separator.enum';
+import { BreadcrumbsModule } from './breadcrumbs.module';
 
 export default {
-  title: 'BreadcrumbsComponent',
+  title: 'Breadcrumbs',
   component: BreadcrumbsComponent,
+  argTypes: {
+    separator: {
+      options: BreadcrumbSeparator,
+      control: 'select',
+    },
+    display: {
+      options: BreadcrumbDisplay,
+      control: 'select',
+    },
+  },
   decorators: [
     moduleMetadata({
-      imports: [],
+      imports: [BreadcrumbsModule],
     }),
   ],
 } as Meta<BreadcrumbsComponent>;
 
-const Template: Story<BreadcrumbsComponent> = (args: BreadcrumbsComponent) => ({
-  props: args,
-});
-
-export const SimpleChevron = Template.bind({});
-SimpleChevron.args = {
-  breadcrumbs: [
-    {
-      text: 'item 0',
-      uri: '#',
-    },
-    {
-      text: 'item 1',
-      uri: '#',
-    },
-    {
-      text: 'item 2',
-      uri: '#',
-    },
-  ],
-  separator: BreadcrumbSeparator.CHEVRON,
-  display: BreadcrumbDisplay.SIMPLE,
+/** Simple Chevron story */
+export const SimpleChevron: StoryObj<BreadcrumbsComponent> = {
+  args: {
+    breadcrumbs: [
+      {
+        text: 'item 0',
+        uri: '#',
+      },
+      {
+        text: 'item 1',
+        uri: '#',
+      },
+      {
+        text: 'item 2',
+        uri: '#',
+      },
+    ],
+    separator: BreadcrumbSeparator.CHEVRON,
+    display: BreadcrumbDisplay.SIMPLE,
+  },
 };
 
-export const SimpleSlash = Template.bind({});
-SimpleSlash.args = {
-  breadcrumbs: [
-    {
-      text: 'item 0',
-      uri: '#',
-    },
-    {
-      text: 'item 1',
-      uri: '#',
-    },
-    {
-      text: 'item 2',
-      uri: '#',
-    },
-  ],
-  separator: BreadcrumbSeparator.SLASH,
-  display: BreadcrumbDisplay.SIMPLE,
+/** Simple slash story */
+export const SimpleSlash: StoryObj<BreadcrumbsComponent> = {
+  args: {
+    breadcrumbs: [
+      {
+        text: 'item 0',
+        uri: '#',
+      },
+      {
+        text: 'item 1',
+        uri: '#',
+      },
+      {
+        text: 'item 2',
+        uri: '#',
+      },
+    ],
+    separator: BreadcrumbSeparator.SLASH,
+    display: BreadcrumbDisplay.SIMPLE,
+  },
 };
 
-export const Contained = Template.bind({});
-Contained.args = {
-  breadcrumbs: [
-    {
-      text: 'item 0',
-      uri: '#',
-    },
-    {
-      text: 'item 1',
-      uri: '#',
-    },
-    {
-      text: 'item 2',
-      uri: '#',
-    },
-  ],
-  separator: BreadcrumbSeparator.CHEVRON,
-  display: BreadcrumbDisplay.CONTAINED,
+/** Container story */
+export const Contained: StoryObj<BreadcrumbsComponent> = {
+  args: {
+    breadcrumbs: [
+      {
+        text: 'item 0',
+        uri: '#',
+      },
+      {
+        text: 'item 1',
+        uri: '#',
+      },
+      {
+        text: 'item 2',
+        uri: '#',
+      },
+    ],
+    separator: BreadcrumbSeparator.CHEVRON,
+    display: BreadcrumbDisplay.CONTAINED,
+  },
 };
 
-export const Full = Template.bind({});
-Full.args = {
-  breadcrumbs: [
-    {
-      text: 'item 0',
-      uri: '#',
-    },
-    {
-      text: 'item 1',
-      uri: '#',
-    },
-    {
-      text: 'item 2',
-      uri: '#',
-    },
-  ],
-  separator: BreadcrumbSeparator.CHEVRON,
-  display: BreadcrumbDisplay.FULL,
+/** Full width story */
+export const Full: StoryObj<BreadcrumbsComponent> = {
+  args: {
+    breadcrumbs: [
+      {
+        text: 'item 0',
+        uri: '#',
+      },
+      {
+        text: 'item 1',
+        uri: '#',
+      },
+      {
+        text: 'item 2',
+        uri: '#',
+      },
+    ],
+    separator: BreadcrumbSeparator.CHEVRON,
+    display: BreadcrumbDisplay.FULL,
+  },
 };

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
@@ -17,8 +17,8 @@ const Template: Story<BreadcrumbsComponent> = (args: BreadcrumbsComponent) => ({
   props: args,
 });
 
-export const Primary = Template.bind({});
-Primary.args = {
+export const SimpleChevron = Template.bind({});
+SimpleChevron.args = {
   breadcrumbs: [
     {
       text: 'item 0',
@@ -35,4 +35,64 @@ Primary.args = {
   ],
   separator: BreadcrumbSeparator.CHEVRON,
   display: BreadcrumbDisplay.SIMPLE,
+};
+
+export const SimpleSlash = Template.bind({});
+SimpleSlash.args = {
+  breadcrumbs: [
+    {
+      text: 'item 0',
+      uri: '#',
+    },
+    {
+      text: 'item 1',
+      uri: '#',
+    },
+    {
+      text: 'item 2',
+      uri: '#',
+    },
+  ],
+  separator: BreadcrumbSeparator.SLASH,
+  display: BreadcrumbDisplay.SIMPLE,
+};
+
+export const Contained = Template.bind({});
+Contained.args = {
+  breadcrumbs: [
+    {
+      text: 'item 0',
+      uri: '#',
+    },
+    {
+      text: 'item 1',
+      uri: '#',
+    },
+    {
+      text: 'item 2',
+      uri: '#',
+    },
+  ],
+  separator: BreadcrumbSeparator.CHEVRON,
+  display: BreadcrumbDisplay.CONTAINED,
+};
+
+export const Full = Template.bind({});
+Full.args = {
+  breadcrumbs: [
+    {
+      text: 'item 0',
+      uri: '#',
+    },
+    {
+      text: 'item 1',
+      uri: '#',
+    },
+    {
+      text: 'item 2',
+      uri: '#',
+    },
+  ],
+  separator: BreadcrumbSeparator.CHEVRON,
+  display: BreadcrumbDisplay.FULL,
 };

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
@@ -7,7 +7,7 @@ export default {
   decorators: [
     moduleMetadata({
       imports: [],
-    })
+    }),
   ],
 } as Meta<BreadcrumbsComponent>;
 
@@ -15,7 +15,9 @@ const Template: Story<BreadcrumbsComponent> = (args: BreadcrumbsComponent) => ({
   props: args,
 });
 
-
 export const Primary = Template.bind({});
 Primary.args = {
-}
+  path: [],
+  seperator: '>',
+  display: 'simple',
+};

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
@@ -21,7 +21,20 @@ const Template: Story<BreadcrumbsComponent> = (args: BreadcrumbsComponent) => ({
 
 export const Primary = Template.bind({});
 Primary.args = {
-  path: ['test1', 'test2', 'test3'],
+  breadcrumbs: [
+    {
+      text: 'item 0',
+      uri: '#',
+    },
+    {
+      text: 'item 1',
+      uri: '#',
+    },
+    {
+      text: 'item 2',
+      uri: '#',
+    },
+  ],
   seperator: BreadcrumbSeperator.CHEVRON,
   display: BreadcrumbDisplay.SIMPLE,
 };

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
@@ -1,0 +1,21 @@
+import { moduleMetadata, Story, Meta } from '@storybook/angular';
+import { BreadcrumbsComponent } from './breadcrumbs.component';
+
+export default {
+  title: 'BreadcrumbsComponent',
+  component: BreadcrumbsComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [],
+    })
+  ],
+} as Meta<BreadcrumbsComponent>;
+
+const Template: Story<BreadcrumbsComponent> = (args: BreadcrumbsComponent) => ({
+  props: args,
+});
+
+
+export const Primary = Template.bind({});
+Primary.args = {
+}

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.stories.ts
@@ -1,5 +1,9 @@
 import { moduleMetadata, Story, Meta } from '@storybook/angular';
-import { BreadcrumbsComponent } from './breadcrumbs.component';
+import {
+  BreadcrumbDisplay,
+  BreadcrumbSeperator,
+  BreadcrumbsComponent,
+} from './breadcrumbs.component';
 
 export default {
   title: 'BreadcrumbsComponent',
@@ -17,7 +21,7 @@ const Template: Story<BreadcrumbsComponent> = (args: BreadcrumbsComponent) => ({
 
 export const Primary = Template.bind({});
 Primary.args = {
-  path: [],
-  seperator: '>',
-  display: 'simple',
+  path: ['test1', 'test2', 'test3'],
+  seperator: BreadcrumbSeperator.CHEVRON,
+  display: BreadcrumbDisplay.SIMPLE,
 };

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
@@ -1,8 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
+/**
+ *
+ */
 @Component({
   selector: 'ui-breadcrumbs',
   templateUrl: './breadcrumbs.component.html',
   styleUrls: ['./breadcrumbs.component.scss'],
 })
-export class BreadcrumbsComponent {}
+export class BreadcrumbsComponent {
+  @Input() path: string[] = [];
+  @Input() seperator = '>';
+  @Input() display = '';
+}

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
@@ -10,6 +10,18 @@ import { Component, Input } from '@angular/core';
 })
 export class BreadcrumbsComponent {
   @Input() path: string[] = [];
-  @Input() seperator = '>';
-  @Input() display = '';
+  @Input() seperator: BreadcrumbSeperator = BreadcrumbSeperator.CHEVRON;
+  @Input() display: BreadcrumbDisplay = BreadcrumbDisplay.SIMPLE;
+
+  BreadcrumbsTypes = BreadcrumbDisplay;
+  BreadcrumbsSeperators = BreadcrumbSeperator;
+}
+export enum BreadcrumbDisplay {
+  SIMPLE,
+  CONTAINED,
+  FULL,
+}
+export enum BreadcrumbSeperator {
+  CHEVRON,
+  SLASH,
 }

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
@@ -9,7 +9,7 @@ import { Component, Input } from '@angular/core';
   styleUrls: ['./breadcrumbs.component.scss'],
 })
 export class BreadcrumbsComponent {
-  @Input() path: string[] = [];
+  @Input() breadcrumbs: Breadcrumb[] = [];
   @Input() seperator: BreadcrumbSeperator = BreadcrumbSeperator.CHEVRON;
   @Input() display: BreadcrumbDisplay = BreadcrumbDisplay.SIMPLE;
 
@@ -24,4 +24,12 @@ export enum BreadcrumbDisplay {
 export enum BreadcrumbSeperator {
   CHEVRON,
   SLASH,
+}
+/** Interface of breadcrumb */
+export interface Breadcrumb {
+  alias?: string;
+  uri: string;
+  text?: string;
+  key?: string;
+  queryParams?: any;
 }

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'ui-breadcrumbs',
+  templateUrl: './breadcrumbs.component.html',
+  styleUrls: ['./breadcrumbs.component.scss'],
+})
+export class BreadcrumbsComponent {}

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 
 /**
- *
+ * UI Breadcrumbs Component
  */
 @Component({
   selector: 'ui-breadcrumbs',
@@ -13,18 +13,28 @@ export class BreadcrumbsComponent {
   @Input() seperator: BreadcrumbSeperator = BreadcrumbSeperator.CHEVRON;
   @Input() display: BreadcrumbDisplay = BreadcrumbDisplay.SIMPLE;
 
+  //In order to be able to use enumerations in html
   BreadcrumbsTypes = BreadcrumbDisplay;
   BreadcrumbsSeperators = BreadcrumbSeperator;
 }
+
+/**
+ * Enumeration of possible display styles
+ */
 export enum BreadcrumbDisplay {
   SIMPLE,
   CONTAINED,
   FULL,
 }
+
+/**
+ * Enumeration of possible seperators styles
+ */
 export enum BreadcrumbSeperator {
   CHEVRON,
   SLASH,
 }
+
 /** Interface of breadcrumb */
 export interface Breadcrumb {
   alias?: string;

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
@@ -1,4 +1,7 @@
 import { Component, Input } from '@angular/core';
+import { BreadcrumbDisplay } from './enums/breadcrumb-display.enum';
+import { BreadcrumbSeparator } from './enums/breadcrumb-separator.enum';
+import { Breadcrumb } from './interfaces/breadcrumb.interface';
 
 /**
  * UI Breadcrumbs Component
@@ -10,36 +13,10 @@ import { Component, Input } from '@angular/core';
 })
 export class BreadcrumbsComponent {
   @Input() breadcrumbs: Breadcrumb[] = [];
-  @Input() seperator: BreadcrumbSeperator = BreadcrumbSeperator.CHEVRON;
+  @Input() separator: BreadcrumbSeparator = BreadcrumbSeparator.CHEVRON;
   @Input() display: BreadcrumbDisplay = BreadcrumbDisplay.SIMPLE;
 
   //In order to be able to use enumerations in html
   BreadcrumbsTypes = BreadcrumbDisplay;
-  BreadcrumbsSeperators = BreadcrumbSeperator;
-}
-
-/**
- * Enumeration of possible display styles
- */
-export enum BreadcrumbDisplay {
-  SIMPLE,
-  CONTAINED,
-  FULL,
-}
-
-/**
- * Enumeration of possible seperators styles
- */
-export enum BreadcrumbSeperator {
-  CHEVRON,
-  SLASH,
-}
-
-/** Interface of breadcrumb */
-export interface Breadcrumb {
-  alias?: string;
-  uri: string;
-  text?: string;
-  key?: string;
-  queryParams?: any;
+  BreadcrumbsSeparators = BreadcrumbSeparator;
 }

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.module.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.module.ts
@@ -2,6 +2,9 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BreadcrumbsComponent } from './breadcrumbs.component';
 
+/**
+ * UI Breadcrumbs Module.
+ */
 @NgModule({
   declarations: [BreadcrumbsComponent],
   imports: [CommonModule],

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.module.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.module.ts
@@ -5,5 +5,6 @@ import { BreadcrumbsComponent } from './breadcrumbs.component';
 @NgModule({
   declarations: [BreadcrumbsComponent],
   imports: [CommonModule],
+  exports: [BreadcrumbsComponent],
 })
 export class BreadcrumbsModule {}

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.module.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BreadcrumbsComponent } from './breadcrumbs.component';
+
+@NgModule({
+  declarations: [BreadcrumbsComponent],
+  imports: [CommonModule],
+})
+export class BreadcrumbsModule {}

--- a/libs/ui/src/lib/breadcrumbs/enums/breadcrumb-display.enum.ts
+++ b/libs/ui/src/lib/breadcrumbs/enums/breadcrumb-display.enum.ts
@@ -1,0 +1,8 @@
+/**
+ * Enumeration of possible display styles
+ */
+export enum BreadcrumbDisplay {
+  SIMPLE,
+  CONTAINED,
+  FULL,
+}

--- a/libs/ui/src/lib/breadcrumbs/enums/breadcrumb-display.enum.ts
+++ b/libs/ui/src/lib/breadcrumbs/enums/breadcrumb-display.enum.ts
@@ -2,7 +2,7 @@
  * Enumeration of possible display styles
  */
 export enum BreadcrumbDisplay {
-  SIMPLE,
-  CONTAINED,
-  FULL,
+  SIMPLE = 'simple',
+  CONTAINED = 'contained',
+  FULL = 'full',
 }

--- a/libs/ui/src/lib/breadcrumbs/enums/breadcrumb-separator.enum.ts
+++ b/libs/ui/src/lib/breadcrumbs/enums/breadcrumb-separator.enum.ts
@@ -1,0 +1,7 @@
+/**
+ * Enumeration of possible separators styles
+ */
+export enum BreadcrumbSeparator {
+  CHEVRON,
+  SLASH,
+}

--- a/libs/ui/src/lib/breadcrumbs/enums/breadcrumb-separator.enum.ts
+++ b/libs/ui/src/lib/breadcrumbs/enums/breadcrumb-separator.enum.ts
@@ -2,6 +2,6 @@
  * Enumeration of possible separators styles
  */
 export enum BreadcrumbSeparator {
-  CHEVRON,
-  SLASH,
+  CHEVRON = 'chevron',
+  SLASH = 'slash',
 }

--- a/libs/ui/src/lib/breadcrumbs/interfaces/breadcrumb.interface.ts
+++ b/libs/ui/src/lib/breadcrumbs/interfaces/breadcrumb.interface.ts
@@ -1,0 +1,8 @@
+/** Interface of breadcrumb */
+export interface Breadcrumb {
+  alias?: string;
+  uri: string;
+  text?: string;
+  key?: string;
+  queryParams?: any;
+}


### PR DESCRIPTION
# Description

The feature added is a new breadcrump component linked the new ui library designed thanks to tailwind. The breadcrumps component has three inputs : display, seperator and breadcrumps (list of breadcrump, using same interface as in the safe library).

## Ticket

I can't paste the azure ticket link because I do not have access to Azure. Here is the ticket id however : [AB#61944](https://dev.azure.com/WHOHQ/2888b816-2d79-49ef-a86e-561e6cd456a0/_workitems/edit/61944)

## Type of change

Please delete options that are not relevant.

- [X ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I used storybook to test the visual of the component created and the impact of the parameters used

## Sreenshots
![1](https://user-images.githubusercontent.com/94597541/232711651-0c2d5f85-0890-480e-a62b-5c8626f9d02e.png)

![2](https://user-images.githubusercontent.com/94597541/232711834-cc6b2ed0-853a-4287-aaa0-2558922a112a.png)

![3](https://user-images.githubusercontent.com/94597541/232711856-5054a2c8-1539-46ba-96ff-f9303850be13.png)

![4](https://user-images.githubusercontent.com/94597541/232711881-7add6220-f523-4906-8af7-55c1cc24e9ef.png)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
