### PR TITLE
bugfix/AB#67468_ABC-cannot-always-change-date

### DIFF
--- a/libs/ui/src/lib/date/date-picker/date-picker.component.html
+++ b/libs/ui/src/lib/date/date-picker/date-picker.component.html
@@ -8,6 +8,7 @@
     [value]="value"
     topView="decade"
     (valueChange)="handleChange($event)"
+    (activeViewChange)="viewChangeAction = true"
   >
     <kendo-multiviewcalendar-messages
       today="{{ 'kendo.datepicker.today' | translate }}"

--- a/libs/ui/src/lib/date/date-picker/date-picker.component.ts
+++ b/libs/ui/src/lib/date/date-picker/date-picker.component.ts
@@ -22,12 +22,15 @@ export class DatePickerComponent {
 
   value!: Date;
 
+  viewChangeAction = false;
+
   /**
    * Handles the selection of a content
    *
    * @param value selected date
    */
   public handleChange(value: Date) {
+    this.viewChangeAction = false;
     this.value = value;
     this.selectedValue.emit(value);
   }

--- a/libs/ui/src/lib/date/date-range/date-range.component.html
+++ b/libs/ui/src/lib/date/date-range/date-range.component.html
@@ -8,6 +8,7 @@
     [showViewHeader]="true"
     [views]="2"
     topView="decade"
+    (activeViewChange)="viewChangeAction = true"
   >
     <kendo-multiviewcalendar-messages
       today="{{ 'kendo.datepicker.today' | translate }}"

--- a/libs/ui/src/lib/date/date-range/date-range.component.ts
+++ b/libs/ui/src/lib/date/date-range/date-range.component.ts
@@ -26,12 +26,15 @@ export class DateRangeComponent {
     end: null,
   } as unknown as SelectionRange;
 
+  viewChangeAction = false;
+
   /**
    * Handles the selection of a content
    *
    * @param event SelectionRange
    */
   public onChange(event: SelectionRange) {
+    this.viewChangeAction = false;
     this.range = event as any;
     this.selectedValue.emit(this.range);
   }

--- a/libs/ui/src/lib/date/date-wrapper.directive.ts
+++ b/libs/ui/src/lib/date/date-wrapper.directive.ts
@@ -90,9 +90,9 @@ export class DateWrapperDirective implements AfterContentInit, OnDestroy {
             this.document
               .getElementsByTagName('kendo-multiviewcalendar')
               .item(0)
-              ?.contains(event.target)
-          ) ||
-          typeof +event.target.textContent !== 'number'
+              ?.contains(event.target) ||
+            this.uiDateWrapper.viewChangeAction
+          )
         ) {
           this.closeCalendar();
         }


### PR DESCRIPTION
# Description

fix: add viewChange check in calendar close event stream

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67468)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to screenshots below

## Sreenshots

Date picker:
![chrome-capture-2023-5-22 (1)](https://github.com/ReliefApplications/oort-frontend/assets/123092672/a9cb4cf3-4b64-4c36-a91f-5af0accdb7c0)
Date range:
![chrome-capture-2023-5-22](https://github.com/ReliefApplications/oort-frontend/assets/123092672/61a83668-403c-4921-a0eb-61067ee9d43e)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
