### PR TITLE
fix/AB#66940-side-menu-on-app-preview

### DIFF
--- a/apps/back-office/src/app/app-preview/app-preview.component.html
+++ b/apps/back-office/src/app/app-preview/app-preview.component.html
@@ -2,11 +2,16 @@
   [title]="title"
   [leftSidenav]="leftSidenav"
   [toolbar]="toolbar"
+  [sideMenu]="sideMenu"
 ></safe-layout>
 <ng-template #toolbar>
   <app-preview-toolbar></app-preview-toolbar>
 </ng-template>
 <!--Need the nav variable, don't remove let-nav, used in layout-->
 <ng-template #leftSidenav let-nav>
-  <safe-navbar [nav]="nav" [navGroups]="navGroups"></safe-navbar>
+  <safe-navbar
+    [nav]="nav"
+    [navGroups]="navGroups"
+    [vertical]="!(!sideMenu && largeDevice)"
+  ></safe-navbar>
 </ng-template>

--- a/apps/back-office/src/app/app-preview/app-preview.component.ts
+++ b/apps/back-office/src/app/app-preview/app-preview.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AbilityBuilder } from '@casl/ability';
 import { TranslateService } from '@ngx-translate/core';
@@ -82,7 +82,14 @@ export class AppPreviewComponent
    * Role to preview with.
    */
   public role = '';
-
+  /**
+   * Use side menu or not.
+   */
+  public sideMenu = false;
+  /**
+   * Is large device.
+   */
+  public largeDevice: boolean;
   /**
    * Main component of Application preview capacity.
    *
@@ -100,6 +107,17 @@ export class AppPreviewComponent
     private translate: TranslateService
   ) {
     super();
+    this.largeDevice = window.innerWidth > 1024;
+  }
+
+  /**
+   * Change the display depending on windows size.
+   *
+   * @param event Event that implies a change in window size
+   */
+  @HostListener('window:resize', ['$event'])
+  onResize(event: any): void {
+    this.largeDevice = event.target.innerWidth > 1024;
   }
 
   /**
@@ -121,6 +139,7 @@ export class AppPreviewComponent
           this.title = application.name + ' (Preview)';
           const ability = getAbilityForAppPreview(application, this.role);
           const adminNavItems: any[] = [];
+          this.sideMenu = application?.sideMenu ?? false;
           if (ability.can('read', 'User')) {
             adminNavItems.push({
               name: this.translate.instant('common.user.few'),


### PR DESCRIPTION
# Description
App preview component didn't check if it should hide the left side menu in the application's info.

## Ticket
[AB#66940 - ABC - Side menu on app preview](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66940)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Unchecking the "side menu" option in the application settings, and going to the application preview.

## Sreenshots
![image](https://github.com/ReliefApplications/oort-frontend/assets/28535394/756174af-5ac5-40e9-94bb-489fc9c98434)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
