### PR TITLE
bug: summary card preview is not available

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1356,6 +1356,9 @@
 								"datasource": "Add a button in widget's header to view card's data source"
 							}
 						},
+						"preview": {
+							"title": "Preview card"
+						},
 						"textEditor": {
 							"alert": "You can add variables e.g: {{data.variable}} and calculate e.g: {{calc.round( value ; precision )}}",
 							"title": "Text editor"

--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1563,6 +1563,18 @@
 			"unlock": "Unlock",
 			"unstick": "Unstick"
 		},
+		"pager": {
+			"firstPage": "Go to the first page",
+			"items": "items",
+			"itemsPerPage": "items per page",
+			"label": "'Page navigation, page {currentPage} of {totalPages}'",
+			"lastPage": "Go to the last page",
+			"nextPage": "Go to the next page",
+			"of": "of",
+			"page": "Page",
+			"pageNumberInputTitle": "Page Number",
+			"previousPage": "Go to the previous page"
+		},
 		"tilelayout": {
 			"component": {
 				"items": "items",

--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1371,7 +1371,7 @@
 							}
 						},
 						"preview": {
-							"title": "Preview card"
+							"title": "Preview"
 						},
 						"textEditor": {
 							"alert": "You can add variables e.g: {{data.variable}} and calculate e.g: {{calc.round( value ; precision )}}",

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1570,6 +1570,18 @@
 			"unlock": "Déverrouiller",
 			"unstick": "Désépingler"
 		},
+		"pager": {
+			"firstPage": "Aller à la première page",
+			"items": "éléments",
+			"itemsPerPage": "éléments par page",
+			"label": "'Navigation de page, page {currentPage} sur {totalPages}'",
+			"lastPage": "Aller à la dernière page",
+			"nextPage": "Aller à la page suivante",
+			"of": "sur",
+			"page": "Page",
+			"pageNumberInputTitle": "Numéro de page",
+			"previousPage": "Aller à la page précédente"
+		},
 		"tilelayout": {
 			"component": {
 				"items": "articles",

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1363,7 +1363,9 @@
 								"datasource": "Ajoute un bouton pour afficher la source de données de la carte"
 							}
 						},
-						"preview": {},
+						"preview": {
+							"title": "Prévisualisation"
+						},
 						"textEditor": {
 							"alert": "Vous pouvez ajouter des variables ex: {{data.variable}} et faire des calculs ex: {{calc.round( value ; precision )}}",
 							"title": "Éditeur de texte"

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1563,6 +1563,18 @@
 			"unlock": "******",
 			"unstick": "******"
 		},
+		"pager": {
+			"firstPage": "******",
+			"items": "******",
+			"itemsPerPage": "******",
+			"label": "******",
+			"lastPage": "******",
+			"nextPage": "******",
+			"of": "******",
+			"page": "******",
+			"pageNumberInputTitle": "******",
+			"previousPage": "******"
+		},
 		"tilelayout": {
 			"component": {
 				"items": "******",

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1356,6 +1356,9 @@
 								"datasource": "******"
 							}
 						},
+						"preview": {
+							"title": "******"
+						},
 						"textEditor": {
 							"alert": "****** {{data.variable}} ****** {{calc.round( value ; precision )}}",
 							"title": "******"

--- a/libs/safe/src/lib/components/widgets/editor-settings/editor-settings.component.html
+++ b/libs/safe/src/lib/components/widgets/editor-settings/editor-settings.component.html
@@ -25,6 +25,26 @@
         </form>
       </ng-template>
     </mat-tab>
+    <!-- Preview -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <safe-icon icon="preview" [size]="24"></safe-icon>
+        <span>{{
+          'components.widget.settings.summaryCard.card.preview.title'
+            | translate
+        }}</span>
+      </ng-template>
+      <ng-template matTabContent>
+        <safe-editor
+          #widgetContent
+          class="flex-1 h-full w-full"
+          [title]="tile.settings.title"
+          [text]="tile.settings.text"
+          [record]="tile.settings.record"
+        >
+        </safe-editor>
+      </ng-template>
+    </mat-tab>
     <!-- Resource and record selection  -->
     <mat-tab>
       <ng-template mat-tab-label>

--- a/libs/safe/src/lib/components/widgets/editor-settings/editor-settings.component.html
+++ b/libs/safe/src/lib/components/widgets/editor-settings/editor-settings.component.html
@@ -26,7 +26,7 @@
       </ng-template>
     </mat-tab>
     <!-- Preview -->
-    <mat-tab>
+    <mat-tab *ngIf="tileForm.value">
       <ng-template mat-tab-label>
         <safe-icon icon="preview" [size]="24"></safe-icon>
         <span>{{
@@ -38,9 +38,9 @@
         <safe-editor
           #widgetContent
           class="flex-1 h-full w-full"
-          [title]="tile.settings.title"
-          [text]="tile.settings.text"
-          [record]="tile.settings.record"
+          [title]="tileForm.value.title"
+          [text]="tileForm.value.text"
+          [record]="tileForm.value.record"
         >
         </safe-editor>
       </ng-template>

--- a/libs/safe/src/lib/components/widgets/editor-settings/editor-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/editor-settings/editor-settings.component.ts
@@ -50,7 +50,7 @@ export type EditorFormType = ReturnType<typeof createEditorForm>;
 })
 export class SafeEditorSettingsComponent implements OnInit, AfterViewInit {
   // === REACTIVE FORM ===
-  tileForm: ReturnType<typeof createEditorForm> | undefined;
+  tileForm!: EditorFormType;
 
   // === WIDGET ===
   @Input() tile: any;

--- a/libs/safe/src/lib/components/widgets/editor-settings/editor-settings.module.ts
+++ b/libs/safe/src/lib/components/widgets/editor-settings/editor-settings.module.ts
@@ -15,6 +15,7 @@ import { SafeGraphQLSelectModule } from '../../graphql-select/graphql-select.mod
 import { SafeButtonModule } from '../../ui/button/button.module';
 import { MatLegacySelectModule } from '@angular/material/legacy-select';
 import { SafeCoreGridModule } from '../../ui/core-grid/core-grid.module';
+import { SafeEditorModule } from '../editor/editor.module';
 
 /**
  * Module for the safeEditorSetting component
@@ -37,6 +38,7 @@ import { SafeCoreGridModule } from '../../ui/core-grid/core-grid.module';
     SafeButtonModule,
     MatLegacySelectModule,
     SafeCoreGridModule,
+    SafeEditorModule,
   ],
   exports: [SafeEditorSettingsComponent],
   providers: [

--- a/libs/safe/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/safe/src/lib/components/widgets/editor/editor.component.ts
@@ -17,9 +17,9 @@ import {
 export class SafeEditorComponent implements OnInit {
   // === WIDGET CONFIGURATION ===
   @Input() header = true;
-  @Input() public title = '';
-  @Input() public text = '';
-  @Input() public record = '';
+  @Input() public title: string | null | undefined = '';
+  @Input() public text: string | null | undefined = '';
+  @Input() public record: string | null | undefined = '';
 
   // === TEXT SANITIZED ===
   public safeText: SafeHtml = '';
@@ -34,7 +34,7 @@ export class SafeEditorComponent implements OnInit {
 
   /** Sanitize the text. */
   ngOnInit(): void {
-    if (!this.record) {
+    if (!this.record && this.text) {
       this.safeText = this.sanitizer.bypassSecurityTrustHtml(this.text);
       return;
     }
@@ -49,13 +49,15 @@ export class SafeEditorComponent implements OnInit {
       .subscribe((res) => {
         const regex = /{{data\.(.*?)}}/g;
         const data = res.data?.record.data || {};
-        // replace all {{data.<field>}} with the value from the data
-        const textWithAddedData = this.text.replace(regex, (match) => {
-          const field = match.replace('{{data.', '').replace('}}', '');
-          return data[field] || match;
-        });
-        this.safeText =
-          this.sanitizer.bypassSecurityTrustHtml(textWithAddedData);
+        if (this.text) {
+          // replace all {{data.<field>}} with the value from the data
+          const textWithAddedData = this.text.replace(regex, (match) => {
+            const field = match.replace('{{data.', '').replace('}}', '');
+            return data[field] || match;
+          });
+          this.safeText =
+            this.sanitizer.bypassSecurityTrustHtml(textWithAddedData);
+        }
       });
   }
 }

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -47,6 +47,33 @@
         ></safe-text-editor-tab>
       </ng-template>
     </mat-tab>
+    <!-- Card text preview -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <safe-icon icon="article" [size]="24"></safe-icon>
+        <span>{{
+          'components.widget.settings.summaryCard.card.preview.title'
+            | translate
+        }}</span>
+      </ng-template>
+      <ng-template matTabContent>
+        <!-- TODO Preview here -->
+        <!-- <safe-summary-card-item
+            *ngFor="let card of cards; let i = index"
+            class="k-tilelayout-item k-card"
+            [style.order]="i"
+            style.grid-column-end="{{
+              'span ' +
+                (card.width && card.width > colsNumber
+                  ? colsNumber
+                  : card.width)
+            }}"
+            style.grid-row-end="{{ 'span ' + card.height }}"
+            [card]="card"
+          >
+          </safe-summary-card-item> -->
+      </ng-template>
+    </mat-tab>
     <!-- Card display settings -->
     <mat-tab>
       <ng-template mat-tab-label>

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -57,21 +57,8 @@
         }}</span>
       </ng-template>
       <ng-template matTabContent>
-        <!-- TODO Preview here -->
-        <!-- <safe-summary-card-item
-            *ngFor="let card of cards; let i = index"
-            class="k-tilelayout-item k-card"
-            [style.order]="i"
-            style.grid-column-end="{{
-              'span ' +
-                (card.width && card.width > colsNumber
-                  ? colsNumber
-                  : card.width)
-            }}"
-            style.grid-row-end="{{ 'span ' + card.height }}"
-            [card]="card"
-          >
-          </safe-summary-card-item> -->
+        <safe-summary-card [settings]="tileForm.value" [widget]="tile">
+        </safe-summary-card>
       </ng-template>
     </mat-tab>
     <!-- Card display settings -->

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -48,9 +48,9 @@
       </ng-template>
     </mat-tab>
     <!-- Card text preview -->
-    <mat-tab>
+    <mat-tab *ngIf="tileForm && !tileForm.invalid">
       <ng-template mat-tab-label>
-        <safe-icon icon="article" [size]="24"></safe-icon>
+        <safe-icon icon="preview" [size]="24"></safe-icon>
         <span>{{
           'components.widget.settings.summaryCard.card.preview.title'
             | translate

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -100,6 +100,8 @@ export class SafeSummaryCardSettingsComponent implements OnInit, AfterViewInit {
   // === WIDGET ===
   @Input() tile: any;
 
+  @Input() cards: any;
+
   // === EMIT THE CHANGES APPLIED ===
   // eslint-disable-next-line @angular-eslint/no-output-native
   @Output() change: EventEmitter<any> = new EventEmitter();

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -99,8 +99,6 @@ export class SafeSummaryCardSettingsComponent implements OnInit, AfterViewInit {
   // === WIDGET ===
   @Input() tile: any;
 
-  @Input() cards: any;
-
   // === EMIT THE CHANGES APPLIED ===
   // eslint-disable-next-line @angular-eslint/no-output-native
   @Output() change: EventEmitter<any> = new EventEmitter();

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -7,7 +7,6 @@ import {
   AfterViewInit,
 } from '@angular/core';
 import { Validators, FormGroup, FormControl } from '@angular/forms';
-
 import { get } from 'lodash';
 import { extendWidgetForm } from '../common/display-settings/extendWidgetForm';
 import { Apollo } from 'apollo-angular';

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.module.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.module.ts
@@ -12,6 +12,7 @@ import { SafeDisplayTabModule } from './display-tab/display.module';
 import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
+import { SummaryCardItemModule } from '../summary-card/summary-card-item/summary-card-item.module';
 
 /** Summary Card Settings Module */
 @NgModule({
@@ -30,6 +31,7 @@ import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy
     FormsModule,
     ReactiveFormsModule,
     MatRadioModule,
+    SummaryCardItemModule,
   ],
   exports: [SafeSummaryCardSettingsComponent],
 })

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.module.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.module.ts
@@ -12,7 +12,7 @@ import { SafeDisplayTabModule } from './display-tab/display.module';
 import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
-import { SummaryCardItemModule } from '../summary-card/summary-card-item/summary-card-item.module';
+import { SafeSummaryCardModule } from '../summary-card/summary-card.module';
 
 /** Summary Card Settings Module */
 @NgModule({
@@ -31,7 +31,7 @@ import { SummaryCardItemModule } from '../summary-card/summary-card-item/summary
     FormsModule,
     ReactiveFormsModule,
     MatRadioModule,
-    SummaryCardItemModule,
+    SafeSummaryCardModule,
   ],
   exports: [SafeSummaryCardSettingsComponent],
 })


### PR DESCRIPTION
# Description

Added preview for summary cards and text-widgets

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/64934/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

There was no preview and now there is one

## Sreenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/9751045/b74455fe-d6d9-47e2-9b46-0778d4eb4b76)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
