### PR TITLE
AB#65167 webmap options related to searchbar

### DIFF
--- a/libs/safe/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.ts
@@ -135,7 +135,21 @@ export class WebmapSelectComponent implements ControlValueAccessor, OnInit {
         } else {
           this.nextPage = false;
         }
-        this.items.next(this.items.getValue().concat(search.results));
+        if (text) {
+          this.items.next(
+            this.items
+              .getValue()
+              .concat(
+                search.results.filter(
+                  (a) =>
+                    a.id != this.value ||
+                    a.title.toLowerCase().includes(text.toLowerCase())
+                )
+              )
+          );
+        } else {
+          this.items.next(this.items.getValue().concat(search.results));
+        }
         this.loading = false;
       });
   }


### PR DESCRIPTION
# Description

Suppressing display of the selected webmap if its title does not match the search text.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/65167

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I selected an element and did a search where the keywords were different than the element title.

## Sreenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/65243509/4b6d3317-bacb-4a66-af8a-fa58617ce588)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules