### PR TITLE
fix-2.0.x/AB#2367383 Incorrect 'activate-filtering' text

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
@@ -79,9 +79,10 @@
               <ui-icon icon="tune" variant="grey"></ui-icon>
               <!-- todo(translate) -->
               {{
-                dashboard.showFilter
-                  ? 'Deactivate filtering'
-                  : 'Activate filtering'
+                (this.showFilter
+                  ? 'models.dashboard.deactivateFiltering'
+                  : 'models.dashboard.activateFiltering'
+                ) | translate
               }}
             </button>
             <button uiMenuItem (click)="onAppSelection()">

--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
@@ -79,7 +79,7 @@
               <ui-icon icon="tune" variant="grey"></ui-icon>
               <!-- todo(translate) -->
               {{
-                (this.showFilter
+                (showFilter
                   ? 'models.dashboard.deactivateFiltering'
                   : 'models.dashboard.activateFiltering'
                 ) | translate


### PR DESCRIPTION
# Description

The issue was caused by the property used to track the filter, we were using a property which is only updated when loading the page.

The solution was to update it to use the variable that controls the filter state, which changes each time we update the filter state.

I also restored the translations of the button, the text was hardcoded on english.

## Ticket

[67383 - ABC - Incorrect 'activate filtering' text
](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67383)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Modified the filter state in the page and confirm it's changing

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
