### PR TITLE
fix/AB#67842-current-zoom-not-appearing

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1351,7 +1351,9 @@
 						"popup": "Pop-up",
 						"properties": {
 							"defaultVisibility": "Visible by default",
+							"from": "from zoom ",
 							"opacity": "Opacity",
+							"to": " to zoom",
 							"visibilityRange": "Visibility range",
 							"zoom": "Current zoom"
 						},

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1367,7 +1367,9 @@
 						"popup": "Popup",
 						"properties": {
 							"defaultVisibility": "Visible par défaut",
+							"from": "de zoom ",
 							"opacity": "Opacité",
+							"to": " à zoom",
 							"visibilityRange": "Plage de visibilité",
 							"zoom": "Zoom"
 						},

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1351,7 +1351,9 @@
 						"popup": "******",
 						"properties": {
 							"defaultVisibility": "******",
+							"from": "******",
 							"opacity": "******",
+							"to": "******",
 							"visibilityRange": "******",
 							"zoom": "******"
 						},

--- a/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.html
@@ -27,6 +27,7 @@
         <ng-template uiTabContent>
           <safe-layer-properties
             [form]="form"
+            [currentZoom]="currentZoom"
             [destroyTab$]="destroyTab$"
             [currentMapContainerRef]="data.currentMapContainerRef"
           ></safe-layer-properties>

--- a/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/layer-properties/layer-properties.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/layer-properties/layer-properties.component.html
@@ -40,6 +40,10 @@
             'components.widget.settings.map.edit.properties.visibilityRange'
               | translate
           }}
+          ({{'components.widget.settings.map.edit.properties.from' | translate}}
+            {{form.get('layerDefinition')?.get('minZoom')?.value}}
+            {{'components.widget.settings.map.edit.properties.to' | translate}}
+            {{form.get('layerDefinition')?.get('maxZoom')?.value}})
         </h3>
         <!--@TODO TAILWIND-->
         <div class="flex flex-row gap-2">

--- a/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/layer-properties/layer-properties.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/layer-properties/layer-properties.component.ts
@@ -17,7 +17,7 @@ import { MapComponent } from '../../../../ui/map';
 })
 export class LayerPropertiesComponent implements AfterViewInit {
   @Input() form!: LayerFormT;
-  // @Input() currentZoom!: number | undefined;
+  @Input() currentZoom!: number | undefined;
 
   // Display of map
   @Input() currentMapContainerRef!: BehaviorSubject<ViewContainerRef | null>;
@@ -26,12 +26,6 @@ export class LayerPropertiesComponent implements AfterViewInit {
   @Input() destroyTab$!: Subject<boolean>;
 
   @ViewChild(MapComponent, { static: false }) mapComponent?: MapComponent;
-
-  /** @returns Get current zoom from map component */
-  get currentZoom() {
-    if (this.mapComponent) return this.mapComponent.map.getZoom();
-    else return '';
-  }
 
   ngAfterViewInit(): void {
     this.currentMapContainerRef


### PR DESCRIPTION
# Description
The MapComponent ViewChild was always undefined, regardless of the lifecycle hook etc, so the  get currentZoom() didn't return any value. Now using again the currentZoom input (updated ways in the parent component when the zoom event ends), the zoom value is correctly displayed
Added next to the visibility range the min and max values selected.

## Ticket
[AB#67842 - DB - Current zoom not appearing in edit-layer-modal](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67842)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Changing the map current zoom and the visibility range, and watching the updated numbers correctly displayed in the settings.

## Sreenshots
![layer](https://github.com/ReliefApplications/oort-frontend/assets/28535394/12d89e81-6c1b-4d7c-9351-3217bf3781cd)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
