### PR TITLE
fix-2.1.x/AB#68191_successive_modals_when_closing_form_edition

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/form-builder/form-builder.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/form-builder/form-builder.component.ts
@@ -53,6 +53,8 @@ export class FormBuilderComponent implements OnInit {
   public hasChanges = false;
   private isStep = false;
 
+  public isModalOpened = false;
+
   /**
    * Form builder page
    *
@@ -84,7 +86,13 @@ export class FormBuilderComponent implements OnInit {
    * @returns boolean of observable of boolean
    */
   canDeactivate(): Observable<boolean> | boolean {
+    if (this.isModalOpened) {
+      this.isModalOpened = false;
+      return false;
+    }
+
     if (this.hasChanges) {
+      this.isModalOpened = true;
       const dialogRef = this.confirmService.openConfirmModal({
         title: this.translate.instant('components.form.update.exit'),
         content: this.translate.instant('components.form.update.exitMessage'),
@@ -93,6 +101,7 @@ export class FormBuilderComponent implements OnInit {
       });
       return dialogRef.closed.pipe(
         map((value) => {
+          this.isModalOpened = false;
           if (value) {
             this.authService.canLogout.next(true);
             window.localStorage.removeItem(`form:${this.id}`);


### PR DESCRIPTION
# Description

Added a condition to check if the modal is already opened. I didn't understand the origin of the bug. It only appeared with certain pages and not everytime. (guard?, pages with the same system of modal?)

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68191

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I added a new question to a form from its edition page and tried to navigate to other pages.

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules