### PR TITLE
Fix/ab#61981 child modal displaying behind parent modal

### DIFF
--- a/apps/back-office/src/app/app.module.ts
+++ b/apps/back-office/src/app/app.module.ts
@@ -59,6 +59,12 @@ import { MatPaginatorIntl } from '@angular/material/paginator';
 // Code editor component for Angular applications
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 
+// Fullscreen
+import {
+  OverlayContainer,
+  FullscreenOverlayContainer,
+} from '@angular/cdk/overlay';
+
 /**
  * Initialize authentication in the platform.
  * Configuration in environment file.
@@ -167,6 +173,7 @@ export const httpTranslateLoader = (http: HttpClient) =>
     PopupService,
     ResizeBatchService,
     IconsService,
+    { provide: OverlayContainer, useClass: FullscreenOverlayContainer },
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/front-office/src/app/app.module.ts
+++ b/apps/front-office/src/app/app.module.ts
@@ -67,6 +67,12 @@ import { MAT_LEGACY_TOOLTIP_DEFAULT_OPTIONS as MAT_TOOLTIP_DEFAULT_OPTIONS } fro
 import { DateInputsModule } from '@progress/kendo-angular-dateinputs';
 import { MatPaginatorIntl } from '@angular/material/paginator';
 
+// Fullscreen
+import {
+  OverlayContainer,
+  FullscreenOverlayContainer,
+} from '@angular/cdk/overlay';
+
 /**
  * Initialize authentication in the platform.
  * Configuration in environment file.
@@ -168,6 +174,7 @@ export const httpTranslateLoader = (http: HttpClient) =>
     PopupService,
     ResizeBatchService,
     IconsService,
+    { provide: OverlayContainer, useClass: FullscreenOverlayContainer },
   ],
   bootstrap: [AppComponent],
 })

--- a/libs/safe/src/lib/directives/fullscreen/fullscreen.module.ts
+++ b/libs/safe/src/lib/directives/fullscreen/fullscreen.module.ts
@@ -1,20 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FullScreenDirective } from './fullscreen.directive';
-import {
-  OverlayContainer,
-  FullscreenOverlayContainer,
-} from '@angular/cdk/overlay';
-
 /**
  *  Fullscreen module.
  */
 @NgModule({
   declarations: [FullScreenDirective],
   imports: [CommonModule],
-  providers: [
-    { provide: OverlayContainer, useClass: FullscreenOverlayContainer },
-  ],
   exports: [FullScreenDirective],
 })
 export class FullScreenModule {}


### PR DESCRIPTION
# Description

Child modals used to open behind parent modals. The cause was the implementation of the fullscreen mode in a previous change.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/61981/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Fullscreen injection has been moved to the front and back office app.module providers.
The child modal now works properly and the fullscreen still works

## Sreenshots

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
