### PR TITLE
bugfix/AB#66622_DB-with-heat-map-styling-on-map-widget-cluster-should-not-display-on-legend-of-map

### DIFF
--- a/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.html
@@ -156,7 +156,8 @@
       <!-- Previously : layerDefinition.drawingInfo.renderer.type -->
       <ui-tab
         *ngIf="
-          form.get('layerDefinition.featureReduction')?.value !== 'heatmap'
+          form.get('layerDefinition.drawingInfo.renderer.type')?.value !==
+          'heatmap'
         "
         [disabled]="!isDatasourceValid"
       >

--- a/libs/safe/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-forms.ts
@@ -184,6 +184,13 @@ const createLayerDefinitionForm = (type: LayerType, value?: any): FormGroup => {
             'drawingInfo',
             createLayerDrawingInfoForm(drawingInfo)
           );
+          // If new type is heatmap and we currently have a cluster set, reset the featureReduction
+          if (
+            type === 'heatmap' &&
+            formGroup.get('featureReduction.type')?.value === 'cluster'
+          ) {
+            formGroup.get('featureReduction.type')?.patchValue({ type: null });
+          }
           setTypeListeners();
         });
     };

--- a/libs/safe/src/lib/services/map/map-layers.service.ts
+++ b/libs/safe/src/lib/services/map/map-layers.service.ts
@@ -154,7 +154,7 @@ export class SafeMapLayersService {
           if (response.errors) {
             throw new Error(response.errors[0].message);
           }
-          return response.data.layer;
+          return this.featureReductionCleaner(response.data.layer);
         })
       );
   }
@@ -176,7 +176,7 @@ export class SafeMapLayersService {
           if (response.errors) {
             throw new Error(response.errors[0].message);
           }
-          return response.data.layers;
+          return response.data.layers.map(this.featureReductionCleaner);
         })
       );
   }
@@ -357,4 +357,23 @@ export class SafeMapLayersService {
       (value.geoField || (value.latitudeField && value.longitudeField))
     );
   };
+
+  /**
+   * Method to disable any previously saved heatmap layers with also a cluster feature reduction
+   * !!!!!! This method should eventually begone !!!!!!
+   *
+   * @param layerModel layerModel data to clean
+   * @returns clean layerModel
+   */
+  private featureReductionCleaner(layerModel: LayerModel): LayerModel {
+    if (
+      layerModel.layerDefinition?.drawingInfo?.renderer?.type === 'heatmap' &&
+      layerModel.layerDefinition.featureReduction
+    ) {
+      layerModel.layerDefinition.featureReduction.clusterRadius = null as any;
+      layerModel.layerDefinition.featureReduction.type = null as any;
+      layerModel.layerDefinition.featureReduction.drawingInfo = null as any;
+    }
+    return layerModel;
+  }
 }


### PR DESCRIPTION
# Description

feat: aggregation tab hidden when layer style type is heatmap 
feat: clean any feature reduction from backend data if layer style type is heatmap 
feat: if layer style type is set to heatmap reset any cluster types set in the aggregation tab

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66622/)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please refer screenshot below

## Sreenshots

Aggregation tab hidden


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
