### PR TITLE
fix/resource-creation-on-search-grid

### DIFF
--- a/libs/safe/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -655,7 +655,7 @@ export class SafeCoreGridComponent
               console.error(error);
             }
           }
-          if (this.settings.query.temporaryRecords) {
+          if (this.settings.query.temporaryRecords?.length) {
             //Handles temporary records for resources creation in forms
             this.getTemporaryRecords();
           }

--- a/libs/safe/src/lib/survey/components/resource.ts
+++ b/libs/safe/src/lib/survey/components/resource.ts
@@ -7,13 +7,24 @@ import {
 import * as SurveyCreator from 'survey-creator';
 import { resourceConditions } from './resources';
 import { Dialog } from '@angular/cdk/dialog';
-import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import {
+  FormControl,
+  UntypedFormBuilder,
+  UntypedFormGroup,
+} from '@angular/forms';
 import { SafeResourceDropdownComponent } from '../../components/resource-dropdown/resource-dropdown.component';
 import { DomService } from '../../services/dom/dom.service';
-import { buildSearchButton, buildAddButton } from './utils';
+import {
+  buildSearchButton,
+  buildAddButton,
+  processNewCreatedRecords,
+} from './utils';
 import get from 'lodash/get';
 import { Question, QuestionResource } from '../types';
 import { JsonMetadata, SurveyModel } from 'survey-angular';
+
+/** Question's temporary records */
+export const temporaryRecordsForm = new FormControl([]);
 
 /**
  * Inits the resource question component of for survey.
@@ -541,6 +552,20 @@ export const init = (
             this.populateChoices(question);
           }
         }
+        if (question.addRecord && question.canSearch) {
+          // If search button exists, updates grid displayed records when new records are created with the add button
+          question.registerFunctionOnPropertyValueChanged(
+            'newCreatedRecords',
+            async () => {
+              const settings = await processNewCreatedRecords(
+                question,
+                false,
+                []
+              );
+              temporaryRecordsForm.setValue(settings.query.temporaryRecords);
+            }
+          );
+        }
       }
     },
     /**
@@ -607,7 +632,8 @@ export const init = (
           question,
           question.gridFieldsSettings,
           false,
-          dialog
+          dialog,
+          temporaryRecordsForm
         );
         actionsButtons.appendChild(searchBtn);
 

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -6,15 +6,22 @@ import {
 } from '../graphql/queries';
 import { BehaviorSubject } from 'rxjs';
 import * as SurveyCreator from 'survey-creator';
-import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import {
+  FormControl,
+  UntypedFormBuilder,
+  UntypedFormGroup,
+} from '@angular/forms';
 import { Dialog } from '@angular/cdk/dialog';
 import { SafeResourceDropdownComponent } from '../../components/resource-dropdown/resource-dropdown.component';
 import { SafeCoreGridComponent } from '../../components/ui/core-grid/core-grid.component';
 import { DomService } from '../../services/dom/dom.service';
-import { buildSearchButton, buildAddButton } from './utils';
+import {
+  buildSearchButton,
+  buildAddButton,
+  processNewCreatedRecords,
+} from './utils';
 import { QuestionResource } from '../types';
 import { SurveyModel } from 'survey-angular';
-import localForage from 'localforage';
 
 /** Create the list of filter values for resources */
 export const resourcesFilterValues = new BehaviorSubject<
@@ -31,6 +38,9 @@ export const resourceConditions = [
   { value: '>=', text: 'greater or equals' },
   { value: '<=', text: 'less or equals' },
 ];
+
+/** Question temporary records */
+const temporaryRecordsForm = new FormControl([]);
 
 /**
  * Inits the resources question component for survey.
@@ -787,7 +797,8 @@ export const init = (
               question,
               question.gridFieldsSettings,
               true,
-              dialog
+              dialog,
+              temporaryRecordsForm
             );
             actionsButtons.appendChild(searchBtn);
 
@@ -894,53 +905,8 @@ export const init = (
     question: any
   ) => {
     instance.multiSelect = true;
-    const query = question.gridFieldsSettings || {};
-    const temporaryRecords: any[] = [];
     const promises: any[] = [];
-    question.newCreatedRecords?.forEach((recordId: string) => {
-      const promise = new Promise<void>((resolve, reject) => {
-        localForage
-          .getItem(recordId)
-          .then((data: any) => {
-            if (data != null) {
-              // We ensure to make it only if such a record is found
-              const parsedData = JSON.parse(data);
-              temporaryRecords.push({
-                id: recordId,
-                template: parsedData.template,
-                ...parsedData.data,
-                isTemporary: true,
-              });
-            }
-            resolve();
-          })
-          .catch((error: any) => {
-            console.error(error); // Handle any errors that occur while getting the item
-            reject(error);
-          });
-      });
-      promises.push(promise);
-    });
-    const uuidRegExpr =
-      /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
-    const settings = {
-      query: {
-        ...query,
-        temporaryRecords: temporaryRecords,
-        filter: {
-          logic: 'and',
-          filters: [
-            {
-              field: 'ids',
-              operator: 'eq',
-              value:
-                question.value.filter((id: string) => !uuidRegExpr.test(id)) ||
-                [], //We exclude the temporary records by excluding id in UUID format
-            },
-          ],
-        },
-      },
-    };
+    const settings = await processNewCreatedRecords(question, true, promises);
     if (!question.readOnlyGrid) {
       Object.assign(settings, {
         actions: {
@@ -952,6 +918,10 @@ export const init = (
           remove: true,
         },
       });
+    }
+    // If search button exists, updates grid displayed records
+    if (question.canSearch) {
+      temporaryRecordsForm.setValue(settings.query.temporaryRecords);
     }
     instance.settings = settings;
     Promise.allSettled(promises).then(() => {

--- a/libs/safe/src/lib/survey/components/utils.ts
+++ b/libs/safe/src/lib/survey/components/utils.ts
@@ -1,21 +1,24 @@
 import { Dialog } from '@angular/cdk/dialog';
-import { UntypedFormGroup } from '@angular/forms';
+import { UntypedFormControl } from '@angular/forms';
 import { surveyLocalization } from 'survey-angular';
+import localForage from 'localforage';
 
 /**
  * Build the search button for resource and resources components
  *
  * @param question The question object
- * @param fieldsSettingsForm The form used for the button
+ * @param fieldsSettingsForm The raw value from the form used for the grid settings
  * @param multiselect Indicate if we need multiselect
  * @param dialog The Dialog service
+ * @param temporaryRecords The form used to save and keep the temporary records updated
  * @returns The button DOM element
  */
 export const buildSearchButton = (
   question: any,
-  fieldsSettingsForm: UntypedFormGroup,
+  fieldsSettingsForm: any,
   multiselect: boolean,
-  dialog: Dialog
+  dialog: Dialog,
+  temporaryRecords: UntypedFormControl
 ): any => {
   const searchButton = document.createElement('button');
   searchButton.innerText = surveyLocalization.getString(
@@ -24,6 +27,11 @@ export const buildSearchButton = (
   );
   searchButton.style.marginRight = '8px';
   if (fieldsSettingsForm) {
+    temporaryRecords.valueChanges.subscribe((res: any) => {
+      if (res) {
+        fieldsSettingsForm.temporaryRecords = res;
+      }
+    });
     searchButton.onclick = async () => {
       const { SafeResourceGridModalComponent } = await import(
         '../../components/search-resource-grid-modal/search-resource-grid-modal.component'
@@ -146,4 +154,93 @@ export const buildAddButton = (
     }
   );
   return addButton;
+};
+
+/**
+ * Updates the newCreatedRecords for resource and resources questions
+ *
+ * @param question The question object
+ * @param multiselect Indicate if the questions is multiselect
+ * @param promises Promises array to be do something after they're all reject or resolved.
+ * @returns The grid settings updated
+ */
+export const processNewCreatedRecords = (
+  question: any,
+  multiselect: boolean,
+  promises: Promise<void>[]
+): any => {
+  const query = question.gridFieldsSettings || {};
+  const temporaryRecords: any[] = [];
+  if (multiselect) {
+    question.newCreatedRecords?.forEach((recordId: string) => {
+      const promise = new Promise<void>((resolve, reject) => {
+        localForage
+          .getItem(recordId)
+          .then((data: any) => {
+            if (data != null) {
+              // We ensure to make it only if such a record is found
+              const parsedData = JSON.parse(data);
+              temporaryRecords.push({
+                id: recordId,
+                template: parsedData.template,
+                ...parsedData.data,
+                isTemporary: true,
+              });
+            }
+            resolve();
+          })
+          .catch((error: any) => {
+            console.error(error); // Handle any errors that occur while getting the item
+            reject(error);
+          });
+      });
+      promises.push(promise);
+    });
+  } else {
+    new Promise<void>((resolve, reject) => {
+      localForage
+        .getItem(question.newCreatedRecords)
+        .then((data: any) => {
+          if (data != null) {
+            // We ensure to make it only if such a record is found
+            const parsedData = JSON.parse(data);
+            temporaryRecords.push({
+              id: question.newCreatedRecords,
+              template: parsedData.template,
+              ...parsedData.data,
+              isTemporary: true,
+            });
+          }
+          resolve();
+        })
+        .catch((error: any) => {
+          console.error(error); // Handle any errors that occur while getting the item
+          reject(error);
+        });
+    });
+  }
+
+  const uuidRegExpr =
+    /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+  const settings = {
+    query: {
+      ...query,
+      temporaryRecords: temporaryRecords,
+      filter: {
+        logic: 'and',
+        ...(multiselect && {
+          filters: [
+            {
+              field: 'ids',
+              operator: 'eq',
+              value:
+                question.value.filter((id: string) => !uuidRegExpr.test(id)) ||
+                [], //We exclude the temporary records by excluding id in UUID format
+            },
+          ],
+        }),
+      },
+    },
+  };
+  return settings;
 };


### PR DESCRIPTION
# Description
In resource and resources questions with "can add" and "can search" features, if a new record is created it appears in the dropdown/tagbox options, but not in the grid options opened with the "can search" button because the temporary records weren't updated to appear in the grid settings.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Creating resource and resources questions with "can add" and "can search" features, then creating new temporary records with the "can add" and seeing them in the grid opened with the "can search" button.

## Screenshots
![grid-search](https://github.com/ReliefApplications/oort-frontend/assets/28535394/2e3854a2-17a5-451b-a265-176ccd15f433)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
