### PR TITLE
fix/OORT-640-send-email-to-recipients-not-in-distribution-list

### DIFF
--- a/libs/safe/src/lib/services/email/email.service.ts
+++ b/libs/safe/src/lib/services/email/email.service.ts
@@ -230,7 +230,7 @@ export class SafeEmailService {
           dialogRef.afterClosed().subscribe((value) => {
             if (value) {
               this.sendMail(
-                recipient,
+                value.to,
                 value.subject,
                 value.html,
                 filter,


### PR DESCRIPTION
# Description
Sending emails to recipients not in the distribution list wasn't working because the form field was ignored, and only the emails used in the email preview (the ones in the distribution list) was used.

## Ticket
[OORT-640: Sending emails to recipients not in the distribution list not working](https://oortcloud.atlassian.net/browse/OORT-640)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Changing the emails field to other emails and confirming that the email is delivered to everyone. 

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
