### PR TITLE
fix/OORT-630_resources_roles_permissions

### DIFF
--- a/libs/safe/src/lib/components/role-summary/role-resources/role-resources.component.ts
+++ b/libs/safe/src/lib/components/role-summary/role-resources/role-resources.component.ts
@@ -316,6 +316,10 @@ export class RoleResourcesComponent
                 : data?.editResource
             );
             this.resources.data = tableElements;
+            const cachedIndex = this.cachedResources.findIndex(
+              (x) => x.id === resource.id
+            );
+            this.cachedResources[cachedIndex] = tableElements[index].resource;
             if (isEqual(resource.id, this.openedResource?.id)) {
               this.openedResource = tableElements[index].resource;
             }


### PR DESCRIPTION
# Description
Roles permissions on resources were were showing wrong when we updated because the cached resources were used in the table but never updated, that's why when refreshing the page the correct permissions were displayed. 

## Ticket
[OORT-630: Roles permissions on resources flickering on update](https://oortcloud.atlassian.net/browse/OORT-630)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Updating the role permissions multiple times.

## Sreenshots
![fix-r](https://github.com/ReliefApplications/oort-frontend/assets/28535394/608b4e73-5c8f-4d13-b23e-4bffc8ddbd07)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
