### PR TITLE
feat/add-substr-calculation

### DIFF
--- a/libs/safe/src/lib/components/edit-calculated-field-modal/utils/keys.ts
+++ b/libs/safe/src/lib/components/edit-calculated-field-modal/utils/keys.ts
@@ -28,6 +28,9 @@ const calcFunctions: Record<string, { signature: string }> = {
   if: {
     signature: 'if( condition ; then ; else )',
   },
+  substr: {
+    signature: 'substr( value ; startIndex ; length )',
+  },
 
   // DOUBLE ARGUMENTS
   sub: {
@@ -89,6 +92,9 @@ const calcFunctions: Record<string, { signature: string }> = {
   size: {
     signature: 'size( value )',
   },
+  toInt: {
+    signature: 'toInt( value )',
+  },
 
   // ONE OR NO ARGUMENTS
   today: {
@@ -114,7 +120,9 @@ export const getCalcKeys = (): string[] => {
  * @returns List of info keys
  */
 export const getInfoKeys = (): string[] =>
-  ['createdAt', 'updatedAt'].map((k) => INFO_PREFIX + k + PLACEHOLDER_SUFFIX);
+  ['createdAt', 'updatedAt', 'incrementalId'].map(
+    (k) => INFO_PREFIX + k + PLACEHOLDER_SUFFIX
+  );
 
 /**
  * Returns an array with the keys for data autocompletion.


### PR DESCRIPTION
# Description

This PR adds the calc keys for the `toInt`, `toLong` and `substr` calc keys for the calculated fields, along with the `incrementalId` info key

## Ticket

No ticket linked to this PR

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By starting to type all these keys in the calculated fields expression editor

## Sreenshots
![Peek 2023-05-02 13-25](https://user-images.githubusercontent.com/102038450/236903911-104e86ea-b6cc-4697-b7d1-8f1f5cc14175.gif)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
