### PR TITLE
AB#64572_prevent_sending_emails_without_subject 

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -549,6 +549,15 @@
 			"subject": "Subject",
 			"withoutRecords": "Without records"
 		},
+		"emailPreview": {
+			"errors": {
+				"missingSubject": "Subject cannot be left empty."
+			},
+			"from": "From",
+			"subject": "Subject",
+			"title": "Email Preview",
+			"to": "To"
+		},
 		"form": {
 			"aggregation": {
 				"delete": {

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -549,6 +549,15 @@
 			"subject": "Objet",
 			"withoutRecords": "Sans enregistrements"
 		},
+		"emailPreview": {
+			"errors": {
+				"missingSubject": "L'objet du mail ne peut être vide."
+			},
+			"from": "De",
+			"subject": "Objet",
+			"title": "Prévisualisation de mail",
+			"to": "À"
+		},
 		"floating": {
 			"menuButton": {
 				"ariaLabel": "***"

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -549,6 +549,15 @@
 			"subject": "******",
 			"withoutRecords": "******"
 		},
+		"emailPreview": {
+			"errors": {
+				"missingSubject": "******"
+			},
+			"from": "******",
+			"subject": "******",
+			"title": "******",
+			"to": "******"
+		},
 		"form": {
 			"aggregation": {
 				"delete": {

--- a/libs/safe/src/lib/components/email-preview/email-preview.component.html
+++ b/libs/safe/src/lib/components/email-preview/email-preview.component.html
@@ -5,6 +5,9 @@
       <mat-form-field>
         <mat-label>Subject</mat-label>
         <input matInput formControlName="subject" type="text" />
+        <mat-error *ngIf="this.form.controls.subject.hasError('required')">
+          Subject is <strong>required</strong>
+        </mat-error>
       </mat-form-field>
       <mat-form-field>
         <mat-label>From</mat-label>
@@ -34,6 +37,7 @@
       category="secondary"
       variant="primary"
       [mat-dialog-close]="form.value"
+      [disabled]="!form.valid"
       cdkFocusInitial
     >
       {{ 'common.send' | translate }}

--- a/libs/safe/src/lib/components/email-preview/email-preview.component.html
+++ b/libs/safe/src/lib/components/email-preview/email-preview.component.html
@@ -1,20 +1,20 @@
 <safe-modal>
-  <h1 mat-dialog-title>Email Preview</h1>
+  <h1 mat-dialog-title>{{ 'components.emailPreview.title' | translate }}</h1>
   <div mat-dialog-content>
-    <form class="flex flex-col" [formGroup]="form" *ngIf="form">
+    <form class="flex flex-col gap-4" [formGroup]="form" *ngIf="form">
       <mat-form-field>
-        <mat-label>Subject</mat-label>
+        <mat-label>{{ 'components.emailPreview.subject' | translate }}</mat-label>
         <input matInput formControlName="subject" type="text" />
         <mat-error *ngIf="this.form.controls.subject.hasError('required')">
-          Subject is <strong>required</strong>
+          {{ 'components.emailPreview.errors.missingSubject' | translate }}
         </mat-error>
       </mat-form-field>
       <mat-form-field>
-        <mat-label>From</mat-label>
+        <mat-label>{{ 'components.emailPreview.from' | translate }}</mat-label>
         <input matInput formControlName="from" type="text" />
       </mat-form-field>
       <mat-form-field id="previewEmailTo">
-        <mat-label>To</mat-label>
+        <mat-label>{{ 'components.emailPreview.to' | translate }}</mat-label>
         <mat-chip-list formControlName="to">
           <mat-chip *ngFor="let email of form.controls.to.value">
             {{ email }}

--- a/libs/safe/src/lib/components/email-preview/email-preview.component.ts
+++ b/libs/safe/src/lib/components/email-preview/email-preview.component.ts
@@ -1,5 +1,9 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import {
+  UntypedFormBuilder,
+  UntypedFormGroup,
+  Validators,
+} from '@angular/forms';
 import {
   MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
   MatLegacyDialogRef as MatDialogRef,
@@ -57,7 +61,7 @@ export class SafeEmailPreviewComponent implements OnInit {
     this.form = this.formBuilder.group({
       from: [{ value: this.data.from, disabled: true }],
       to: [{ value: this.data.to, disabled: true }],
-      subject: this.data.subject,
+      subject: [this.data.subject, Validators.required],
       html: this.data.html,
       files: [[]],
     });


### PR DESCRIPTION
# Description

Switched subject email type to required, added a mat error and added verification to avoid the send of incorrect form.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/64572

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tried to send a mail without form subject.

## Sreenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/65243509/7f36b675-2e9f-4e1e-8675-530cdb59378c)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
