### PR TITLE
Feat/ab#59598 adding position settings for contextual filter

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
@@ -77,7 +77,7 @@
             <mat-icon>tune</mat-icon>
             <!-- todo(translate) -->
             {{
-              dashboard.showFilter
+              showFilter
                 ? 'Deactivate filtering'
                 : 'Activate filtering'
             }}
@@ -187,4 +187,4 @@
   (goToNextStep)="goToNextStep.emit($event)"
   (add)="onAdd($event)"
 ></safe-widget-grid>
-<safe-dashboard-filter *ngIf="dashboard?.showFilter"></safe-dashboard-filter>
+<safe-dashboard-filter *ngIf="showFilter"></safe-dashboard-filter>

--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
@@ -75,11 +75,10 @@
         <mat-menu #menu="matMenu">
           <button mat-menu-item (click)="toggleFiltering()">
             <mat-icon>tune</mat-icon>
-            <!-- todo(translate) -->
             {{
               showFilter
-                ? 'Deactivate filtering'
-                : 'Activate filtering'
+                ? ('models.dashboard.deactivateFiltering' | translate)
+                : ('models.dashboard.activateFiltering' | translate)
             }}
           </button>
           <button mat-menu-item (click)="onAppSelection()">

--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
@@ -46,6 +46,7 @@ import { Observable } from 'rxjs';
 import { firstValueFrom } from 'rxjs';
 import { FormControl } from '@angular/forms';
 import { isEqual } from 'lodash';
+import localForage from 'localforage';
 
 /** Default number of records fetched per page */
 const ITEMS_PER_PAGE = 10;
@@ -202,6 +203,8 @@ export class DashboardComponent
    */
   override ngOnDestroy(): void {
     super.ngOnDestroy();
+    localForage.removeItem(this.applicationId + 'contextualFilterPosition'); //remove temporary contextual filter data
+    localForage.removeItem(this.applicationId + 'contextualFilter');
     this.dashboardService.closeDashboard();
   }
 

--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
@@ -500,6 +500,9 @@ export class DashboardComponent
     }
   }
 
+  /**
+   * Toggles the filter for the current dashboard.
+   */
   toggleFiltering(): void {
     if (this.dashboard) {
       this.apollo

--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
@@ -69,6 +69,7 @@ export class DashboardComponent
   public loading = true;
   public tiles: any[] = [];
   public dashboard?: Dashboard;
+  public showFilter?: boolean;
 
   // === GRID ===
   private generatedTiles = 0;
@@ -163,6 +164,7 @@ export class DashboardComponent
                 ? this.dashboard.step.workflow?.page?.application?.id
                 : '';
               this.loading = loading;
+              this.showFilter = this.dashboard.showFilter;
             } else {
               this.snackBar.openSnackBar(
                 this.translateService.instant(
@@ -505,12 +507,13 @@ export class DashboardComponent
    */
   toggleFiltering(): void {
     if (this.dashboard) {
+      this.showFilter = !this.showFilter;
       this.apollo
         .mutate<EditDashboardMutationResponse>({
           mutation: EDIT_DASHBOARD,
           variables: {
             id: this.id,
-            showFilter: !this.dashboard.showFilter,
+            showFilter: this.showFilter,
           },
         })
         .subscribe({

--- a/apps/back-office/src/environments/environment.ts
+++ b/apps/back-office/src/environments/environment.ts
@@ -26,6 +26,17 @@ const authConfig: AuthConfig = {
   responseType: 'code',
   showDebugInformation: true,
 };
+/*const authConfig: AuthConfig = {
+  issuer:
+    'https://login.microsoftonline.com/fbacd48d-ccf4-480d-baf0-31048368055f/v2.0',
+  redirectUri: 'http://localhost:4200/',
+  postLogoutRedirectUri: 'http://localhost:4200/auth/',
+  clientId: 'd62083d8-fdc0-4a6a-8618-652380eebdb9',
+  scope: 'openid profile email offline_access',
+  responseType: 'code',
+  showDebugInformation: true,
+  strictDiscoveryDocumentValidation: false,
+};*/
 
 /**
  * Environment file for local development.

--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -402,7 +402,8 @@
 			"customStyling": "Custom Styling",
 			"dashboard": {
 				"editFilter": "Edit filter",
-				"empty": "No content available. Wait for your administrator to build some."
+				"empty": "No content available. Wait for your administrator to build some.",
+				"filterSettings": "Filter settings"
 			},
 			"delete": {
 				"confirmationMessage": "Do you confirm the deletion of the application {{name}}?"

--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -403,7 +403,10 @@
 			"dashboard": {
 				"editFilter": "Edit filter",
 				"empty": "No content available. Wait for your administrator to build some.",
-				"filterSettings": "Filter settings"
+				"filterSettings": "Filter settings",
+				"settings": {
+					"defaultPosition": "Default position for the filter"
+				}
 			},
 			"delete": {
 				"confirmationMessage": "Do you confirm the deletion of the application {{name}}?"
@@ -1704,6 +1707,7 @@
 			"type": "Notification type"
 		},
 		"dashboard": {
+			"activateFiltering": "Activate filtering",
 			"context": {
 				"datasource": {
 					"alert": "Select a datasource, in order to set one page per record of the datasource. You can also set a template, which would be loaded by default if no specific page is created for a record.",
@@ -1722,6 +1726,7 @@
 					"element": "Element"
 				}
 			},
+			"deactivateFiltering": "Deactivate filtering",
 			"share": "Share Dashboard"
 		},
 		"form": {

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -403,7 +403,10 @@
 			"dashboard": {
 				"editFilter": "Modifier le filtre",
 				"empty": "Aucun contenu n'est disponible. Veuillez attendre que votre administrateur en crée.",
-				"filterSettings": "Paramètres du filtre"
+				"filterSettings": "Paramètres du filtre",
+				"settings": {
+					"defaultPosition": "Position par défaut du filtre"
+				}
 			},
 			"delete": {
 				"confirmationMessage": "Voulez-vous vraiment supprimer cette application ?"
@@ -1712,6 +1715,7 @@
 			"type": "Type"
 		},
 		"dashboard": {
+			"activateFiltering": "Activer le filtre",
 			"context": {
 				"datasource": {
 					"alert": "Sélectionnez une source de données, afin de définir une page par enregistrement de la source de données. Vous pouvez également définir un modèle qui sera chargé par défaut si aucune page spécifique n'est créée pour un enregistrement.",
@@ -1730,6 +1734,7 @@
 					"element": "Élément"
 				}
 			},
+			"deactivateFiltering": "Désactiver le filtre",
 			"share": "Partager le tableau de bord"
 		},
 		"form": {

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -402,7 +402,8 @@
 			"customStyling": "Style personnalisé",
 			"dashboard": {
 				"editFilter": "Modifier le filtre",
-				"empty": "Aucun contenu n'est disponible. Veuillez attendre que votre administrateur en crée."
+				"empty": "Aucun contenu n'est disponible. Veuillez attendre que votre administrateur en crée.",
+				"filterSettings": "Paramètres du filtre"
 			},
 			"delete": {
 				"confirmationMessage": "Voulez-vous vraiment supprimer cette application ?"

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -403,7 +403,10 @@
 			"dashboard": {
 				"editFilter": "******",
 				"empty": "******",
-				"filterSettings": "******"
+				"filterSettings": "******",
+				"settings": {
+					"defaultPosition": "******"
+				}
 			},
 			"delete": {
 				"confirmationMessage": "****** {{name}} ******"
@@ -1704,6 +1707,7 @@
 			"type": "******"
 		},
 		"dashboard": {
+			"activateFiltering": "******",
 			"context": {
 				"datasource": {
 					"alert": "******",
@@ -1722,6 +1726,7 @@
 					"element": "******"
 				}
 			},
+			"deactivateFiltering": "******",
 			"share": "******"
 		},
 		"form": {

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -402,7 +402,8 @@
 			"customStyling": "******",
 			"dashboard": {
 				"editFilter": "******",
-				"empty": "******"
+				"empty": "******",
+				"filterSettings": "******"
 			},
 			"delete": {
 				"confirmationMessage": "****** {{name}} ******"

--- a/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
+++ b/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
@@ -4,6 +4,8 @@
   [minSizeOnClosed]="48"
   [elementWidth]="containerWidth"
   [elementHeight]="containerHeight"
+  [elementLeftOffset]="containerLeftOffset"
+  [elementTopOffset]="containerTopOffset"
   [opened]="isDrawerOpen"
   class="pointer-events-auto"
 >
@@ -105,7 +107,8 @@
         'h-full':
           position === filterPosition.LEFT || position === filterPosition.RIGHT,
         'flex-col':
-          position === filterPosition.LEFT || position === filterPosition.RIGHT
+          position === filterPosition.LEFT || position === filterPosition.RIGHT,
+        hidden: isDrawerOpen
       }"
       class="dashboard-filter-content bg-white p-3"
     >

--- a/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
+++ b/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
@@ -109,7 +109,8 @@
           position === filterPosition.LEFT || position === filterPosition.RIGHT,
         'flex-col':
           position === filterPosition.LEFT || position === filterPosition.RIGHT,
-        hidden: isDrawerOpen
+        'animate-fadeOut': !isDrawerOpen,
+        'animate-fadeIn': isDrawerOpen
       }"
       class="dashboard-filter-content bg-white p-3"
     >

--- a/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
+++ b/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
@@ -30,8 +30,8 @@
       }"
       class="relative flex justify-between bg-primary-500 text-white"
     >
-      <!-- Edition -->
       <div class="flex-auto">
+        <!-- Edition -->
         <safe-button
           [isIcon]="true"
           icon="edit"
@@ -41,7 +41,18 @@
           "
         >
         </safe-button>
+        <!-- Default position -->
+        <safe-button
+          [isIcon]="true"
+          icon="settings"
+          (click)="openSettings()"
+          [matTooltip]="
+            'components.application.dashboard.filterSettings' | translate
+          "
+        >
+        </safe-button>
       </div>
+
       <!-- Position -->
       <div
         [ngClass]="{

--- a/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
+++ b/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
@@ -30,7 +30,14 @@
       }"
       class="relative flex justify-between bg-primary-500 text-white"
     >
-      <div class="flex-auto">
+      <div
+        [ngClass]="{
+          'flex-col':
+            position === filterPosition.LEFT ||
+            position === filterPosition.RIGHT
+        }"
+        class="flex flex-auto"
+      >
         <!-- Edition -->
         <safe-button
           [isIcon]="true"

--- a/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
+++ b/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.html
@@ -7,6 +7,7 @@
   [elementLeftOffset]="containerLeftOffset"
   [elementTopOffset]="containerTopOffset"
   [opened]="isDrawerOpen"
+  [dashboardSurveyCreatorContainer]="dashboardSurveyCreatorContainer"
   class="pointer-events-auto"
 >
   <div
@@ -112,7 +113,10 @@
       }"
       class="dashboard-filter-content bg-white p-3"
     >
-      <div #dashboardSurveyCreatorContainer></div>
+      <div
+        #dashboardSurveyCreatorContainer
+        class="overflow-scroll"
+      ></div>
       <!-- <form
         [ngClass]="{
           'flex-col':

--- a/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -55,7 +55,7 @@ export class DashboardFilterComponent
   public survey: Survey.Model = new Survey.Model();
   public surveyStructure: any = {};
   @ViewChild('dashboardSurveyCreatorContainer')
-  dashboardSurveyCreatorContainer!: ElementRef;
+  dashboardSurveyCreatorContainer!: ElementRef<HTMLElement>;
 
   public applicationId?: string;
 
@@ -98,6 +98,7 @@ export class DashboardFilterComponent
             .then((contextualFilter) => {
               if (contextualFilter) {
                 this.surveyStructure = contextualFilter;
+                this.initSurvey();
               } else if (application.contextualFilter) {
                 this.surveyStructure = application.contextualFilter;
                 this.initSurvey();
@@ -108,10 +109,8 @@ export class DashboardFilterComponent
             .then((contextualFilterPosition) => {
               if (contextualFilterPosition) {
                 this.position = contextualFilterPosition as FilterPosition;
-                console.log('loaded from cache', this.position);
               } else if (application.contextualFilterPosition) {
                 this.position = application.contextualFilterPosition;
-                console.log('initial pos', this.position);
               }
             });
         }
@@ -158,7 +157,6 @@ export class DashboardFilterComponent
   public onEditFilter() {
     import('./filter-builder-modal/filter-builder-modal.component').then(
       ({ FilterBuilderModalComponent }) => {
-        console.log('editing struct', this.surveyStructure);
         const dialogRef = this.dialog.open(FilterBuilderModalComponent, {
           data: { surveyStructure: this.surveyStructure },
           autoFocus: false,
@@ -220,7 +218,6 @@ export class DashboardFilterComponent
     this.survey.showNavigationButtons = false;
     this.survey.render(this.dashboardSurveyCreatorContainer?.nativeElement);
     this.survey.onValueChanged.add(this.onValueChange.bind(this));
-    console.log('survey init,', this.survey.getAllQuestions());
   }
 
   /**

--- a/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   ElementRef,
   HostListener,
-  Input,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -36,7 +35,7 @@ export class DashboardFilterComponent
   implements OnInit, OnDestroy
 {
   // Filter
-  @Input() position: FilterPosition = FilterPosition.BOTTOM;
+  position!: FilterPosition;
   public positionList = [
     FilterPosition.LEFT,
     FilterPosition.TOP,
@@ -111,6 +110,8 @@ export class DashboardFilterComponent
                 this.position = contextualFilterPosition as FilterPosition;
               } else if (application.contextualFilterPosition) {
                 this.position = application.contextualFilterPosition;
+              } else {
+                this.position = FilterPosition.BOTTOM; //case where there are no default position set up
               }
             });
         }

--- a/libs/safe/src/lib/components/dashboard-filter/directives/drawer-positioner/drawer-positioner.directive.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/directives/drawer-positioner/drawer-positioner.directive.ts
@@ -65,12 +65,8 @@ export class SafeDrawerPositionerDirective
     if (changes.position?.currentValue) {
       this.setPosition(changes.position.currentValue);
     }
-    console.log(changes.opened, 'changes');
-    if (
-      changes.opened &&
-      changes.opened.currentValue != changes.opened.previousValue
-    ) {
-      //this.displayDrawer(changes.opened.currentValue);
+    if (changes.opened?.currentValue !== changes.opened?.previousValue) {
+      this.displayDrawer(changes.opened.currentValue);
     }
     // Width has to be set when the element is in horizontal(at the TOP or BOTTOM of the parent context) position
     if (
@@ -200,6 +196,7 @@ export class SafeDrawerPositionerDirective
       default:
         break;
     }
+    setTimeout(() => this.displayDrawer(this.opened), 0); //Waiting to acquire the right client size
   }
 
   /**
@@ -230,17 +227,17 @@ export class SafeDrawerPositionerDirective
    * Open animation for Y axis
    *
    * @param open Is element open
-   * @param isAbsoluteValue Has to use absolute value(for BOTTOM)
+   * @param translateToTheBottom Has to use absolute value(for BOTTOM)
    */
-  private translateY(open: boolean, isAbsoluteValue: boolean = false) {
+  private translateY(open: boolean, translateToTheBottom: boolean = false) {
     if (open) {
-      this.el.nativeElement.style.transform = `translateY(0px)`;
+      this.el.nativeElement.style.transform = `translateY(0)`;
     } else {
       // If close we would translate the element out leaving the minSizeOnClosed value visible
+      const heightToTranslate =
+        this.minSizeOnClosed - this.el.nativeElement.clientHeight;
       this.el.nativeElement.style.transform = `translateY(${
-        isAbsoluteValue
-          ? Math.abs(this.minSizeOnClosed - this.el.nativeElement.clientHeight)
-          : this.minSizeOnClosed - this.el.nativeElement.clientHeight
+        translateToTheBottom ? -heightToTranslate : heightToTranslate
       }px)`;
     }
   }
@@ -249,17 +246,17 @@ export class SafeDrawerPositionerDirective
    * Open animation for X axis
    *
    * @param open Is element open
-   * @param isAbsoluteValue Has to use absolute value(for RIGHT)
+   * @param translateToTheRight Has to use absolute value(for RIGHT)
    */
-  private translateX(open: boolean, isAbsoluteValue: boolean = false) {
+  private translateX(open: boolean, translateToTheRight: boolean = false) {
     if (open) {
       this.el.nativeElement.style.transform = `translateX(0px)`;
     } else {
       // If close we would translate the element out leaving the minSizeOnClosed value visible
+      const widthToTranslate =
+        this.minSizeOnClosed - this.el.nativeElement.clientWidth;
       this.el.nativeElement.style.transform = `translateX(${
-        isAbsoluteValue
-          ? Math.abs(this.minSizeOnClosed - this.el.nativeElement.clientWidth)
-          : this.minSizeOnClosed - this.el.nativeElement.clientWidth
+        translateToTheRight ? -widthToTranslate : widthToTranslate
       }px)`;
     }
   }

--- a/libs/safe/src/lib/components/dashboard-filter/directives/drawer-positioner/drawer-positioner.directive.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/directives/drawer-positioner/drawer-positioner.directive.ts
@@ -57,6 +57,7 @@ export class SafeDrawerPositionerDirective
       'transform ease-in-out .3s'
     );
     this.setPosition(this.position);
+    console.log(this.el.nativeElement.style);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -64,7 +65,7 @@ export class SafeDrawerPositionerDirective
       this.setPosition(changes.position.currentValue);
     }
     if (changes.opened) {
-      this.displayDrawer(changes.opened.currentValue);
+      //this.displayDrawer(changes.opened.currentValue); disabled for now as it messes things up
     }
     // Width has to be set when the element is in horizontal(at the TOP or BOTTOM of the parent context) position
     if (
@@ -125,6 +126,11 @@ export class SafeDrawerPositionerDirective
           'width',
           this.elementWidth
         );
+        this.renderer.setStyle(
+          this.el.nativeElement,
+          'max-height',
+          this.elementHeight
+        );
         break;
       // Set the width as it's in the horizontal side of the parent context, but also set the bottom property to 0
       case FilterPosition.BOTTOM:
@@ -138,6 +144,11 @@ export class SafeDrawerPositionerDirective
           this.el.nativeElement,
           'width',
           this.elementWidth
+        );
+        this.renderer.setStyle(
+          this.el.nativeElement,
+          'max-height',
+          this.elementHeight
         );
         break;
       // Set the height as it's in the vertical side of the parent context, fixed element is in the left of parent context by default
@@ -175,7 +186,7 @@ export class SafeDrawerPositionerDirective
       default:
         break;
     }
-    this.displayDrawer(this.opened);
+    //this.displayDrawer(this.opened);  disabled for now as it messes things up
   }
 
   /**

--- a/libs/safe/src/lib/components/dashboard-filter/directives/drawer-positioner/drawer-positioner.directive.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/directives/drawer-positioner/drawer-positioner.directive.ts
@@ -30,6 +30,8 @@ export class SafeDrawerPositionerDirective
   @Input() minSizeOnClosed = 48;
   // If the element is open or not
   @Input() opened = false;
+  @Input()
+  dashboardSurveyCreatorContainer!: any;
 
   /**
    * Class constructor
@@ -57,15 +59,18 @@ export class SafeDrawerPositionerDirective
       'transform ease-in-out .3s'
     );
     this.setPosition(this.position);
-    console.log(this.el.nativeElement.style);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.position?.currentValue) {
       this.setPosition(changes.position.currentValue);
     }
-    if (changes.opened) {
-      //this.displayDrawer(changes.opened.currentValue); disabled for now as it messes things up
+    console.log(changes.opened, 'changes');
+    if (
+      changes.opened &&
+      changes.opened.currentValue != changes.opened.previousValue
+    ) {
+      //this.displayDrawer(changes.opened.currentValue);
     }
     // Width has to be set when the element is in horizontal(at the TOP or BOTTOM of the parent context) position
     if (
@@ -103,11 +108,20 @@ export class SafeDrawerPositionerDirective
     // Reset drawer containers styles
     this.renderer.setStyle(this.el.nativeElement, 'height', 'max-content');
     this.renderer.setStyle(this.el.nativeElement, 'width', 'max-content');
+    this.renderer.setStyle(
+      this.dashboardSurveyCreatorContainer,
+      'height',
+      this.elementHeight
+    );
     // Remove any positioning from the element first in order to not conflict with each position properties later
     this.renderer.removeStyle(this.el.nativeElement, 'right');
     this.renderer.removeStyle(this.el.nativeElement, 'bottom');
     this.renderer.removeStyle(this.el.nativeElement, 'top');
     this.renderer.removeStyle(this.el.nativeElement, 'left');
+    this.renderer.removeStyle(
+      this.dashboardSurveyCreatorContainer,
+      'max-height'
+    );
     switch (position) {
       // Set the width as it's in the horizontal side of the parent context, fixed element is in the top of parent context by default
       case FilterPosition.TOP:
@@ -127,10 +141,10 @@ export class SafeDrawerPositionerDirective
           this.elementWidth
         );
         this.renderer.setStyle(
-          this.el.nativeElement,
+          this.dashboardSurveyCreatorContainer,
           'max-height',
-          this.elementHeight
-        );
+          `${Number(this.elementHeight.split('px')[0]) / 3}px`
+        ); // The filter cannot take more than a third of the screen in height
         break;
       // Set the width as it's in the horizontal side of the parent context, but also set the bottom property to 0
       case FilterPosition.BOTTOM:
@@ -146,10 +160,10 @@ export class SafeDrawerPositionerDirective
           this.elementWidth
         );
         this.renderer.setStyle(
-          this.el.nativeElement,
+          this.dashboardSurveyCreatorContainer,
           'max-height',
-          this.elementHeight
-        );
+          `${Number(this.elementHeight.split('px')[0]) / 3}px`
+        ); // The filter cannot take more than a third of the screen in height
         break;
       // Set the height as it's in the vertical side of the parent context, fixed element is in the left of parent context by default
       case FilterPosition.LEFT:
@@ -186,7 +200,6 @@ export class SafeDrawerPositionerDirective
       default:
         break;
     }
-    //this.displayDrawer(this.opened);  disabled for now as it messes things up
   }
 
   /**
@@ -197,34 +210,6 @@ export class SafeDrawerPositionerDirective
   private displayDrawer(open: boolean) {
     switch (this.position) {
       case FilterPosition.TOP:
-        // TOP has an especial behavior as the overflow for the top side of the parent if is not in the viewport, it would be visible
-        // We will have to set the parent element as the container reference(e.g. setting transform property, but the positioned element would lose fixed behavior)
-        /*if (open) {
-          this.el.nativeElement.style.transform = `translateY(0px)`;
-          setTimeout(() => {
-            this.renderer.setStyle(
-              document
-                .getElementsByClassName('dashboard-filter-content')
-                .item(0),
-              'visibility',
-              'initial'
-            );
-          }, 200);
-        } else {
-          // If close we would translate the element out leaving the minSizeOnClosed value visible
-          this.el.nativeElement.style.transform = `translateY(${
-            this.minSizeOnClosed - this.el.nativeElement.clientHeight
-          }px)`;
-          setTimeout(() => {
-            this.renderer.setStyle(
-              document
-                .getElementsByClassName('dashboard-filter-content')
-                .item(0),
-              'visibility',
-              'collapse'
-            );
-          }, 50);
-        }*/
         this.translateY(open);
         break;
       case FilterPosition.BOTTOM:
@@ -257,11 +242,6 @@ export class SafeDrawerPositionerDirective
           ? Math.abs(this.minSizeOnClosed - this.el.nativeElement.clientHeight)
           : this.minSizeOnClosed - this.el.nativeElement.clientHeight
       }px)`;
-      console.log(
-        'translating by',
-        this.el.nativeElement.clientHeight,
-        this.el.nativeElement.clientWidth
-      );
     }
   }
 
@@ -281,11 +261,6 @@ export class SafeDrawerPositionerDirective
           ? Math.abs(this.minSizeOnClosed - this.el.nativeElement.clientWidth)
           : this.minSizeOnClosed - this.el.nativeElement.clientWidth
       }px)`;
-      console.log(
-        'translating by',
-        this.el.nativeElement.clientHeight,
-        this.el.nativeElement.clientWidth
-      );
     }
   }
 }

--- a/libs/safe/src/lib/components/dashboard-filter/directives/drawer-positioner/drawer-positioner.directive.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/directives/drawer-positioner/drawer-positioner.directive.ts
@@ -24,6 +24,8 @@ export class SafeDrawerPositionerDirective
   @Input() elementWidth!: string;
   // The element height, as the directive host is positioned fixed, we need to set the height manually in order to match the parent element
   @Input() elementHeight!: string;
+  @Input() elementLeftOffset!: string;
+  @Input() elementTopOffset!: string;
   // The minimum amount of element size(in px) remaining visible when the element is collapsed
   @Input() minSizeOnClosed = 48;
   // If the element is open or not
@@ -96,15 +98,28 @@ export class SafeDrawerPositionerDirective
    * @param position Position to set
    */
   private setPosition(position: FilterPosition) {
+    this.renderer.setStyle(this.el.nativeElement, 'position', 'relative');
     // Reset drawer containers styles
     this.renderer.setStyle(this.el.nativeElement, 'height', 'max-content');
     this.renderer.setStyle(this.el.nativeElement, 'width', 'max-content');
     // Remove any positioning from the element first in order to not conflict with each position properties later
     this.renderer.removeStyle(this.el.nativeElement, 'right');
     this.renderer.removeStyle(this.el.nativeElement, 'bottom');
+    this.renderer.removeStyle(this.el.nativeElement, 'top');
+    this.renderer.removeStyle(this.el.nativeElement, 'left');
     switch (position) {
       // Set the width as it's in the horizontal side of the parent context, fixed element is in the top of parent context by default
       case FilterPosition.TOP:
+        this.renderer.setStyle(
+          this.el.nativeElement,
+          'top',
+          this.elementTopOffset
+        );
+        this.renderer.setStyle(
+          this.el.nativeElement,
+          'left',
+          this.elementLeftOffset
+        );
         this.renderer.setStyle(
           this.el.nativeElement,
           'width',
@@ -114,6 +129,11 @@ export class SafeDrawerPositionerDirective
       // Set the width as it's in the horizontal side of the parent context, but also set the bottom property to 0
       case FilterPosition.BOTTOM:
         this.renderer.setStyle(this.el.nativeElement, 'bottom', 0);
+        this.renderer.setStyle(
+          this.el.nativeElement,
+          'left',
+          this.elementLeftOffset
+        );
         this.renderer.setStyle(
           this.el.nativeElement,
           'width',
@@ -127,6 +147,16 @@ export class SafeDrawerPositionerDirective
           'height',
           this.elementHeight
         );
+        this.renderer.setStyle(
+          this.el.nativeElement,
+          'left',
+          this.elementLeftOffset
+        );
+        this.renderer.setStyle(
+          this.el.nativeElement,
+          'top',
+          this.elementTopOffset
+        );
         break;
       // Set the height as it's in the vertical side of the parent context, but also set the right property to 0
       case FilterPosition.RIGHT:
@@ -135,6 +165,11 @@ export class SafeDrawerPositionerDirective
           this.el.nativeElement,
           'height',
           this.elementHeight
+        );
+        this.renderer.setStyle(
+          this.el.nativeElement,
+          'top',
+          this.elementTopOffset
         );
         break;
       default:
@@ -153,7 +188,7 @@ export class SafeDrawerPositionerDirective
       case FilterPosition.TOP:
         // TOP has an especial behavior as the overflow for the top side of the parent if is not in the viewport, it would be visible
         // We will have to set the parent element as the container reference(e.g. setting transform property, but the positioned element would lose fixed behavior)
-        if (open) {
+        /*if (open) {
           this.el.nativeElement.style.transform = `translateY(0px)`;
           setTimeout(() => {
             this.renderer.setStyle(
@@ -178,7 +213,8 @@ export class SafeDrawerPositionerDirective
               'collapse'
             );
           }, 50);
-        }
+        }*/
+        this.translateY(open);
         break;
       case FilterPosition.BOTTOM:
         this.translateY(open, true);
@@ -210,6 +246,11 @@ export class SafeDrawerPositionerDirective
           ? Math.abs(this.minSizeOnClosed - this.el.nativeElement.clientHeight)
           : this.minSizeOnClosed - this.el.nativeElement.clientHeight
       }px)`;
+      console.log(
+        'translating by',
+        this.el.nativeElement.clientHeight,
+        this.el.nativeElement.clientWidth
+      );
     }
   }
 
@@ -229,6 +270,11 @@ export class SafeDrawerPositionerDirective
           ? Math.abs(this.minSizeOnClosed - this.el.nativeElement.clientWidth)
           : this.minSizeOnClosed - this.el.nativeElement.clientWidth
       }px)`;
+      console.log(
+        'translating by',
+        this.el.nativeElement.clientHeight,
+        this.el.nativeElement.clientWidth
+      );
     }
   }
 }

--- a/libs/safe/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
@@ -183,7 +183,7 @@ export class FilterBuilderModalComponent
    * Custom SurveyJS method, save the survey when edited.
    */
   saveMySurvey = () => {
-    this.dialogRef.close(this.surveyCreator);
+    this.dialogRef.close(this.surveyCreator.text);
   };
 
   ngOnDestroy(): void {

--- a/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.html
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.html
@@ -1,0 +1,13 @@
+<safe-modal [closable]="true">
+  <div class="flex flex-auto justify-end">
+    <ng-container *ngFor="let position of positionList">
+      <safe-button
+        matSuffix
+        [isIcon]="true"
+        icon="{{ position + '_panel_open' }}"
+        [fontSet]="'material-symbols-outlined'"
+        (click)="setDefaultPosition(position)"
+      ></safe-button>
+    </ng-container>
+  </div>
+</safe-modal>

--- a/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.html
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.html
@@ -1,5 +1,6 @@
 <safe-modal [closable]="true">
   <div class="flex flex-auto justify-end">
+    {{'components.application.dashboard.settings.defaultPosition' | translate}}
     <ng-container *ngFor="let position of positionList">
       <safe-button
         matSuffix

--- a/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.html
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.html
@@ -1,6 +1,6 @@
 <safe-modal [closable]="true">
-  <div class="flex flex-auto justify-end">
-    {{'components.application.dashboard.settings.defaultPosition' | translate}}
+  <h3>{{ 'components.application.dashboard.settings.defaultPosition' | translate }}</h3>
+  <div class="flex flex-auto">
     <ng-container *ngFor="let position of positionList">
       <safe-button
         matSuffix

--- a/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.spec.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FilterSettingsModalComponent } from './filter-settings-modal.component';
+
+describe('FilterSettingsModalComponent', () => {
+  let component: FilterSettingsModalComponent;
+  let fixture: ComponentFixture<FilterSettingsModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FilterSettingsModalComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FilterSettingsModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.ts
@@ -1,0 +1,55 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import {
+  MatLegacyDialogRef as MatDialogRef,
+  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
+} from '@angular/material/legacy-dialog';
+import { FilterPosition } from '../enums/dashboard-filters.enum';
+import { SafeModalModule } from '../../ui/modal/modal.module';
+import { CommonModule } from '@angular/common';
+
+/**
+ * Data for the settings modal
+ */
+interface SettingsData {
+  positionList: FilterPosition[];
+}
+
+/**
+ * Settings for the dashboard filter component
+ */
+@Component({
+  standalone: true,
+  selector: 'safe-filter-settings-modal',
+  templateUrl: './filter-settings-modal.component.html',
+  styleUrls: ['./filter-settings-modal.component.scss'],
+  imports: [SafeModalModule, CommonModule],
+})
+export class FilterSettingsModalComponent implements OnInit {
+  public positionList: FilterPosition[] = [];
+  private defaultPosition: FilterPosition = FilterPosition.BOTTOM;
+
+  /**
+   * Settings modal for the dashboard component
+   *
+   * @param dialogRef Reference to the modal
+   * @param data Data to use to configure the settings
+   */
+  constructor(
+    private dialogRef: MatDialogRef<FilterSettingsModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: SettingsData
+  ) {}
+
+  ngOnInit(): void {
+    this.positionList = this.data.positionList;
+  }
+
+  /**
+   * Sets the default position for the dashboard filter component
+   *
+   * @param position Position to set
+   */
+  setDefaultPosition(position: FilterPosition) {
+    this.defaultPosition = position;
+    this.dialogRef.close(this.defaultPosition);
+  }
+}

--- a/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/filter-settings-modal/filter-settings-modal.component.ts
@@ -6,6 +6,7 @@ import {
 import { FilterPosition } from '../enums/dashboard-filters.enum';
 import { SafeModalModule } from '../../ui/modal/modal.module';
 import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
 
 /**
  * Data for the settings modal
@@ -22,7 +23,7 @@ interface SettingsData {
   selector: 'safe-filter-settings-modal',
   templateUrl: './filter-settings-modal.component.html',
   styleUrls: ['./filter-settings-modal.component.scss'],
-  imports: [SafeModalModule, CommonModule],
+  imports: [SafeModalModule, CommonModule, TranslateModule],
 })
 export class FilterSettingsModalComponent implements OnInit {
   public positionList: FilterPosition[] = [];

--- a/libs/safe/src/lib/components/dashboard-filter/graphql/mutations.ts
+++ b/libs/safe/src/lib/components/dashboard-filter/graphql/mutations.ts
@@ -16,6 +16,24 @@ export const EDIT_APPLICATION_FILTER = gql`
   }
 `;
 
+/** Graphql request for editing an application by its id */
+export const EDIT_APPLICATION_FILTER_POSITION = gql`
+  mutation editApplication($id: ID!, $contextualFilterPosition: String) {
+    editApplication(
+      id: $id
+      contextualFilterPosition: $contextualFilterPosition
+    ) {
+      id
+      description
+      name
+      createdAt
+      modifiedAt
+      status
+      contextualFilterPosition
+    }
+  }
+`;
+
 /** Edit application gql mutation response interface */
 export interface EditApplicationMutationResponse {
   editApplication: Application;

--- a/libs/safe/src/lib/models/application.model.ts
+++ b/libs/safe/src/lib/models/application.model.ts
@@ -36,4 +36,5 @@ export interface Application {
   distributionLists?: DistributionList[];
   customNotifications?: Connection<CustomNotification>;
   contextualFilter?: any;
+  contextualFilterPosition?: any;
 }

--- a/libs/safe/src/lib/services/application/graphql/queries.ts
+++ b/libs/safe/src/lib/services/application/graphql/queries.ts
@@ -111,6 +111,7 @@ export const GET_APPLICATION_BY_ID = gql`
       locked
       lockedByUser
       contextualFilter
+      contextualFilterPosition
     }
   }
 `;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,8 +30,22 @@ module.exports = {
           100: 'rgb(var(--secondary-100) / <alpha-value>)', //lighter
           150: 'rgb(var(--secondary-150) / <alpha-value>)', //darker
           200: 'rgb(var(--secondary-200) / <alpha-value>)', //200
-        }
-      }
+        },
+      },
+      keyframes: {
+        fadeIn: {
+          '0%': { opacity: 0 },
+          '100%': { opacity: 1 },
+        },
+        fadeOut: {
+          '0%': { opacity: 1 },
+          '100%': { opacity: 0 },
+        },
+      },
+      animation: {
+        fadeIn: 'fadeIn 0.5s forwards',
+        fadeOut: 'fadeOut 0.1s forwards',
+      },
     },
   },
   plugins: [],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,9 +16,9 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "paths": {
+      "@oort-front/leaflet": ["libs/leaflet/src/index.ts"],
       "@oort-front/safe": ["libs/safe/src/index.ts"],
-      "@oort-front/ui": ["libs/ui/src/index.ts"],
-      "@oort-front/leaflet": ["libs/leaflet/src/index.ts"]
+      "@oort-front/ui": ["libs/ui/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
# Description

Added settings button to be able to change filter default position.
Added support for activate/deactivate without having to reload.
Embedded the filter inside of the dashboard rather than in the page.
Fixed bug where survey would not load.
Added support for long filters: they do not  cover the entirety of the page and I added a scrollbar.

## Ticket

[Ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/59598/)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tried to open and set the settings. Deactivate/reactivate: it should open in the settings position.
Tried to edit the filter. Changes should be reflected immediately. 
Tried to create long filters. The size of the filter is capped and a scrollbar appears.
Tried to change position and open/close the filter.

## Sreenshots

![Screenshot from 2023-05-04 11-37-47](https://user-images.githubusercontent.com/59645813/236181097-9cb35072-d65f-43f2-9331-431d54c6d46e.png)
![Screenshot from 2023-05-04 11-37-53](https://user-images.githubusercontent.com/59645813/236181101-72315165-2afa-4e87-9a16-7a8aa3bfa06a.png)
![Screenshot from 2023-05-04 11-38-07](https://user-images.githubusercontent.com/59645813/236181105-f7da85cb-0378-4732-85fb-2f727681cf72.png)
![Screenshot from 2023-05-04 12-29-51](https://user-images.githubusercontent.com/59645813/236181107-65af83e9-84e4-4cb7-978a-e7d9360bd07b.png)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
