### PR TITLE
Feat/ab#11381 ability in grid to select unselect all columns

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1455,6 +1455,7 @@
 			"underline": "Underline",
 			"undo": "Undo",
 			"unlink": "Remove Link",
+			"unselectAll": "Unselect all",
 			"viewSource": "View source"
 		},
 		"fileselect": {

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1463,6 +1463,7 @@
 			"underline": "Souligner",
 			"undo": "Annuler",
 			"unlink": "Supprimer le lien",
+			"unselectAll": "Tout déselectionner",
 			"viewSource": "Voir la source"
 		},
 		"fileselect": {

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1455,6 +1455,7 @@
 			"underline": "******",
 			"undo": "******",
 			"unlink": "******",
+			"unselectAll": "******",
 			"viewSource": "******"
 		},
 		"fileselect": {

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -49,6 +49,7 @@
       class="!w-full"
     />
     <kendo-grid-column-chooser *ngIf="reorderable"></kendo-grid-column-chooser>
+    <button kendoButton (click)="selectAllColumns()">{{ allColumnsSelected ? 'kendo.editor.unselectAll' | translate : 'kendo.editor.selectAll' |translate }}</button>
     <button
       *ngIf="actions.add && canAdd"
       kendoButton

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -49,7 +49,13 @@
       class="!w-full"
     />
     <kendo-grid-column-chooser *ngIf="reorderable"></kendo-grid-column-chooser>
-    <button kendoButton (click)="selectAllColumns()">{{ allColumnsSelected ? 'kendo.editor.unselectAll' | translate : 'kendo.editor.selectAll' |translate }}</button>
+    <button kendoButton (click)="selectAllColumns()">
+      {{
+        allColumnsSelected
+          ? ('kendo.editor.unselectAll' | translate)
+          : ('kendo.editor.selectAll' | translate)
+      }}
+    </button>
     <button
       *ngIf="actions.add && canAdd"
       kendoButton

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -177,6 +177,7 @@ export class SafeGridComponent implements OnInit, AfterViewInit, OnChanges {
   @Input() resizable = true;
   @Input() reorderable = true;
   @Input() canAdd = false;
+  public allColumnsSelected = true;
 
   /** @returns The column menu */
   get columnMenu(): { columnChooser: boolean; filter: boolean } {
@@ -485,7 +486,23 @@ export class SafeGridComponent implements OnInit, AfterViewInit, OnChanges {
    * Sets and emits new grid configuration after column visibility event.
    */
   onColumnVisibilityChange(): void {
+    if (this.grid?.columns.toArray().every((c: any) => c.hidden === false))
+      this.allColumnsSelected = true;
     this.columnChange.emit();
+  }
+
+  /** Selects/unselects all columns */
+  selectAllColumns() {
+    this.allColumnsSelected = !this.allColumnsSelected;
+    if (this.allColumnsSelected) {
+      this.grid?.columns.forEach((c: any) => {
+        c.hidden = false;
+      });
+    } else {
+      this.grid?.columns.forEach((c: any) => {
+        if (c.field) c.hidden = true;
+      });
+    }
   }
 
   /** @returns Visible columns of the grid. */


### PR DESCRIPTION
# Description

Added a button to select/unselect all columns in the grid component. Upon unselecting everything, only checkbox, details, and three dots  columns will stay.

## Ticket
[
Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/11381/)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

In a grid with some columns, play along with the columns editor. Try to select/unselect all. Changes are reflected inside of the columns editor.

## Sreenshots

![Screenshot from 2023-05-11 12-07-08](https://github.com/ReliefApplications/oort-frontend/assets/59645813/d6df95cb-6e16-4967-8e77-1275ca64d951)
![Screenshot from 2023-05-11 12-07-11](https://github.com/ReliefApplications/oort-frontend/assets/59645813/fffbdba8-bdf1-4b19-a90a-032634ce7c89)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
