### PR TITLE
bugfix/AB#68401_DB-unable-to-save-cluster-layer

### DIFF
--- a/libs/safe/src/lib/components/ui/map/utils/create-div-icon.ts
+++ b/libs/safe/src/lib/components/ui/map/utils/create-div-icon.ts
@@ -147,8 +147,18 @@ export const createClusterDivIcon = (
   const size =
     (childCount / 50) * (MAX_CLUSTER_SIZE - MIN_CLUSTER_SIZE) +
     MIN_CLUSTER_SIZE;
-  const mainColor = Color.rgb(color).fade(0.2).toString();
-  const ringColor = Color.rgb(color).fade(0.7).toString();
+  const mainColor = Color.rgb(
+    // eslint-disable-next-line no-extra-boolean-cast
+    Boolean(color) ? color : DEFAULT_MARKER_ICON_OPTIONS.color
+  )
+    .fade(0.2)
+    .toString();
+  const ringColor = Color.rgb(
+    // eslint-disable-next-line no-extra-boolean-cast
+    Boolean(color) ? color : DEFAULT_MARKER_ICON_OPTIONS.color
+  )
+    .fade(0.7)
+    .toString();
   const styles = `
   background-color: ${mainColor};
   opacity: ${opacity};

--- a/libs/safe/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/map-forms.ts
@@ -19,6 +19,7 @@ import {
 import { IconName } from '../../icon-picker/icon-picker.const';
 import { LayerType } from '../../ui/map/interfaces/layer-settings.type';
 import { set } from 'lodash';
+import { DEFAULT_MARKER_ICON_OPTIONS } from '../../ui/map/utils/create-div-icon';
 
 type Nullable<T> = { [P in keyof T]: T[P] | null };
 
@@ -240,7 +241,14 @@ export const createLayerDrawingInfoForm = (value: any): FormGroup => {
       type: [type, Validators.required],
       ...(type === 'simple' && {
         symbol: fb.group({
-          color: [get(value, 'renderer.symbol.color', ''), Validators.required],
+          color: [
+            get(
+              value,
+              'renderer.symbol.color',
+              DEFAULT_MARKER_ICON_OPTIONS.color
+            ),
+            Validators.required,
+          ],
           size: [get(value, 'renderer.symbol.size', 24)],
           style: new FormControl<IconName>(
             get(value, 'renderer.symbol.style', 'location-dot')


### PR DESCRIPTION
# Description

fix: add default color in cluster icon create method and featureReduction form control in order to avoid color format error on empty values

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68041)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Sreenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
