### PR TITLE
bugfix/AB#67616_ABC-multiple-layers-created-in-legend-on-geofield-change-in-layer

### DIFF
--- a/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -138,7 +138,7 @@ export class SafeMapSettingsComponent
     });
     this.tileForm
       .get('initialState')
-      ?.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(1000))
+      ?.valueChanges.pipe(debounceTime(1000), takeUntil(this.destroy$))
       .subscribe((value) =>
         this.updateMapSettings({
           initialState: value,
@@ -146,13 +146,13 @@ export class SafeMapSettingsComponent
       );
     this.tileForm
       .get('basemap')
-      ?.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(1000))
+      ?.valueChanges.pipe(debounceTime(1000), takeUntil(this.destroy$))
       .subscribe((value) =>
         this.updateMapSettings({ basemap: value } as MapConstructorSettings)
       );
     this.tileForm
       .get('controls')
-      ?.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(1000))
+      ?.valueChanges.pipe(debounceTime(1000), takeUntil(this.destroy$))
       .subscribe((value) => {
         this.updateMapSettings({
           controls: value,
@@ -160,7 +160,7 @@ export class SafeMapSettingsComponent
       });
     this.tileForm
       .get('arcGisWebMap')
-      ?.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(1000))
+      ?.valueChanges.pipe(debounceTime(1000), takeUntil(this.destroy$))
       .subscribe((value) =>
         this.updateMapSettings({
           arcGisWebMap: value,
@@ -168,7 +168,7 @@ export class SafeMapSettingsComponent
       );
     this.tileForm
       .get('layers')
-      ?.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(1000))
+      ?.valueChanges.pipe(debounceTime(1000), takeUntil(this.destroy$))
       .subscribe((value) =>
         this.updateMapSettings({
           layers: value,


### PR DESCRIPTION
# Description

fix: fetch new layer on properties change in datasource tab, otherwise update current layer properties
fix: deleted unnecessary debounceTime pipes plus reorder takeUntil destroyers to the end of pipeline to make them work successfully

## Ticket

[Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67616)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
