### PR TITLE
Fix/ab#60342 wrong style on summary cards

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
@@ -52,28 +52,55 @@ const ICON_EXTENSIONS: any = {
  * @param fieldsValue Field value.
  * @param fields Available fields.
  * @param styles Array of layout styles.
- * @param wholeCardStyles Boolean indicating if styles should be applied to the wholecard.
  * @returns The parsed html.
  */
 export const parseHtml = (
   html: string,
   fieldsValue: any,
   fields: any,
-  styles?: any[],
-  wholeCardStyles?: boolean
+  styles?: any[]
 ) => {
   if (fieldsValue) {
     const htmlWithRecord = replaceRecordFields(
       html,
       fieldsValue,
       fields,
-      styles,
-      wholeCardStyles
+      styles
     );
     return applyOperations(htmlWithRecord);
   } else {
     return applyOperations(html);
   }
+};
+
+/**
+ * gets the style for the cards
+ *
+ * @param wholeCardStyles boolean
+ * @param styles available
+ * @param fieldsValue array of fields to apply the filters
+ * @returns the html styles
+ */
+export const getCardStyle = (
+  wholeCardStyles: boolean = false,
+  styles: any[] = [],
+  fieldsValue: any[]
+) => {
+  if (wholeCardStyles) {
+    let lastRowStyle = '';
+    if (fieldsValue) {
+      styles.map((style: any) => {
+        if (style.fields.length === 0) {
+          console.log('fields', style, fieldsValue);
+          if (applyFilters(style.filter, fieldsValue)) {
+            lastRowStyle = getLayoutStyle(style);
+          }
+        }
+      });
+    }
+    return lastRowStyle;
+  }
+  return '';
 };
 
 /**
@@ -83,31 +110,15 @@ export const parseHtml = (
  * @param fieldsValue Content of the fields.
  * @param fields Available fields.
  * @param styles Array of layout styles.
- * @param wholeCardStyles Boolean indicating if styles should be applied to the whole card.
  * @returns formatted html.
  */
 const replaceRecordFields = (
   html: string,
   fieldsValue: any[],
   fields: any,
-  styles: any[] = [],
-  wholeCardStyles: boolean = false
+  styles: any[] = []
 ): string => {
   let formattedHtml = html;
-  if (wholeCardStyles) {
-    let lastRowStyle: any = null;
-    styles.map((style: any) => {
-      if (style.fields.length === 0) {
-        lastRowStyle = style;
-      }
-    });
-    if (lastRowStyle) {
-      formattedHtml =
-        `<div style='${getLayoutStyle(lastRowStyle)}'>` +
-        formattedHtml +
-        '</div>';
-    }
-  }
   if (fields) {
     for (const field of fields) {
       const value = fieldsValue[field.name];

--- a/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/parser/utils.ts
@@ -84,14 +84,13 @@ export const parseHtml = (
 export const getCardStyle = (
   wholeCardStyles: boolean = false,
   styles: any[] = [],
-  fieldsValue: any[]
+  fieldsValue: any
 ) => {
   if (wholeCardStyles) {
     let lastRowStyle = '';
     if (fieldsValue) {
       styles.map((style: any) => {
         if (style.fields.length === 0) {
-          console.log('fields', style, fieldsValue);
           if (applyFilters(style.filter, fieldsValue)) {
             lastRowStyle = getLayoutStyle(style);
           }
@@ -114,7 +113,7 @@ export const getCardStyle = (
  */
 const replaceRecordFields = (
   html: string,
-  fieldsValue: any[],
+  fieldsValue: any,
   fields: any,
   styles: any[] = []
 ): string => {

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
@@ -1,5 +1,8 @@
-<div
-  class="html-content"
-  (click)="onClick($event)"
-  [innerHTML]="formattedHtml"
-></div>
+<div class="html-content" (click)="onClick($event)">
+  <div
+    class="w-fit h-fit"
+    [innerHTML]="formattedHtml"
+    [style]="cardStyle"
+  >
+  </div>
+</div>

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { SafeDownloadService } from '../../../../services/download/download.service';
-import { parseHtml } from '../parser/utils';
+import { getCardStyle, parseHtml } from '../parser/utils';
 import get from 'lodash/get';
 
 /**
@@ -28,6 +28,7 @@ export class SummaryCardItemContentComponent implements OnInit, OnChanges {
   @Input() wholeCardStyles = false;
 
   public formattedHtml?: SafeHtml;
+  public cardStyle?: string;
 
   /**
    * Content component of Single Item of Summary Card.
@@ -41,30 +42,30 @@ export class SummaryCardItemContentComponent implements OnInit, OnChanges {
   ) {}
 
   ngOnInit(): void {
-    this.formattedHtml = this.sanitizer.bypassSecurityTrustHtml(
-      parseHtml(
-        this.html,
-        this.fieldsValue,
-        this.fields,
-        this.styles,
-        this.wholeCardStyles
-      )
+    this.cardStyle = getCardStyle(
+      this.wholeCardStyles,
+      this.styles,
+      this.fieldsValue
     );
+    this.formattedHtml = this.sanitizer.bypassSecurityTrustHtml(
+      parseHtml(this.html, this.fieldsValue, this.fields, this.styles)
+    );
+    console.log(this.fieldsValue);
   }
 
   /**
    * Detects when the html or record inputs change.
    */
   ngOnChanges(): void {
-    this.formattedHtml = this.sanitizer.bypassSecurityTrustHtml(
-      parseHtml(
-        this.html,
-        this.fieldsValue,
-        this.fields,
-        this.styles,
-        this.wholeCardStyles
-      )
+    this.cardStyle = getCardStyle(
+      this.wholeCardStyles,
+      this.styles,
+      this.fieldsValue
     );
+    this.formattedHtml = this.sanitizer.bypassSecurityTrustHtml(
+      parseHtml(this.html, this.fieldsValue, this.fields, this.styles)
+    );
+    console.log(this.fieldsValue);
   }
 
   /**

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -50,7 +50,6 @@ export class SummaryCardItemContentComponent implements OnInit, OnChanges {
     this.formattedHtml = this.sanitizer.bypassSecurityTrustHtml(
       parseHtml(this.html, this.fieldsValue, this.fields, this.styles)
     );
-    console.log(this.fieldsValue);
   }
 
   /**
@@ -65,7 +64,6 @@ export class SummaryCardItemContentComponent implements OnInit, OnChanges {
     this.formattedHtml = this.sanitizer.bypassSecurityTrustHtml(
       parseHtml(this.html, this.fieldsValue, this.fields, this.styles)
     );
-    console.log(this.fieldsValue);
   }
 
   /**


### PR DESCRIPTION
# Description

Styling was calculated a bit randomly for the whole cards, we just took the latest style. It is now calculated using the filters.

## Ticket

[Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/60342/)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Same style was applied to all cards. Now the right style is applied.

## Sreenshots

![Screenshot from 2023-05-26 11-21-31](https://github.com/ReliefApplications/oort-frontend/assets/59645813/bf2d827f-4d50-457a-bd7f-fd308359ea2d)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
