### PR TITLE
fix/OORT-643-resource-type-questions-breaking-schema

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -626,6 +626,7 @@
 		},
 		"formBuilder": {
 			"errors": {
+				"duplicatedRelatedName": "Duplicated related name for question {{question}} on page {{page}}. Please provide a unique related name (snake case format) to save the form.",
 				"missingGridField": "Missing an available field grid for question {{question}} on page {{page}}. Please select a least one in Custom Question Properties to save the form.",
 				"missingRelatedName": "Missing related name for question {{question}} on page {{page}}. Please provide a valid data value name (snake case format) to save the form.",
 				"missingTemplate": "Missing related resource template for question {{question}} on page {{page}}. Please select a template to save the form."

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -631,6 +631,7 @@
 		},
 		"formBuilder": {
 			"errors": {
+				"duplicatedRelatedName": "Nom lié en double pour la question {{question}} à la page {{page}}. Veuillez fournir un nom lié unique (au format snake_case) pour sauvegarder le formulaire.",
 				"missingGridField": "Champs disponible de table de données manquant pour la question {{question}} à la page {{page}}. Veuillez en sélectionner au moins un dans la propriété Custom Question pour sauvegarder le formulaire.",
 				"missingRelatedName": "Nom lié manquant pour la question {{question}} à la page {{page}}. Veuillez entrer un nom valide pour la valeur de la donnée (au format snake_case) pour sauvegarder le formulaire.",
 				"missingTemplate": "Ressource liée manquante pour la question {{question}} à la page {{page}}. Veuillez sélectionner un modèle pour sauvegarder le formulaire."

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -626,6 +626,7 @@
 		},
 		"formBuilder": {
 			"errors": {
+				"duplicatedRelatedName": "****** {{question}} ****** {{page}} ******",
 				"missingGridField": "****** {{question}} ****** {{page}} ******",
 				"missingRelatedName": "****** {{question}} ****** {{page}} ******",
 				"missingTemplate": "****** {{question}} ****** {{page}} ******"

--- a/libs/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -94,6 +94,8 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
   surveyCreator!: SurveyCreator.SurveyCreator;
   public json: any;
 
+  private relatedNames!: string[];
+
   /**
    * The constructor function is a special function that is called when a new instance of the class is
    * created.
@@ -376,6 +378,7 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
    * Makes sure that value names are existent and snake case, to not cause backend problems.
    */
   private async validateValueNames(): Promise<void> {
+    this.relatedNames = [];
     const survey = new Survey.SurveyModel(this.surveyCreator.JSON);
     survey.pages.forEach((page: Survey.PageModel) => {
       page.questions.forEach((question: Survey.Question) =>
@@ -516,6 +519,19 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
     if (['resource', 'resources'].includes(question.getType())) {
       if (question.relatedName) {
         question.relatedName = this.toSnakeCase(question.relatedName);
+        if (this.relatedNames.includes(question.relatedName)) {
+          throw new Error(
+            this.translate.instant(
+              'components.formBuilder.errors.duplicatedRelatedName',
+              {
+                question: question.name,
+                page: page.name,
+              }
+            )
+          );
+        } else {
+          this.relatedNames.push(question.relatedName);
+        }
       } else {
         throw new Error(
           this.translate.instant(


### PR DESCRIPTION
# Description
Duplicated related name in resource/resources question messed up the schema generation and breaks all widgets that uses it on the applications, so:

Added a check to prevent users from creating resouce/resources questions with duplicated related_name.
Also checked that the editForm mutation in the backend already prevents questions in different forms from having the same related_name if using the same resource (the same name with diferent resources and in diferent forms doesn't give any problem).

## Ticket
[OORT-643: Resource type questions breaking schema](https://oortcloud.atlassian.net/browse/OORT-643)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Testing the problem by creating resources questions with the same related name, and then adding the check that disallows this and seeing the problem go away from the widgets that used this form.

## Sreenshots
![rn1](https://github.com/ReliefApplications/oort-frontend/assets/28535394/a0313ada-b650-4881-a90a-5a61f7968e0e)
![rn2](https://github.com/ReliefApplications/oort-frontend/assets/28535394/7f6e54d1-6e34-4d3c-afde-39c4383656e6)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
