### PR TITLE
Fix 2.0.x/ab#67618 summary cards infinite loading on scroll

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -83,6 +83,7 @@ export class SafeSummaryCardComponent
 
   public searchControl = new FormControl('');
   private searching = false;
+  private scrolling = false;
 
   @ViewChild('summaryCardGrid') summaryCardGrid!: ElementRef<HTMLDivElement>;
   @ViewChild('pdf') pdf!: any;
@@ -276,8 +277,10 @@ export class SafeSummaryCardComponent
     }));
 
     this.cachedCards =
-      (this.pageInfo.pageIndex + 1) * this.pageInfo.pageSize >
-        this.cachedCards.length && !this.searching
+      ((this.pageInfo.pageIndex + 1) * this.pageInfo.pageSize >
+        this.cachedCards.length &&
+        !this.searching) ||
+      this.scrolling
         ? [...this.cachedCards, ...newCards]
         : newCards;
 
@@ -295,6 +298,7 @@ export class SafeSummaryCardComponent
       this.pageInfo.skip = this.cards.length;
     }
     this.searching = false;
+    this.scrolling = false;
   }
 
   /**
@@ -431,6 +435,7 @@ export class SafeSummaryCardComponent
             },
           })
           .then(this.updateCards.bind(this));
+        this.scrolling = true;
       }
     }
   }


### PR DESCRIPTION
# Description

Fixed infitinite loading when scrolling on summary cards.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created summary cards with a large amount of data and tried to scroll.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules