### PR TITLE
fixed Geospatial question buttons overlapping sidebar

### DIFF
--- a/libs/safe/src/lib/components/ui/map/map.component.html
+++ b/libs/safe/src/lib/components/ui/map/map.component.html
@@ -1,3 +1,3 @@
 <div class="h-full flex flex-col">
-  <div [id]="mapId" class="group flex-1"></div>
+  <div [id]="mapId" class="group flex-1 z-[998]"></div>
 </div>


### PR DESCRIPTION
# Description

Fixed geospatial question buttons overlapping sidebar menu when editing a form.

## Ticket

Please insert link to ticket

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested verifying in the application if now geospatial question is not overlapping sidebar menu when editing a form anymore.

## Screenshots

![Captura de tela de 2023-06-29 10-52-02](https://github.com/ReliefApplications/oort-frontend/assets/56398308/19a1bc36-5367-485d-b59b-e60e8eeb9347)


# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
