### PR TITLE
Bug/ab#67912 more than selected flags are shown

### DIFF
--- a/libs/safe/src/lib/utils/parser/utils.ts
+++ b/libs/safe/src/lib/utils/parser/utils.ts
@@ -144,7 +144,7 @@ const replaceRecordFields = (
   let formattedHtml = html;
   if (fields) {
     for (const field of fields) {
-      let value = fieldsValue[field.name];
+      const value = fieldsValue[field.name];
       const style = getLayoutsStyle(styles, field.name, fieldsValue);
       let convertedValue = '';
       if (!isNil(value)) {
@@ -161,7 +161,7 @@ const replaceRecordFields = (
         );
         const match = avatarRgx.exec(formattedHtml);
         if (Array.isArray(value) && value.length > 0) {
-          value = value.filter((v: string) => {
+          const avatarValue = value.filter((v: string) => {
             const lowercaseValue = v.toLowerCase();
             return (
               lowercaseValue.endsWith('.jpg') ||
@@ -171,16 +171,18 @@ const replaceRecordFields = (
               lowercaseValue.endsWith('.bmp')
             );
           });
-          const avatarGroup = createAvatarGroup(
-            value,
-            Number(match?.groups?.width),
-            Number(match?.groups?.height),
-            Number(match?.groups?.maxItems)
-          );
-          formattedHtml = formattedHtml.replace(
-            avatarRgx,
-            avatarGroup.innerHTML
-          );
+          if (avatarValue.length > 0) {
+            const avatarGroup = createAvatarGroup(
+              avatarValue,
+              Number(match?.groups?.width),
+              Number(match?.groups?.height),
+              Number(match?.groups?.maxItems)
+            );
+            formattedHtml = formattedHtml.replace(
+              avatarRgx,
+              avatarGroup.innerHTML
+            );
+          }
         } else {
           formattedHtml = formattedHtml.replace(avatarRgx, '');
         }

--- a/libs/safe/src/lib/utils/parser/utils.ts
+++ b/libs/safe/src/lib/utils/parser/utils.ts
@@ -144,7 +144,7 @@ const replaceRecordFields = (
   let formattedHtml = html;
   if (fields) {
     for (const field of fields) {
-      const value = fieldsValue[field.name];
+      let value = fieldsValue[field.name];
       const style = getLayoutsStyle(styles, field.name, fieldsValue);
       let convertedValue = '';
       if (!isNil(value)) {
@@ -161,6 +161,16 @@ const replaceRecordFields = (
         );
         const match = avatarRgx.exec(formattedHtml);
         if (Array.isArray(value) && value.length > 0) {
+          value = value.filter((v: string) => {
+            const lowercaseValue = v.toLowerCase();
+            return (
+              lowercaseValue.endsWith('.jpg') ||
+              lowercaseValue.endsWith('.png') ||
+              lowercaseValue.endsWith('.jpeg') ||
+              lowercaseValue.endsWith('.gif') ||
+              lowercaseValue.endsWith('.bmp')
+            );
+          });
           const avatarGroup = createAvatarGroup(
             value,
             Number(match?.groups?.width),

--- a/libs/safe/src/lib/utils/parser/utils.ts
+++ b/libs/safe/src/lib/utils/parser/utils.ts
@@ -162,14 +162,18 @@ const replaceRecordFields = (
         const match = avatarRgx.exec(formattedHtml);
         if (Array.isArray(value) && value.length > 0) {
           const avatarValue = value.filter((v: string) => {
-            const lowercaseValue = v.toLowerCase();
-            return (
-              lowercaseValue.endsWith('.jpg') ||
-              lowercaseValue.endsWith('.png') ||
-              lowercaseValue.endsWith('.jpeg') ||
-              lowercaseValue.endsWith('.gif') ||
-              lowercaseValue.endsWith('.bmp')
-            );
+            if (typeof v === 'string') {
+              const lowercaseValue = v.toLowerCase();
+              return (
+                lowercaseValue.endsWith('.jpg') ||
+                lowercaseValue.endsWith('.png') ||
+                lowercaseValue.endsWith('.jpeg') ||
+                lowercaseValue.endsWith('.gif') ||
+                lowercaseValue.endsWith('.bmp')
+              );
+            } else {
+              return null;
+            }
           });
           if (avatarValue.length > 0) {
             const avatarGroup = createAvatarGroup(


### PR DESCRIPTION
# Description

Broken images are shown when the link is not valid. I added a filter before displaying avatars images.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67912/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Broken images were displayed before the fix, it's not the case now.

## Sreenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/9751045/61abf107-0ab3-45a2-a306-5da0972f4a4f)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
