### PR TITLE
Feat/ab#11381 recreating kendo column chooser

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1455,6 +1455,7 @@
 			"underline": "Underline",
 			"undo": "Undo",
 			"unlink": "Remove Link",
+			"unselectAll": "Unselect all",
 			"viewSource": "View source"
 		},
 		"fileselect": {

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1463,6 +1463,7 @@
 			"underline": "Souligner",
 			"undo": "Annuler",
 			"unlink": "Supprimer le lien",
+			"unselectAll": "Tout déselectionner",
 			"viewSource": "Voir la source"
 		},
 		"fileselect": {

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1455,6 +1455,7 @@
 			"underline": "******",
 			"undo": "******",
 			"unlink": "******",
+			"unselectAll": "******",
 			"viewSource": "******"
 		},
 		"fileselect": {

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
@@ -1,20 +1,17 @@
 <div class="max-h-80 overflow-auto mt-1">
   <div class="flex justify-center">
-    <safe-button
+    <button
       kendoButton
       (click)="uncheckAllCheckboxes()"
-      icon="deselect"
-      [matTooltip]="'kendo.editor.unselectAll' | translate"
-    ></safe-button>
-    <safe-button
+    >{{'kendo.editor.unselectAll' | translate}}</button>
+    <button
       kendoButton
       (click)="checkAllCheckboxes()"
-      icon="select_all"
       [matTooltip]="'kendo.editor.selectAll' | translate"
-    ></safe-button>
+    >{{'kendo.editor.selectAll' | translate}}</button>
   </div>
 
-  <safe-divider class="mb-0 mt-px"></safe-divider>
+  <safe-divider class="mb-0 mt-1"></safe-divider>
 
   <div *ngFor="let column of columns">
     <ng-container *ngIf="column.title">

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
@@ -1,17 +1,33 @@
 <div *ngFor="let column of columns">
   <ng-container *ngIf="column.title">
-    <mat-checkbox color="blue" [(ngModel)]="!column.hidden">{{
-      column.hidden
-    }}</mat-checkbox
+    <mat-checkbox color="primary" [(ngModel)]="column.visible"></mat-checkbox
     >{{ column.title }}
   </ng-container>
 </div>
 
 <div class="flex justify-center">
-  <safe-button (click)="checkAllCheckboxes()">Select all</safe-button>
-  <safe-button (click)="uncheckAllCheckboxes()">Unselect all</safe-button>
-</div>
-<div class="flex justify-center">
-  <safe-button>Apply</safe-button>
-  <safe-button (click)="reset()">Reset</safe-button>
+  <div class="grid grid-cols-2 gap-1">
+    <div class="flex flex-col items-end">
+      <safe-button
+        (click)="uncheckAllCheckboxes()"
+        class="text-xs hover:bg-slate-100 rounded mb-px"
+        >{{ 'kendo.editor.unselectAll' | translate }}</safe-button
+      >
+      <safe-button (click)="reset()" class="hover:bg-slate-100 rounded">{{
+        'kendo.grid.columnsReset' | translate
+      }}</safe-button>
+    </div>
+    <div class="flex flex-col">
+      <safe-button
+        (click)="checkAllCheckboxes()"
+        class="bg-blue-500 hover:bg-blue-600 text-white rounded mb-px"
+        >{{ 'kendo.editor.selectAll' | translate }}</safe-button
+      >
+      <safe-button
+        (click)="apply()"
+        class="bg-blue-500 hover:bg-blue-600 text-white rounded"
+        >{{ 'kendo.grid.columnsApply' | translate }}</safe-button
+      >
+    </div>
+  </div>
 </div>

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
@@ -1,0 +1,17 @@
+<div *ngFor="let column of columns">
+  <ng-container *ngIf="column.title">
+    <mat-checkbox color="blue" [(ngModel)]="!column.hidden">{{
+      column.hidden
+    }}</mat-checkbox
+    >{{ column.title }}
+  </ng-container>
+</div>
+
+<div class="flex justify-center">
+  <safe-button (click)="checkAllCheckboxes()">Select all</safe-button>
+  <safe-button (click)="uncheckAllCheckboxes()">Unselect all</safe-button>
+</div>
+<div class="flex justify-center">
+  <safe-button>Apply</safe-button>
+  <safe-button (click)="reset()">Reset</safe-button>
+</div>

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
@@ -1,22 +1,20 @@
-<div class="max-h-80 overflow-auto">
+<div class="max-h-80 overflow-auto mt-1">
   <div class="flex justify-center">
-    <kendo-button
+    <safe-button
+      kendoButton
       (click)="uncheckAllCheckboxes()"
-      iconClass="fa fa-taxi"
-      class="mr-px"
+      icon="deselect"
       [matTooltip]="'kendo.editor.unselectAll' | translate"
-    >
-    </kendo-button>
-    <kendo-button
+    ></safe-button>
+    <safe-button
+      kendoButton
       (click)="checkAllCheckboxes()"
-      iconClass="fa fa-taxi"
-      class="ml-px"
+      icon="select_all"
       [matTooltip]="'kendo.editor.selectAll' | translate"
-    >
-    </kendo-button>
+    ></safe-button>
   </div>
 
-  <safe-divider class="m-px"></safe-divider>
+  <safe-divider class="mb-0 mt-px"></safe-divider>
 
   <div *ngFor="let column of columns">
     <ng-container *ngIf="column.title">

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
@@ -1,33 +1,48 @@
-<div *ngFor="let column of columns">
-  <ng-container *ngIf="column.title">
-    <mat-checkbox color="primary" [(ngModel)]="column.visible"></mat-checkbox
-    >{{ column.title }}
-  </ng-container>
-</div>
+<div class="max-h-80 overflow-auto">
+  <div class="flex justify-center">
+    <kendo-button
+      (click)="uncheckAllCheckboxes()"
+      iconClass="fa fa-taxi"
+      class="mr-px"
+      [matTooltip]="'kendo.editor.unselectAll' | translate"
+    >
+    </kendo-button>
+    <kendo-button
+      (click)="checkAllCheckboxes()"
+      iconClass="fa fa-taxi"
+      class="ml-px"
+      [matTooltip]="'kendo.editor.selectAll' | translate"
+    >
+    </kendo-button>
+  </div>
 
-<div class="flex justify-center">
-  <div class="grid grid-cols-2 gap-1">
-    <div class="flex flex-col items-end">
-      <safe-button
-        (click)="uncheckAllCheckboxes()"
-        class="text-xs hover:bg-slate-100 rounded mb-px"
-        >{{ 'kendo.editor.unselectAll' | translate }}</safe-button
-      >
-      <safe-button (click)="reset()" class="hover:bg-slate-100 rounded">{{
-        'kendo.grid.columnsReset' | translate
-      }}</safe-button>
-    </div>
-    <div class="flex flex-col">
-      <safe-button
-        (click)="checkAllCheckboxes()"
-        class="bg-blue-500 hover:bg-blue-600 text-white rounded mb-px"
-        >{{ 'kendo.editor.selectAll' | translate }}</safe-button
-      >
-      <safe-button
-        (click)="apply()"
-        class="bg-blue-500 hover:bg-blue-600 text-white rounded"
-        >{{ 'kendo.grid.columnsApply' | translate }}</safe-button
-      >
+  <safe-divider class="m-px"></safe-divider>
+
+  <div *ngFor="let column of columns">
+    <ng-container *ngIf="column.title">
+      <mat-checkbox color="primary" [(ngModel)]="column.visible"></mat-checkbox
+      >{{ column.title }}
+    </ng-container>
+  </div>
+
+  <div class="flex justify-center mb-1">
+    <div class="grid grid-cols-2 gap-1">
+      <div class="flex flex-col items-end">
+        <button
+          (click)="reset()"
+          class="k-button k-button-solid-base k-button-solid k-button-md k-rounded-md k-button-rectangle mr-px"
+        >
+          {{ 'kendo.grid.columnsReset' | translate }}
+        </button>
+      </div>
+      <div class="flex flex-col">
+        <button
+          class="k-button k-button-solid-primary k-button-solid k-button-md k-rounded-md k-button-rectangle ml-px"
+          (click)="apply()"
+        >
+          {{ 'kendo.grid.columnsApply' | translate }}
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
@@ -7,7 +7,6 @@
     <button
       kendoButton
       (click)="checkAllCheckboxes()"
-      [matTooltip]="'kendo.editor.selectAll' | translate"
     >{{'kendo.editor.selectAll' | translate}}</button>
   </div>
 

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.html
@@ -1,42 +1,39 @@
-<div class="max-h-80 overflow-auto mt-1">
-  <div class="flex justify-center">
-    <button
-      kendoButton
-      (click)="uncheckAllCheckboxes()"
-    >{{'kendo.editor.unselectAll' | translate}}</button>
-    <button
-      kendoButton
-      (click)="checkAllCheckboxes()"
-    >{{'kendo.editor.selectAll' | translate}}</button>
+<div class="mt-1">
+  <!-- Select all / unselect all -->
+  <div class="flex flex-col px-2 gap-1">
+    <button kendoButton (click)="uncheckAllCheckboxes()">
+      {{ 'kendo.editor.unselectAll' | translate }}
+    </button>
+    <button kendoButton (click)="checkAllCheckboxes()">
+      {{ 'kendo.editor.selectAll' | translate }}
+    </button>
   </div>
 
-  <safe-divider class="mb-0 mt-1"></safe-divider>
+  <safe-divider class="my-2"></safe-divider>
 
-  <div *ngFor="let column of columns">
-    <ng-container *ngIf="column.title">
-      <mat-checkbox color="primary" [(ngModel)]="column.visible"></mat-checkbox
-      >{{ column.title }}
+  <!-- Columns -->
+  <div class="flex flex-col gap-1 px-2 max-h-52 overflow-auto">
+    <ng-container *ngFor="let column of columns">
+      <label *ngIf="column.title" class="flex items-center gap-1 cursor-pointer hover:bg-gray-300">
+        <input type="checkbox" kendoCheckBox [(ngModel)]="column.visible" />
+        <span>{{ column.title }}</span>
+      </label>
     </ng-container>
   </div>
 
-  <div class="flex justify-center mb-1">
-    <div class="grid grid-cols-2 gap-1">
-      <div class="flex flex-col items-end">
-        <button
-          (click)="reset()"
-          class="k-button k-button-solid-base k-button-solid k-button-md k-rounded-md k-button-rectangle mr-px"
-        >
-          {{ 'kendo.grid.columnsReset' | translate }}
-        </button>
-      </div>
-      <div class="flex flex-col">
-        <button
-          class="k-button k-button-solid-primary k-button-solid k-button-md k-rounded-md k-button-rectangle ml-px"
-          (click)="apply()"
-        >
-          {{ 'kendo.grid.columnsApply' | translate }}
-        </button>
-      </div>
-    </div>
+  <!-- Actions -->
+  <div class="flex flex-row p-2 gap-2 mt-4">
+    <button
+      (click)="reset()"
+      class="k-button k-button-solid-base k-button-solid k-button-md k-rounded-md k-button-rectangle mr-px"
+    >
+      {{ 'kendo.grid.columnsReset' | translate }}
+    </button>
+    <button
+      class="k-button k-button-solid-primary k-button-solid k-button-md k-rounded-md k-button-rectangle ml-px"
+      (click)="apply()"
+    >
+      {{ 'kendo.grid.columnsApply' | translate }}
+    </button>
   </div>
 </div>

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.spec.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SafeGridColumnChooserComponent } from './grid-column-chooser.component';
+
+describe('GridColumnChooserComponent', () => {
+  let component: SafeGridColumnChooserComponent;
+  let fixture: ComponentFixture<SafeGridColumnChooserComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SafeGridColumnChooserComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SafeGridColumnChooserComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.ts
@@ -1,7 +1,9 @@
 import { Component, Inject, QueryList } from '@angular/core';
-import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import {
+  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
+  MatLegacyDialogRef as MatDialogRef,
+} from '@angular/material/legacy-dialog';
 import { ColumnBase } from '@progress/kendo-angular-grid';
-import * as _ from 'lodash';
 
 /** Data provided from the opening of the dialog */
 interface DialogData {
@@ -18,45 +20,54 @@ interface DialogData {
 })
 export class SafeGridColumnChooserComponent {
   private originalColumns: QueryList<ColumnBase>;
-  public columns: ColumnBase[];
+  public columns: { title: string; visible: boolean }[];
 
   /**
    * Column chooser for the grid widget
    *
    * @param data Data provided from the opening of the dialog
+   * @param dialogRef Reference to the modal
    */
-  constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: DialogData,
+    private dialogRef: MatDialogRef<SafeGridColumnChooserComponent>
+  ) {
     this.originalColumns = data.columns;
-    this.columns = _.cloneDeep(this.originalColumns.toArray());
-    console.log(this.columns);
+    this.columns = this.originalColumns.toArray().map((column) => {
+      return { title: column.title, visible: !column.hidden };
+    });
   }
 
   /**
    * Resets the columns to their original state
    */
   public reset() {
-    this.columns = _.cloneDeep(this.originalColumns.toArray());
+    this.columns = this.originalColumns.toArray().map((column) => {
+      return { title: column.title, visible: !column.hidden };
+    });
   }
 
   /**
    * Applies visibility changes to the grid
    */
   public apply() {
-    //this.originalColumns = this.columns;
+    this.originalColumns.toArray().forEach((column, index) => {
+      column.hidden = !this.columns[index].visible;
+    });
+    this.dialogRef.close();
   }
 
   /** Checks all the columns checkboxes */
   public checkAllCheckboxes() {
     this.columns.forEach((column) => {
-      column.hidden = false;
+      column.visible = true;
     });
-    console.log(this.columns.map((column) => column.hidden));
   }
 
   /** Unchecks all the columns checkboxes */
   public uncheckAllCheckboxes() {
     this.columns.forEach((column) => {
-      if (column.title) column.hidden = true;
+      if (column.title) column.visible = false;
     });
   }
 }

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.ts
@@ -1,14 +1,12 @@
-import { Component, Inject, QueryList } from '@angular/core';
 import {
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
-  MatLegacyDialogRef as MatDialogRef,
-} from '@angular/material/legacy-dialog';
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  QueryList,
+} from '@angular/core';
 import { ColumnBase } from '@progress/kendo-angular-grid';
-
-/** Data provided from the opening of the dialog */
-interface DialogData {
-  columns: QueryList<ColumnBase>;
-}
 
 /**
  * Column chooser
@@ -18,43 +16,39 @@ interface DialogData {
   templateUrl: './grid-column-chooser.component.html',
   styleUrls: ['./grid-column-chooser.component.scss'],
 })
-export class SafeGridColumnChooserComponent {
-  private originalColumns: QueryList<ColumnBase>;
-  public columns: { title: string; visible: boolean }[];
+export class SafeGridColumnChooserComponent implements OnInit {
+  @Input() originalColumns: QueryList<ColumnBase> | undefined;
+  @Output() hideColumnChooser = new EventEmitter<boolean>();
+  public columns: { title: string; visible: boolean }[] = [];
 
   /**
    * Column chooser for the grid widget
-   *
-   * @param data Data provided from the opening of the dialog
-   * @param dialogRef Reference to the modal
    */
-  constructor(
-    @Inject(MAT_DIALOG_DATA) public data: DialogData,
-    private dialogRef: MatDialogRef<SafeGridColumnChooserComponent>
-  ) {
-    this.originalColumns = data.columns;
-    this.columns = this.originalColumns.toArray().map((column) => {
-      return { title: column.title, visible: !column.hidden };
-    });
+  ngOnInit() {
+    if (this.originalColumns)
+      this.columns = this.originalColumns?.toArray().map((column) => {
+        return { title: column.title, visible: !column.hidden };
+      });
   }
 
   /**
    * Resets the columns to their original state
    */
   public reset() {
-    this.columns = this.originalColumns.toArray().map((column) => {
-      return { title: column.title, visible: !column.hidden };
-    });
+    if (this.originalColumns)
+      this.columns = this.originalColumns.toArray().map((column) => {
+        return { title: column.title, visible: !column.hidden };
+      });
   }
 
   /**
    * Applies visibility changes to the grid
    */
   public apply() {
-    this.originalColumns.toArray().forEach((column, index) => {
+    this.originalColumns?.toArray().forEach((column, index) => {
       column.hidden = !this.columns[index].visible;
     });
-    this.dialogRef.close();
+    this.hideColumnChooser.emit(false);
   }
 
   /** Checks all the columns checkboxes */

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   EventEmitter,
+  HostListener,
   Input,
   OnInit,
   Output,
@@ -20,6 +21,7 @@ export class SafeGridColumnChooserComponent implements OnInit {
   @Input() originalColumns: QueryList<ColumnBase> | undefined;
   @Output() hideColumnChooser = new EventEmitter<boolean>();
   public columns: { title: string; visible: boolean }[] = [];
+  private show = true;
 
   /**
    * Column chooser for the grid widget
@@ -39,6 +41,21 @@ export class SafeGridColumnChooserComponent implements OnInit {
       this.columns = this.originalColumns.toArray().map((column) => {
         return { title: column.title, visible: !column.hidden };
       });
+  }
+
+  /** Listen to click event on the document */
+  @HostListener('click')
+  clickInside() {
+    this.show = true;
+  }
+
+  /** Listen to document click event and close the component if outside of it */
+  @HostListener('document:click')
+  clickout() {
+    if (!this.show) {
+      this.hideColumnChooser.emit(false);
+    }
+    this.show = false;
   }
 
   /**

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.component.ts
@@ -1,0 +1,62 @@
+import { Component, Inject, QueryList } from '@angular/core';
+import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { ColumnBase } from '@progress/kendo-angular-grid';
+import * as _ from 'lodash';
+
+/** Data provided from the opening of the dialog */
+interface DialogData {
+  columns: QueryList<ColumnBase>;
+}
+
+/**
+ * Column chooser
+ */
+@Component({
+  selector: 'safe-grid-column-chooser',
+  templateUrl: './grid-column-chooser.component.html',
+  styleUrls: ['./grid-column-chooser.component.scss'],
+})
+export class SafeGridColumnChooserComponent {
+  private originalColumns: QueryList<ColumnBase>;
+  public columns: ColumnBase[];
+
+  /**
+   * Column chooser for the grid widget
+   *
+   * @param data Data provided from the opening of the dialog
+   */
+  constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) {
+    this.originalColumns = data.columns;
+    this.columns = _.cloneDeep(this.originalColumns.toArray());
+    console.log(this.columns);
+  }
+
+  /**
+   * Resets the columns to their original state
+   */
+  public reset() {
+    this.columns = _.cloneDeep(this.originalColumns.toArray());
+  }
+
+  /**
+   * Applies visibility changes to the grid
+   */
+  public apply() {
+    //this.originalColumns = this.columns;
+  }
+
+  /** Checks all the columns checkboxes */
+  public checkAllCheckboxes() {
+    this.columns.forEach((column) => {
+      column.hidden = false;
+    });
+    console.log(this.columns.map((column) => column.hidden));
+  }
+
+  /** Unchecks all the columns checkboxes */
+  public uncheckAllCheckboxes() {
+    this.columns.forEach((column) => {
+      if (column.title) column.hidden = true;
+    });
+  }
+}

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.module.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.module.ts
@@ -5,6 +5,7 @@ import { SafeGridColumnChooserComponent } from './grid-column-chooser.component'
 import { DropDownsModule } from '@progress/kendo-angular-dropdowns';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { FormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
 
 @NgModule({
   declarations: [SafeGridColumnChooserComponent],
@@ -14,6 +15,7 @@ import { FormsModule } from '@angular/forms';
     DropDownsModule,
     MatCheckboxModule,
     FormsModule,
+    TranslateModule,
   ],
   exports: [SafeGridColumnChooserComponent],
 })

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.module.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SafeButtonModule } from '../../button/button.module';
+import { SafeGridColumnChooserComponent } from './grid-column-chooser.component';
+import { DropDownsModule } from '@progress/kendo-angular-dropdowns';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { FormsModule } from '@angular/forms';
+
+@NgModule({
+  declarations: [SafeGridColumnChooserComponent],
+  imports: [
+    CommonModule,
+    SafeButtonModule,
+    DropDownsModule,
+    MatCheckboxModule,
+    FormsModule,
+  ],
+  exports: [SafeGridColumnChooserComponent],
+})
+export class SafeGridColumnChooserModule {}

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.module.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.module.ts
@@ -2,20 +2,26 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SafeButtonModule } from '../../button/button.module';
 import { SafeGridColumnChooserComponent } from './grid-column-chooser.component';
-import { DropDownsModule } from '@progress/kendo-angular-dropdowns';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-
+import { SafeDividerModule } from '../../divider/divider.module';
+import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
+import { ButtonModule } from '@progress/kendo-angular-buttons';
+/**
+ * Component to replace the kendo column chooser
+ */
 @NgModule({
   declarations: [SafeGridColumnChooserComponent],
   imports: [
     CommonModule,
     SafeButtonModule,
-    DropDownsModule,
     MatCheckboxModule,
     FormsModule,
     TranslateModule,
+    SafeDividerModule,
+    ButtonModule,
+    MatTooltipModule,
   ],
   exports: [SafeGridColumnChooserComponent],
 })

--- a/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.module.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid-column-chooser/grid-column-chooser.module.ts
@@ -2,12 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SafeButtonModule } from '../../button/button.module';
 import { SafeGridColumnChooserComponent } from './grid-column-chooser.component';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { SafeDividerModule } from '../../divider/divider.module';
-import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
 import { ButtonModule } from '@progress/kendo-angular-buttons';
+import { InputsModule } from '@progress/kendo-angular-inputs';
+
 /**
  * Component to replace the kendo column chooser
  */
@@ -16,12 +16,11 @@ import { ButtonModule } from '@progress/kendo-angular-buttons';
   imports: [
     CommonModule,
     SafeButtonModule,
-    MatCheckboxModule,
     FormsModule,
     TranslateModule,
     SafeDividerModule,
     ButtonModule,
-    MatTooltipModule,
+    InputsModule,
   ],
   exports: [SafeGridColumnChooserComponent],
 })

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -57,7 +57,7 @@
     <kendo-popup
       [anchor]="anchor.element"
       (anchorViewportLeave)="showColumnChooser = false"
-      [anchorAlign]="{ vertical: 'bottom', horizontal: 'left' }"
+      [collision]="{ horizontal: 'fit', vertical: 'fit' }"
       *ngIf="showColumnChooser"
     >
       <safe-grid-column-chooser

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -48,7 +48,6 @@
       [formControl]="search"
       class="!w-full"
     />
-    <kendo-grid-column-chooser *ngIf="reorderable"></kendo-grid-column-chooser>
     <button
       kendoButton
       icon="columns"

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -49,8 +49,10 @@
       class="!w-full"
     />
 
+    <!-- Column Chooser -->
     <kendo-button
       #anchor
+      fillMode="flat"
       (click)="toggleColumnChooser()"
       icon="columns"
     ></kendo-button>

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -48,12 +48,24 @@
       [formControl]="search"
       class="!w-full"
     />
-    <button
-      kendoButton
+
+    <kendo-button
+      #anchor
+      (click)="toggleColumnChooser()"
       icon="columns"
-      *ngIf="reorderable"
-      (click)="openColumnToggler()"
-    ></button>
+    ></kendo-button>
+    <kendo-popup
+      [anchor]="anchor.element"
+      (anchorViewportLeave)="showColumnChooser = false"
+      [anchorAlign]="{ vertical: 'bottom', horizontal: 'left' }"
+      *ngIf="showColumnChooser"
+    >
+      <safe-grid-column-chooser
+        [originalColumns]="grid?.columns"
+        (hideColumnChooser)="toggleColumnChooser($event)"
+      ></safe-grid-column-chooser>
+    </kendo-popup>
+
     <button
       *ngIf="actions.add && canAdd"
       kendoButton

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -50,6 +50,12 @@
     />
     <kendo-grid-column-chooser *ngIf="reorderable"></kendo-grid-column-chooser>
     <button
+      kendoButton
+      icon="columns"
+      *ngIf="reorderable"
+      (click)="openColumnToggler()"
+    ></button>
+    <button
       *ngIf="actions.add && canAdd"
       kendoButton
       (click)="action.emit({ action: 'add' })"

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -55,6 +55,7 @@ import {
   MatLegacySnackBarRef as MatSnackBarRef,
   LegacyTextOnlySnackBar as TextOnlySnackBar,
 } from '@angular/material/legacy-snack-bar';
+import { SafeGridColumnChooserComponent } from '../grid-column-chooser/grid-column-chooser.component';
 
 /**
  * Factory for creating scroll strategy
@@ -464,6 +465,13 @@ export class SafeGridComponent implements OnInit, AfterViewInit, OnChanges {
     this.selectedItems = this.data.data.filter((x) =>
       this.selectedRows.includes(x.id)
     );
+  }
+
+  /** Opens modal for columns*/
+  public openColumnToggler() {
+    this.dialog.open(SafeGridColumnChooserComponent, {
+      data: { columns: this.grid?.columns },
+    });
   }
 
   // === LAYOUT ===

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -55,7 +55,6 @@ import {
   MatLegacySnackBarRef as MatSnackBarRef,
   LegacyTextOnlySnackBar as TextOnlySnackBar,
 } from '@angular/material/legacy-snack-bar';
-import { SafeGridColumnChooserComponent } from '../grid-column-chooser/grid-column-chooser.component';
 
 /**
  * Factory for creating scroll strategy
@@ -194,6 +193,7 @@ export class SafeGridComponent implements OnInit, AfterViewInit, OnChanges {
   @Input() selectedRows: string[] = [];
   @Output() selectionChange = new EventEmitter();
   public selectedItems: any[] = [];
+  public showColumnChooser = false;
 
   // === FILTER ===
   @Input() filterable = true;
@@ -218,7 +218,7 @@ export class SafeGridComponent implements OnInit, AfterViewInit, OnChanges {
 
   // === TEMPLATE ===
   @ViewChild(GridComponent)
-  private grid?: GridComponent;
+  public grid?: GridComponent;
 
   // === ADMIN ===
   @Input() admin = false;
@@ -467,12 +467,14 @@ export class SafeGridComponent implements OnInit, AfterViewInit, OnChanges {
     );
   }
 
-  /** Opens modal for columns*/
-  public openColumnToggler() {
-    this.dialog.open(SafeGridColumnChooserComponent, {
-      data: { columns: this.grid?.columns },
-      maxHeight: '800px',
-    });
+  /**
+   * Toggles the menu for choosing columns
+   *
+   * @param showColumnChooser optional parameter to decide of the state of the popup
+   */
+  public toggleColumnChooser(showColumnChooser?: boolean) {
+    if (showColumnChooser) this.showColumnChooser = showColumnChooser;
+    else this.showColumnChooser = !this.showColumnChooser;
   }
 
   // === LAYOUT ===

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -471,6 +471,7 @@ export class SafeGridComponent implements OnInit, AfterViewInit, OnChanges {
   public openColumnToggler() {
     this.dialog.open(SafeGridColumnChooserComponent, {
       data: { columns: this.grid?.columns },
+      maxHeight: '800px',
     });
   }
 

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.module.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.module.ts
@@ -22,6 +22,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { SafeDateModule } from '../../../../pipes/date/date.module';
 import { SafeButtonModule } from '../../button/button.module';
 import { SafeDateFilterMenuModule } from '../date-filter-menu/date-filter-menu.module';
+import { SafeGridColumnChooserModule } from '../grid-column-chooser/grid-column-chooser.module';
 
 /** Module for the grid component */
 @NgModule({
@@ -50,6 +51,7 @@ import { SafeDateFilterMenuModule } from '../date-filter-menu/date-filter-menu.m
     SafeDropdownFilterModule,
     SafeDropdownFilterMenuModule,
     SafeDateFilterMenuModule,
+    SafeGridColumnChooserModule,
     // === ROW ===
     SafeGridRowActionsModule,
     // === TOOLBAR ===

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.module.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.module.ts
@@ -23,6 +23,7 @@ import { SafeDateModule } from '../../../../pipes/date/date.module';
 import { SafeButtonModule } from '../../button/button.module';
 import { SafeDateFilterMenuModule } from '../date-filter-menu/date-filter-menu.module';
 import { SafeGridColumnChooserModule } from '../grid-column-chooser/grid-column-chooser.module';
+import { PopupModule } from '@progress/kendo-angular-popup';
 
 /** Module for the grid component */
 @NgModule({
@@ -43,6 +44,7 @@ import { SafeGridColumnChooserModule } from '../grid-column-chooser/grid-column-
     DateInputsModule,
     DropDownsModule,
     ButtonsModule,
+    PopupModule,
     // === UTILS ===
     SafeExpandedCommentModule,
     // === FILTER ===


### PR DESCRIPTION
# Description

Tried to imitate the column toggler. It replicates the functionalities of the kendo one but adds the ability to select/unselect all columns. Maybe some styling needs to be done.

## Ticket

[Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/11381/)

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Created a grid widget. Clicked on the button to show the column chooser. The popup opens. Try to click on all buttons. 'Select all' should check all checkboxes, 'unselect all' should unselect all of them. 'Reset' should reset all checkboxes to their state when opening the modal. 'Apply' should update the visibility of the columns.

## Sreenshots

![Screenshot from 2023-05-17 10-17-29](https://github.com/ReliefApplications/oort-frontend/assets/59645813/e2671892-bd1f-4b83-a5c3-e83cf27b4a65)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
