### PR TITLE
fix/AB#66301-display-of-select-label

### DIFF
--- a/libs/ui/src/lib/select-menu/components/select-option.component.ts
+++ b/libs/ui/src/lib/select-menu/components/select-option.component.ts
@@ -6,8 +6,8 @@ import {
   ContentChildren,
   forwardRef,
   QueryList,
-  AfterViewInit,
   ElementRef,
+  AfterContentInit,
 } from '@angular/core';
 
 /**
@@ -18,7 +18,7 @@ import {
   templateUrl: './select-option.component.html',
   styleUrls: ['./select-option.component.scss'],
 })
-export class SelectOptionComponent implements AfterViewInit {
+export class SelectOptionComponent implements AfterContentInit {
   @Input() value!: any;
   @Input() selected = false;
   @Input() isGroup = false;
@@ -38,8 +38,7 @@ export class SelectOptionComponent implements AfterViewInit {
    */
   constructor(private el: ElementRef) {}
 
-  ngAfterViewInit(): void {
-    // Set the text content of each option
+  ngAfterContentInit(): void {
     this.label =
       this.el.nativeElement.querySelector('span').firstChild.textContent;
   }


### PR DESCRIPTION
# Description
In some cases, the label of select menu is incorrect, the id was displayed instead of the label because of the angular lifecycle hooks in the select-option component

## Ticket
[AB#66301 - ABC - Display of select label](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66301)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Changing the
## Sreenshots
![image](https://github.com/ReliefApplications/oort-frontend/assets/28535394/09159fe7-d089-4f85-a8e8-ce3f091d40a3)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
