### PR TITLE
Bugfix/ab#66900 2.0.x abc unable to drag the scroll bar to the bottom on expression list

### DIFF
--- a/libs/safe/src/lib/components/edit-calculated-field-modal/edit-calculated-field-modal.component.ts
+++ b/libs/safe/src/lib/components/edit-calculated-field-modal/edit-calculated-field-modal.component.ts
@@ -121,27 +121,7 @@ export class SafeEditCalculatedFieldModalComponent
     this.editorComponent?.onKeyDown
       .pipe(takeUntil(this.destroy$))
       .subscribe((e) => {
-        if (e.event.code === 'ArrowDown' || e.event.code === 'ArrowUp') {
-          const collectionGroup = document.querySelector(
-            '.tox-collection__group'
-          );
-          // If autocomplete list in the DOM, trigger scrolling events
-          if (collectionGroup) {
-            if (!this.editorService.activeItemScrollListener) {
-              // Initialize listener
-              this.editorService.initScrollActive(
-                collectionGroup,
-                e.editor.getElement()
-              );
-              // Execute directly first keydown event when no listener is ready
-              this.editorService.handleKeyDownEvent(
-                e.event,
-                collectionGroup,
-                e.editor.getElement()
-              );
-            }
-          }
-        }
+        this.editorService.editorComponentKeyDownHandler(e);
       });
   }
 

--- a/libs/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
+++ b/libs/safe/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
@@ -87,27 +87,7 @@ export class SafeTabFieldsComponent
     this.editorComponent?.onKeyDown
       .pipe(takeUntil(this.destroy$))
       .subscribe((e) => {
-        if (e.event.code === 'ArrowDown' || e.event.code === 'ArrowUp') {
-          const collectionGroup = document.querySelector(
-            '.tox-collection__group'
-          );
-          // If autocomplete list in the DOM, trigger scrolling events
-          if (collectionGroup) {
-            if (!this.editorService.activeItemScrollListener) {
-              // Initialize listener
-              this.editorService.initScrollActive(
-                collectionGroup,
-                e.editor.getElement()
-              );
-              // Execute directly first keydown event when no listener is ready
-              this.editorService.handleKeyDownEvent(
-                e.event,
-                collectionGroup,
-                e.editor.getElement()
-              );
-            }
-          }
-        }
+        this.editorService.editorComponentKeyDownHandler(e);
       });
   }
 

--- a/libs/safe/src/lib/components/widgets/editor-settings/editor-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/editor-settings/editor-settings.component.ts
@@ -137,27 +137,7 @@ export class SafeEditorSettingsComponent
     this.editorComponent?.onKeyDown
       .pipe(takeUntil(this.destroy$))
       .subscribe((e) => {
-        if (e.event.code === 'ArrowDown' || e.event.code === 'ArrowUp') {
-          const collectionGroup = document.querySelector(
-            '.tox-collection__group'
-          );
-          // If autocomplete list in the DOM, trigger scrolling events
-          if (collectionGroup) {
-            if (!this.editorService.activeItemScrollListener) {
-              // Initialize listener
-              this.editorService.initScrollActive(
-                collectionGroup,
-                e.editor.getElement()
-              );
-              // Execute directly first keydown event when no listener is ready
-              this.editorService.handleKeyDownEvent(
-                e.event,
-                collectionGroup,
-                e.editor.getElement()
-              );
-            }
-          }
-        }
+        this.editorService.editorComponentKeyDownHandler(e);
       });
   }
 

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.ts
@@ -1,8 +1,17 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  Input,
+  OnChanges,
+  ViewChild,
+} from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { SafeEditorService } from '../../../../services/editor/editor.service';
 import { WIDGET_EDITOR_CONFIG } from '../../../../const/tinymce.const';
 import { getCalcKeys, getDataKeys } from '../../summary-card/parser/utils';
+import { SafeUnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
+import { takeUntil } from 'rxjs';
+import { EditorComponent } from '@tinymce/tinymce-angular';
 
 /**
  * Component used in the card-modal-settings for editing the content of the card.
@@ -12,12 +21,16 @@ import { getCalcKeys, getDataKeys } from '../../summary-card/parser/utils';
   templateUrl: './text-editor-tab.component.html',
   styleUrls: ['./text-editor-tab.component.scss'],
 })
-export class SafeTextEditorTabComponent implements OnChanges {
+export class SafeTextEditorTabComponent
+  extends SafeUnsubscribeComponent
+  implements OnChanges, AfterViewInit
+{
   @Input() form!: UntypedFormGroup;
   @Input() fields: any[] = [];
 
   /** tinymce editor */
   public editor = WIDGET_EDITOR_CONFIG;
+  @ViewChild(EditorComponent) editorComponent!: EditorComponent;
 
   /**
    * SafeTextEditorTabComponent constructor.
@@ -25,10 +38,39 @@ export class SafeTextEditorTabComponent implements OnChanges {
    * @param editorService Editor service used to get main URL and current language
    */
   constructor(private editorService: SafeEditorService) {
+    super();
     // Set the editor base url based on the environment file
     this.editor.base_url = editorService.url;
     // Set the editor language
     this.editor.language = editorService.language;
+  }
+
+  ngAfterViewInit(): void {
+    this.editorComponent?.onKeyDown
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((e) => {
+        if (e.event.code === 'ArrowDown' || e.event.code === 'ArrowUp') {
+          const collectionGroup = document.querySelector(
+            '.tox-collection__group'
+          );
+          // If autocomplete list in the DOM, trigger scrolling events
+          if (collectionGroup) {
+            if (!this.editorService.activeItemScrollListener) {
+              // Initialize listener
+              this.editorService.initScrollActive(
+                collectionGroup,
+                e.editor.getElement()
+              );
+              // Execute directly first keydown event when no listener is ready
+              this.editorService.handleKeyDownEvent(
+                e.event,
+                collectionGroup,
+                e.editor.getElement()
+              );
+            }
+          }
+        }
+      });
   }
 
   ngOnChanges(): void {

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.ts
@@ -49,27 +49,7 @@ export class SafeTextEditorTabComponent
     this.editorComponent?.onKeyDown
       .pipe(takeUntil(this.destroy$))
       .subscribe((e) => {
-        if (e.event.code === 'ArrowDown' || e.event.code === 'ArrowUp') {
-          const collectionGroup = document.querySelector(
-            '.tox-collection__group'
-          );
-          // If autocomplete list in the DOM, trigger scrolling events
-          if (collectionGroup) {
-            if (!this.editorService.activeItemScrollListener) {
-              // Initialize listener
-              this.editorService.initScrollActive(
-                collectionGroup,
-                e.editor.getElement()
-              );
-              // Execute directly first keydown event when no listener is ready
-              this.editorService.handleKeyDownEvent(
-                e.event,
-                collectionGroup,
-                e.editor.getElement()
-              );
-            }
-          }
-        }
+        this.editorService.editorComponentKeyDownHandler(e);
       });
   }
 

--- a/libs/safe/src/lib/services/editor/editor.service.ts
+++ b/libs/safe/src/lib/services/editor/editor.service.ts
@@ -94,9 +94,14 @@ export class SafeEditorService {
           }
           if (this.activeItemScrollListener) {
             this.activeItemScrollListener();
+            this.activeItemScrollListener = null;
           }
         },
         fetch: async (pattern: string) => {
+          if (this.activeItemScrollListener) {
+            this.activeItemScrollListener();
+            this.activeItemScrollListener = null;
+          }
           this.allowScrolling();
           return keys
             .filter((key) => key.includes(pattern))
@@ -187,6 +192,26 @@ export class SafeEditorService {
           showItem = collectionGroup.lastElementChild;
         }
         showItem?.scrollIntoView(false);
+      }
+    }
+  }
+
+  /**
+   * Handle editor component keydown event
+   *
+   * @param e Editor component keydown event
+   */
+  public editorComponentKeyDownHandler(e: any) {
+    if (e.event.code === 'ArrowDown' || e.event.code === 'ArrowUp') {
+      const collectionGroup = document.querySelector('.tox-collection__group');
+      // If autocomplete list in the DOM, trigger scrolling events
+      if (collectionGroup) {
+        if (!this.activeItemScrollListener) {
+          // Initialize listener
+          this.initScrollActive(collectionGroup, e.editor.getBody());
+          // Execute directly first keydown event when no listener is ready
+          this.handleKeyDownEvent(e.event, collectionGroup, e.editor.getBody());
+        }
       }
     }
   }

--- a/libs/safe/src/lib/services/editor/editor.service.ts
+++ b/libs/safe/src/lib/services/editor/editor.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@angular/core';
+import { Inject, Injectable, Renderer2, RendererFactory2 } from '@angular/core';
 import { EDITOR_LANGUAGE_PAIRS } from '../../const/tinymce.const';
 import { TranslateService } from '@ngx-translate/core';
 import { Editor, RawEditorSettings } from 'tinymce';
@@ -14,6 +14,9 @@ export class SafeEditorService {
   /** environment variable */
   private environment: any;
 
+  private editorScrollListener!: any;
+  activeItemScrollListener!: any;
+  private renderer!: Renderer2;
   /**
    * Compute the base url based on the environment file
    *
@@ -57,11 +60,14 @@ export class SafeEditorService {
    *
    * @param environment Environment file used to get main url of the page
    * @param translate Angular Translate Service
+   * @param _renderer RenderFactory2
    */
   constructor(
     @Inject('environment') environment: any,
-    private translate: TranslateService
+    private translate: TranslateService,
+    _renderer: RendererFactory2
   ) {
+    this.renderer = _renderer.createRenderer(null, null);
     this.environment = environment;
   }
 
@@ -72,7 +78,6 @@ export class SafeEditorService {
    * @param keys list of keys
    */
   addCalcAndKeysAutoCompleter(editor: RawEditorSettings, keys: string[]) {
-    this.allowScrolling();
     const defaultSetup = editor.setup;
     editor.setup = (e: Editor) => {
       if (defaultSetup && typeof defaultSetup === 'function') defaultSetup(e);
@@ -83,11 +88,20 @@ export class SafeEditorService {
           e.selection.setRng(rng);
           e.insertContent(value);
           autocompleteApi.hide();
+          // On successful action clean related listeners
+          if (this.editorScrollListener) {
+            this.editorScrollListener();
+          }
+          if (this.activeItemScrollListener) {
+            this.activeItemScrollListener();
+          }
         },
-        fetch: async (pattern: string) =>
-          keys
+        fetch: async (pattern: string) => {
+          this.allowScrolling();
+          return keys
             .filter((key) => key.includes(pattern))
-            .map((key) => ({ value: key, text: key })),
+            .map((key) => ({ value: key, text: key }));
+        },
       });
     };
   }
@@ -98,12 +112,82 @@ export class SafeEditorService {
    * The editor still closes when a value is successfully selected.
    */
   private allowScrolling() {
-    setTimeout(function () {
+    if (this.editorScrollListener) {
+      this.editorScrollListener();
+    }
+    setTimeout(() => {
       const autoCompleterContainer = document.querySelector('.tox-tinymce-aux');
       if (!autoCompleterContainer) return;
-      autoCompleterContainer.addEventListener('mousedown', function (event) {
-        event.stopPropagation();
-      });
+      this.editorScrollListener = this.renderer.listen(
+        autoCompleterContainer,
+        'mousedown',
+        function (event: any) {
+          event.stopPropagation();
+        }
+      );
     }, 500);
+  }
+  /**
+   * Sets the active item of autocomplete list into view using the arrow down and up keys
+   *
+   * @param collectionGroup autocomplete collection list
+   * @param editor editor element
+   */
+  public initScrollActive(collectionGroup: Element, editor: HTMLElement) {
+    if (collectionGroup) {
+      this.renderer.setAttribute(collectionGroup, 'tabindex', '1');
+      (collectionGroup as any).focus();
+      this.activeItemScrollListener = this.renderer.listen(
+        collectionGroup,
+        'keydown',
+        (e: any) => {
+          this.handleKeyDownEvent(e, collectionGroup, editor);
+        }
+      );
+    }
+  }
+
+  /**
+   * Sets the active item of autocomplete list into view using the arrow down and up keys
+   *
+   * @param e KeyBoardEvent
+   * @param collectionGroup autocomplete collection list
+   * @param editor editor element
+   */
+  public handleKeyDownEvent(
+    e: KeyboardEvent,
+    collectionGroup: Element,
+    editor: any
+  ) {
+    if (e.code === 'Tab') {
+      if (this.activeItemScrollListener) {
+        this.activeItemScrollListener();
+        this.activeItemScrollListener = null;
+      }
+      editor.focus();
+    } else if (e.code === 'ArrowDown' || e.code === 'ArrowUp') {
+      const currentActiveItem = Array.from(collectionGroup.children).filter(
+        (item) => item.className.includes('tox-collection__item--active')
+      );
+      if (currentActiveItem.length) {
+        let showItem =
+          e.code === 'ArrowDown'
+            ? currentActiveItem[0].nextElementSibling
+            : currentActiveItem[0].previousElementSibling;
+        // If first or last element on related keydown, then trigger scroll to first or last list element directly
+        if (
+          e.code === 'ArrowDown' &&
+          !currentActiveItem[0].nextElementSibling
+        ) {
+          showItem = collectionGroup.firstElementChild;
+        } else if (
+          e.code === 'ArrowUp' &&
+          !currentActiveItem[0].previousElementSibling
+        ) {
+          showItem = collectionGroup.lastElementChild;
+        }
+        showItem?.scrollIntoView(false);
+      }
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oort-front",
-  "version": "2.0.0-beta.15",
+  "version": "2.0.0-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oort-front",
-      "version": "2.0.0-beta.15",
+      "version": "2.0.0-beta.14",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "~15.1.1",


### PR DESCRIPTION
# Description

feat: add scroll feature on arrowup and arrowdown keydown events for editor autocomplete list
feat: add tab event to focus editor on keydowning or scrolling from autocomplete list to get a better UX on editor
feat: improve event handling with angular renderer to avoid memory leaks

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66900)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
