### PR TITLE
custom styling of summary cards

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1927,6 +1927,7 @@
 			},
 			"display": {
 				"border": "Show widget border",
+				"customizable": "Allow customization",
 				"searchable": "Allow search",
 				"title": "Widget display"
 			},

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1943,6 +1943,7 @@
 			},
 			"display": {
 				"border": "Afficher la bordure du widget",
+				"customizable": "Autoriser la customisation",
 				"searchable": "Autoriser la recherche",
 				"title": "Affichage des widgets"
 			},

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1927,6 +1927,7 @@
 			},
 			"display": {
 				"border": "******",
+				"customizable": "******",
 				"searchable": "******",
 				"title": "******"
 			},

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -53,8 +53,38 @@
         }}</span>
       </ng-container>
       <ng-template uiTabContent>
-        <safe-summary-card [settings]="tileForm.value" [widget]="tile">
-        </safe-summary-card>
+        <div class="flex flex-col lg:flex-row gap-5">
+          <safe-summary-card
+            #summaryCard
+            class="max-h-[75vh] overflow-auto"
+            [settings]="tileForm.value"
+            [widget]="tile"
+          >
+          </safe-summary-card>
+          <div
+            class="flex flex-col lg:w-[475px] lg:max-w-[40%] px-6 py-2 gap-5"
+            *ngIf="summaryCard.displayMode === 'cards'"
+          >
+            <ui-toggle
+              [formControl]="$any(tileForm.get('widgetDisplay.customizable'))"
+            >
+              <ng-container ngProjectAs="label">{{
+                'models.widget.display.customizable' | translate
+              }}</ng-container>
+            </ui-toggle>
+            <div
+              class="grow h-[300px]"
+              *ngIf="$any(tileForm.get('widgetDisplay.customizable'))?.value"
+            >
+              <ngx-monaco-editor
+                class="h-full"
+                [formControl]="$any(tileForm.get('widgetDisplay.customCSS'))"
+                [options]="editorOptions"
+              >
+              </ngx-monaco-editor>
+            </div>
+          </div>
+        </div>
       </ng-template>
     </ui-tab>
     <!-- Card display settings -->

--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.module.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.module.ts
@@ -21,6 +21,7 @@ import { SafeDisplayTabModule } from './display-tab/display.module';
 import { SummaryCardGeneralComponent } from './summary-card-general/summary-card-general.component';
 import { SafeSummaryCardSettingsComponent } from './summary-card-settings.component';
 import { SafeTextEditorTabModule } from './text-editor-tab/text-editor.module';
+import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 
 /** Summary Card Settings Module */
 @NgModule({
@@ -47,6 +48,7 @@ import { SafeTextEditorTabModule } from './text-editor-tab/text-editor.module';
     SafeSummaryCardModule,
     TabsModule,
     ToggleModule,
+    MonacoEditorModule,
   ],
   exports: [SafeSummaryCardSettingsComponent],
 })

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
@@ -1,7 +1,11 @@
 <!-- Default Header -->
-<div class="widget-header k-card-header" *ngIf="card.title">
+<div
+  class="card-header rounded-t-lg"
+  *ngIf="card.title"
+  [ngStyle]="customCSS ? getCustomCSSProperties('.card-header') : {}"
+>
   <!-- Title -->
-  <span class="widget-title" [title]="card.title">{{ card.title }}</span>
+  <span class="card-title" [title]="card.title">{{ card.title }}</span>
   <!-- Actions -->
   <div class="floating-button"></div>
 </div>
@@ -17,6 +21,7 @@
   [fieldsValue]="fieldsValue"
   [styles]="card.useStyles ? styles : []"
   [wholeCardStyles]="card.wholeCardStyles"
-  class="flex-1 overflow-auto p-[14px]"
+  class="flex-1 overflow-auto p-[14px] rounded-b-lg"
+  [ngStyle]="customCSS ? getCustomCSSProperties('.card-content') : {}"
 >
 </safe-summary-card-item-content>

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.scss
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.scss
@@ -1,0 +1,22 @@
+.card-header {
+  box-sizing: border-box;
+  height: 40px;
+  position: relative;
+  z-index: 1001;
+  color: black;
+  text-align: left;
+  line-height: 40px;
+  padding: 0 40px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  border-bottom: 1px solid #d1d5db;
+
+  .card-title {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    flex: 1;
+    margin: unset;
+  }
+}

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.ts
@@ -12,6 +12,7 @@ import { CardT } from '../summary-card.component';
 })
 export class SummaryCardItemComponent implements OnInit, OnChanges {
   @Input() card!: CardT;
+  @Input() customCSS: any = null;
   public fields: any[] = [];
   public fieldsValue: any = null;
   public styles: any[] = [];
@@ -48,6 +49,21 @@ export class SummaryCardItemComponent implements OnInit, OnChanges {
     // this.layout = this.card.layout;
     this.styles = get(this.card.layout, 'query.style', []);
     // this.styles = get(this.card, 'meta.style', []);
+  }
+
+  /**
+   * Gets a customCSS properties
+   *
+   * @param className class name
+   * @returns property object
+   */
+  getCustomCSSProperties(className: string): object {
+    try {
+      const customObject = JSON.parse(this.customCSS);
+      return customObject[className as keyof typeof customObject];
+    } catch (e) {
+      return {};
+    }
   }
 
   /**

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -66,8 +66,13 @@
     <div class="w-full grow overflow-auto" #summaryCardGrid>
       <kendo-pdf-export #pdf paperSize="A4" margin="2cm">
         <div
-          class="summary-card-container k-widget k-tile-layout k-grid-flow-col"
+          class="summary-card-container"
           style.grid-template-columns="{{ 'repeat(' + colsNumber + ', 1fr)' }}"
+          [ngStyle]="
+            settings.widgetDisplay?.customizable
+              ? getCustomCSSProperties('.card-grid-wrapper')
+              : {}
+          "
         >
           <ng-container
             *safeSkeleton="
@@ -80,7 +85,7 @@
           >
             <safe-summary-card-item
               *ngFor="let card of cards; let i = index"
-              class="k-tilelayout-item k-card flex flex-col"
+              class="flex flex-col rounded-lg overflow-hidden summary-card-content"
               [style.order]="i"
               style.grid-column-end="{{
                 'span ' +
@@ -90,6 +95,16 @@
               }}"
               style.grid-row-end="{{ 'span ' + card.height }}"
               [card]="card"
+              [customCSS]="
+                settings.widgetDisplay?.customizable
+                  ? settings.widgetDisplay?.customCSS
+                  : null
+              "
+              [ngStyle]="
+                settings.widgetDisplay?.customizable
+                  ? getCustomCSSProperties('.card-container')
+                  : {}
+              "
             >
             </safe-summary-card-item>
           </ng-container>

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.scss
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.scss
@@ -5,12 +5,9 @@
   padding: 16px;
   grid-auto-flow: row;
   background-color: unset;
-  max-height: 80vh;
+}
 
-  .k-card {
-    border: none;
-    border-radius: 0;
-    overflow: hidden;
-    box-shadow: 0 2px 5px 0 rgba(134, 134, 134, 0.2);
-  }
+.summary-card-content {
+  border: 1px solid #d1d5db;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 }

--- a/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/safe/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -516,4 +516,21 @@ export class SafeSummaryCardComponent
   override ngOnDestroy(): void {
     super.ngOnDestroy();
   }
+
+  /**
+   * Gets a customCSS properties
+   *
+   * @param className class name
+   * @returns property object
+   */
+  getCustomCSSProperties(className: string): object {
+    try {
+      const customObject = JSON.parse(
+        this.settings.widgetDisplay?.customCSS as string
+      );
+      return customObject[className as keyof typeof customObject];
+    } catch (e) {
+      return {};
+    }
+  }
 }


### PR DESCRIPTION
# Description

Added an option to custom the style of summary cards through a line editor.

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68357

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I created a new summary card widget and played with the customization of the different elements.

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/65243509/78f8ade5-113c-4f4a-90cd-14528d1e7e25)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
