### PR TITLE
fix: size of tabs title and overflow

### DIFF
--- a/libs/ui/src/lib/tabs/components/tab/tab.component.html
+++ b/libs/ui/src/lib/tabs/components/tab/tab.component.html
@@ -3,7 +3,7 @@
     [disabled]="disabled"
     [attr.selected]="selected"
     [ngClass]="resolveTabClasses"
-    class="w-full whitespace-nowrap py-2 text-sm font-medium"
+    class="w-full whitespace-nowrap py-2 text-sm font-medium button-min-width"
     (click)="openTab.emit()"
   >
     <ng-content select="label"></ng-content>

--- a/libs/ui/src/lib/tabs/components/tab/tab.component.scss
+++ b/libs/ui/src/lib/tabs/components/tab/tab.component.scss
@@ -1,4 +1,4 @@
-:host {
+.button-min-width {
   min-width: 150px;
   @media (max-width: 598px) {
     min-width: unset !important;

--- a/libs/ui/src/lib/tabs/tabs.component.ts
+++ b/libs/ui/src/lib/tabs/tabs.component.ts
@@ -93,6 +93,7 @@ export class TabsComponent implements AfterContentInit, OnDestroy {
     } else {
       classes.push('border-b');
       classes.push('mb-4');
+      classes.push('overflow-x-auto');
     }
     return classes;
   }


### PR DESCRIPTION
# Description
Size of tabs title and overflow hiding tabs and the title.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Creating tabs with different numbers of tab elements and with different title sizes.

## Screenshots
![tabs](https://github.com/ReliefApplications/oort-frontend/assets/28535394/b42b494d-9e31-4f38-bfe2-cfca108b8c00)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
