### PR TITLE
Fix/ab#63712 duplication marker geospatial field

### DIFF
--- a/libs/safe/src/lib/components/geospatial-map/geospatial-map.component.ts
+++ b/libs/safe/src/lib/components/geospatial-map/geospatial-map.component.ts
@@ -238,6 +238,7 @@ export class GeospatialMapComponent
       }
     });
 
+    //Reproduce the same behavior for the "move" feature
     this.mapComponent?.map.on('moveend', () => {
       const finishContainer = document.querySelector(
         'div[title="Drag Layers"]'

--- a/libs/safe/src/lib/components/geospatial-map/geospatial-map.component.ts
+++ b/libs/safe/src/lib/components/geospatial-map/geospatial-map.component.ts
@@ -238,6 +238,16 @@ export class GeospatialMapComponent
       }
     });
 
+    this.mapComponent?.map.on('moveend', () => {
+      const finishContainer = document.querySelector(
+        'div[title="Drag Layers"]'
+      );
+      const finishButton = finishContainer?.querySelector('.action-finishMode');
+      if (finishButton) {
+        (finishButton as HTMLAnchorElement).click();
+      }
+    });
+
     // set language
     const setLang = (lang: string) => {
       if (AVAILABLE_GEOMAN_LANGUAGES.includes(lang)) {


### PR DESCRIPTION
# Description

Reproduces the changes made for the "remove" event for the "move" event. 
Might not be a 100% foolproof but fixes this exact duplication behavior.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/63712

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested directly in back-office using this process : 
- Move the map
- Place a marker and "validate" it
- Delete it
- Move the map again
- Try to place a marker again but cancel the action

Previously this made the map bug but now it does not (see gif)

## Screenshots

![geolocal23](https://github.com/ReliefApplications/oort-frontend/assets/103029022/a472e77a-c279-4bc4-9f3a-2a9510dc99c1)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
