### PR TITLE
bugfix/AB#67622_ABC-tooltips-not-appearing-when-dashboard-in-fullscreen-mode

### DIFF
--- a/libs/ui/src/lib/tooltip/tooltip.directive.ts
+++ b/libs/ui/src/lib/tooltip/tooltip.directive.ts
@@ -86,14 +86,17 @@ export class TooltipDirective implements OnDestroy {
    * Show the tooltip and place it on the screen accordingly to its width and height
    */
   private showHint() {
+    // Fullscreen only renders the current fulsscreened element,
+    // Therefor we check if exists to take it as a reference, else we use the document body by default
+    const elementRef = this.document.fullscreenElement ?? this.document.body;
     this.elToolTip.textContent = this.uiTooltip;
     this.renderer.addClass(this.elToolTip, 'opacity-0');
-    this.renderer.appendChild(this.document.body, this.elToolTip);
+    this.renderer.appendChild(elementRef, this.elToolTip);
     // Management of tooltip placement in the screen (including screen edges cases)
     const hostPos = this.elementRef.nativeElement.getBoundingClientRect();
     const tooltipPos = this.elToolTip.getBoundingClientRect();
     this.renderer.removeClass(this.elToolTip, 'opacity-0');
-    this.renderer.removeChild(this.document.body, this.elToolTip);
+    this.renderer.removeChild(elementRef, this.elToolTip);
 
     const top = hostPos.bottom;
     const left = hostPos.left;
@@ -116,7 +119,7 @@ export class TooltipDirective implements OnDestroy {
     }
     this.renderer.setStyle(this.elToolTip, 'top', topValue);
     this.renderer.setStyle(this.elToolTip, 'left', leftValue);
-    this.renderer.appendChild(this.document.body, this.elToolTip);
+    this.renderer.appendChild(elementRef, this.elToolTip);
   }
 
   /**


### PR DESCRIPTION
# Description

feat: take fullscreen element as reference if exists in order to attach tooltip elements there

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67622)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
