### PR TITLE
feat/AB#67731-paginator-navigation-by-page-number

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -99,6 +99,7 @@
       [skip]="pageInfo.skip"
       [pageSizeOptions]="[10, 25, 50, 100]"
       [totalItems]="pageInfo.length"
+      [pageNumberNavigation]="true"
       [ariaLabel]="'components.notifications.paginator.ariaLabel' | translate"
       (pageChange)="onPage($event)"
     >

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -100,6 +100,7 @@
       [pageSizeOptions]="[10, 25, 50, 100]"
       [totalItems]="pageInfo.length"
       [pageNumberNavigation]="true"
+      [displayedPageNumbers]="3"
       [ariaLabel]="'components.notifications.paginator.ariaLabel' | translate"
       (pageChange)="onPage($event)"
     >

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -102,8 +102,7 @@
       [skip]="pageInfo.skip"
       [pageSizeOptions]="[10, 25, 50, 100]"
       [totalItems]="pageInfo.length"
-      [pageNumberNavigation]="true"
-      [displayedPageNumbers]="3"
+      [displayedPageNumbers]="5"
       [ariaLabel]="'components.notifications.paginator.ariaLabel' | translate"
       (pageChange)="onPage($event)"
     >

--- a/libs/ui/src/lib/paginator/paginator.component.html
+++ b/libs/ui/src/lib/paginator/paginator.component.html
@@ -42,6 +42,10 @@
             class="border shadow-sm k-pager-numbers-wrap rounded-md ml-auto sm:ml-4"
           >
             <kendo-datapager-prev-buttons></kendo-datapager-prev-buttons>
+            <kendo-datapager-numeric-buttons
+              *ngIf="pageNumberNavigation"
+              [buttonCount]="3"
+            ></kendo-datapager-numeric-buttons>
             <kendo-datapager-next-buttons></kendo-datapager-next-buttons>
           </div>
         </div>

--- a/libs/ui/src/lib/paginator/paginator.component.html
+++ b/libs/ui/src/lib/paginator/paginator.component.html
@@ -43,7 +43,7 @@
           >
             <kendo-datapager-prev-buttons></kendo-datapager-prev-buttons>
             <kendo-datapager-numeric-buttons
-              *ngIf="pageNumberNavigation"
+              *ngIf="displayedPageNumbers"
               [buttonCount]="displayedPageNumbers"
             ></kendo-datapager-numeric-buttons>
             <kendo-datapager-next-buttons></kendo-datapager-next-buttons>

--- a/libs/ui/src/lib/paginator/paginator.component.html
+++ b/libs/ui/src/lib/paginator/paginator.component.html
@@ -44,7 +44,7 @@
             <kendo-datapager-prev-buttons></kendo-datapager-prev-buttons>
             <kendo-datapager-numeric-buttons
               *ngIf="pageNumberNavigation"
-              [buttonCount]="3"
+              [buttonCount]="displayedPageNumbers"
             ></kendo-datapager-numeric-buttons>
             <kendo-datapager-next-buttons></kendo-datapager-next-buttons>
           </div>

--- a/libs/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/src/lib/paginator/paginator.component.ts
@@ -18,6 +18,7 @@ export class PaginatorComponent {
   @Input() pageSizeOptions = [5, 10, 15];
   @Input() ariaLabel = '';
   @Input() pageIndex = 0;
+  @Input() pageNumberNavigation = false;
   @Output() pageChange: EventEmitter<UIPageChangeEvent> = new EventEmitter();
 
   // Generate random unique identifier for each paginator component

--- a/libs/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/src/lib/paginator/paginator.component.ts
@@ -19,6 +19,7 @@ export class PaginatorComponent {
   @Input() ariaLabel = '';
   @Input() pageIndex = 0;
   @Input() pageNumberNavigation = false;
+  @Input() displayedPageNumbers = 2;
   @Output() pageChange: EventEmitter<UIPageChangeEvent> = new EventEmitter();
 
   // Generate random unique identifier for each paginator component

--- a/libs/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/src/lib/paginator/paginator.component.ts
@@ -18,8 +18,7 @@ export class PaginatorComponent {
   @Input() pageSizeOptions = [5, 10, 15];
   @Input() ariaLabel = '';
   @Input() pageIndex = 0;
-  @Input() pageNumberNavigation = false;
-  @Input() displayedPageNumbers = 2;
+  @Input() displayedPageNumbers = 0;
   @Output() pageChange: EventEmitter<UIPageChangeEvent> = new EventEmitter();
 
   // Generate random unique identifier for each paginator component


### PR DESCRIPTION
# Description
Added optional navigation by page number in ui-paginator by creating the input pageNumberNavigation (by default set as false).
Displaying it only in the summary-card widget

## Ticket
[AB#67731 - ABC - Improve ui-paginator to enable navigation by page number](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67731)

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Enabled the navigation by clicking on the page number in the summary card widget and testing change pages with it.

## Sreenshots
![sc](https://github.com/ReliefApplications/oort-frontend/assets/28535394/931f9d95-a2a6-44e8-8218-5135bb165af1)
![story](https://github.com/ReliefApplications/oort-frontend/assets/28535394/0df60ce3-d2e7-4e74-bc23-b9619e70c71d)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
