### PR TITLE
Feat 2.1.x/db#68038 prevent dashboard to be loaded after navigation is done

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
@@ -69,6 +69,7 @@ export class DashboardComponent
   public isFullScreen = false;
   // === DATA ===
   public id = '';
+  public prevId = '';
   public applicationId?: string;
   public loading = true;
   public tiles: any[] = [];
@@ -234,7 +235,11 @@ export class DashboardComponent
    * @returns Promise
    */
   private async initDashboardWithId(id: string) {
-    if (this.dashboard?.id === id) return; // don't init the dashboard if the id is the same
+    console.log('initPage');
+
+    // Don't init the dashboard if the id is the same
+    if (this.prevId === id) return;
+    this.prevId = id;
 
     const rootElement = this.elementRef.nativeElement;
     this.renderer.setAttribute(rootElement, 'data-dashboard-id', id);

--- a/apps/front-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
+++ b/apps/front-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
@@ -25,7 +25,7 @@ import {
 } from '@oort-front/safe';
 import { TranslateService } from '@ngx-translate/core';
 import { map, takeUntil } from 'rxjs/operators';
-import { Observable, firstValueFrom } from 'rxjs';
+import { Observable } from 'rxjs';
 import { SnackbarService } from '@oort-front/ui';
 
 /**


### PR DESCRIPTION
# Description

Changing between dashboards very quickly was causing them to display the wrong dashboard instead of the one selected.

The cause was due to how we fetched them, we were using a simple query to get them which wasn't being cancelled when changing to another dashboard, so when changing quickly between pages if the latest query resolved wasn't the current selected page the data displayed would be wrong.

The solution was to update the `query` to a `watchQuery`, which transforms it in a subscription giving us the possibility to cancel it when loading a new page. The code was rearranged to accommodate the changes.

Replicated the changes on the front-office and app-preview

## Ticket

[#68038 DB Prevent dashboard to be loaded after navigation is done](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68038/)

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Switched within dashboards quickly to confirm that the correct dashboard is loaded 
- [x] Used the dashboards as usual to make sure there aren't any regressions

## Screenshots

![ezgif com-video-to-gif](https://github.com/ReliefApplications/oort-frontend/assets/94831019/1822ea40-520d-4e05-9010-3200b9a9205d)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
