### PR TITLE
Feat 2.0.x/ab#56268 create larger tab col in email tab

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -714,6 +714,7 @@
 			},
 			"fields": {
 				"available": "Available fields",
+				"column": "Column width (px)",
 				"format": {
 					"info": "Left empty to ignore formatting",
 					"title": "Display format"

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -719,6 +719,7 @@
 			},
 			"fields": {
 				"available": "Champs disponibles",
+				"column": "Largeur de la colonne (px)",
 				"format": {
 					"info": "Laissez vide pour utiliser le mode classique",
 					"title": "Mode d'affichage"

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -714,6 +714,7 @@
 			},
 			"fields": {
 				"available": "******",
+				"column": "******",
 				"format": {
 					"info": "******",
 					"title": "******"

--- a/libs/safe/src/lib/components/query-builder/query-builder-forms.ts
+++ b/libs/safe/src/lib/components/query-builder/query-builder-forms.ts
@@ -60,6 +60,7 @@ export const addNewField = (
       return formBuilder.group({
         name: [{ value: field.name, disabled: true }],
         label: [field.label],
+        width: [newField ? null : field.width],
         type: [newField ? field.type.ofType.name : field.type],
         kind: [newField ? field.type.kind : field.kind],
         fields: formBuilder.array(
@@ -108,6 +109,7 @@ export const addNewField = (
           field.label ? field.label : prettifyLabel(field.name),
           Validators.required,
         ],
+        width: [newField ? null : field.width],
         format: [get(field, 'format', null)],
       });
     }

--- a/libs/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
+++ b/libs/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.html
@@ -139,21 +139,13 @@
       ></safe-icon>
     </div>
   </div>
-
 </div>
 <!-- Edited field -->
 <div class="flex-1" *ngIf="fieldForm">
   <ng-container *ngIf="fieldForm.value.kind === 'SCALAR'">
-    <form
-      [formGroup]="fieldForm"
-      class="p-4 rounded-lg border border-gray-300"
-    >
+    <form [formGroup]="fieldForm" class="p-4 rounded-lg border border-gray-300">
       <div class="flex gap-2">
-        <safe-button
-          [isIcon]="true"
-          icon="arrow_back"
-          (click)="onCloseField()"
-        >
+        <safe-button [isIcon]="true" icon="arrow_back" (click)="onCloseField()">
         </safe-button>
         <mat-form-field appearance="outline">
           <mat-label>{{ 'models.form.field.name' | translate }}</mat-label>
@@ -167,6 +159,12 @@
         <mat-form-field appearance="outline">
           <mat-label>{{ 'models.form.field.label' | translate }}</mat-label>
           <input matInput formControlName="label" type="text" />
+        </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>
+            {{ 'components.queryBuilder.fields.column' | translate }}
+          </mat-label>
+          <input matInput formControlName="width" type="number" />
         </mat-form-field>
       </div>
       <h3 style="margin: 0">

--- a/libs/safe/src/lib/services/email/email.service.ts
+++ b/libs/safe/src/lib/services/email/email.service.ts
@@ -274,6 +274,7 @@ export class SafeEmailService {
               name: fullName,
               title,
               subFields,
+              width: f.width,
             };
           }
           default: {
@@ -281,6 +282,7 @@ export class SafeEmailService {
             return {
               name: fullName,
               title,
+              width: f.width,
             };
           }
         }


### PR DESCRIPTION
# Description

Added an input to define column width from field selection options for email. Modification so that the value is correctly sent to the back for the generation of the email. 

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Signal%20App/Stories

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Column width value has been defined and then loaded properly. The sending of the value in the request has been checked from the network tab.

## Sreenshots

![image](https://user-images.githubusercontent.com/65243509/233380354-453fb2ae-9007-49fa-bdfa-99864ee60986.png)

![image](https://user-images.githubusercontent.com/65243509/233380488-ede37aa3-d786-4d11-a442-e905c96f928b.png)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
