### PR TITLE
bugfix/AB#67532_ABC-unable-to-create-aggregation

### DIFF
--- a/libs/safe/src/lib/components/ui/aggregation-builder/aggregation-builder.component.html
+++ b/libs/safe/src/lib/components/ui/aggregation-builder/aggregation-builder.component.html
@@ -5,7 +5,7 @@
     <safe-tagbox
       class="flex flex-1"
       [choices$]="fields$"
-      [formControl]="$any(aggregationForm.get('sourceFields'))"
+      [control]="$any(aggregationForm.get('sourceFields'))"
       [label]="'components.aggregationBuilder.sourceFields' | translate"
     ></safe-tagbox>
   </div>

--- a/libs/safe/src/lib/components/ui/tagbox/tagbox.component.html
+++ b/libs/safe/src/lib/components/ui/tagbox/tagbox.component.html
@@ -36,7 +36,6 @@
       (optionSelected)="add($event)"
       [uiChipListFor]="chipList"
       [chipInputSeparatorKeyCodes]="separatorKeysCodes"
-      [disabled]="choicesEmpty"
       class="bg-transparent block overflow-hidden border-0 rounded-md w-full p-0 text-gray-900 placeholder:text-gray-400 sm:text-sm sm:leading-6 focus:ring-0 focus:ring-inset"
       (chipTokenEnd)="add($event)"
     />

--- a/libs/safe/src/lib/components/ui/tagbox/tagbox.component.ts
+++ b/libs/safe/src/lib/components/ui/tagbox/tagbox.component.ts
@@ -30,12 +30,15 @@ export class SafeTagboxComponent
   public separatorKeysCodes: number[] = [ENTER, COMMA];
   @ViewChild('textInput') private textInput?: ElementRef<HTMLInputElement>;
 
-  public inputControl: FormControl = new UntypedFormControl('');
-  public showInput = false;
   public choicesEmpty = false;
+  public inputControl: FormControl = new UntypedFormControl({
+    value: '',
+    disabled: this.choicesEmpty,
+  });
+  public showInput = false;
 
   // === OUTPUT CONTROL ===
-  @Input() formControl!: FormControl;
+  @Input() control!: FormControl;
 
   /**
    * Tagbox constructor
@@ -47,9 +50,14 @@ export class SafeTagboxComponent
   ngOnInit(): void {
     this.choices$.pipe(takeUntil(this.destroy$)).subscribe((choices: any[]) => {
       this.choicesEmpty = choices.length === 0;
+      if (this.choicesEmpty) {
+        this.inputControl.disable();
+      } else {
+        this.inputControl.enable();
+      }
       this.selectedChoices = this.choicesEmpty
         ? []
-        : this.formControl.value
+        : this.control.value
             .map((value: string) =>
               choices.find((choice) => value === choice[this.valueKey])
             )
@@ -114,9 +122,7 @@ export class SafeTagboxComponent
       this.selectedChoices.push(
         this.availableChoices.find((x) => x[this.displayKey] === value)
       );
-      this.formControl.setValue(
-        this.selectedChoices.map((x) => x[this.valueKey])
-      );
+      this.control.setValue(this.selectedChoices.map((x) => x[this.valueKey]));
       this.filteredChoices = this.availableChoices.filter(
         (x) => x[this.displayKey] !== value
       );
@@ -145,9 +151,7 @@ export class SafeTagboxComponent
             (x) => x[this.valueKey] === choice[this.valueKey]
           )
       );
-      this.formControl.setValue(
-        this.selectedChoices.map((x) => x[this.valueKey])
-      );
+      this.control.setValue(this.selectedChoices.map((x) => x[this.valueKey]));
     }
   }
 }


### PR DESCRIPTION
# Description

fix: formControl class instance load within safe-tagbox component changing the form control input name to a non reserved keyword 
fix: disable state of the input by using the attached formcontrol instead of input default property

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67532/)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
