### PR TITLE
comment kendo picker and console log trigger keys

### DIFF
--- a/projects/safe/src/lib/components/form/form.component.ts
+++ b/projects/safe/src/lib/components/form/form.component.ts
@@ -205,6 +205,13 @@ export class SafeFormComponent implements OnInit, OnDestroy, AfterViewInit {
     });
     this.survey.onValueChanged.add(this.valueChange.bind(this));
 
+    this.survey.onValueChanged.add(() => {
+      console.log(
+        'ON VALUE CHANGED PRINT TRIGGER KEYS',
+        this.survey.triggerKeys
+      );
+    });
+
     // Sets default language as form language if it is in survey locales
     // const currentLang = this.usedLocales.find(
     //   (lang) => lang.value === this.translate.currentLang

--- a/projects/safe/src/lib/survey/widgets/text-widget.ts
+++ b/projects/safe/src/lib/survey/widgets/text-widget.ts
@@ -1,4 +1,5 @@
 import { DomService } from '../../services/dom/dom.service';
+/*
 import {
   DatePickerComponent,
   DateTimePickerComponent,
@@ -11,8 +12,9 @@ import { SafeButtonComponent } from '../../components/ui/button/button.component
 import { ButtonSize } from '../../components/ui/button/button-size.enum';
 import { JsonMetadata, SurveyModel } from 'survey-angular';
 import { Question, QuestionText } from '../types';
+*/
 
-type DateInputFormat = 'date' | 'datetime' | 'datetime-local' | 'time';
+// type DateInputFormat = 'date' | 'datetime' | 'datetime-local' | 'time';
 
 /**
  * Custom definition for overriding the text question. Allowed support for dates.
@@ -21,7 +23,9 @@ type DateInputFormat = 'date' | 'datetime' | 'datetime-local' | 'time';
  * @param domService Shared DOM service
  */
 export const init = (Survey: any, domService: DomService): void => {
-  const widget = {
+  console.log('REMOVE KENDO DATE PICKER', Survey, domService);
+  /*
+  *  const widget = {
     name: 'text-widget',
     widgetIsLoaded: (): boolean => true,
     isFit: (question: Question): boolean => question.getType() === 'text',
@@ -250,7 +254,7 @@ export const init = (Survey: any, domService: DomService): void => {
       }
     },
   };
-
+  */
   /**
    * Get date for input display.
    *
@@ -258,15 +262,14 @@ export const init = (Survey: any, domService: DomService): void => {
    * @param inputType question input type
    * @returns formatted date
    */
-  const getDateDisplay = (value: any, inputType: string): Date => {
-    const date = new Date(value);
-    if (inputType === 'time') {
-      return new Date(date.getTime() + date.getTimezoneOffset() * 60 * 1000);
-    } else {
-      return date;
-    }
-  };
-
+  //const getDateDisplay = (value: any, inputType: string): Date => {
+  // const date = new Date(value);
+  // if (inputType === 'time') {
+  // return new Date(date.getTime() + date.getTimezoneOffset() * 60 * 1000);
+  // } else {
+  // return date;
+  // }
+  // };
   /**
    * Set date for question / parameter value
    *
@@ -274,17 +277,16 @@ export const init = (Survey: any, domService: DomService): void => {
    * @param inputType question input type
    * @returns formatted date
    */
-  const setDateValue = (value: Date, inputType: string): Date | string => {
-    if (inputType === 'time') {
-      // for time fields, translate the date to UTC
-      return new Date(
-        Date.UTC(1970, 0, 1, value.getHours(), value.getMinutes())
-      );
-    } else {
-      return value.toISOString();
-    }
-  };
-
+  // const setDateValue = (value: Date, inputType: string): Date | string => {
+  // if (inputType === 'time') {
+  // for time fields, translate the date to UTC
+  //return new Date(
+  // Date.UTC(1970, 0, 1, value.getHours(), value.getMinutes())
+  // );
+  // } else {
+  // return value.toISOString();
+  // }
+  //};
   /**
    * It creates a date, datetime or time picker instance based on the input type
    *
@@ -292,48 +294,47 @@ export const init = (Survey: any, domService: DomService): void => {
    * @param element - The element that the directive is attached to.
    * @returns The picker instance, or null if the type is not allowed
    */
-  const createPickerInstance = (
-    inputType: DateInputFormat,
-    element: any
-  ):
-    | DatePickerComponent
-    | DateTimePickerComponent
-    | TimePickerComponent
-    | null => {
-    switch (inputType) {
-      case 'date':
-        const datePicker = domService.appendComponentToBody(
-          DatePickerComponent,
-          element
-        );
-        const datePickerInstance: DatePickerComponent = datePicker.instance;
-        datePickerInstance.format = 'dd/MM/yyyy';
-        return datePickerInstance;
-      case 'datetime':
-      case 'datetime-local':
-        const dateTimePicker = domService.appendComponentToBody(
-          DateTimePickerComponent,
-          element
-        );
-        const dateTimePickerInstance: DateTimePickerComponent =
-          dateTimePicker.instance;
-        dateTimePickerInstance.format = 'dd/MM/yyyy HH:mm';
-        return dateTimePickerInstance;
-      case 'time':
-        const timePicker = domService.appendComponentToBody(
-          TimePickerComponent,
-          element
-        );
-        const timePickerInstance: TimePickerComponent = timePicker.instance;
-        timePickerInstance.format = 'HH:mm';
-        return timePickerInstance;
-      default:
-        return null;
-    }
-  };
-
-  Survey.CustomWidgetCollection.Instance.addCustomWidget(
-    widget,
-    'customwidget'
-  );
+  // const createPickerInstance = (
+  // inputType: DateInputFormat,
+  // element: any
+  // ):
+  //  | DatePickerComponent
+  //  | DateTimePickerComponent
+  //  | TimePickerComponent
+  //  | null => {
+  //  switch (inputType) {
+  //    case 'date':
+  //      const datePicker = domService.appendComponentToBody(
+  //        DatePickerComponent,
+  //        element
+  //      );
+  //      const datePickerInstance: DatePickerComponent = datePicker.instance;
+  //      datePickerInstance.format = 'dd/MM/yyyy';
+  //      return datePickerInstance;
+  //    case 'datetime':
+  //    case 'datetime-local':
+  //      const dateTimePicker = domService.appendComponentToBody(
+  //        DateTimePickerComponent,
+  //        element
+  //      );
+  //      const dateTimePickerInstance: DateTimePickerComponent =
+  //        dateTimePicker.instance;
+  //      dateTimePickerInstance.format = 'dd/MM/yyyy HH:mm';
+  //      return dateTimePickerInstance;
+  //    case 'time':
+  //      const timePicker = domService.appendComponentToBody(
+  //        TimePickerComponent,
+  //        element
+  //      );
+  //      const timePickerInstance: TimePickerComponent = timePicker.instance;
+  //      timePickerInstance.format = 'HH:mm';
+  //      return timePickerInstance;
+  //    default:
+  //      return null;
+  //  }
+  //};
+  // Survey.CustomWidgetCollection.Instance.addCustomWidget(
+  // widget,
+  // 'customwidget'
+  //);
 };


### PR DESCRIPTION
# Description

No changes done really. Just commented the custom kendo picker part and added some console logs just to show that dates can be updated by triggers natively in surveyJS. It seems that the issue is somewhere in the lack of communication between the surveyJS form and triggers and the kendo date picker.
It does not work directly in surveyJS when using the today() expression but I suspect this is another different issue.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/58698

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested by creating two date questions and one radio group. When one option of the radio group is selected, a trigger will replace the value of one date question by the value of the other. Works with native surveyJS date picker but not kendo.
- [x] Tested by creating one date question and one radio group. When one option of the radio group is selected, a trigger will set the value of the date question to today(). Does not work either with surveyJS date picker nor kendo one.

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/103029022/52cf9fb7-7d3d-445d-a45b-b5789e94949c)

![triggerDate](https://github.com/ReliefApplications/oort-frontend/assets/103029022/2b98fcfa-8fb7-4b1e-a37e-ec1941f71397)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
