### PR TITLE
Bugfix/ab#65516 db style applied in the text widget editor is not getting reflected on widget

### DIFF
--- a/libs/safe/src/lib/components/widgets/editor/editor.component.html
+++ b/libs/safe/src/lib/components/widgets/editor/editor.component.html
@@ -4,5 +4,8 @@
       settings.title
     }}</span>
   </kendo-tilelayout-item-header>
-  <div class="overflow-auto py-2 px-3" [innerHtml]="safeHtml"></div>
+  <div
+    class="overflow-auto no-tailwindcss-base py-2 px-3"
+    [innerHtml]="safeHtml"
+  ></div>
 </div>

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
@@ -1,6 +1,6 @@
 <div class="html-content" (click)="onClick($event)">
   <div
-    class="w-fit h-fit"
+    class="w-fit h-fit no-tailwindcss-base"
     [innerHTML]="formattedHtml"
     [style]="cardStyle"
   >

--- a/libs/safe/src/lib/style/styles.scss
+++ b/libs/safe/src/lib/style/styles.scss
@@ -727,6 +727,28 @@ mat-tab-group[vertical] {
 
 // Define new colors
 @layer base {
+  // Revert all default changes of base layer in this custom class
+  // https://tailwindcss.com/docs/preflight
+  .no-tailwindcss-base,
+  .no-tailwindcss-base *,
+  .no-tailwindcss-base > * {
+    font-size: revert;
+    font-weight: revert;
+    margin: revert;
+    display: revert;
+    vertical-align: revert;
+    max-width: revert;
+    height: revert;
+    border-width: revert;
+    border-style: revert;
+    border-color: revert;
+    border-style: revert;
+    outline: revert;
+    list-style: revert;
+    padding: revert;
+    color: revert;
+    text-decoration: revert;
+  }
   :root {
     --primary-50: #{$primary_50};
     --primary-100: #{$primary_100};


### PR DESCRIPTION
# Description

feat: add custom class to revert all tailwind base layer changes if needed
feat: update text and summary card widget text editor displayers with the new custom class aforementioned

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/65516)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please refer to screenshots below

## Sreenshots

Summary card widget text
![summary format](https://github.com/ReliefApplications/oort-frontend/assets/123092672/2191fba7-3d32-445c-8496-8a6033c5c890)

Text widget text
![text format](https://github.com/ReliefApplications/oort-frontend/assets/123092672/b777c2de-3cee-4cc4-8c48-f1733f5d8f26)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
