### PR TITLE
Feat/ab#68048 show navitems as links instead of classic buttons

### DIFF
--- a/libs/safe/src/lib/components/navbar/navbar.component.html
+++ b/libs/safe/src/lib/components/navbar/navbar.component.html
@@ -1,3 +1,4 @@
+<!-- By default, vertical navigation -->
 <ng-container *ngIf="vertical; else horizontalMenu">
   <section class="pt-2 flex flex-col gap-y-7">
     <ng-container *ngFor="let group of navGroups; let i = index" class="h-full">
@@ -113,6 +114,7 @@
     </ng-container>
   </section>
 </ng-container>
+<!-- Horizontal navigation -->
 <ng-template #horizontalMenu>
   <section class="flex border-b">
     <ng-container *ngFor="let group of navGroups; let i = index" class="h-full">

--- a/libs/safe/src/lib/components/navbar/navbar.component.html
+++ b/libs/safe/src/lib/components/navbar/navbar.component.html
@@ -42,11 +42,12 @@
                 [cdkDragDisabled]="!item.orderable"
                 class="show-icons"
               >
-                <li
-                  [routerLink]="item.path"
-                  routerLinkActive="text-primary-600 bg-gray-50"
-                >
-                  <a class="group" (click)="largeDevice ? null : nav.toggle()">
+                <li routerLinkActive="text-primary-600 bg-gray-50">
+                  <a
+                    class="group"
+                    (click)="largeDevice ? null : nav.toggle()"
+                    [routerLink]="item.path"
+                  >
                     <ui-icon variant="grey" [icon]="item.icon"> </ui-icon>
                     <p class="truncate m-0" [uiTooltip]="item.name">
                       {{ item.name }}
@@ -131,11 +132,12 @@
               [cdkDragDisabled]="!item.orderable"
               class="show-icons w-full max-w-[200px]"
             >
-              <li
-                [routerLink]="item.path"
-                routerLinkActive="text-primary-600 bg-gray-50"
-              >
-                <a class="group" (click)="largeDevice ? null : nav.toggle()">
+              <li routerLinkActive="text-primary-600 bg-gray-50">
+                <a
+                  class="group"
+                  (click)="largeDevice ? null : nav.toggle()"
+                  [routerLink]="item.path"
+                >
                   <ui-icon variant="grey" [icon]="item.icon"> </ui-icon>
                   <p class="truncate m-0" [uiTooltip]="item.name">
                     {{ item.name }}


### PR DESCRIPTION
# Description

By moving the routerLink to the link we are now able to open in a new tab and copy link address again.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68048/

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/9751045/2f685133-a969-4dbd-8a37-a25378f30899)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
