### PR TITLE
Moved searchbar to header

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -56,15 +56,6 @@
   </kendo-tilelayout-item-header>
   <!-- Cards display mode -->
   <ng-container *ngIf="displayMode === 'cards'">
-    <!-- Search -->
-    <!-- <div class="bg-zinc-50 p-2" *ngIf="!!settings.widgetDisplay?.searchable">
-      <input
-        [placeholder]="'common.placeholder.search' | translate"
-        kendoTextBox
-        [formControl]="searchControl"
-        class="!w-full"
-      />
-    </div> -->
     <!-- Export -->
     <div class="w-full grow overflow-auto" #summaryCardGrid>
       <kendo-pdf-export #pdf paperSize="A4" margin="2cm">

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -11,6 +11,15 @@
     <span class="widget-title" [title]="settings.title">{{
       settings.title
     }}</span>
+    <!-- Searchbar -->
+    <div *ngIf="settings.widgetDisplay?.searchable"
+    class="px-2 shadow-sm rounded-md border-0 ring-1 ring-inset ring-gray-300 flex items-center m-1 w-[30%] max-w-[200px]">
+      <input
+        class="h-full bg-transparent w-full"
+        [placeholder]="'common.placeholder.search' | translate"
+        [formControl]="searchControl"
+      />
+    </div>
     <!-- Switch between grid and cards view -->
     <div class="flex">
       <!-- Data source button -->
@@ -48,14 +57,14 @@
   <!-- Cards display mode -->
   <ng-container *ngIf="displayMode === 'cards'">
     <!-- Search -->
-    <div class="bg-zinc-50 p-2" *ngIf="!!settings.widgetDisplay?.searchable">
+    <!-- <div class="bg-zinc-50 p-2" *ngIf="!!settings.widgetDisplay?.searchable">
       <input
         [placeholder]="'common.placeholder.search' | translate"
         kendoTextBox
         [formControl]="searchControl"
         class="!w-full"
       />
-    </div>
+    </div> -->
     <!-- Export -->
     <div class="w-full grow overflow-auto" #summaryCardGrid>
       <kendo-pdf-export #pdf paperSize="A4" margin="2cm">

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -12,8 +12,10 @@
       settings.title
     }}</span>
     <!-- Searchbar -->
-    <div *ngIf="settings.widgetDisplay?.searchable"
-    class="px-2 shadow-sm rounded-md border-0 ring-1 ring-inset ring-gray-300 flex items-center m-1 w-[30%] max-w-[200px]">
+    <div
+      *ngIf="settings.widgetDisplay?.searchable && displayMode === 'cards'"
+      class="px-2 shadow-sm rounded-md border-0 ring-1 ring-inset ring-gray-300 flex items-center m-1 w-[30%] max-w-[200px]"
+    >
       <input
         class="h-full bg-transparent w-full"
         [placeholder]="'common.placeholder.search' | translate"


### PR DESCRIPTION
# Description

The searchbar for the summary widget component has been moved to the header of the widget.

## Ticket

[67613- ABC show search in header summary card](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67613)

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] Check that the searchbar shows correctly in the header

## Screenshots

![Screenshot from 2023-06-22 10-59-29](https://github.com/ReliefApplications/oort-frontend/assets/94831019/d8f19ce6-fadb-440d-8cfc-eb883d2e27d6)
![Screenshot from 2023-06-22 10-59-56](https://github.com/ReliefApplications/oort-frontend/assets/94831019/16fab2bf-82fe-424a-897c-493ff1cc96e6)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
