### PR TITLE
fix/OORT-645-read-only-resource-questions

### DIFF
--- a/libs/safe/src/lib/survey/components/resource.ts
+++ b/libs/safe/src/lib/survey/components/resource.ts
@@ -636,7 +636,9 @@ export const init = (
         });
         question.registerFunctionOnPropertyValueChanged('addRecord', () => {
           addBtn.style.display =
-            question.addRecord && question.addTemplate ? '' : 'none';
+            question.addRecord && question.addTemplate && !question.isReadOnly
+              ? ''
+              : 'none';
         });
       }
     },

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -820,7 +820,11 @@ export const init = (
             );
             question.registerFunctionOnPropertyValueChanged('addRecord', () => {
               addBtn.style.display =
-                question.addRecord && question.addTemplate ? '' : 'none';
+                question.addRecord &&
+                question.addTemplate &&
+                !question.isReadOnly
+                  ? ''
+                  : 'none';
             });
           }
         }

--- a/libs/safe/src/lib/survey/components/utils.ts
+++ b/libs/safe/src/lib/survey/components/utils.ts
@@ -76,7 +76,7 @@ export const buildAddButton = (
     'oort:addNewRecord',
     question.survey.locale
   );
-  if (question.addRecord && question.addTemplate) {
+  if (question.addRecord && question.addTemplate && !question.isReadOnly) {
     addButton.onclick = async () => {
       const { SafeResourceModalComponent } = await import(
         '../../components/resource-modal/resource-modal.component'
@@ -136,6 +136,14 @@ export const buildAddButton = (
     };
   }
   addButton.style.display =
-    question.addRecord && question.addTemplate ? '' : 'none';
+    question.addRecord && question.addTemplate && !question.isReadOnly
+      ? ''
+      : 'none';
+  question.registerFunctionOnPropertyValueChanged(
+    'readOnly',
+    (value: boolean) => {
+      addButton.style.display = value ? 'none' : '';
+    }
+  );
   return addButton;
 };


### PR DESCRIPTION
# Description
we don't want the user to add records in resource/resources questions if we set it as read-only, so corrected the logic that add the "add new record" button and listen to the "read-only" propriety updates.

## Ticket
[OORT-645: Bug on read only resource questions]([url](https://oortcloud.atlassian.net/browse/OORT-645))

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Changing the  "read-only" propriety of resource/resources questions with the "add new record" selected to make sure that everything works as expected.

## Sreenshots
![ro](https://github.com/ReliefApplications/oort-frontend/assets/28535394/50556417-745c-426c-9fc5-27b1a57dbee5)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
