### PR TITLE
feat/AB#67382_ABC-if-no-header-value-for-summary-card-dont-display-it

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
@@ -17,6 +17,6 @@
   [fieldsValue]="fieldsValue"
   [styles]="card.useStyles ? styles : []"
   [wholeCardStyles]="card.wholeCardStyles"
-  style="flex: 1"
+  class="flex flex-1"
 >
 </safe-summary-card-item-content>

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
@@ -5,7 +5,7 @@
     [ngTemplateOutlet]="headerTemplate"
   ></ng-container>
   <!-- Default Header -->
-  <div class="widget-header k-card-header" *ngIf="!headerTemplate">
+  <div class="widget-header k-card-header" *ngIf="!headerTemplate && card.title">
     <!-- Title -->
     <span class="widget-title" [title]="card.title">{{ card.title }}</span>
     <!-- Actions -->

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  TemplateRef,
-} from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { get } from 'lodash';
 import { CardT } from '../summary-card.component';
 


### PR DESCRIPTION
# Description

feat: hide summary card header if no title is provided

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67382/)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please refer to screenshot below

## Sreenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/4e1df90e-763b-4231-8162-c6b70d503527)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
