### PR TITLE
Feat 2.0.x/ab#67377 UI paginator summary cards

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -91,16 +91,18 @@
       </kendo-pdf-export>
     </div>
     <!-- Pagination -->
-    <kendo-datapager
+    <ui-paginator
       *ngIf="settings.widgetDisplay?.usePagination"
-      [style.width.%]="100"
-      [pageSize]="pageInfo.first"
-      [pageSizeValues]="[10, 25, 50, 100]"
+      [disabled]="loading"
+      [pageIndex]="pageInfo.pageIndex"
+      [pageSize]="pageInfo.pageSize"
       [skip]="pageInfo.skip"
-      [total]="pageInfo.totalCount"
-      (pageChange)="onPageChange($event)"
+      [pageSizeOptions]="[10, 25, 50, 100]"
+      [totalItems]="pageInfo.length"
+      [ariaLabel]="'components.notifications.paginator.ariaLabel' | translate"
+      (pageChange)="onPage($event)"
     >
-    </kendo-datapager>
+    </ui-paginator>
   </ng-container>
   <!-- Grid display mode -->
   <ng-container *ngIf="displayMode === 'grid'">

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -32,10 +32,9 @@ export type CardT = NonNullable<SummaryCardFormT['value']['card']> &
     cardAggregationData: any;
   }>;
 import { Layout } from '../../../models/layout.model';
-import { PageChangeEvent } from '@progress/kendo-angular-grid';
 import { FormControl } from '@angular/forms';
 import { clone, isNaN } from 'lodash';
-import { SnackbarService } from '@oort-front/ui';
+import { SnackbarService, UIPageChangeEvent } from '@oort-front/ui';
 import { Dialog } from '@angular/cdk/dialog';
 
 /** Maximum width of the widget in column units */
@@ -67,12 +66,11 @@ export class SafeSummaryCardComponent
   // === GRID ===
   public colsNumber = MAX_COL_SPAN;
 
-  // === DYNAMIC CARDS PAGINATION ===
   public pageInfo = {
-    first: DEFAULT_PAGE_SIZE,
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+    length: 0,
     skip: 0,
-    hasNextPage: false,
-    totalCount: 0,
   };
   public loading = true;
 
@@ -84,6 +82,7 @@ export class SafeSummaryCardComponent
   private fields: any[] = [];
 
   public searchControl = new FormControl('');
+  private searching = false;
 
   @ViewChild('summaryCardGrid') summaryCardGrid!: ElementRef<HTMLDivElement>;
   @ViewChild('pdf') pdf!: any;
@@ -206,6 +205,8 @@ export class SafeSummaryCardComponent
     const needRefetch = !this.settings.card?.aggregation;
     const skippedFields = ['id', 'incrementalId'];
 
+    this.searching = true;
+
     if (!needRefetch)
       this.cards = this.cachedCards.filter((card: any) => {
         const data = clone(card.record || card.cardAggregationData || {});
@@ -242,9 +243,11 @@ export class SafeSummaryCardComponent
             value: parseFloat(search),
           });
       });
+      this.pageInfo.pageIndex = 0;
       this.pageInfo.skip = 0;
       this.dataQuery?.refetch({
         skip: 0,
+        first: this.pageInfo.pageSize,
         filter: {
           logic: 'or',
           filters,
@@ -273,18 +276,25 @@ export class SafeSummaryCardComponent
     }));
 
     this.cachedCards =
-      this.pageInfo.skip > 0 ? [...this.cachedCards, ...newCards] : newCards;
+      (this.pageInfo.pageIndex + 1) * this.pageInfo.pageSize >
+        this.cachedCards.length && !this.searching
+        ? [...this.cachedCards, ...newCards]
+        : newCards;
 
     this.cards = this.settings.widgetDisplay?.usePagination
       ? this.cachedCards.slice(
-          this.pageInfo.skip,
-          this.pageInfo.skip + this.pageInfo.first
+          this.pageInfo.pageSize * this.pageInfo.pageIndex,
+          this.pageInfo.pageSize * (this.pageInfo.pageIndex + 1)
         )
       : this.cachedCards;
-    this.pageInfo.totalCount = get(res.data[layoutQueryName], 'totalCount', 0);
-    this.pageInfo.hasNextPage = this.pageInfo.totalCount > this.cards.length;
+    this.pageInfo.length = get(res.data[layoutQueryName], 'totalCount', 0);
 
     this.loading = res.loading;
+
+    if (this.searching && this.searchControl.value != '') {
+      this.pageInfo.skip = this.cards.length;
+    }
+    this.searching = false;
   }
 
   /**
@@ -330,7 +340,7 @@ export class SafeSummaryCardComponent
             this.dataQuery = this.apollo.watchQuery<any>({
               query: builtQuery,
               variables: {
-                first: this.pageInfo.first,
+                first: this.pageInfo.pageSize,
                 filter: layoutQuery.filter,
                 sortField: get(layoutQuery, 'sort.field', null),
                 sortOrder: get(layoutQuery, 'sort.order', ''),
@@ -412,7 +422,7 @@ export class SafeSummaryCardComponent
       e.target.scrollHeight - (e.target.clientHeight + e.target.scrollTop) <
       50
     ) {
-      if (!this.loading && this.pageInfo.hasNextPage) {
+      if (!this.loading && this.pageInfo.length > this.cards.length) {
         this.loading = true;
         this.dataQuery
           ?.fetchMore({
@@ -426,33 +436,46 @@ export class SafeSummaryCardComponent
   }
 
   /**
-   * Triggered when the page changes.
+   * Handles page event.
    *
-   * @param e Kendo paginator page change event
+   * @param e page event.
    */
-  public onPageChange(e: PageChangeEvent) {
-    this.pageInfo.first = e.take;
-    this.pageInfo.skip = e.skip;
+  onPage(e: UIPageChangeEvent): void {
+    this.pageInfo.pageIndex = e.pageIndex;
 
-    this.summaryCardGrid.nativeElement.scroll({
-      top: 0,
-      left: 0,
-      behavior: 'smooth',
-    });
+    // Checks if with new page/size more data needs to be fetched
+    if (
+      (e.pageIndex > e.previousPageIndex ||
+        e.pageSize > this.pageInfo.pageSize) &&
+      (e.pageIndex + 1) * e.pageSize > this.cachedCards.length &&
+      e.totalItems > this.cachedCards.length
+    ) {
+      // Sets the new fetch quantity of data needed
+      this.pageInfo.pageSize =
+        (e.pageIndex + 1) * e.pageSize - this.cachedCards.length;
 
-    // Check if the data is already cached
-    if (this.cachedCards.length >= e.skip + e.take)
-      this.cards = this.cachedCards.slice(e.skip, e.skip + e.take);
-    else {
+      this.summaryCardGrid.nativeElement.scroll({
+        top: 0,
+        left: 0,
+        behavior: 'smooth',
+      });
+
       this.loading = true;
       this.dataQuery
         ?.fetchMore({
           variables: {
+            first: this.pageInfo.pageSize,
             skip: this.cachedCards.length,
           },
         })
         .then(this.updateCards.bind(this));
+    } else {
+      this.cards = this.cachedCards.slice(
+        e.pageSize * this.pageInfo.pageIndex,
+        e.pageSize * (this.pageInfo.pageIndex + 1)
+      );
     }
+    this.pageInfo.pageSize = e.pageSize;
   }
 
   /**

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.module.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.module.ts
@@ -6,11 +6,10 @@ import { SafeSummaryCardComponent } from './summary-card.component';
 import { SummaryCardItemModule } from './summary-card-item/summary-card-item.module';
 import { IndicatorsModule } from '@progress/kendo-angular-indicators';
 import { SafeGridWidgetModule } from '../grid/grid.module';
-import { TooltipModule, ButtonModule } from '@oort-front/ui';
+import { TooltipModule, ButtonModule, PaginatorModule } from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { InputsModule } from '@progress/kendo-angular-inputs';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { PagerModule } from '@progress/kendo-angular-pager';
 import { SafeSkeletonModule } from '../../../directives/skeleton/skeleton.module';
 
 /** Summary Card Widget Module */
@@ -29,8 +28,8 @@ import { SafeSkeletonModule } from '../../../directives/skeleton/skeleton.module
     InputsModule,
     FormsModule,
     ReactiveFormsModule,
-    PagerModule,
     SafeSkeletonModule,
+    PaginatorModule,
   ],
   exports: [SafeSummaryCardComponent],
 })

--- a/libs/ui/src/lib/paginator/paginator.component.html
+++ b/libs/ui/src/lib/paginator/paginator.component.html
@@ -5,6 +5,7 @@
     class="absolute inset-0 bg-white opacity-50"
   ></div>
   <kendo-datapager
+    class="border-none"
     [attr.aria-label]="ariaLabel"
     [attr.aria-controls]="paginatorId"
     [style.width.%]="100"

--- a/libs/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/src/lib/paginator/paginator.component.ts
@@ -14,6 +14,7 @@ export class PaginatorComponent {
   @Input() disabled = false;
   @Input() totalItems = 0;
   @Input() pageSize = 10;
+  @Input() skip = 0;
   @Input() pageSizeOptions = [5, 10, 15];
   @Input() ariaLabel = '';
   @Input() pageIndex = 0;
@@ -21,8 +22,6 @@ export class PaginatorComponent {
 
   // Generate random unique identifier for each paginator component
   paginatorId = uuidv4();
-  // Paginator properties
-  skip = 0;
 
   /**
    * Update page data on page change


### PR DESCRIPTION
# Description

Changed kendo paginator for ui-paginator component on summary cards. Fixed several bugs related to pagination such as:
- if we were not on the first page and performed a search, a bad pagination was displayed (26 - 1 of 1 item)
- number of fetched data didn't match the pagination select value (select set to 50 but fetching 25 elements)
- if fetching was needed, then when changing the pagination select value, wrong cards were were displayed (10 → 100, only 10 displayed elements)
- wrong cards were were displayed if more element were fetched than before (25 → 100, only the last 75 were displayed)

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67377

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

I tested pagination with a large amount of data (101) and tried to do text searches.

## Sreenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/65243509/7ecfd73a-7a35-4779-8327-ed3bc4caac8e)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules