### PR TITLE
bugfix/AB#66900_ABC-unable-to-drag-the-scroll-bar-to-the-bottom-on-expression-list

### DIFF
--- a/libs/safe/src/lib/components/editor-control/editor-control.component.ts
+++ b/libs/safe/src/lib/components/editor-control/editor-control.component.ts
@@ -202,10 +202,19 @@ export class SafeEditorControlComponent
         );
         // If autocomplete list in the DOM, trigger scrolling events
         if (collectionGroup) {
-          this.editorService.initScrollActive(
-            collectionGroup,
-            e.editor.getElement()
-          );
+          if (!this.editorService.activeItemScrollListener) {
+            // Initialize listener
+            this.editorService.initScrollActive(
+              collectionGroup,
+              e.editor.getElement()
+            );
+            // Execute directly first keydown event when no listener is ready
+            this.editorService.handleKeyDownEvent(
+              e.event,
+              collectionGroup,
+              e.editor.getElement()
+            );
+          }
         }
       }
     });

--- a/libs/safe/src/lib/components/editor-control/editor-control.component.ts
+++ b/libs/safe/src/lib/components/editor-control/editor-control.component.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ControlValueAccessor, FormsModule, NgControl } from '@angular/forms';
-import { Subject } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
   EditorComponent,
@@ -160,6 +160,7 @@ export class SafeEditorControlComponent
   // eslint-disable-next-line @angular-eslint/no-input-rename
   @Input('aria-describedby') userAriaDescribedBy!: string;
 
+  private destroy$ = new Subject<void>();
   /**
    * Component for using TinyMCE editor with formControl
    *
@@ -188,12 +189,25 @@ export class SafeEditorControlComponent
   }
 
   ngAfterViewInit(): void {
-    this.editor.onFocusIn.subscribe(() => {
+    this.editor.onFocusIn.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.onFocusIn();
     });
-
-    this.editor.onFocusOut.subscribe((e) => {
+    this.editor.onFocusOut.pipe(takeUntil(this.destroy$)).subscribe((e) => {
       this.onFocusOut(e.event);
+    });
+    this.editor.onKeyDown.pipe(takeUntil(this.destroy$)).subscribe((e) => {
+      if (e.event.code === 'ArrowDown' || e.event.code === 'ArrowUp') {
+        const collectionGroup = document.querySelector(
+          '.tox-collection__group'
+        );
+        // If autocomplete list in the DOM, trigger scrolling events
+        if (collectionGroup) {
+          this.editorService.initScrollActive(
+            collectionGroup,
+            e.editor.getElement()
+          );
+        }
+      }
     });
     // this.editor.onInit.subscribe(() => {});
   }
@@ -279,6 +293,8 @@ export class SafeEditorControlComponent
 
   ngOnDestroy(): void {
     this.stateChanges.complete();
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   /** Updates the value when the editor content changes */

--- a/libs/safe/src/lib/services/editor/editor.service.ts
+++ b/libs/safe/src/lib/services/editor/editor.service.ts
@@ -95,9 +95,14 @@ export class SafeEditorService {
           }
           if (this.activeItemScrollListener) {
             this.activeItemScrollListener();
+            this.activeItemScrollListener = null;
           }
         },
         fetch: async (pattern: string) => {
+          if (this.activeItemScrollListener) {
+            this.activeItemScrollListener();
+            this.activeItemScrollListener = null;
+          }
           this.allowScrolling();
           return keys
             .filter((key) => key.includes(pattern))

--- a/libs/safe/src/lib/services/editor/editor.service.ts
+++ b/libs/safe/src/lib/services/editor/editor.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@angular/core';
+import { Inject, Injectable, Renderer2, RendererFactory2 } from '@angular/core';
 import { EDITOR_LANGUAGE_PAIRS } from '../../const/tinymce.const';
 import { TranslateService } from '@ngx-translate/core';
 import { Editor, RawEditorSettings } from 'tinymce';
@@ -13,6 +13,10 @@ import { Editor, RawEditorSettings } from 'tinymce';
 export class SafeEditorService {
   /** environment variable */
   private environment: any;
+
+  private editorScrollListener!: any;
+  private activeItemScrollListener!: any;
+  private renderer!: Renderer2;
 
   /**
    * Compute the base url based on the environment file
@@ -57,11 +61,14 @@ export class SafeEditorService {
    *
    * @param environment Environment file used to get main url of the page
    * @param translate Angular Translate Service
+   * @param _renderer RendererFactory2
    */
   constructor(
     @Inject('environment') environment: any,
-    private translate: TranslateService
+    private translate: TranslateService,
+    _renderer: RendererFactory2
   ) {
+    this.renderer = _renderer.createRenderer(null, null);
     this.environment = environment;
   }
 
@@ -72,7 +79,6 @@ export class SafeEditorService {
    * @param keys list of keys
    */
   addCalcAndKeysAutoCompleter(editor: RawEditorSettings, keys: string[]) {
-    this.allowScrolling();
     const defaultSetup = editor.setup;
     editor.setup = (e: Editor) => {
       if (defaultSetup && typeof defaultSetup === 'function') defaultSetup(e);
@@ -83,27 +89,95 @@ export class SafeEditorService {
           e.selection.setRng(rng);
           e.insertContent(value);
           autocompleteApi.hide();
+          // On successful action clean related listeners
+          if (this.editorScrollListener) {
+            this.editorScrollListener();
+          }
+          if (this.activeItemScrollListener) {
+            this.activeItemScrollListener();
+          }
         },
-        fetch: async (pattern: string) =>
-          keys
+        fetch: async (pattern: string) => {
+          this.allowScrolling();
+          return keys
             .filter((key) => key.includes(pattern))
-            .map((key) => ({ value: key, text: key })),
+            .map((key) => ({ value: key, text: key }));
+        },
       });
     };
   }
 
   /**
-   * Allows scrolling within the TinyMCE autocompleter container, and prevents the autocompleter from closing when clicking on the scrollbar.
-   *  This function sets a timeout to give TinyMCE some time to render its elements before trying to access them.
+   * Allows scrolling within the TinyMCE autocomplete container, and prevents the autocomplete from closing when clicking on the scrollbar.
+   * This function sets a timeout to give TinyMCE some time to render its elements before trying to access them.
    * The editor still closes when a value is successfully selected.
    */
   private allowScrolling() {
-    setTimeout(function () {
+    if (this.editorScrollListener) {
+      this.editorScrollListener();
+    }
+    setTimeout(() => {
       const autoCompleterContainer = document.querySelector('.tox-tinymce-aux');
       if (!autoCompleterContainer) return;
-      autoCompleterContainer.addEventListener('mousedown', function (event) {
-        event.stopPropagation();
-      });
+      this.editorScrollListener = this.renderer.listen(
+        autoCompleterContainer,
+        'mousedown',
+        function (event: any) {
+          event.stopPropagation();
+        }
+      );
+    }, 500);
+  }
+
+  /**
+   * Sets the active item of autocomplete list into view using the arrow down and up keys
+   *
+   * @param collectionGroup autocomplete collection list
+   * @param editor editor element
+   */
+  public initScrollActive(collectionGroup: Element, editor: HTMLElement) {
+    if (this.activeItemScrollListener) {
+      this.activeItemScrollListener();
+    }
+    setTimeout(() => {
+      if (collectionGroup) {
+        this.renderer.setAttribute(collectionGroup, 'tabindex', '1');
+        (collectionGroup as any).focus();
+        this.activeItemScrollListener = this.renderer.listen(
+          collectionGroup,
+          'keydown',
+          (e: any) => {
+            if (e.code === 'Tab') {
+              editor.focus();
+            } else if (e.code === 'ArrowDown' || e.code === 'ArrowUp') {
+              const currentActiveItem = Array.from(
+                collectionGroup.children
+              ).filter((item) =>
+                item.className.includes('tox-collection__item--active')
+              );
+              if (currentActiveItem.length) {
+                let showItem =
+                  e.code === 'ArrowDown'
+                    ? currentActiveItem[0].nextElementSibling
+                    : currentActiveItem[0].previousElementSibling;
+                // If first or last element on related keydown, then trigger scroll to first or last list element directly
+                if (
+                  e.code === 'ArrowDown' &&
+                  !currentActiveItem[0].nextElementSibling
+                ) {
+                  showItem = collectionGroup.firstElementChild;
+                } else if (
+                  e.code === 'ArrowUp' &&
+                  !currentActiveItem[0].previousElementSibling
+                ) {
+                  showItem = collectionGroup.lastElementChild;
+                }
+                showItem?.scrollIntoView(false);
+              }
+            }
+          }
+        );
+      }
     }, 500);
   }
 }

--- a/libs/safe/src/lib/services/editor/editor.service.ts
+++ b/libs/safe/src/lib/services/editor/editor.service.ts
@@ -15,7 +15,7 @@ export class SafeEditorService {
   private environment: any;
 
   private editorScrollListener!: any;
-  private activeItemScrollListener!: any;
+  public activeItemScrollListener!: any;
   private renderer!: Renderer2;
 
   /**
@@ -136,48 +136,60 @@ export class SafeEditorService {
    * @param editor editor element
    */
   public initScrollActive(collectionGroup: Element, editor: HTMLElement) {
-    if (this.activeItemScrollListener) {
-      this.activeItemScrollListener();
+    if (collectionGroup) {
+      this.renderer.setAttribute(collectionGroup, 'tabindex', '1');
+      (collectionGroup as any).focus();
+      this.activeItemScrollListener = this.renderer.listen(
+        collectionGroup,
+        'keydown',
+        (e: any) => {
+          this.handleKeyDownEvent(e, collectionGroup, editor);
+        }
+      );
     }
-    setTimeout(() => {
-      if (collectionGroup) {
-        this.renderer.setAttribute(collectionGroup, 'tabindex', '1');
-        (collectionGroup as any).focus();
-        this.activeItemScrollListener = this.renderer.listen(
-          collectionGroup,
-          'keydown',
-          (e: any) => {
-            if (e.code === 'Tab') {
-              editor.focus();
-            } else if (e.code === 'ArrowDown' || e.code === 'ArrowUp') {
-              const currentActiveItem = Array.from(
-                collectionGroup.children
-              ).filter((item) =>
-                item.className.includes('tox-collection__item--active')
-              );
-              if (currentActiveItem.length) {
-                let showItem =
-                  e.code === 'ArrowDown'
-                    ? currentActiveItem[0].nextElementSibling
-                    : currentActiveItem[0].previousElementSibling;
-                // If first or last element on related keydown, then trigger scroll to first or last list element directly
-                if (
-                  e.code === 'ArrowDown' &&
-                  !currentActiveItem[0].nextElementSibling
-                ) {
-                  showItem = collectionGroup.firstElementChild;
-                } else if (
-                  e.code === 'ArrowUp' &&
-                  !currentActiveItem[0].previousElementSibling
-                ) {
-                  showItem = collectionGroup.lastElementChild;
-                }
-                showItem?.scrollIntoView(false);
-              }
-            }
-          }
-        );
+  }
+
+  /**
+   * Sets the active item of autocomplete list into view using the arrow down and up keys
+   *
+   * @param e KeyBoardEvent
+   * @param collectionGroup autocomplete collection list
+   * @param editor editor element
+   */
+  public handleKeyDownEvent(
+    e: KeyboardEvent,
+    collectionGroup: Element,
+    editor: any
+  ) {
+    if (e.code === 'Tab') {
+      if (this.activeItemScrollListener) {
+        this.activeItemScrollListener();
+        this.activeItemScrollListener = null;
       }
-    }, 500);
+      editor.focus();
+    } else if (e.code === 'ArrowDown' || e.code === 'ArrowUp') {
+      const currentActiveItem = Array.from(collectionGroup.children).filter(
+        (item) => item.className.includes('tox-collection__item--active')
+      );
+      if (currentActiveItem.length) {
+        let showItem =
+          e.code === 'ArrowDown'
+            ? currentActiveItem[0].nextElementSibling
+            : currentActiveItem[0].previousElementSibling;
+        // If first or last element on related keydown, then trigger scroll to first or last list element directly
+        if (
+          e.code === 'ArrowDown' &&
+          !currentActiveItem[0].nextElementSibling
+        ) {
+          showItem = collectionGroup.firstElementChild;
+        } else if (
+          e.code === 'ArrowUp' &&
+          !currentActiveItem[0].previousElementSibling
+        ) {
+          showItem = collectionGroup.lastElementChild;
+        }
+        showItem?.scrollIntoView(false);
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description

feat: add scroll feature on arrowup and arrowdown keydown events for editor autocomplete list 
feat: add tab event to focus editor on keydowning or scrolling from autocomplete list to get a better UX on editor 
feat: improve event handling with angular renderer to avoid memory leaks

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66900)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
