### PR TITLE
Bug/ab#68121 scroll bar is not displaying on summary cards

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.html
@@ -1,4 +1,4 @@
-<div class="flex-1 overflow-auto p-[14px]" (click)="onClick($event)">
+<div class="flex-1 p-[14px]" (click)="onClick($event)">
   <div
     class="w-fit h-fit no-tailwindcss-base"
     [innerHTML]="formattedHtml"

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
@@ -17,6 +17,6 @@
   [fieldsValue]="fieldsValue"
   [styles]="card.useStyles ? styles : []"
   [wholeCardStyles]="card.wholeCardStyles"
-  class="flex flex-1"
+  class="flex flex-1 overflow-auto"
 >
 </safe-summary-card-item-content>


### PR DESCRIPTION
# Description

I fixed the overflow for summary cards

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68121/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The scrollbar is available after the fix

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/9751045/810e7288-0337-47b9-b636-7f76f0a4afff)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
