### PR TITLE
bugfix/AB#65126_DB-proper-web-map-is-not-displaying-map-widget

### DIFF
--- a/libs/safe/src/lib/components/widgets/map-settings/map-layer/map-layer.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-layer/map-layer.component.ts
@@ -128,7 +128,6 @@ export class MapLayerComponent
 
   ngOnInit(): void {
     this.form = createLayerForm(this.layer);
-    console.log(this.form.value);
     this.setIsDatasourceValid(this.form.get('datasource')?.value);
     this.form
       .get('datasource')

--- a/libs/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -40,9 +40,7 @@
         <!-- Remove value -->
         <safe-button
           matSuffix
-          (click)="
-            form.get('basemap')?.setValue(null); $event.stopPropagation()
-          "
+          (click)="clearFormField('basemap', $event)"
           [isIcon]="true"
           icon="close"
           variant="danger"

--- a/libs/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
@@ -43,4 +43,18 @@ export class MapPropertiesComponent extends SafeUnsubscribeComponent {
         emitEvent: false,
       });
   }
+
+  /**
+   * Reset given form field value if there is a value previously to avoid triggering
+   * not necessary actions
+   *
+   * @param formField Current form field
+   * @param event click event
+   */
+  clearFormField(formField: string, event: Event) {
+    if (this.form.get(formField)?.value) {
+      this.form.get(formField)?.setValue(null);
+    }
+    event.stopPropagation();
+  }
 }

--- a/libs/safe/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.ts
@@ -86,6 +86,10 @@ export class WebmapSelectComponent implements ControlValueAccessor, OnInit {
    * @param e event
    */
   public selectionOnChange(e: any) {
+    // If no value is set into no this.value return
+    if (!e.value && !this.value) {
+      return;
+    }
     this.value = e.value;
     this.onChanged(this.value);
   }

--- a/libs/safe/src/lib/services/map/arcgis.service.ts
+++ b/libs/safe/src/lib/services/map/arcgis.service.ts
@@ -130,64 +130,90 @@ export class ArcgisService {
     const baseMapLayers: L.Layer[] = [];
     for (const layer of webMap.baseMap.baseMapLayers) {
       const opacity = get(layer, 'opacity', 1);
-      switch (layer.layerType) {
-        case 'VectorTileLayer': {
-          // When using the styleUrl of the given layer, the built in vectorTileLayer function duplicates the url to fetch it
-          // So we will use the id in the styleUrls to fetch the vector tile layer
-          // This regex matches the content for => {{url}}/items/tileLayerId/blabla/blabla
-          let id = layer.styleUrl.match(/(?<=items\/).*?(?=\/)/gi);
-          let esriUrlContent: any = null;
-          const styleUrlContent: any = await this.httpGet(layer.styleUrl);
-          // @TODO WHO map contains buggy basemap within(id=b047fc319898445287111763e4fcf300) which breaks the whole
-          // layer flow, current one and the next ones
-          // this would solve that and only load the no buggy layers
-          try {
-            // Get the styleUrl content to use the esriUrlContent.serviceItemId (if it exists) instead of the id
-            if (styleUrlContent.sources.esri?.url) {
-              esriUrlContent = await this.httpGet(
-                styleUrlContent.sources.esri.url
-              );
+      if (get(layer, 'visibility', true)) {
+        switch (layer.layerType) {
+          case 'VectorTileLayer': {
+            // Automatically load layer
+            if (layer.itemId) {
+              if (
+                layer.styleUrl &&
+                layer.styleUrl.includes('VectorTileServer')
+              ) {
+                const url = layer.styleUrl.substring(
+                  0,
+                  layer.styleUrl.indexOf('VectorTileServer') +
+                    'VectorTileServer'.length
+                );
+                // const styleUrlContent: any = await this.httpGet(layer.styleUrl);
+                // ('https://tiles.arcgis.com/tiles/5T5nSi527N4F7luB/arcgis/rest/services/WHO_Polygon_Basemap_labels/VectorTileServer');
+                // one possible issue could be about the projection!
+                const vectorTileLayer = Vector.vectorTileLayer(url, {
+                  token: this.esriApiKey,
+                  opacity,
+                });
+                vectorTileLayer.label = layer.title;
+                baseMapLayers.push(vectorTileLayer);
+              } else {
+                const vectorTileLayer = Vector.vectorTileLayer(layer.itemId, {
+                  token: this.esriApiKey,
+                  opacity,
+                });
+                vectorTileLayer.label = layer.title;
+                baseMapLayers.push(vectorTileLayer);
+              }
+            } else {
+              // When using the styleUrl of the given layer, the built in vectorTileLayer function duplicates the url to fetch it
+              // So we will use the id in the styleUrls to fetch the vector tile layer
+              // This regex matches the content for => {{url}}/items/tileLayerId/blabla/blabla
+              let id = layer.styleUrl.match(/(?<=items\/).*?(?=\/)/gi);
+              let esriUrlContent: any = null;
+              const styleUrlContent: any = await this.httpGet(layer.styleUrl);
+              // @TODO WHO map contains buggy basemap within(id=b047fc319898445287111763e4fcf300) which breaks the whole
+              // layer flow, current one and the next ones
+              // this would solve that and only load the no buggy layers
+              try {
+                // Get the styleUrl content to use the esriUrlContent.serviceItemId (if it exists) instead of the id
+                if (styleUrlContent.sources.esri?.url) {
+                  esriUrlContent = await this.httpGet(
+                    styleUrlContent.sources.esri.url
+                  );
+                }
+              } catch (error) {
+                console.error(error);
+                break;
+              }
+              id = esriUrlContent ? esriUrlContent?.serviceItemId : id;
+              const vectorTileLayer = Vector.vectorTileLayer(id, {
+                token: this.esriApiKey,
+                opacity,
+              });
+              vectorTileLayer.label = layer.title;
+              baseMapLayers.push(vectorTileLayer);
             }
-          } catch (error) {
-            console.log(layer);
-            console.log(styleUrlContent);
-            console.log(error);
             break;
           }
-          id = esriUrlContent
-            ? esriUrlContent?.serviceItemId
-            : id
-            ? id
-            : layer.itemId;
-          const vectorTileLayer = Vector.vectorTileLayer(id, {
-            token: this.esriApiKey,
-            opacity,
-          });
-          vectorTileLayer.label = layer.title;
-          baseMapLayers.push(vectorTileLayer);
-          break;
-        }
-        case 'ArcGISTiledMapServiceLayer': {
-          const tiledMapLayer = Esri.tiledMapLayer({
-            pane: 'tilePane',
-            url: layer.url,
-            token: this.esriApiKey,
-            opacity,
-          });
-          (tiledMapLayer as any).label = layer.title;
-          baseMapLayers.push(tiledMapLayer);
-          break;
-        }
-        // case 'ArcGISImageServiceLayer': {
-        //   (Esri as any).imageMapLayer({
-        //     pane: 'tilePane',
-        //     url: layer.url,
-        //     token: this.esriApiKey,
-        //   }).addTo(map);
-        //   break;
-        // }
-        default: {
-          break;
+          case 'ArcGISTiledMapServiceLayer': {
+            const tiledMapLayer = Esri.tiledMapLayer({
+              pane: 'tilePane',
+              url: layer.url,
+              token: this.esriApiKey,
+              opacity,
+            });
+            (tiledMapLayer as any).label = layer.title;
+            baseMapLayers.push(tiledMapLayer);
+            break;
+          }
+          // case 'ArcGISImageServiceLayer': {
+          //   (Esri as any).imageMapLayer({
+          //     pane: 'tilePane',
+          //     url: layer.url,
+          //     token: this.esriApiKey,
+          //   }).addTo(map);
+          //   break;
+          // }
+          default: {
+            break;
+          }
         }
       }
     }
@@ -271,7 +297,6 @@ export class ArcgisService {
         break;
       }
       case 'ArcGISFeatureLayer': {
-        console.log(layer);
         let featureLayer: L.Layer | undefined = undefined;
         if (layer.url) {
           // if (layer.itemId) {

--- a/libs/safe/src/lib/services/map/arcgis.service.ts
+++ b/libs/safe/src/lib/services/map/arcgis.service.ts
@@ -149,6 +149,8 @@ export class ArcgisService {
               );
             }
           } catch (error) {
+            console.log(layer);
+            console.log(styleUrlContent);
             console.log(error);
             break;
           }

--- a/libs/safe/src/lib/services/map/arcgis.service.ts
+++ b/libs/safe/src/lib/services/map/arcgis.service.ts
@@ -137,12 +137,20 @@ export class ArcgisService {
           // This regex matches the content for => {{url}}/items/tileLayerId/blabla/blabla
           let id = layer.styleUrl.match(/(?<=items\/).*?(?=\/)/gi);
           let esriUrlContent: any = null;
-          // Get the styleUrl content to use the esriUrlContent.serviceItemId (if it exists) instead of the id
           const styleUrlContent: any = await this.httpGet(layer.styleUrl);
-          if (styleUrlContent.sources.esri?.url) {
-            esriUrlContent = await this.httpGet(
-              styleUrlContent.sources.esri.url
-            );
+          // @TODO WHO map contains buggy basemap within(id=b047fc319898445287111763e4fcf300) which breaks the whole
+          // layer flow, current one and the next ones
+          // this would solve that and only load the no buggy layers
+          try {
+            // Get the styleUrl content to use the esriUrlContent.serviceItemId (if it exists) instead of the id
+            if (styleUrlContent.sources.esri?.url) {
+              esriUrlContent = await this.httpGet(
+                styleUrlContent.sources.esri.url
+              );
+            }
+          } catch (error) {
+            console.log(error);
+            break;
           }
           id = esriUrlContent
             ? esriUrlContent?.serviceItemId

--- a/libs/safe/src/lib/services/map/map-controls.service.ts
+++ b/libs/safe/src/lib/services/map/map-controls.service.ts
@@ -376,6 +376,8 @@ export class SafeMapControlsService {
       instance.map = map;
       instance.mapEvent = mapEvent;
       L.DomEvent.addListener(div, 'mousedown', L.DomEvent.stopPropagation);
+      L.DomEvent.addListener(div, 'click', L.DomEvent.stopPropagation);
+      L.DomEvent.addListener(div, 'wheel', L.DomEvent.stopPropagation);
       return div;
     };
     map.addControl(customZoomControl);

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "esri-leaflet-geocoder": "^3.1.4",
         "esri-leaflet-heatmap": "^2.0.1",
         "esri-leaflet-renderers": "^3.0.0",
-        "esri-leaflet-vector": "^4.0.1",
+        "esri-leaflet-vector": "^4.1.0",
         "extract-files": "^13.0.0",
         "geojson": "^0.5.0",
         "graphql": "^16",
@@ -18699,9 +18699,9 @@
       }
     },
     "node_modules/esri-leaflet-vector": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/esri-leaflet-vector/-/esri-leaflet-vector-4.0.2.tgz",
-      "integrity": "sha512-dP3daznKobK2uS5w5E5DPHQ1DWlacJeM4+Df7jkvC8ijjluBe+ARigAWK7p/xtH95gf21p83Ts++dS/2QDQSPA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/esri-leaflet-vector/-/esri-leaflet-vector-4.1.0.tgz",
+      "integrity": "sha512-yOK0wEVG/3qC18yPtEtdqx3mWM/onFbHBG5g/+GIDanalr3/ny4DSQPrno73cyBpZT9xLyKzDjX0gB7CxlbcAg==",
       "peerDependencies": {
         "esri-leaflet": ">2.3.0",
         "leaflet": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "esri-leaflet-geocoder": "^3.1.4",
     "esri-leaflet-heatmap": "^2.0.1",
     "esri-leaflet-renderers": "^3.0.0",
-    "esri-leaflet-vector": "^4.0.1",
+    "esri-leaflet-vector": "^4.1.0",
     "extract-files": "^13.0.0",
     "geojson": "^0.5.0",
     "graphql": "^16",


### PR DESCRIPTION
fix: not trigger map layers or basemaps update when clearing basemap or webmap form field if no value is currently set there fix: catch buggy tile vector layers until find out buggy layers source problem

# Description

It looks like there is some buggy behavior because of one of the basemap layers of the WHO maps "does not exist" even if can be loaded from the arcGIS map viewer(no access to item details there) because of the style content url is relative to the WHO maps content.

This PR would avoid to try to load buggy style content layers if so and avoid breaking any layer flow behavior if user selects a buggy webmap previouslye

## Ticket

[Link to ticket 1](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/65126/)
[Link to ticket 2](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/65169/)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to screenshots below

## Sreenshots

Relative url for arcGIS online (we cannot manage this, we need absolute urls from where fetch data)
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/7a9ecea9-0db7-4920-bdc9-040b74a0e34f)

And if trying to fetch it with the item id, we cannot because it does not exist:https://who.maps.arcgis.com/home/item.html?id=b047fc319898445287111763e4fcf300

With the buggy try-catch firewall:
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/ab6bb3e8-7652-4b21-829e-2957a713446b)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
