### PR TITLE
AB#67618 : Add spinner to replace skeleton on scroll

### DIFF
--- a/libs/safe/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/safe/src/lib/components/widgets/editor/editor.component.ts
@@ -99,7 +99,6 @@ export class SafeEditorComponent implements OnInit {
     );
 
     if (get(apolloRes, 'data')) {
-      console.log(this.settings);
       this.layout = apolloRes.data.resource.layouts?.edges[0].node;
       if (this.settings.useStyles) {
         this.styles = this.layout?.query.style;

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -90,6 +90,7 @@
         </div>
       </kendo-pdf-export>
     </div>
+    <ui-spinner *ngIf="scrolling"></ui-spinner>
     <!-- Pagination -->
     <ui-paginator
       *ngIf="settings.widgetDisplay?.usePagination"

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -428,7 +428,7 @@ export class SafeSummaryCardComponent
       e.target.scrollHeight - (e.target.clientHeight + e.target.scrollTop) <
       50
     ) {
-      if (!this.loading && this.pageInfo.length > this.cards.length) {
+      if (!this.scrolling && this.pageInfo.length > this.cards.length) {
         this.dataQuery
           ?.fetchMore({
             variables: {

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -83,7 +83,7 @@ export class SafeSummaryCardComponent
 
   public searchControl = new FormControl('');
   private searching = false;
-  private scrolling = false;
+  public scrolling = false;
 
   @ViewChild('summaryCardGrid') summaryCardGrid!: ElementRef<HTMLDivElement>;
   @ViewChild('pdf') pdf!: any;
@@ -159,7 +159,9 @@ export class SafeSummaryCardComponent
     ) {
       this.summaryCardGrid.nativeElement.addEventListener(
         'scroll',
-        (event: any) => this.loadOnScroll(event)
+        (event: any) => {
+          this.loadOnScroll(event);
+        }
       );
     }
   }
@@ -427,7 +429,6 @@ export class SafeSummaryCardComponent
       50
     ) {
       if (!this.loading && this.pageInfo.length > this.cards.length) {
-        this.loading = true;
         this.dataQuery
           ?.fetchMore({
             variables: {

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.module.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.module.ts
@@ -6,7 +6,12 @@ import { SafeSummaryCardComponent } from './summary-card.component';
 import { SummaryCardItemModule } from './summary-card-item/summary-card-item.module';
 import { IndicatorsModule } from '@progress/kendo-angular-indicators';
 import { SafeGridWidgetModule } from '../grid/grid.module';
-import { TooltipModule, ButtonModule, PaginatorModule } from '@oort-front/ui';
+import {
+  TooltipModule,
+  ButtonModule,
+  PaginatorModule,
+  SpinnerModule,
+} from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { InputsModule } from '@progress/kendo-angular-inputs';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -30,6 +35,7 @@ import { SafeSkeletonModule } from '../../../directives/skeleton/skeleton.module
     ReactiveFormsModule,
     SafeSkeletonModule,
     PaginatorModule,
+    SpinnerModule,
   ],
   exports: [SafeSummaryCardComponent],
 })


### PR DESCRIPTION
# Description

When using infinite scrolling on summary cards, adds a spinner to indicate that we are loading more elements and not a skeleton like before

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories/?workitem=67618

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested in back-office with resource at 29 elements

## Screenshots
![infiniteScrolling](https://github.com/ReliefApplications/oort-frontend/assets/103029022/b9cd80b3-be4c-40ef-b6c5-77e53495efaa)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
