### PR TITLE
Fix/ab#67729 not filter items value not match selected option

### DIFF
--- a/libs/safe/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.html
@@ -12,7 +12,7 @@
     <!-- Search -->
     <ng-container *ngTemplateOutlet="search"></ng-container>
     <!-- Regular options -->
-    <ui-select-option *ngFor="let item of items$ | async" [value]="item.id">
+    <ui-select-option *ngFor="let item of items$ | async" [value]="item.id" [ngClass]="{'hidden': item.id === ngControl.control?.value}">
       {{ item.title }}
     </ui-select-option>
   </ui-select-menu>

--- a/libs/ui/src/lib/select-menu/select-menu.component.html
+++ b/libs/ui/src/lib/select-menu/select-menu.component.html
@@ -10,7 +10,7 @@
   <ng-container *ngIf="customTemplate">
     <ng-container
       *ngTemplateOutlet="
-        customTemplate.template;
+        customTemplate.template; 
         context: customTemplate.context
       "
     ></ng-container>


### PR DESCRIPTION
# Description

Filtered out items in select when the search value does not match with the selected option in webmap select

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67729

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested verifying in the application if we put some text in the search that doesn't match with the selected option it's not displayed.

## Sreenshots

![Peek 22-06-2023 10-40](https://github.com/ReliefApplications/oort-frontend/assets/56398308/981a2d0a-67ed-4875-96de-3c0d9c0ab226)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
