### PR TITLE
fix/AB#67640-select-records-resource-question

### DIFF
--- a/libs/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.html
+++ b/libs/safe/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.html
@@ -26,7 +26,6 @@
     <ui-button
       category="secondary"
       variant="primary"
-      uiDialogClose
       cdkFocusInitial
       (click)="closeModal()"
       *ngIf="selectable"

--- a/libs/safe/src/lib/survey/widgets/dropdown-widget.ts
+++ b/libs/safe/src/lib/survey/widgets/dropdown-widget.ts
@@ -57,6 +57,9 @@ export const init = (Survey: any, domService: DomService): void => {
         'visibleChoices',
         question._propertyValueChangedVirtual
       );
+      question.registerFunctionOnPropertyValueChanged('value', () => {
+        dropdownInstance.value = question.value;
+      });
       updateChoices();
       el.parentElement?.appendChild(dropdownDiv);
     },


### PR DESCRIPTION
# Description
Resources question didn't update the question value using the "Search" button because the SafeResourceGridModalComponent modal was closing wrongly with the uiDialogClose directive on the submit button.
Also, the resource question didn't update the value displayed in the dropbox widget when choosing it with the "Search" button (only if you saved or refresh the page) because the question.value updates weren't updating the dropdownInstance value

## Ticket
[AB#67640 - ABC - Impossible to select records on resources question](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67640)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Changing the value in resource and resources questions using the "Search" button.

## Sreenshots
![fix](https://github.com/ReliefApplications/oort-frontend/assets/28535394/66f9c478-c90b-4cbe-b58e-8b1e793a14b5)

![fix2](https://github.com/ReliefApplications/oort-frontend/assets/28535394/ad481cd5-6e57-425f-8ca2-b0e0a6ca3f8f)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
