### PR TITLE
AB#64572 - email is not sent anymore and instead returns an error

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -143,6 +143,7 @@
 					"noDistributionList": "Something went wrong during the email sending: no distribution list found",
 					"noTemplate": "Something went wrong during the email sending: no template found"
 				},
+				"noSubject": "Please enter a subject for your mail",
 				"processing": "Sending email...",
 				"ready": "Email ready",
 				"sent": "Email sent"

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -143,6 +143,7 @@
 					"noDistributionList": "Un problème est survenu lors de l'envoi de l'e-mail: aucune liste de distribution détectée",
 					"noTemplate": "Un problème est survenu lors de l'envoi de l'e-mail: aucun template détecté"
 				},
+				"noSubject": "Veuillez choisir un objet pour votre mail",
 				"processing": "Envoi en cours...",
 				"ready": "E-mail prêt",
 				"sent": "E-mail envoyé"

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -143,6 +143,7 @@
 					"noDistributionList": "******",
 					"noTemplate": "******"
 				},
+				"noSubject": "******",
 				"processing": "******",
 				"ready": "******",
 				"sent": "******"

--- a/libs/safe/src/lib/services/email/email.service.ts
+++ b/libs/safe/src/lib/services/email/email.service.ts
@@ -183,7 +183,7 @@ export class SafeEmailService {
     const snackBarRef = this.snackBar.openComponentSnackBar(
       SafeSnackbarSpinnerComponent,
       {
-        duration: 0,
+        duration: 10000,
         data: {
           message: this.translate.instant(
             'common.notifications.email.processing'
@@ -229,17 +229,33 @@ export class SafeEmailService {
           });
           dialogRef.afterClosed().subscribe((value) => {
             if (value) {
-              this.sendMail(
-                recipient,
-                value.subject,
-                value.html,
-                filter,
-                query,
-                sortField,
-                sortOrder,
-                attachment,
-                value.files
-              );
+              if (value.subject) {
+                this.sendMail(
+                  recipient,
+                  value.subject,
+                  value.html,
+                  filter,
+                  query,
+                  sortField,
+                  sortOrder,
+                  attachment,
+                  value.files
+                );
+              } else {
+                this.snackBar.openComponentSnackBar(
+                  SafeSnackbarSpinnerComponent,
+                  {
+                    duration: 1000,
+                    data: {
+                      message: this.translate.instant(
+                        'common.notifications.email.noSubject'
+                      ),
+                      loading: false,
+                      error: true,
+                    },
+                  }
+                );
+              }
             }
           });
         },


### PR DESCRIPTION
# Description

When sending an email with an empty subject, the email is not sent and instead returns an error. I had a problem with the use of the snackbar, the use of snackbarRef just did not open the snackbar.

## Ticket

[Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/64572/)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

In a grid, try sending a mail with an empty subject, it should be prevented

## Sreenshots


![Screenshot from 2023-05-24 17-28-21](https://github.com/ReliefApplications/oort-frontend/assets/59645813/69f7fa5e-423a-4abd-ba04-ad3bd832a69e)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
