### PR TITLE
Fix 2.1.x/db#68160 correct display for geospacial fields records grid

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
+++ b/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
@@ -78,7 +78,7 @@
             <ng-container *ngIf="!recordsDefaultColumns.includes(column)">
               <th uiCellHeader *cdkHeaderCellDef scope="col">{{ column }}</th>
               <td uiCell *cdkCellDef="let element">
-                <div>{{ element.data[column] }}</div>
+                <div>{{ formatValue(element.data[column]) }}</div>
               </td>
             </ng-container>
             <ng-container *ngIf="column === '_incrementalId'">

--- a/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
@@ -367,6 +367,29 @@ export class RecordsTabComponent
   }
 
   /**
+   * Formats the passed value to be readable
+   *
+   * @param value Value to format
+   * @returns Formatted value
+   */
+  formatValue(value: any): string {
+    // Geospacial field
+    if (
+      typeof value === 'object' &&
+      value.type === 'Feature' &&
+      value.geometry
+    ) {
+      return [
+        get(value, 'properties.address'),
+        get(value, 'properties.countryName'),
+      ]
+        .filter((x) => x)
+        .join(', ');
+    }
+    return value;
+  }
+
+  /**
    * Fetch records, using GraphQL
    *
    * @param refetch rebuild query


### PR DESCRIPTION
# Description

Geospacial fields weren't correctly displayed on the record grid.
A new formatter function has been added so it shows them as they should.

## Ticket

[db#68160 correct display for geospacial fields records grid
](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68160)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Checked geospacial fields on the records grid

## Screenshots

Geospacial field now
![Screenshot from 2023-06-29 10-16-30](https://github.com/ReliefApplications/oort-frontend/assets/94831019/f8db4647-abb6-4224-b711-190e091443bb)

Geospacial field previously
![Screenshot from 2023-06-29 10-19-20](https://github.com/ReliefApplications/oort-frontend/assets/94831019/b2f7d428-decb-451d-9c22-d1ee27a3728f)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
