### PR TITLE
fix/AB#64928-fix-text-editor-available-resource-fields

### DIFF
--- a/libs/safe/src/lib/components/widgets/editor-settings/graphql/queries.ts
+++ b/libs/safe/src/lib/components/widgets/editor-settings/graphql/queries.ts
@@ -27,6 +27,10 @@ export const GET_RESOURCES = gql`
           layouts {
             totalCount
           }
+          metadata {
+            name
+            type
+          }
         }
         cursor
       }

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
@@ -80,6 +80,10 @@ export const GET_RESOURCES = gql`
           layouts {
             totalCount
           }
+          metadata {
+            name
+            type
+          }
         }
         cursor
       }


### PR DESCRIPTION
# Description
In both cases, it was working when saving the widget and then reopening it because the query GET_RESOURCE used to load the resource info when opening gets the metadata info (where the fields are). But the query to load new resources was the GET_RESOURCES, which did not get this data from the backend.

## Ticket
[ABC- Summary card- On text editor the fields list are not available to select and configure summary card widget](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/64928)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
In the texts widget and summary cards settings adding resources  and layout, and getting into the text editor and being able to see and selected the resource fields

## Sreenshots
Summary card:
![summary-card](https://github.com/ReliefApplications/oort-frontend/assets/28535394/3073c4e1-9d29-44d4-bfd2-9aa2ea8a31d2)

![image](https://github.com/ReliefApplications/oort-frontend/assets/28535394/06a621b8-23b2-4bf3-82ca-97d7bdf9073f)

text widget:
![text](https://github.com/ReliefApplications/oort-frontend/assets/28535394/cb33e078-6399-419d-8560-dfaa76a6dd14)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
