### PR TITLE
AB#57973 : Fix placement of tooltips

### DIFF
--- a/projects/safe/src/lib/survey/global-properties/tooltip.ts
+++ b/projects/safe/src/lib/survey/global-properties/tooltip.ts
@@ -26,9 +26,7 @@ export const init = (Survey: any): void => {
  */
 export const render = (question: Question, el: HTMLElement): void => {
   // Display the tooltip
-  const header = el?.parentElement?.parentElement?.querySelector(
-    '.sv_q_title'
-  ) as HTMLElement;
+  const header = el?.parentElement?.querySelector('.sv_q_title') as HTMLElement;
   if (header) {
     header.title = get(question, 'localizableStrings.tooltip.renderedText', '');
     const span = document.createElement('span');


### PR DESCRIPTION
# Description

Before when having 2 or more questions on one line, the tooltips were all placed next to the first question. This is now fixed

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/57973

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested directly in the back-office by creating a non-start-with-new-line question

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/103029022/cd2aed35-9be8-49bc-8fd2-b8c5de1f837e)

# Checklist:

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
