### PR TITLE
feat-2.1.x / #59588 DB - Maps - Zoom in / zoom out styling

### DIFF
--- a/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.html
+++ b/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.html
@@ -1,0 +1,30 @@
+<!-- Component wrapper -->
+<div class="relative flex flex-col items-center">
+  <button
+    class="w-6 h-6 top-1 relative flex items-center justify-center bg-white rounded-md border-2 border-solid border-black border-opacity-20"
+    (click)="zoomIn()"
+  >
+    <span class="font-bold">+</span>
+  </button>
+  <!-- Actual input range -->
+  <input
+    name="slider"
+    style="--value:{{ currentZoom }}; --min:{{ minZoom }}; --max:{{
+      maxZoom
+    }}"
+    class="h-full w-1"
+    type="range"
+    min="{{ minZoom }}"
+    max="{{ maxZoom }}"
+    value="{{ currentZoom }}"
+    step="1"
+    orient="vertical"
+    (input)="onChangeFunction($event.target)"
+  />
+  <button
+    class="w-6 h-6 bottom-1 relative flex items-center justify-center bg-white rounded-md border-2 border-solid border-black border-opacity-20"
+    (click)="zoomOut()"
+  >
+    <span class="font-bold">-</span>
+  </button>
+</div>

--- a/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.scss
+++ b/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.scss
@@ -1,0 +1,53 @@
+
+
+input[type=range][orient=vertical]
+{
+    writing-mode: bt-lr !important; /* IE */
+    -webkit-appearance: slider-vertical !important; /* Chromium */
+}
+
+/** Chrome*/
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  input[type='range'] {
+    overflow: hidden;
+    accent-color: theme('colors.primary.500');
+  }
+
+  input[type=range]::-webkit-slider-runnable-track {
+    background-color: #CCCCCC;
+    border: 0.2px solid #CCCCCC;
+  }
+
+  input[type='range']::-webkit-slider-thumb {
+    background: theme('colors.primary.500');
+    box-shadow: -10px 80px 0 80px theme('colors.primary.500');
+  }
+}
+
+/** Firefox*/
+input[type="range"]::-moz-range-progress {
+  background-color: theme('colors.primary.500');
+  border: 0.2px solid theme('colors.primary.500');
+}
+input[type="range"]::-moz-range-track {
+  background-color: #CCCCCC;
+  border: 0.2px solid #CCCCCC;
+}
+input[type=range]::-moz-range-thumb {
+  background: theme('colors.primary.500');
+  border: 0.2px solid theme('colors.primary.500');
+}
+
+/* Internet explorer*/
+input[type="range"]::-ms-fill-lower {
+  background-color: theme('colors.primary.500');
+  border: 0.2px solid theme('colors.primary.500');
+}
+input[type="range"]::-ms-fill-upper {
+  background-color: #CCCCCC;
+  border: 0.2px solid #CCCCCC;
+}
+input[type=range]::-ms-thumb {
+  background: theme('colors.primary.500');
+  border: 0.2px solid theme('colors.primary.500');
+}

--- a/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.spec.ts
+++ b/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MapZoomComponent } from './map-zoom.component';
+
+describe('MapZoomComponent', () => {
+  let component: MapZoomComponent;
+  let fixture: ComponentFixture<MapZoomComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MapZoomComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MapZoomComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.ts
+++ b/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.ts
@@ -1,0 +1,52 @@
+import { Component, EventEmitter, OnDestroy, OnInit } from '@angular/core';
+import { MapEvent, MapEventType } from '../interfaces/map.interface';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+/** Zoom slider component for the map widget */
+@Component({
+  standalone: true,
+  selector: 'safe-map-zoom',
+  templateUrl: './map-zoom.component.html',
+  styleUrls: ['./map-zoom.component.scss'],
+  imports: [FormsModule, CommonModule],
+})
+export class MapZoomComponent implements OnInit, OnDestroy {
+  public maxZoom!: number;
+  public minZoom!: number;
+  public map: any;
+  public currentZoom = 4;
+  public mapEvent!: EventEmitter<MapEvent>;
+
+  ngOnInit() {
+    this.mapEvent.subscribe((event) => {
+      if (event.type === MapEventType.ZOOM_END)
+        this.currentZoom = event.content.zoom;
+    });
+  }
+
+  /**
+   * When value of input changes, calculates the position where the bubble is to go and sends the new value to the map
+   *
+   * @param value The value from the slider
+   */
+  onChangeFunction(value: EventTarget | null) {
+    if (value) {
+      this.map.setZoom(+((value as HTMLInputElement)?.value ?? value));
+    }
+  }
+
+  /** Zooms in one level further */
+  zoomIn() {
+    if (this.currentZoom < this.maxZoom) this.map.setZoom(this.currentZoom + 1);
+  }
+
+  /** Zooms out of one level */
+  zoomOut() {
+    if (this.currentZoom > this.minZoom) this.map.setZoom(this.currentZoom - 1);
+  }
+
+  ngOnDestroy(): void {
+    this.mapEvent.unsubscribe();
+  }
+}

--- a/libs/safe/src/lib/components/ui/map/map.component.scss
+++ b/libs/safe/src/lib/components/ui/map/map.component.scss
@@ -68,11 +68,21 @@
   align-items: baseline;
   gap: 4px;
 }
-  
+
 ::ng-deep .leaflet-layerstree-header {
   &:not(.leaflet-layerstree-nevershow) {
     display: flex;
   }
   align-items: baseline;
   gap: 4px;
+}
+
+::ng-deep .leaflet-verticalcenter {
+  position: absolute;
+  width: 100px !important;
+  z-index: 1000;
+  pointer-events: none;
+  top: 45%;
+  transform: translateY(-40%);
+  padding-top: 10px;
 }

--- a/libs/safe/src/lib/components/ui/map/map.component.ts
+++ b/libs/safe/src/lib/components/ui/map/map.component.ts
@@ -88,6 +88,10 @@ export class MapComponent
   };
   private arcGisWebMap: any;
 
+  // === ZOOM ===
+  public currentZoom = 2;
+  public zoomControl: any = undefined;
+
   // === MARKERS ===
   private baseTree!: L.Control.Layers.TreeObject;
   private layersTree: L.Control.Layers.TreeObject[] = [];
@@ -144,6 +148,7 @@ export class MapComponent
     });
 
     this.map.on('zoomend', () => {
+      this.currentZoom = this.map.getZoom();
       this.mapEvent.emit({
         type: MapEventType.ZOOM_END,
         content: { zoom: this.map.getZoom() },
@@ -278,6 +283,10 @@ export class MapComponent
         ),
         initialState.viewpoint.zoom
       );
+
+      this.currentZoom = initialState.viewpoint.zoom;
+      this.mapControlsService.addControlPlaceholders(this.map);
+
       // Set the needed map instance for it's popup service instance
       this.mapPopupService.setMap = this.map;
     } else {
@@ -349,10 +358,6 @@ export class MapComponent
       this.setLayersControl(flatten(basemaps), flatten(layers));
     });
 
-    // Add zoom control
-    if (initMap) {
-      L.control.zoom({ position: 'bottomright' }).addTo(this.map);
-    }
     this.setMapControls(controls, initMap);
   }
 
@@ -397,6 +402,16 @@ export class MapComponent
       this.map,
       controls.download ?? true
     );
+    // Add zoom control
+    if (!this.zoomControl) {
+      this.zoomControl = this.mapControlsService.getZoomControl(
+        this.map,
+        this.map.getMaxZoom(),
+        this.map.getMinZoom(),
+        this.map.getZoom(),
+        this.mapEvent
+      );
+    }
     // Add legend control
     this.mapControlsService.getLegendControl(this.map, controls.legend ?? true);
     // Add layer control

--- a/libs/safe/src/lib/services/map/map-controls.service.ts
+++ b/libs/safe/src/lib/services/map/map-controls.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@angular/core';
+import { EventEmitter, Inject, Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { MARKER_OPTIONS } from '../../components/ui/map/const/marker-options';
 import { MapDownloadComponent } from '../../components/ui/map/map-download/map-download.component';
@@ -14,6 +14,8 @@ import * as Geocoding from 'esri-leaflet-geocoder';
 import { AVAILABLE_MEASURE_LANGUAGES } from '../../components/ui/map/const/language';
 import { MapLayersComponent } from '../../components/ui/map/map-layers/map-layers.component';
 import { legendControl } from '../../components/ui/map/controls/legend.control';
+import { MapZoomComponent } from '../../components/ui/map/map-zoom/map-zoom.component';
+import { MapEvent } from '../../components/ui/map/interfaces/map.interface';
 
 /**
  * Shared map control service.
@@ -340,6 +342,69 @@ export class SafeMapControlsService {
         this.downloadControl = null;
       }
     }
+  }
+
+  /**
+   * Add a zoom slider to control the zoom level of the map
+   *
+   * @param map map widget
+   * @param maxZoom maximum zoom for the map
+   * @param minZoom minimum zoom for the map
+   * @param currentZoom currentZoom of the map
+   * @param mapEvent listen to map events to get correct zoom
+   * @returns zoomControl
+   */
+  public getZoomControl(
+    map: L.Map,
+    maxZoom: number,
+    minZoom: number,
+    currentZoom: number,
+    mapEvent: EventEmitter<MapEvent>
+  ) {
+    const customZoomControl = new L.Control(<any>{
+      position: 'verticalcenterright',
+    });
+    customZoomControl.onAdd = () => {
+      const div = L.DomUtil.create('div');
+      const component = this.domService.appendComponentToBody(
+        MapZoomComponent,
+        div
+      );
+      const instance: MapZoomComponent = component.instance;
+      instance.maxZoom = maxZoom;
+      instance.minZoom = minZoom;
+      instance.currentZoom = currentZoom;
+      instance.map = map;
+      instance.mapEvent = mapEvent;
+      L.DomEvent.addListener(div, 'mousedown', L.DomEvent.stopPropagation);
+      return div;
+    };
+    map.addControl(customZoomControl);
+    return customZoomControl;
+  }
+
+  /**
+   * Adds custom zoom control (different from the leaflet default one
+   *
+   * @param map Leaflet map
+   */
+  public addControlPlaceholders(map: any) {
+    const corners = map._controlCorners,
+      l = 'leaflet-',
+      container = map._controlContainer;
+
+    /**
+     * Creates new corner for the map
+     *
+     * @param vSide vertical side
+     * @param hSide horizontal side
+     */
+    function createCorner(vSide: string, hSide: string) {
+      const className = l + vSide + ' ' + l + hSide;
+
+      corners[vSide + hSide] = L.DomUtil.create('div', className, container);
+    }
+    createCorner('verticalcenter', 'right');
   }
 
   /**


### PR DESCRIPTION
# Description

A new custom zoom control for maps has been implemented, it now includes a range input which shows the current zoom and it's interactive.

The control is styled with tailwind but for the _range input_, since tailwind doesn't support any specific styling for it.
The styling has been done with pure css, the accent color is based on the primary color for tailwind.

The control has been tested on chrome and firefox browsers, but not on internet explorer. I wasn't able to find a way to get it on my OS.
It won't break in any case, but It would be better if we check that it has the same style as the other browsers.

## Ticket

[#59588 DB - Maps - Zoom in / zoom out styling
](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/59588/)


## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] The new control has been tested on a chrome based browser
- [x] The new control has been tested on a firefox based browser


## Screenshots

Chrome browser:
![Screenshot from 2023-06-05 11-01-36](https://github.com/ReliefApplications/oort-frontend/assets/94831019/b474ceff-5dd2-46fd-987e-040451a46045)

Firefox browser:
![Screenshot from 2023-06-05 11-02-34](https://github.com/ReliefApplications/oort-frontend/assets/94831019/39ba0766-73d3-439c-84a4-f36a1d8501a7)



# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
