### PR TITLE
Fix/ab#67763 saved field to update quick action not available

### DIFF
--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -137,58 +137,23 @@
               >
               </ui-button>
             </div>
-           
-            <ng-container *ngIf="modification.value.field">
-              <!-- @todo: replace with ngSwitch and better manage all types -->
+
+            <ng-container
+              *ngIf="
+                modification.value.field &&
+                scalarField(modification.value.field)
+              "
+            >
               <ng-container
-                *ngIf="
-                  ['Int', 'Float'].includes(getScalarField(modification.value.field).type.name)
+                *ngTemplateOutlet="
+                  modificationTemplate;
+                  context: {
+                    formGroup: $any(modification),
+                    field: scalarField(modification.value.field)
+                  }
                 "
-              >
-                <div uiFormFieldDirective>
-                  <label>{{
-                    'components.widget.settings.grid.buttons.callback.modifyValue'
-                      | translate
-                  }}</label>
-                  <input formControlName="value" type="number" />
-                </div>
-              </ng-container>
-              <ng-container
-                *ngIf="getScalarField(modification.value.field).type.name === 'Boolean'"
-              >
-                <div uiFormFieldDirective>
-                  <label>{{
-                    'components.widget.settings.grid.buttons.callback.modifyValue'
-                      | translate
-                  }}</label>
-                  <ui-select-menu formControlName="value">
-                    <ui-select-option>--</ui-select-option>
-                    <ui-select-option [value]="true">{{
-                      'common.true' | translate
-                    }}</ui-select-option>
-                    <ui-select-option [value]="false">{{
-                      'common.false' | translate
-                    }}</ui-select-option>
-                  </ui-select-menu>
-                </div>
-              </ng-container>
-              <ng-container
-                *ngIf="
-                  !['Int', 'Float'].includes(
-                    getScalarField(modification.value.field).type.name
-                  ) && getScalarField(modification.value.field).type.name !== 'Boolean'
-                "
-              >
-                <div uiFormFieldDirective>
-                  <label>{{
-                    'components.widget.settings.grid.buttons.callback.modifyValue'
-                      | translate
-                  }}</label>
-                  <input formControlName="value" type="string" />
-                </div>
-              </ng-container>
+              ></ng-container>
             </ng-container>
-          
           </form>
           <ui-button
             [isIcon]="true"
@@ -450,3 +415,50 @@
     </ng-container>
   </div>
 </form>
+
+<!-- Template for auto modification -->
+<ng-template #modificationTemplate let-field="field" let-formGroup="formGroup">
+  <div [formGroup]="formGroup">
+    <!-- @todo: replace with ngSwitch and better manage all types -->
+    <ng-container *ngIf="['Int', 'Float'].includes(field.type.name)">
+      <div uiFormFieldDirective>
+        <label>{{
+          'components.widget.settings.grid.buttons.callback.modifyValue'
+            | translate
+        }}</label>
+        <input formControlName="value" type="number" />
+      </div>
+    </ng-container>
+    <ng-container *ngIf="field.type.name === 'Boolean'">
+      <div uiFormFieldDirective>
+        <label>{{
+          'components.widget.settings.grid.buttons.callback.modifyValue'
+            | translate
+        }}</label>
+        <ui-select-menu formControlName="value">
+          <ui-select-option>--</ui-select-option>
+          <ui-select-option [value]="true">{{
+            'common.true' | translate
+          }}</ui-select-option>
+          <ui-select-option [value]="false">{{
+            'common.false' | translate
+          }}</ui-select-option>
+        </ui-select-menu>
+      </div>
+    </ng-container>
+    <ng-container
+      *ngIf="
+        !['Int', 'Float'].includes(field.type.name) &&
+        field.type.name !== 'Boolean'
+      "
+    >
+      <div uiFormFieldDirective>
+        <label>{{
+          'components.widget.settings.grid.buttons.callback.modifyValue'
+            | translate
+        }}</label>
+        <input formControlName="value" type="string" />
+      </div>
+    </ng-container>
+  </div>
+</ng-template>

--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -124,7 +124,7 @@
                 <ui-select-option>--</ui-select-option>
                 <ui-select-option
                   *ngFor="let field of scalarFields"
-                  [value]="field"
+                  [value]="field.name"
                   >{{ field.name }}</ui-select-option
                 >
               </ui-select-menu>
@@ -137,11 +137,12 @@
               >
               </ui-button>
             </div>
+           
             <ng-container *ngIf="modification.value.field">
               <!-- @todo: replace with ngSwitch and better manage all types -->
               <ng-container
                 *ngIf="
-                  ['Int', 'Float'].includes(modification.value.field.type.name)
+                  ['Int', 'Float'].includes(getScalarField(modification.value.field).type.name)
                 "
               >
                 <div uiFormFieldDirective>
@@ -153,7 +154,7 @@
                 </div>
               </ng-container>
               <ng-container
-                *ngIf="modification.value.field.type.name === 'Boolean'"
+                *ngIf="getScalarField(modification.value.field).type.name === 'Boolean'"
               >
                 <div uiFormFieldDirective>
                   <label>{{
@@ -174,8 +175,8 @@
               <ng-container
                 *ngIf="
                   !['Int', 'Float'].includes(
-                    modification.value.field.type.name
-                  ) && modification.value.field.type.name !== 'Boolean'
+                    getScalarField(modification.value.field).type.name
+                  ) && getScalarField(modification.value.field).type.name !== 'Boolean'
                 "
               >
                 <div uiFormFieldDirective>
@@ -187,6 +188,7 @@
                 </div>
               </ng-container>
             </ng-container>
+          
           </form>
           <ui-button
             [isIcon]="true"

--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -440,12 +440,13 @@ export class ButtonConfigComponent
     this.deleteButton.emit(true);
   }
 
-  public getScalarField(field: string): any {
-    const scalarField = this.scalarFields.filter((val: any) => {
-      if (val.name === field) {
-        return val;
-      }
-    });
-    return scalarField[0];
+  /**
+   * Get scalar field from name
+   *
+   * @param fieldName field name
+   * @returns scalar field ( if exists )
+   */
+  public scalarField(fieldName: string): any {
+    return this.scalarFields.find((field: any) => field.name === fieldName);
   }
 }

--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -439,4 +439,13 @@ export class ButtonConfigComponent
   public emitDeleteButton(): void {
     this.deleteButton.emit(true);
   }
+
+  public getScalarField(field: string): any{
+    const scalarField = this.scalarFields.filter((val: any) => {
+      if(val.name === field){
+        return val;
+      }
+    })
+    return scalarField[0];
+  }
 }

--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -440,12 +440,12 @@ export class ButtonConfigComponent
     this.deleteButton.emit(true);
   }
 
-  public getScalarField(field: string): any{
+  public getScalarField(field: string): any {
     const scalarField = this.scalarFields.filter((val: any) => {
-      if(val.name === field){
+      if (val.name === field) {
         return val;
       }
-    })
+    });
     return scalarField[0];
   }
 }

--- a/libs/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -148,8 +148,6 @@ export class SafeGridWidgetComponent
 
   ngOnInit() {
     this.gridSettings = { ...this.settings };
-    console.log(this.gridSettings);
-    console.log(this.settings);
     delete this.gridSettings.query;
     if (this.settings.resource) {
       const layouts = get(this.settings, 'layouts', []);
@@ -473,7 +471,6 @@ export class SafeGridWidgetComponent
     modifications: any[],
     ids: any[]
   ): Promise<any> {
-    console.log(modifications);
     const update: any = {};
     for (const modification of modifications) {
       update[modification.field] = modification.value;

--- a/libs/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -39,6 +39,7 @@ import { Layout } from '../../../models/layout.model';
 import { TranslateService } from '@ngx-translate/core';
 import { cleanRecord } from '../../../utils/cleanRecord';
 import get from 'lodash/get';
+import set from 'lodash/set';
 import { SafeApplicationService } from '../../../services/application/application.service';
 import { Aggregation } from '../../../models/aggregation.model';
 import { SafeAggregationService } from '../../../services/aggregation/aggregation.service';
@@ -473,7 +474,9 @@ export class SafeGridWidgetComponent
   ): Promise<any> {
     const update: any = {};
     for (const modification of modifications) {
-      update[modification.field] = modification.value;
+      if (modification.field) {
+        set(update, modification.field, modification.value);
+      }
     }
     const data = cleanRecord(update);
     return firstValueFrom(

--- a/libs/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -148,6 +148,8 @@ export class SafeGridWidgetComponent
 
   ngOnInit() {
     this.gridSettings = { ...this.settings };
+    console.log(this.gridSettings);
+    console.log(this.settings);
     delete this.gridSettings.query;
     if (this.settings.resource) {
       const layouts = get(this.settings, 'layouts', []);
@@ -471,9 +473,10 @@ export class SafeGridWidgetComponent
     modifications: any[],
     ids: any[]
   ): Promise<any> {
+    console.log(modifications);
     const update: any = {};
     for (const modification of modifications) {
-      update[modification.field.name] = modification.value;
+      update[modification.field] = modification.value;
     }
     const data = cleanRecord(update);
     return firstValueFrom(

--- a/libs/safe/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/safe/src/lib/survey/global-properties/reference-data.ts
@@ -264,7 +264,7 @@ export const render = (
     // Prevent selected choices to be removed when sending the value
     question.clearIncorrectValuesCallback = () => {
       // console.log(question.visibleChoices);
-      console.log(question.value);
+      // console.log(question.value);
     };
     // look on changes
     question.registerFunctionOnPropertyValueChanged(


### PR DESCRIPTION
# Description

 Fixed already saved 'field to update' value in quick action section of grid is not available on page refresh.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67763

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested verifying in the application if now saved 'field to update' value in quick action section of grid is available on page refresh.

## Sreenshots

![Peek 23-06-2023 09-35](https://github.com/ReliefApplications/oort-frontend/assets/56398308/c42d2d5d-10f2-4296-9444-0df06e4a8670)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
