### PR TITLE
bugfix/AB#67532_ABC-unable-to-create-aggregation

### DIFF
--- a/libs/safe/src/lib/components/ui/tagbox/tagbox.component.ts
+++ b/libs/safe/src/lib/components/ui/tagbox/tagbox.component.ts
@@ -141,12 +141,10 @@ export class SafeTagboxComponent
    * @param choice Choice to remove.
    */
   remove(choice: any): void {
-    const index = this.selectedChoices.findIndex(
-      (x) => x[this.valueKey] === choice[this.valueKey]
-    );
-
-    if (index >= 0) {
-      this.selectedChoices.splice(index, 1);
+    if (choice) {
+      this.selectedChoices = this.selectedChoices.filter(
+        (x) => x[this.valueKey] !== choice[this.valueKey]
+      );
       this.filteredChoices = this.availableChoices.filter(
         (choice) =>
           !this.selectedChoices.find(

--- a/libs/safe/src/lib/components/ui/tagbox/tagbox.component.ts
+++ b/libs/safe/src/lib/components/ui/tagbox/tagbox.component.ts
@@ -113,8 +113,7 @@ export class SafeTagboxComponent
    * @param event Chip event with the text input.
    */
   add(event: string | any): void {
-    const value = (event[this.displayKey] ?? event).trim();
-
+    const value = event[this.displayKey] ?? event;
     if (
       value &&
       this.availableChoices.some((x) => x[this.displayKey] === value)
@@ -124,7 +123,10 @@ export class SafeTagboxComponent
       );
       this.control.setValue(this.selectedChoices.map((x) => x[this.valueKey]));
       this.filteredChoices = this.availableChoices.filter(
-        (x) => x[this.displayKey] !== value
+        (choice) =>
+          !this.selectedChoices.find(
+            (x) => x[this.valueKey] === choice[this.valueKey]
+          )
       );
     }
     this.inputControl.setValue('', { emitEvent: false });


### PR DESCRIPTION
# Description

fix: random autocomplete panel close event using the same open/close handler of the select-menu component from the UI library
fix: show choices in the autocomplete list on selection of choice, it was showing selected choices also

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67532/)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
