### PR TITLE
fix: tagbox and dropdown question enable/disable status

### DIFF
--- a/libs/safe/src/lib/survey/widgets/dropdown-widget.ts
+++ b/libs/safe/src/lib/survey/widgets/dropdown-widget.ts
@@ -60,6 +60,13 @@ export const init = (Survey: any, domService: DomService): void => {
       question.registerFunctionOnPropertyValueChanged('value', () => {
         dropdownInstance.value = question.value;
       });
+      question.registerFunctionOnPropertyValueChanged(
+        'readOnly',
+        (value: boolean) => {
+          dropdownInstance.readonly = value;
+          dropdownInstance.disabled = value;
+        }
+      );
       updateChoices();
       el.parentElement?.appendChild(dropdownDiv);
     },

--- a/libs/safe/src/lib/survey/widgets/tagbox-widget.ts
+++ b/libs/safe/src/lib/survey/widgets/tagbox-widget.ts
@@ -94,6 +94,13 @@ export const init = (Survey: any, domService: DomService): void => {
         'visibleChoices',
         question._propertyValueChangedVirtual
       );
+      question.registerFunctionOnPropertyValueChanged(
+        'readOnly',
+        (value: boolean) => {
+          tagboxInstance.readonly = value;
+          tagboxInstance.disabled = value;
+        }
+      );
       updateChoices();
       el.parentElement?.appendChild(tagboxDiv);
     },


### PR DESCRIPTION
# Description
If enableIf logic set for dropdown and tagbox questions, the questions were still disabled and impossible to edit even if enable logic was correct.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Changing the enableIf status of dropdown and tagbox questions dynamically using a boolean question.

## Screenshots
![question](https://github.com/ReliefApplications/oort-frontend/assets/28535394/a65d2adc-329f-4506-beaf-6777d5bb20df)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
