### PR TITLE
fix/AB#67844-disable-layers-control-when-editing-layer

### DIFF
--- a/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -26,6 +26,7 @@ import { SafeConfirmService } from '../../../services/confirm/confirm.service';
 import { TranslateService } from '@ngx-translate/core';
 import { MapComponent } from '../../ui/map';
 import { extendWidgetForm } from '../common/display-settings/extendWidgetForm';
+import { SafeLayoutService } from '../../../services/layout/layout.service';
 
 /** Component for the map widget settings */
 @Component({
@@ -59,6 +60,9 @@ export class SafeMapSettingsComponent
   );
   destroyTab$: Subject<boolean> = new Subject<boolean>();
 
+  // Layers controls right side nav
+  private openedLayersSideNav = false;
+
   /**
    * Class constructor
    *
@@ -66,12 +70,14 @@ export class SafeMapSettingsComponent
    * @param confirmService SafeConfirmService
    * @param translate TranslateService
    * @param cdr ChangeDetectorRef
+   * @param layoutService Shared layout service
    */
   constructor(
     private mapLayersService: SafeMapLayersService,
     private confirmService: SafeConfirmService,
     private translate: TranslateService,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private layoutService: SafeLayoutService
   ) {
     super();
   }
@@ -104,6 +110,14 @@ export class SafeMapSettingsComponent
     );
     this.mapComponent = componentRef.instance;
     this.currentMapContainerRef.next(this.mapContainerRef);
+
+    this.layoutService.rightSidenav$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((view: any) => {
+        if (view.inputs?.layersMenuExpanded) {
+          this.openedLayersSideNav = true;
+        }
+      });
   }
 
   /**
@@ -363,5 +377,9 @@ export class SafeMapSettingsComponent
   override ngOnDestroy(): void {
     super.ngOnDestroy();
     this.mapContainerRef.detach();
+    // Destroy layers control sidenav when closing the settings
+    if (this.openedLayersSideNav) {
+      this.layoutService.setRightSidenav(null);
+    }
   }
 }

--- a/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -60,7 +60,7 @@ export class SafeMapSettingsComponent
   );
   destroyTab$: Subject<boolean> = new Subject<boolean>();
 
-  // Layers controls right side nav
+  // Layers controls right side nav. Store if sidenav is used, to be able to destroy it when closing the view.
   private openedLayersSideNav = false;
 
   /**


### PR DESCRIPTION
# Description
Ensure that the map layer control sidenav is destroyed when you close the settings component

## Ticket
[AB#67844 - DB - Disable layers control on top right when editing layer](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67844)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Opening the layers control side nav with the map settings (and layer settings) opened, and after closed the sidenav is closed as well.

## Sreenshots
![map](https://github.com/ReliefApplications/oort-frontend/assets/28535394/3277f41b-af47-419b-bfbc-425470a4fe3e)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
