### PR TITLE
Fix 2.1.x/ab#64915 map settings layer control duplicating

### DIFF
--- a/libs/safe/src/lib/components/ui/map/map-layers/map-layers.component.html
+++ b/libs/safe/src/lib/components/ui/map/map-layers/map-layers.component.html
@@ -43,6 +43,7 @@
       icon="close"
       (click)="closeLayersMenu()"
       class="flex-grow text-right"
+      id="layer-control-button-close"
     ></safe-button>
   </div>
   <safe-divider class="m-0"></safe-divider>

--- a/libs/safe/src/lib/components/ui/map/map.component.ts
+++ b/libs/safe/src/lib/components/ui/map/map.component.ts
@@ -342,7 +342,9 @@ export class MapComponent
         tree.basemaps && basemaps.push(tree.basemaps);
         tree.layers && layers.push(tree.layers);
       }
-      this.setLayersControl(flatten(basemaps), flatten(layers));
+      if (!this.layerControl) {
+        this.setLayersControl(flatten(basemaps), flatten(layers));
+      }
     });
 
     // Add zoom control

--- a/libs/safe/src/lib/components/ui/map/map.component.ts
+++ b/libs/safe/src/lib/components/ui/map/map.component.ts
@@ -91,6 +91,7 @@ export class MapComponent
   // === MARKERS ===
   private baseTree!: L.Control.Layers.TreeObject;
   private layersTree: L.Control.Layers.TreeObject[] = [];
+  private layerControlButtons: any;
   private layerControl: any;
 
   // === Controls ===
@@ -308,6 +309,9 @@ export class MapComponent
       }
     }
 
+    // Close layers/bookmarks menu
+    document.getElementById('layer-control-button-close')?.click();
+
     // Get layers
     const promises: Promise<{
       basemaps?: L.Control.Layers.TreeObject[];
@@ -342,9 +346,7 @@ export class MapComponent
         tree.basemaps && basemaps.push(tree.basemaps);
         tree.layers && layers.push(tree.layers);
       }
-      if (!this.layerControl) {
-        this.setLayersControl(flatten(basemaps), flatten(layers));
-      }
+      this.setLayersControl(flatten(basemaps), flatten(layers));
     });
 
     // Add zoom control
@@ -428,7 +430,11 @@ export class MapComponent
     basemaps: L.Control.Layers.TreeObject[],
     layers: L.Control.Layers.TreeObject[]
   ) {
-    this.mapControlsService.getLayerControl(this.map);
+    if (!this.layerControlButtons || !this.layerControlButtons._map) {
+      this.layerControlButtons = this.mapControlsService.getLayerControl(
+        this.map
+      );
+    }
     this.baseTree = {
       label: 'Base Maps',
       children: basemaps,
@@ -558,14 +564,28 @@ export class MapComponent
       drawLayer(layers);
     }
 
-    if (this.layerControl && this.extractSettings().controls.layer) {
-      this.map.removeControl(this.layerControl);
-    }
-
-    this.layerControl = L.control.layers.tree(this.baseTree, layers as any);
-
     if (this.extractSettings().controls.layer) {
-      this.layerControl.addTo(this.map);
+      // this.layerControl.addTo(this.map);
+      if (this.layerControl && this.extractSettings().controls.layer) {
+        if (this.extractSettings().controls.layer) {
+          this.map.removeControl(this.layerControl);
+        }
+        this.layerControl.setBaseTree(this.baseTree);
+        this.layerControl.setOverlayTree(layers as any);
+      } else {
+        this.layerControl = L.control.layers.tree(
+          this.baseTree,
+          layers as any,
+          { collapsed: false }
+        );
+      }
+      if (this.extractSettings().controls.layer) {
+        this.layerControl.addTo(this.map);
+      }
+      this.map
+        .getContainer()
+        .querySelector('.leaflet-control-layers')
+        ?.classList.add('hidden');
     }
   }
 

--- a/libs/safe/src/lib/components/ui/map/map.component.ts
+++ b/libs/safe/src/lib/components/ui/map/map.component.ts
@@ -399,6 +399,10 @@ export class MapComponent
     if (controls.layer) {
       if (this.layerControl) {
         this.layerControl.addTo(this.map);
+        this.map
+          .getContainer()
+          .querySelector('.leaflet-control-layers')
+          ?.classList.add('hidden');
       }
     } else {
       if (this.layerControl) {


### PR DESCRIPTION
# Description

Fixed some issues with the map settings where the layer controls were behaving wrongly, mainly duplicating themselves or disappearing.

The main issue was that we weren't being consistent on the creation of the layers, doing it differently on two parts of the code.

The fixes consisted on making the creation of layer consistent, adding some checks so we don't add the same controls multiple times and closing the layers/bookmarks control on a map reload.

## Ticket

[#64915 DB - Incorrect display of map controls](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/64915/)

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested on a dashboard with a map widget, editing the properties from the settings

## Screenshots
![maps](https://github.com/ReliefApplications/oort-frontend/assets/94831019/6556c28e-bcfa-4996-95fb-b49f0e716b63)



# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
