### PR TITLE
bug: Incorrect select behavior when unselecting items

### DIFF
--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -236,10 +236,10 @@ export class SelectMenuComponent
         } else if (labelValues.length >= 1) {
           this.displayTrigger =
             labelValues[0] + ' (+' + (labelValues.length - 1) + ' others)';
-        } else {
-          this.displayTrigger = '';
         }
       }
+    } else {
+      this.displayTrigger = '';
     }
   }
 


### PR DESCRIPTION
# Description

I remove the display name of the multi-select input when no value is selected

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66292/

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The last selected value was still in the input display before, its empty now in this case

## Sreenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/9751045/0133862e-274c-440e-bc64-c0ec98144bf1)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
