### PR TITLE
Bugfix/ab#67930 db duplicated layers on map change in the map settings

### DIFF
--- a/libs/safe/src/lib/components/ui/map/layer.ts
+++ b/libs/safe/src/lib/components/ui/map/layer.ts
@@ -840,6 +840,7 @@ export class Layer implements LayerModel {
     if (legendControl) {
       legendControl.removeLayer(layer);
     }
+    map.off('zoomend', this.zoomListener);
   }
 
   /**

--- a/libs/safe/src/lib/components/ui/map/map.component.ts
+++ b/libs/safe/src/lib/components/ui/map/map.component.ts
@@ -360,7 +360,10 @@ export class MapComponent
       layers?: L.Control.Layers.TreeObject[];
     }>[] = [];
 
+    // Flag to set again basemap or webmap in map even if no basemap or webmap change is done
+    // For layer change case trigger(on layer change all layers, including basemap and webmaps, are deleted by default)
     let layersRemoved = false;
+
     if (
       this.layerIds.length !== layers?.length ||
       difference(layers, this.layerIds).length

--- a/libs/safe/src/lib/components/ui/map/map.component.ts
+++ b/libs/safe/src/lib/components/ui/map/map.component.ts
@@ -217,7 +217,6 @@ export class MapComponent
     this.setUpMapListeners();
 
     setTimeout(() => {
-      console.log('invalidating');
       this.map.invalidateSize();
       this.mapEvent.emit({
         type: MapEventType.FIRST_LOAD,
@@ -336,19 +335,24 @@ export class MapComponent
       if (this.map.getZoom() !== initialState.viewpoint.zoom) {
         this.map.setZoom(initialState.viewpoint.zoom);
       }
-      const currentCenter = this.map.getCenter();
-      if (
-        initialState.viewpoint.center.latitude !== currentCenter.lat ||
-        initialState.viewpoint.center.longitude !== currentCenter.lng
-      ) {
-        this.map.setView(
-          L.latLng(
-            initialState.viewpoint.center.latitude,
-            initialState.viewpoint.center.longitude
-          ),
-          initialState.viewpoint.zoom
-        );
-      }
+      // Could ask the map to do some unwanted movements
+      // const currentCenter = this.map.getCenter();
+      // if (
+      //   initialState.viewpoint.center.latitude !== currentCenter.lat ||
+      //   initialState.viewpoint.center.longitude !== currentCenter.lng
+      // ) {
+      //   console.log([
+      //     initialState.viewpoint.center.latitude,
+      //     initialState.viewpoint.center.longitude,
+      //   ]);
+      //   this.map.setView(
+      //     L.latLng(
+      //       initialState.viewpoint.center.latitude,
+      //       initialState.viewpoint.center.longitude
+      //     ),
+      //     initialState.viewpoint.zoom
+      //   );
+      // }
     }
 
     // Close layers/bookmarks menu

--- a/libs/safe/src/lib/components/widgets/map-settings/map-layers/map-layers.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-layers/map-layers.component.ts
@@ -211,9 +211,7 @@ export class MapLayersComponent
                     const index = this.mapLayers.findIndex(
                       (layer) => layer.id === id
                     );
-                    if (index > -1) {
-                      // editing already selected layer
-                      this.mapLayers = this.mapLayers.splice(index, 1, res);
+                    if (index !== -1) {
                       this.restoreMapSettingsView();
                     } else {
                       // Selecting a new layer

--- a/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -114,7 +114,7 @@ export class SafeMapSettingsComponent
     this.layoutService.rightSidenav$
       .pipe(takeUntil(this.destroy$))
       .subscribe((view: any) => {
-        if (view.inputs?.layersMenuExpanded) {
+        if (view?.inputs?.layersMenuExpanded) {
           this.openedLayersSideNav = true;
         }
       });

--- a/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -18,12 +18,9 @@ import {
   MapEvent,
   MapEventType,
 } from '../../ui/map/interfaces/map.interface';
-import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, Subject, debounceTime, takeUntil } from 'rxjs';
 import { SafeUnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.component';
 import { LayerModel } from '../../../models/layer.model';
-import { SafeMapLayersService } from '../../../services/map/map-layers.service';
-import { SafeConfirmService } from '../../../services/confirm/confirm.service';
-import { TranslateService } from '@ngx-translate/core';
 import { MapComponent } from '../../ui/map';
 import { extendWidgetForm } from '../common/display-settings/extendWidgetForm';
 import { SafeLayoutService } from '../../../services/layout/layout.service';
@@ -66,16 +63,10 @@ export class SafeMapSettingsComponent
   /**
    * Class constructor
    *
-   * @param mapLayersService SafeMapLayersService to add/edit/remove layers
-   * @param confirmService SafeConfirmService
-   * @param translate TranslateService
    * @param cdr ChangeDetectorRef
    * @param layoutService Shared layout service
    */
   constructor(
-    private mapLayersService: SafeMapLayersService,
-    private confirmService: SafeConfirmService,
-    private translate: TranslateService,
     private cdr: ChangeDetectorRef,
     private layoutService: SafeLayoutService
   ) {
@@ -147,7 +138,7 @@ export class SafeMapSettingsComponent
     });
     this.tileForm
       .get('initialState')
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      ?.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(1000))
       .subscribe((value) =>
         this.updateMapSettings({
           initialState: value,
@@ -155,13 +146,13 @@ export class SafeMapSettingsComponent
       );
     this.tileForm
       .get('basemap')
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      ?.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(1000))
       .subscribe((value) =>
         this.updateMapSettings({ basemap: value } as MapConstructorSettings)
       );
     this.tileForm
       .get('controls')
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      ?.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(1000))
       .subscribe((value) => {
         this.updateMapSettings({
           controls: value,
@@ -169,7 +160,7 @@ export class SafeMapSettingsComponent
       });
     this.tileForm
       .get('arcGisWebMap')
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      ?.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(1000))
       .subscribe((value) =>
         this.updateMapSettings({
           arcGisWebMap: value,
@@ -177,7 +168,7 @@ export class SafeMapSettingsComponent
       );
     this.tileForm
       .get('layers')
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      ?.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(1000))
       .subscribe((value) =>
         this.updateMapSettings({
           layers: value,
@@ -217,7 +208,6 @@ export class SafeMapSettingsComponent
    * @param settings new settings
    */
   private updateMapSettings(settings: MapConstructorSettings) {
-    console.log('update');
     if (this.mapSettings) {
       this.mapSettings = {
         ...this.mapSettings,

--- a/libs/safe/src/lib/services/map/arcgis.service.ts
+++ b/libs/safe/src/lib/services/map/arcgis.service.ts
@@ -27,7 +27,7 @@ import { GradientPipe } from '../../pipes/gradient/gradient.pipe';
 const arcgisProj =
   '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs';
 
-type TreeObject = { label: string; layer: L.Layer };
+export type TreeObject = { label: string; layer: L.Layer };
 
 /**
  * Shared ArcGIS service map.


### PR DESCRIPTION
# Description

fix: no need to slice current mapLayers from edit if is not a delete or new layer
fix: layer duplication on zoom by removing the zoom listener for each layer removal
fix: layer duplication and basemap/webmap/layer trigger by adding/removing those only on basemap/webmap/layer change, if other map settings are changed no layer event is triggered
fix: undefined view on map-settings edit first load by adding '?' check

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67930)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
