### PR TITLE
Fix/ab#66298 fields chart styling

### DIFF
--- a/libs/safe/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.html
+++ b/libs/safe/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.html
@@ -1,11 +1,11 @@
 <div [formGroup]="formGroup" class="flex flex-col last:mb-0">
   <h2>{{ 'common.general' | translate }}</h2>
-  <div uiFormFieldDirective>
+  <div uiFormFieldDirective class="w-[99%]">
     <label>{{ 'common.title' | translate }}</label>
     <input formControlName="title" type="string" />
   </div>
   <ng-container formGroupName="chart">
-    <div uiFormFieldDirective>
+    <div uiFormFieldDirective class="w-[99%]">
       <label>{{ 'components.widget.settings.chart.type' | translate }}</label>
       <ng-template #chartTemplate let-type>
         <img class="chart-icon" [src]="type?.icon" />{{
@@ -28,7 +28,7 @@
       </ui-select-menu>
     </div>
   </ng-container>
-  <div uiFormFieldDirective>
+  <div uiFormFieldDirective class="w-[99%]">
     <label>{{ 'common.resource.one' | translate }}</label>
     <ui-graphql-select
       valueField="id"


### PR DESCRIPTION
# Description

Fixes an issue where the right border of the fields were cut off on Firefox

![image](https://github.com/ReliefApplications/oort-frontend/assets/103029022/3f827a6c-f4af-457f-8fb4-3b49bf5c0ef3)

Sets the width to 99% which is a bit ugly but works

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66298

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested on Firefox and Chrome

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/103029022/dbf96208-b375-4a3b-805e-debed0e393f3)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
