### PR TITLE
Bug/ab#68010 duplicated legends when switching from layers

### DIFF
--- a/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
@@ -11,7 +11,14 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SafeConfirmService } from '../../../../services/confirm/confirm.service';
 import { LayerModel } from '../../../../models/layer.model';
 import { createLayerForm, LayerFormT } from '../map-forms';
-import { takeUntil, BehaviorSubject, Subject, pairwise, startWith } from 'rxjs';
+import {
+  takeUntil,
+  BehaviorSubject,
+  Subject,
+  pairwise,
+  startWith,
+  distinctUntilChanged,
+} from 'rxjs';
 import { MapComponent } from '../../../ui/map/map.component';
 import {
   MapEvent,
@@ -24,7 +31,7 @@ import { SafeMapLayersService } from '../../../../services/map/map-layers.servic
 import { Layer } from '../../../ui/map/layer';
 import { Apollo } from 'apollo-angular';
 import { GetResourceQueryResponse, GET_RESOURCE } from '../graphql/queries';
-import { get } from 'lodash';
+import { get, isEqual } from 'lodash';
 import { SafeUnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
 import { LayerPropertiesModule } from './layer-properties/layer-properties.module';
 import { LayerDatasourceModule } from './layer-datasource/layer-datasource.module';
@@ -266,7 +273,12 @@ export class EditLayerModalComponent
   private setUpEditLayerListeners() {
     // Those listeners would handle any change for layer into the map component reference
     this.form.valueChanges
-      .pipe(startWith(this.form.value), pairwise(), takeUntil(this.destroy$))
+      .pipe(
+        startWith(this.form.value),
+        distinctUntilChanged((prev, next) => isEqual(prev, next)),
+        pairwise(),
+        takeUntil(this.destroy$)
+      )
       .subscribe({
         next: ([prev, next]) => {
           this.updateMapLayer({ delete: true });


### PR DESCRIPTION
# Description

The destroy/creation of forms can trigger some valuechanges even if values are the same.
Using the distinctUntilChanged method to handle the layer change to fix it

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68010/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with loaded layers, with added layers and with layers with cluster by default or without

## Sreenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/9751045/321b3f21-0dd3-4b62-abf0-802e6ef13ea8)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
