### PR TITLE
Fix 2.0.x/abc#67468 cannot alwats change date

### DIFF
--- a/libs/ui/src/lib/date/date-wrapper.directive.ts
+++ b/libs/ui/src/lib/date/date-wrapper.directive.ts
@@ -91,7 +91,8 @@ export class DateWrapperDirective implements AfterContentInit, OnDestroy {
               .getElementsByTagName('kendo-multiviewcalendar')
               .item(0)
               ?.contains(event.target)
-          )
+          ) ||
+          typeof +event.target.textContent !== 'number'
         ) {
           this.closeCalendar();
         }
@@ -193,36 +194,38 @@ export class DateWrapperDirective implements AfterContentInit, OnDestroy {
    * Open the associated calendar
    */
   openCalendar(): void {
-    this.isCalendarOpen = true;
-    const overlayOriginPosition = this.setOverlayOriginPosition();
-    // We create an overlay for the displayed calendar
-    this.overlayRef = this.overlay.create({
-      hasBackdrop: false,
-      // close calendar on user scroll - default behavior, could be changed
-      scrollStrategy: this.overlay.scrollStrategies.close(),
-      // We position the displayed calendar taking current directive host element as reference
-      positionStrategy: this.overlay
-        .position()
-        .flexibleConnectedTo(this.el)
-        .withPositions(overlayOriginPosition),
-    });
-    // Create the template portal for the current calendar
-    const templatePortal = new TemplatePortal(
-      this.uiDateWrapper.calendar,
-      this.viewContainerRef
-    );
-    // Attach it to our overlay
-    this.overlayRef.attach(templatePortal);
-    // We add the needed classes to create the animation on calendar display
-    setTimeout(() => {
-      this.applyCalendarDisplayAnimation(true);
-    }, 0);
-    // Subscribe to all actions that close the calendar
-    this.calendarClosingActionsSubscription =
-      this.calendarClosingActions().subscribe(
-        // If so, close calendar
-        () => this.closeCalendar()
+    if (!this.isCalendarOpen) {
+      this.isCalendarOpen = true;
+      const overlayOriginPosition = this.setOverlayOriginPosition();
+      // We create an overlay for the displayed calendar
+      this.overlayRef = this.overlay.create({
+        hasBackdrop: false,
+        // close calendar on user scroll - default behavior, could be changed
+        scrollStrategy: this.overlay.scrollStrategies.close(),
+        // We position the displayed calendar taking current directive host element as reference
+        positionStrategy: this.overlay
+          .position()
+          .flexibleConnectedTo(this.el)
+          .withPositions(overlayOriginPosition),
+      });
+      // Create the template portal for the current calendar
+      const templatePortal = new TemplatePortal(
+        this.uiDateWrapper.calendar,
+        this.viewContainerRef
       );
+      // Attach it to our overlay
+      this.overlayRef.attach(templatePortal);
+      // We add the needed classes to create the animation on calendar display
+      setTimeout(() => {
+        this.applyCalendarDisplayAnimation(true);
+      }, 0);
+      // Subscribe to all actions that close the calendar
+      this.calendarClosingActionsSubscription =
+        this.calendarClosingActions().subscribe(
+          // If so, close calendar
+          () => this.closeCalendar()
+        );
+    }
   }
 
   /**


### PR DESCRIPTION
# Description

When changing the year on the date picker "decade" view sometimes the overlay was closing, this issue was happening will all date-pickers in the platform.

Issue was caused by the datepicker component, which removed the dom when changing views, causing the overlay to detect it as if it was clicked outside.

## Ticket

[67468 cannot alwats change date(https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67468)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested the component in multiple places multiple times and confirm that it wasn't closing unexpectedly

## Screenshots

Nothing changed, just the behaviour

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
