### PR TITLE
fix: uploading files from default value

### DIFF
--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -30,6 +30,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { SafeUnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component';
 import { SafeFormHelpersService } from '../../services/form-helper/form-helper.service';
 import { SnackbarService } from '@oort-front/ui';
+import { cloneDeep } from 'lodash';
 
 /**
  * This component is used to display forms
@@ -223,9 +224,19 @@ export class SafeFormComponent
    * Handles the value change event when the user completes the survey
    */
   public valueChange(): void {
+    // Cache the survey data, but remove the files from it
+    // to avoid hitting the local storage limit
+    const data = cloneDeep(this.survey.data);
+    Object.keys(data).forEach((key) => {
+      const question = this.survey.getQuestionByName(key);
+      if (question && question.getType() === 'file') {
+        delete data[key];
+      }
+    });
+
     localStorage.setItem(
       this.storageId,
-      JSON.stringify({ data: this.survey.data, date: new Date() })
+      JSON.stringify({ data, date: new Date() })
     );
   }
 


### PR DESCRIPTION
# Description

* Prevents file questions to be saved on cache
* Prevents files with values coming from other questions to be sent to the servers as b64

## Ticket
No ticket linked to this PR

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
* By selecting a file when filling a form, and refreshing -> File should no longer be restored from cache
* By setting a file question with default value from another. When submitting the form, it'll no longer send the first one contents in b64 to the server, preventing large payloads 

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
