### PR TITLE
fix/AB#66660-set-default-width-to-select

### DIFF
--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -156,6 +156,8 @@ export class SelectMenuComponent
         },
       });
     }
+    // Add default width to select menu to avoid visual issues when select being totally empty
+    this.renderer.addClass(this.el.nativeElement, 'min-w-[100px]');
   }
 
   /**


### PR DESCRIPTION
# Description
Add default width to select menu to avoid visual issues when select being totally empty

## Ticket
[AB#66660 - ABC - Set default width to all select](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66660)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
See screenshots below

## Sreenshots
![image](https://github.com/ReliefApplications/oort-frontend/assets/28535394/1089cbb3-7263-4c1d-9196-141bc8447064)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
