### PR TITLE
AB#2366916 grid-buttons-not-visible

### DIFF
--- a/libs/safe/src/lib/components/widgets/grid/grid.component.html
+++ b/libs/safe/src/lib/components/widgets/grid/grid.component.html
@@ -64,7 +64,7 @@
 
 <!-- Quick action buttons -->
 <ng-template #floatingButtonsTemplate>
-  <div>
+  <div class="flex">
     <ng-container *ngFor="let floatingButton of settings.floatingButtons">
       <ui-button
         variant="primary"


### PR DESCRIPTION
# Description

The custom action buttons on the grid widget weren't fully shown if more that one was present.
The solution consisted on adding a flex class to their container.

## Ticket

[AB#2366916 grid-buttons-not-visible
](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66916/)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
![Screenshot from 2023-06-15 15-30-06]


- [x] Creating multiple buttons and using them on the grid

## Screenshots

(https://github.com/ReliefApplications/oort-frontend/assets/94831019/e9cd7fe3-5925-4481-9b4b-a52fde3c7986)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
