### PR TITLE
Feat/ab#63149 summary cards images preview

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1352,6 +1352,7 @@
 							}
 						},
 						"textEditor": {
+							"alert": "You can add variables e.g: {{data.variable}} and calculate e.g: {{calc.round( value ; precision )}}",
 							"title": "Text editor"
 						},
 						"title": "Card settings",

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1360,6 +1360,7 @@
 						},
 						"preview": {},
 						"textEditor": {
+							"alert": "Vous pouvez ajouter des variables ex: {{data.variable}} et faire des calculs ex: {{calc.round( value ; precision )}}",
 							"title": "Éditeur de texte"
 						},
 						"title": "Paramètres de carte",

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1352,6 +1352,7 @@
 							}
 						},
 						"textEditor": {
+							"alert": "****** {{data.variable}} ****** {{calc.round( value ; precision )}}",
 							"title": "******"
 						},
 						"title": "******",

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/card-modal/text-editor-tab/text-editor-tab.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/card-modal/text-editor-tab/text-editor-tab.component.html
@@ -1,9 +1,11 @@
 <form [formGroup]="form">
-  <safe-alert id="text-editor-alert"
+  <!-- Indicate possibilities of the template editor -->
+  <safe-alert class="mb-2"
     ><safe-icon icon="info"></safe-icon>
     {{
       'components.widget.settings.summaryCard.card.textEditor.alert' | translate
     }}
   </safe-alert>
+  <!-- Template editor -->
   <editor [init]="editor" formControlName="html"></editor>
 </form>

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/card-modal/text-editor-tab/text-editor-tab.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/card-modal/text-editor-tab/text-editor-tab.component.html
@@ -1,3 +1,9 @@
 <form [formGroup]="form">
+  <safe-alert id="text-editor-alert"
+    ><safe-icon icon="info"></safe-icon>
+    {{
+      'components.widget.settings.summaryCard.card.textEditor.alert' | translate
+    }}
+  </safe-alert>
   <editor [init]="editor" formControlName="html"></editor>
 </form>

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/card-modal/text-editor-tab/text-editor-tab.component.scss
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/card-modal/text-editor-tab/text-editor-tab.component.scss
@@ -1,0 +1,3 @@
+#text-editor-alert {
+    margin-bottom: 1rem;
+}

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/card-modal/text-editor-tab/text-editor-tab.component.scss
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/card-modal/text-editor-tab/text-editor-tab.component.scss
@@ -1,3 +1,0 @@
-#text-editor-alert {
-    margin-bottom: 1rem;
-}

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/card-modal/text-editor-tab/text-editor.module.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/card-modal/text-editor-tab/text-editor.module.ts
@@ -4,6 +4,8 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { EditorModule, TINYMCE_SCRIPT_SRC } from '@tinymce/tinymce-angular';
 import { SafeTextEditorTabComponent } from './text-editor-tab.component';
+import { SafeAlertModule } from '../../../../ui/alert/alert.module';
+import { SafeIconModule } from '../../../../ui/icon/icon.module';
 
 /** Text editor tab Module for summary cards edition */
 @NgModule({
@@ -14,6 +16,8 @@ import { SafeTextEditorTabComponent } from './text-editor-tab.component';
     EditorModule,
     ReactiveFormsModule,
     FormsModule,
+    SafeAlertModule,
+    SafeIconModule,
   ],
   exports: [SafeTextEditorTabComponent],
   providers: [

--- a/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
@@ -116,10 +116,14 @@ const replaceRecordFields = (
       if (!isNil(value)) {
         switch (field.type) {
           case 'url':
-            convertedValue = `<a href="${value}" style="${style}" target="_blank">${applyLayoutFormat(
-              value,
-              field
-            )}</a>`;
+            if (value.match(/\.(jpeg|jpg|gif|png|bmp)$/)) {
+              convertedValue = `<img src="${value}" style="${style}" alt="${field.name}" />`;
+            } else {
+              convertedValue = `<a href="${value}" style="${style}" target="_blank">${applyLayoutFormat(
+                value,
+                field
+              )}</a>`;
+            }
             break;
           case 'email':
             convertedValue = `<a href="mailto:${value}"

--- a/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
@@ -115,16 +115,21 @@ const replaceRecordFields = (
       let convertedValue = '';
       if (!isNil(value)) {
         switch (field.type) {
-          case 'url':
-            if (value.match(/\.(jpeg|jpg|gif|png|bmp)$/)) {
-              convertedValue = `<img src="${value}" style="${style}" alt="${field.name}" />`;
-            } else {
-              convertedValue = `<a href="${value}" style="${style}" target="_blank">${applyLayoutFormat(
-                value,
-                field
-              )}</a>`;
-            }
+          case 'url': {
+            // Specific case
+            // First, try to find cases where the url is used as src of image or link
+            const srcRegex = new RegExp(
+              `src="${DATA_PREFIX}${field.name}\\b${PLACEHOLDER_SUFFIX}"`,
+              'gi'
+            );
+            formattedHtml = formattedHtml.replace(srcRegex, `src=${value}`);
+            // Then, follow same logic than for other fields
+            convertedValue = `<a href="${value}" style="${style}" target="_blank">${applyLayoutFormat(
+              value,
+              field
+            )}</a>`;
             break;
+          }
           case 'email':
             convertedValue = `<a href="mailto:${value}"
               style="${style}"


### PR DESCRIPTION
# Description

- Adding a preview on summary cards for images from question URL
- Adding an alert to inform user it is possible to use variable and calculations in the summary card text editor

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/63149/

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Images are showing up instead of showing the URL
The alert works

## Sreenshots

![Screenshot 2023-05-12 at 13 13 16](https://github.com/ReliefApplications/oort-frontend/assets/9751045/1d5f4bc2-2070-4441-87e9-cd5518babffa)
![Screenshot 2023-05-12 at 13 13 04](https://github.com/ReliefApplications/oort-frontend/assets/9751045/d50af18c-f5ce-4fc9-baa3-61da6a9d07f2)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
