### PR TITLE
feat 2.0.x / AB#66710 Incorrect styling for date pickers

### DIFF
--- a/libs/safe/src/lib/components/record-history/record-history.component.ts
+++ b/libs/safe/src/lib/components/record-history/record-history.component.ts
@@ -290,6 +290,7 @@ export class SafeRecordHistoryComponent
     // empty => 'All fields' selected
     // other => Field name for filter
     if (fields) this.filterFields = fields;
+    if (!fields) this.filterFields = [];
 
     const startDate = this.filtersDate.get('startDate')?.value
       ? new Date(this.filtersDate.get('startDate')?.value as any)

--- a/libs/ui/src/lib/date/date-picker.directive.ts
+++ b/libs/ui/src/lib/date/date-picker.directive.ts
@@ -36,14 +36,14 @@ export class DatePickerDirective implements OnInit, OnDestroy {
   private inputClasses = [
     'peer',
     'block',
-    'min-h-[auto]',
+    'min-h-[32px]',
     'min-w-[200px]',
     'w-full',
     'rounded',
     'border-0',
     'bg-transparent',
     'px-2',
-    'py-[0.32rem]',
+    'placeholder-transparent',
     'leading-[1.6]',
     'outline-none',
     'transition-all',
@@ -59,6 +59,8 @@ export class DatePickerDirective implements OnInit, OnDestroy {
     'absolute',
     'left-2',
     'bg-white',
+    'my-[2px]',
+    'mr-[5px]',
     'top-0',
     'right-0',
     'bottom-0',
@@ -80,6 +82,24 @@ export class DatePickerDirective implements OnInit, OnDestroy {
     'right-0.5',
     'top-1/2',
     '-translate-y-1/2',
+  ] as const;
+
+  private divClasses = [
+    'relative',
+    'focus-within:ring-2',
+    'focus-within:ring-inset',
+    'focus-within:ring-primary-600',
+    'shadow-sm',
+    'rounded-md',
+    'border-0',
+    'ring-1',
+    'ring-inset',
+    'ring-gray-300',
+    'pl-2',
+    'flex',
+    'items-center',
+    'w-full',
+    'py-0.5',
   ] as const;
 
   /**
@@ -158,9 +178,10 @@ export class DatePickerDirective implements OnInit, OnDestroy {
     });
 
     const inputWrapper = this.renderer.createElement('div');
-    this.renderer.addClass(inputWrapper, 'relative');
-    this.renderer.addClass(inputWrapper, 'border');
-    this.renderer.addClass(inputWrapper, 'rounded');
+
+    this.divClasses.forEach((iClass) => {
+      this.renderer.addClass(inputWrapper, iClass);
+    });
 
     this.renderer.appendChild(
       this.el.nativeElement.parentElement,

--- a/libs/ui/src/lib/date/date-picker.directive.ts
+++ b/libs/ui/src/lib/date/date-picker.directive.ts
@@ -43,15 +43,8 @@ export class DatePickerDirective implements OnInit, OnDestroy {
     'border-0',
     'bg-transparent',
     'px-2',
-    'placeholder-transparent',
     'leading-[1.6]',
     'outline-none',
-    'transition-all',
-    'duration-200',
-    'ease-linear',
-    'focus:placeholder:opacity-100',
-    'peer-focus:text-primary',
-    'motion-reduce:transition-none',
   ] as const;
 
   private labelClasses = [


### PR DESCRIPTION
# Description

The date picker range had a basic styling which didn't correspond with the rest of input styling on the filter.
The solution consisted on updating the date picker directive to use the same tailwind classes for the inputs as the rest of the inputs.

## Ticket

[66710 ABC - Incorrect styling of date pickers
](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66710/)

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Tested the new date range on all the main page filters

## Screenshots

![Screenshot from 2023-06-14 16-43-16](https://github.com/ReliefApplications/oort-frontend/assets/94831019/aefc3cbe-6b3c-4027-9acf-aa1245fe7bab)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
