### PR TITLE
feat/summ-cards-img-files-as-images

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1360,6 +1360,7 @@
 						"display": {
 							"dataSource": "Show link to data source",
 							"header": "Header",
+							"image": "Display image files as images",
 							"title": "Display",
 							"tooltip": {
 								"datasource": "Add a button in widget's header to view card's data source"

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1367,6 +1367,7 @@
 						"display": {
 							"dataSource": "Afficher le lien vers la source de données",
 							"header": "Titre",
+							"image": "Afficher les fichiers image sous forme d'images",
 							"title": "Affichage",
 							"tooltip": {
 								"datasource": "Ajoute un bouton pour afficher la source de données de la carte"

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1360,6 +1360,7 @@
 						"display": {
 							"dataSource": "******",
 							"header": "******",
+							"image": "******",
 							"title": "******",
 							"tooltip": {
 								"datasource": "******"

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/display-tab/display-tab.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/display-tab/display-tab.component.html
@@ -19,22 +19,30 @@
         </mat-form-field>
       </div>
       <mat-divider class="space-divider"></mat-divider>
-      <mat-slide-toggle formControlName="showDataSourceLink">
-        {{
-          'components.widget.settings.summaryCard.card.display.dataSource'
-            | translate
-        }}
-        <safe-icon
-          icon="info_outline"
-          variant="grey"
-          [inline]="true"
-          [size]="18"
-          [matTooltip]="
-            'components.widget.settings.summaryCard.card.display.tooltip.datasource'
+      <div class="flex flex-col gap-1">
+        <mat-slide-toggle formControlName="showDataSourceLink">
+          {{
+            'components.widget.settings.summaryCard.card.display.dataSource'
               | translate
-          "
-        ></safe-icon>
-      </mat-slide-toggle>
+          }}
+          <safe-icon
+            icon="info_outline"
+            variant="grey"
+            [inline]="true"
+            [size]="18"
+            [matTooltip]="
+              'components.widget.settings.summaryCard.card.display.tooltip.datasource'
+                | translate
+            "
+          ></safe-icon>
+        </mat-slide-toggle>
+        <mat-slide-toggle formControlName="displayImages">
+          {{
+            'components.widget.settings.summaryCard.card.display.image'
+              | translate
+          }}
+        </mat-slide-toggle>
+      </div>
     </div>
   </ng-container>
 </form>

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -56,6 +56,7 @@ const createCardForm = (value?: any) => {
     wholeCardStyles: new FormControl<boolean>(
       get(value, 'wholeCardStyles', false)
     ),
+    displayImages: new FormControl<boolean>(get(value, 'displayImages', true)),
   });
 };
 

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
@@ -1,8 +1,7 @@
 <div class="html-content" (click)="onClick($event)">
   <div
-    class="w-fit h-fit"
+    class="w-full h-full"
     [innerHTML]="formattedHtml"
     [style]="cardStyle"
-  >
-  </div>
+  ></div>
 </div>

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { SafeDownloadService } from '../../../../services/download/download.service';
-import { getCardStyle, parseHtml } from '../parser/utils';
+import { ParserOptions, getCardStyle, parseHtml } from '../parser/utils';
 import get from 'lodash/get';
 
 /**
@@ -26,6 +26,8 @@ export class SummaryCardItemContentComponent implements OnInit, OnChanges {
   @Input() fieldsValue: any;
   @Input() styles: any[] = [];
   @Input() wholeCardStyles = false;
+
+  @Input() parserOptions!: ParserOptions;
 
   public formattedHtml?: SafeHtml;
   public cardStyle?: string;
@@ -48,7 +50,13 @@ export class SummaryCardItemContentComponent implements OnInit, OnChanges {
       this.fieldsValue
     );
     this.formattedHtml = this.sanitizer.bypassSecurityTrustHtml(
-      parseHtml(this.html, this.fieldsValue, this.fields, this.styles)
+      parseHtml(
+        this.html,
+        this.fieldsValue,
+        this.fields,
+        this.styles,
+        this.parserOptions
+      )
     );
   }
 
@@ -62,7 +70,13 @@ export class SummaryCardItemContentComponent implements OnInit, OnChanges {
       this.fieldsValue
     );
     this.formattedHtml = this.sanitizer.bypassSecurityTrustHtml(
-      parseHtml(this.html, this.fieldsValue, this.fields, this.styles)
+      parseHtml(
+        this.html,
+        this.fieldsValue,
+        this.fields,
+        this.styles,
+        this.parserOptions
+      )
     );
   }
 

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
@@ -34,6 +34,7 @@
     [styles]="card.useStyles ? styles : []"
     [wholeCardStyles]="card.wholeCardStyles"
     style="flex: 1"
+    [parserOptions]="parserOptions"
   >
   </safe-summary-card-item-content>
 </ng-container>

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.ts
@@ -19,6 +19,7 @@ import { clone, get } from 'lodash';
 import { QueryBuilderService } from '../../../../services/query-builder/query-builder.service';
 import { firstValueFrom } from 'rxjs';
 import { CardT } from '../summary-card.component';
+import { ParserOptions } from '../parser/utils';
 
 /**
  * Single Item component of Summary card widget.
@@ -38,6 +39,13 @@ export class SummaryCardItemComponent implements OnInit, OnChanges {
   private layout: any;
 
   @Input() headerTemplate?: TemplateRef<any>;
+
+  /** @returns the parser options for the card */
+  get parserOptions(): ParserOptions {
+    return {
+      displayImages: this.card.displayImages ?? true,
+    };
+  }
 
   /**
    * Single item component of summary card widget.


### PR DESCRIPTION
# Description

This ticket adds an option in the display tab of the summary cards widget to display image files as images on the cards

## Ticket
No ticket linked to this PR

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
See screenshots

## Sreenshots
![Peek 2023-05-29 13-51](https://github.com/ReliefApplications/oort-frontend/assets/102038450/1153becc-f183-422d-a09d-6740199fe4d6)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
