### PR TITLE
Bugfix/ab#67042 abc map settings update issue

### DIFF
--- a/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
@@ -172,6 +172,13 @@ export class EditLayerModalComponent
         this.setIsDatasourceValid(value);
       });
     if (this.data.mapComponent) {
+      const encapsulatedSettings =
+        this.data.mapComponent.mapSettingsWithoutLayers;
+      // Reset the current map view in order to only see the layer on edition
+      this.data.mapComponent.mapSettings = {
+        ...encapsulatedSettings.settings,
+        layers: [],
+      };
       this.currentZoom = this.data.mapComponent.map.getZoom();
       this.setUpLayer();
     }

--- a/libs/safe/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.html
@@ -4,7 +4,6 @@
     'components.widget.settings.map.properties.webmap' | translate
   }}</label>
   <ui-select-menu
-    (selectedOption)="selectionOnChange($event)"
     (opened)="onOpenSelect()"
     [formControl]="ngControl && $any(ngControl.control)"
     [value]="value"
@@ -19,7 +18,7 @@
   <!-- Remove value -->
   <ui-button
     uiSuffix
-    (click)="selectionOnChange({ value: null }); $event.stopPropagation()"
+    (click)="selectionOnChange(null); $event.stopPropagation()"
     [isIcon]="true"
     icon="close"
     variant="danger"

--- a/libs/safe/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.ts
@@ -101,11 +101,10 @@ export class WebmapSelectComponent
    */
   public selectionOnChange(e: any) {
     // If no value is set into no this.value return
-    if (!e && !this.value) {
+    if (!e && !this.ngControl?.control?.value) {
       return;
     }
-    this.value = e;
-    this.onChanged(this.value);
+    this.onChanged(e);
   }
 
   /**

--- a/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -161,6 +161,14 @@ export class SafeMapSettingsComponent
           arcGisWebMap: value,
         } as MapConstructorSettings)
       );
+    this.tileForm
+      .get('layers')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((value) =>
+        this.updateMapSettings({
+          layers: value,
+        } as MapConstructorSettings)
+      );
   }
 
   /**
@@ -205,7 +213,6 @@ export class SafeMapSettingsComponent
       this.mapSettings = settings;
     }
     if (this.mapComponent) {
-      // Supposed to trigger changes on the map, but nothing happens
       this.mapComponent.mapSettings = this.mapSettings;
     }
   }

--- a/libs/ui/src/lib/slider/slider.component.ts
+++ b/libs/ui/src/lib/slider/slider.component.ts
@@ -146,8 +146,9 @@ export class SliderComponent
    * @param value The value from the slider
    */
   onChangeFunction(value: EventTarget | null) {
-    if (value) {
-      this.currentValue = +((value as HTMLInputElement)?.value ?? value);
+    const newValue = +((value as HTMLInputElement)?.value ?? value);
+    if (newValue !== this.currentValue) {
+      this.currentValue = isNaN(newValue) ? 0 : newValue;
       const min = this.minValue;
       const max = this.maxValue;
       const newVal = Number(((this.currentValue - min) * 100) / (max - min));


### PR DESCRIPTION
# Description

bugfix/[AB#67042](https://dev.azure.com/WHOHQ/2888b816-2d79-49ef-a86e-561e6cd456a0/_workitems/edit/67042)_ABC-map-settings-update-issue
fix: fix mapSettings update in map component when setting them directly and not template binded using a setter and replacing the ngonchanges hook
feat: add layer form control value changes subscription in order to update map layers on layer action(edit, add, delete)
fix: layer list table update on delete
fix: double value changes event on changing webmap, basemap and zoom, as the ui elements already handle any value set for the given control(no need of additional methods such as onSelectionChange)
feat: layer editor view for only current layer when creating or editing a new one

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67042)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please refer to screenshots below

## Sreenshots

Map settings updates on change:
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/dc379f77-b026-4a7d-9526-85e452c94b6d)
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/7e263b8d-95f0-48b9-bf01-02068b4acb35)
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/ad9449c6-a4cd-46c6-a417-191e2d5410fa)

Layers are set:
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/4650b6e6-4a22-48ec-bd4e-a6878cb9298f)
Layer updates set
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/99a46887-856e-446d-b9e0-abd44c8b8e6b)

Single layer view on edit:
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/7a76f89b-4f7a-4b02-8fee-c8785fa0508d)

All layers set in settings:
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/db8e9c4e-747e-4b0d-92e4-79ec4f40d98f)

On delete layer, layer table and map correctly updated:
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/5f2b7587-9d51-459a-a01b-7a7ed0471466)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
