### PR TITLE
bugfix/AB#65781_DB-layer-configuration-with-latitude-and-longitude

### DIFF
--- a/libs/safe/src/lib/components/ui/map/layer.ts
+++ b/libs/safe/src/lib/components/ui/map/layer.ts
@@ -284,7 +284,20 @@ export class Layer implements LayerModel {
     this.name = get(options, 'name', '');
     this.type = get<LayerType>(options, 'type', 'FeatureLayer');
     this.opacity = get(options, 'opacity', 1);
-
+    // Cast all coordinates to number type as the used layouts for map settings could come from a text input
+    if (options.geojson) {
+      const mappedFeatures = options.geojson.features.map((feature: any) => ({
+        ...feature,
+        geometry: {
+          ...feature.geometry,
+          coordinates: feature.geometry.coordinates.map((coordinate: any) => {
+            const numberCoord = Number(coordinate);
+            return !Number.isNaN(numberCoord) ? numberCoord : 0;
+          }),
+        },
+      }));
+      options.geojson.features = mappedFeatures;
+    }
     if (options.type !== 'group') {
       // Not group layer, add other properties
       this.datasource = get(options, 'datasource', null);


### PR DESCRIPTION
fix: cast coordinates to number in order to correctly load them using esri

# Description

### ⚠️ **DOUBLE CHECK** ⚠️ 

This PR would fix any issue from the front on loading layouts from a resource containing fields from a input type that is not a number, which is needed to correctly load layers with esri API.

The problem is that backend retrieves latitude and longitude fields switched as seen in the images below.

Resource with explicitly set `Latitude` and `Longitude` fields
![layout resource](https://github.com/ReliefApplications/oort-frontend/assets/123092672/1aaba700-37db-4d11-bd9d-d43890933f6c)

If you load the layer with `Longitude` in longitude and `Latitude` in latitude, back send them back switched from the original position as seen here:
![wrong resource](https://github.com/ReliefApplications/oort-frontend/assets/123092672/56b56964-e6e8-44e1-b007-714cbf34b573)

If you switch them, the layer is correctly loaded:
![right resource](https://github.com/ReliefApplications/oort-frontend/assets/123092672/52e2ebdd-b906-4c51-96bf-602891edcd04)

And here are the layer request
`Longitude` in longitude and `Latitude` in latitude:
![wrong request](https://github.com/ReliefApplications/oort-frontend/assets/123092672/b462be22-e07f-4273-a53e-74b796b85a59)

Longitude` in latitude and `Latitude` in longitude
![right request](https://github.com/ReliefApplications/oort-frontend/assets/123092672/cc2603b6-7b7e-48f7-896d-c7fad64274a5)


## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/65781)

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please refer to screenshots below

## Sreenshots

Resource:
![layout resource](https://github.com/ReliefApplications/oort-frontend/assets/123092672/fc53127c-34fc-4ca2-94f8-82e2116d7c88)
Loaded laye
![right resource](https://github.com/ReliefApplications/oort-frontend/assets/123092672/cb88506b-0119-4807-ab69-6c03589c97bf)
r:



# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
