### PR TITLE
fix/AB#66730-incorrect-auto-modify-display-in-grid

### DIFF
--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -128,6 +128,14 @@
                   >{{ field.name }}</ui-select-option
                 >
               </ui-select-menu>
+              <ui-button
+                uiSuffix
+                [isIcon]="true"
+                icon="remove_circle_outline"
+                variant="danger"
+                (click)="onDeleteModification(i)"
+              >
+              </ui-button>
             </div>
             <div *ngIf="modification.value.field" uiFormFieldDirective>
               <label>{{
@@ -164,14 +172,6 @@
                 <input formControlName="value" type="string" />
               </ng-container>
             </div>
-
-            <ui-button
-              [isIcon]="true"
-              icon="remove_circle_outline"
-              variant="danger"
-              (click)="onDeleteModification(i)"
-            >
-            </ui-button>
           </form>
           <ui-button
             [isIcon]="true"

--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.module.ts
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { ButtonConfigComponent } from './button-config.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { IconModule, SelectMenuModule, TabsModule } from '@oort-front/ui';
 import { SafeQueryBuilderModule } from '../../../query-builder/query-builder.module';
 import {
   CheckboxModule,
@@ -12,6 +11,9 @@ import {
   ButtonModule,
   FormWrapperModule,
   ErrorMessageModule,
+  IconModule,
+  SelectMenuModule,
+  TabsModule,
 } from '@oort-front/ui';
 
 /**

--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -29,6 +29,7 @@ import {
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { DOCUMENT } from '@angular/common';
+import { isEqual } from 'lodash';
 
 /**
  * UI Select Menu component
@@ -148,7 +149,7 @@ export class SelectMenuComponent
       this.control.valueChanges?.pipe(takeUntil(this.destroy$)).subscribe({
         next: (value) => {
           // If the value is cleared from outside, reset displayed values
-          if (!value || !value.length) {
+          if (this.multiselect ? !value || !value.length : !value) {
             this.selectedValues = [];
             this.optionList.forEach((option) => (option.selected = false));
             this.setDisplayTriggerText();
@@ -289,6 +290,10 @@ export class SelectMenuComponent
     let values = this.optionList.filter((val: any) => {
       if (selectedValues.includes(val.value)) {
         return val;
+      } else if (typeof val.value === 'object') {
+        return selectedValues.find((selected: any) => {
+          return isEqual(val.value, selected);
+        });
       }
     });
     return (values = values.map((val: any) => {


### PR DESCRIPTION
# Description
SelectMenuComponent was incorrect clearing the displayed labels of single-select menus when the control value changed, and the getValuesLabel didn't always find all the selected values if the value was an object.

## Ticket
[AB#66730 - ABC - Incorrect auto modify display in grid button settings](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66730)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Changing the fields and values input and seeing the expected behavior.

## Sreenshots
![image](https://github.com/ReliefApplications/oort-frontend/assets/28535394/7746eeb3-fcde-4668-b169-e5c50c582f64)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
