### PR TITLE
bugfix/multiple-change-touch-fn-register-within-same-control-instance

### DIFF
--- a/libs/safe/src/lib/components/navbar/navbar.component.html
+++ b/libs/safe/src/lib/components/navbar/navbar.component.html
@@ -50,7 +50,7 @@
                   <a class="group" (click)="largeDevice ? null : nav.toggle()">
                     <ui-icon variant="grey" [icon]="item.icon"> </ui-icon>
                     <p class="truncate m-0" [uiTooltip]="item.name">
-                      {{ item.name }}i
+                      {{ item.name }}
                     </p>
                   </a>
                   <div

--- a/libs/ui/src/lib/checkbox/checkbox.component.ts
+++ b/libs/ui/src/lib/checkbox/checkbox.component.ts
@@ -76,7 +76,9 @@ export class CheckboxComponent implements ControlValueAccessor {
    * @param fn callback function
    */
   public registerOnChange(fn: any): void {
-    this.onChange = fn;
+    if (!this.onChange) {
+      this.onChange = fn;
+    }
   }
 
   /**
@@ -85,7 +87,9 @@ export class CheckboxComponent implements ControlValueAccessor {
    * @param fn callback function
    */
   public registerOnTouched(fn: any): void {
-    this.onTouch = fn;
+    if (!this.onTouch) {
+      this.onTouch = fn;
+    }
   }
 
   /**

--- a/libs/ui/src/lib/chip/chip-list.directive.ts
+++ b/libs/ui/src/lib/chip/chip-list.directive.ts
@@ -80,7 +80,9 @@ export class ChipListDirective
    * @param fn callback function
    */
   public registerOnChange(fn: any): void {
-    this.onChange = fn;
+    if (!this.onChange) {
+      this.onChange = fn;
+    }
   }
 
   /**
@@ -89,7 +91,9 @@ export class ChipListDirective
    * @param fn callback function
    */
   public registerOnTouched(fn: any): void {
-    this.onTouch = fn;
+    if (!this.onTouch) {
+      this.onTouch = fn;
+    }
   }
 
   /**

--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -180,7 +180,9 @@ export class SelectMenuComponent
    * event that took place
    */
   registerOnChange(fn: any) {
-    this.onChange = fn;
+    if (!this.onChange) {
+      this.onChange = fn;
+    }
   }
 
   /**
@@ -190,7 +192,9 @@ export class SelectMenuComponent
    * event that took place
    */
   registerOnTouched(fn: any) {
-    this.onTouch = fn;
+    if (!this.onTouch) {
+      this.onTouch = fn;
+    }
   }
 
   /**

--- a/libs/ui/src/lib/slider/slider.component.ts
+++ b/libs/ui/src/lib/slider/slider.component.ts
@@ -96,7 +96,9 @@ export class SliderComponent
    * @param fn event that took place
    */
   registerOnChange(fn: any) {
-    this.onChange = fn;
+    if (!this.onChange) {
+      this.onChange = fn;
+    }
   }
 
   /**
@@ -105,7 +107,9 @@ export class SliderComponent
    * @param fn event that took place
    */
   registerOnTouched(fn: any) {
-    this.onTouch = fn;
+    if (!this.onTouch) {
+      this.onTouch = fn;
+    }
   }
 
   /**

--- a/libs/ui/src/lib/toggle/toggle.component.ts
+++ b/libs/ui/src/lib/toggle/toggle.component.ts
@@ -102,7 +102,9 @@ export class ToggleComponent implements ControlValueAccessor {
    * @param fn callback function
    */
   public registerOnChange(fn: any): void {
-    this.onChange = fn;
+    if (!this.onChange) {
+      this.onChange = fn;
+    }
   }
 
   /**
@@ -111,7 +113,9 @@ export class ToggleComponent implements ControlValueAccessor {
    * @param fn callback function
    */
   public registerOnTouched(fn: any): void {
-    this.onTouch = fn;
+    if (!this.onTouch) {
+      this.onTouch = fn;
+    }
   }
 
   /**


### PR DESCRIPTION
fix: multiple change fn register on same instance(that leads to a broken valuechanges subscription as it register a new change fn within the same form instance even if the instance is not previously destroyed) 
fix: "i" character added in navbar component titles

# Description

In some places with deeply nested controls plus also with a complex components creation/destruction logic flow(such as in the map widget editor) same control instance was registering multiple change functions, which breaks any previously valueChanges subscription done as the new change function is other.

This PR solves that issue registering change function only once on instance creation

## Ticket

Please insert link to ticket

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
