### PR TITLE
Some changes for zoom control css

### DIFF
--- a/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.html
+++ b/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.html
@@ -1,28 +1,28 @@
 <!-- Component wrapper -->
 <div class="relative flex flex-col items-center">
   <button
-    class="w-6 h-6 top-1 relative flex items-center justify-center bg-white rounded-md border-2 border-solid border-black border-opacity-20"
+    class="w-6 h-6 relative flex items-center justify-center bg-white rounded-md border-2 border-solid border-black border-opacity-20"
     (click)="zoomIn()"
   >
     <span class="font-bold">+</span>
   </button>
   <!-- Actual input range -->
-  <input
-    name="slider"
-    style="--value:{{ currentZoom }}; --min:{{ minZoom }}; --max:{{
-      maxZoom
-    }}"
-    class="h-full w-1"
-    type="range"
-    min="{{ minZoom }}"
-    max="{{ maxZoom }}"
-    value="{{ currentZoom }}"
-    step="1"
-    orient="vertical"
-    (input)="onChangeFunction($event.target)"
-  />
+  <div class="h-24 w-6 flex items-center justify-center">
+    <input
+      name="slider"
+      style="--value:{{ currentZoom }}; --min:{{ minZoom }}; --max:{{
+        maxZoom
+      }}"
+      type="range"
+      min="{{ minZoom }}"
+      max="{{ maxZoom }}"
+      value="{{ currentZoom }}"
+      step="1"
+      (input)="onChangeFunction($event.target)"
+    />
+  </div>
   <button
-    class="w-6 h-6 bottom-1 relative flex items-center justify-center bg-white rounded-md border-2 border-solid border-black border-opacity-20"
+    class="w-6 h-6 relative flex items-center justify-center bg-white rounded-md border-2 border-solid border-black border-opacity-20"
     (click)="zoomOut()"
   >
     <span class="font-bold">-</span>

--- a/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.scss
+++ b/libs/safe/src/lib/components/ui/map/map-zoom/map-zoom.component.scss
@@ -1,26 +1,31 @@
+input[type='range'] {
+  -webkit-appearance: none;
+  width: 96px !important;
+  min-width: 96px !important;
+  max-width: 96px !important;
+  height: 4px;
+  transform: rotate(270deg);
+  transform-origin: center;
 
-
-input[type=range][orient=vertical]
-{
-    writing-mode: bt-lr !important; /* IE */
-    -webkit-appearance: slider-vertical !important; /* Chromium */
 }
 
 /** Chrome*/
 @media screen and (-webkit-min-device-pixel-ratio:0) {
   input[type='range'] {
     overflow: hidden;
-    accent-color: theme('colors.primary.500');
+    // accent-color: theme('colors.primary.500');
   }
 
   input[type=range]::-webkit-slider-runnable-track {
+    -webkit-appearance: none;
     background-color: #CCCCCC;
-    border: 0.2px solid #CCCCCC;
   }
 
   input[type='range']::-webkit-slider-thumb {
-    background: theme('colors.primary.500');
-    box-shadow: -10px 80px 0 80px theme('colors.primary.500');
+    -webkit-appearance: none;
+    width: 0px;
+    height: 4px;
+    box-shadow: -80px 0 0 80px theme('colors.primary.500');
   }
 }
 
@@ -34,8 +39,7 @@ input[type="range"]::-moz-range-track {
   border: 0.2px solid #CCCCCC;
 }
 input[type=range]::-moz-range-thumb {
-  background: theme('colors.primary.500');
-  border: 0.2px solid theme('colors.primary.500');
+  opacity: 0;
 }
 
 /* Internet explorer*/
@@ -48,6 +52,5 @@ input[type="range"]::-ms-fill-upper {
   border: 0.2px solid #CCCCCC;
 }
 input[type=range]::-ms-thumb {
-  background: theme('colors.primary.500');
-  border: 0.2px solid theme('colors.primary.500');
+  opacity: 0;
 }


### PR DESCRIPTION
# Description

Some style changes have been made to fix a bug with the custom zoom control where the colored part was always visible, even if the map was totally zoomed out. 

The issue was being caused by having the thumb of the range colored, this was done to match the 'filled' part of the control. This was done on an effort of consistency, having the range vertical was impeding to customize the thumb on chrome further than changing its color.

The fix consisted on updating the control to be horizontal (default state) and style it again to have the same style as before, hiding the thumb.
To replicate the vertical horientation we make use of the transform rotate property. 

## Ticket

[66155 DB-Without applying zoom in on map, able to see zoom section as it is applied zoom in](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66155)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Controller tested on firefox based browser
- [x] Controller tested on chrome based browser

## Screenshots

Firefox browser:
![Screenshot from 2023-06-12 15-43-33](https://github.com/ReliefApplications/oort-frontend/assets/94831019/d39a6554-15ed-400d-8ba0-0428b78bf249)
![Screenshot from 2023-06-12 15-43-45](https://github.com/ReliefApplications/oort-frontend/assets/94831019/f89bd375-5ba6-4fcb-8fc0-3d299527f380)

Chrome browser:
![Screenshot from 2023-06-12 15-56-58](https://github.com/ReliefApplications/oort-frontend/assets/94831019/9d1a3328-7711-4049-a9a4-7e9d3c69dce4)
![Screenshot from 2023-06-12 15-57-05](https://github.com/ReliefApplications/oort-frontend/assets/94831019/6d0ade70-2cea-4803-9c79-58127aea290b)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
