### PR TITLE
Fix 2.1.x/ab#66860 db scrollbar missing on popups

### DIFF
--- a/libs/safe/src/lib/components/ui/map/map-popup/map-popup.component.html
+++ b/libs/safe/src/lib/components/ui/map/map-popup/map-popup.component.html
@@ -34,7 +34,7 @@
       </ui-button>
     </div>
   </header>
-  <div class="max-h-60 overflow-y-auto hide-scroll">
+  <div class="max-h-60 overflow-y-auto">
     <div [innerHTML]="currentHtml"></div>
   </div>
   <div class="pl-2 my-1 flex">


### PR DESCRIPTION
# Description

Popups for map layers weren't showing the scrollbar, so the data was not readable.
It was possible to scroll with the mouse wheel to see it but the scrollbar was hidden by a tailwind class.

The class has been removed and you can now see the scrollbar.

## Ticket

[66860 Scrollbar missing on popups](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66860/)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Check that the scrollbar is visible in a popup
- [x] Check that the scrollbar is usable in a popup

## Screenshots

![Screenshot from 2023-06-21 08-41-04](https://github.com/ReliefApplications/oort-frontend/assets/94831019/c8bf8bf1-cec7-45e9-872b-79c50064b94b)
![Screenshot from 2023-06-21 08-41-12](https://github.com/ReliefApplications/oort-frontend/assets/94831019/604a9756-2fbc-4175-8857-1effae53fb73)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
