### PR TITLE
feat/AB#68728-grid-reference-data-inline-selection

### DIFF
--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -478,7 +478,8 @@
           <!-- EDITION ( dropdown / radiogroup ) -->
           <ng-container
             *ngIf="
-              field.meta.type === 'dropdown' || field.meta.type === 'radiogroup'
+              field.meta.type === 'dropdown' || field.meta.type === 'radiogroup' ||
+              (field.meta.type === 'referenceData' && field.meta.choices)
             "
           >
             <kendo-dropdownlist
@@ -490,6 +491,21 @@
             ></kendo-dropdownlist>
           </ng-container>
         </ng-template>
+          <!-- EDITION ( tagbox ) -->
+        <ng-container
+          *ngIf="field.meta.type === 'tagbox' || (field.meta.type === 'referenceData' && !field.meta.choices)"
+        >
+        <!-- [data]="getTagboxChoices(field)" -->
+          <kendo-multiselect
+            [data]="field.meta.choices"
+            textField="text"
+            [valueField]="'value'"
+            [valuePrimitive]="true"
+            [formControl]="$any(formGroup.get(field.name))"
+            [autoClose]="false"
+          >
+          </kendo-multiselect>
+        </ng-container>
         <!-- EDITION ( date ) -->
         <ng-template
           kendoGridEditTemplate
@@ -625,7 +641,7 @@
       <!-- MULTI SELECT QUESTION TYPES ( checkbox / tagbox / owner / users ) -->
       <kendo-grid-column
         *ngIf="
-          field.type === 'JSON' && multiSelectTypes.includes(field.meta.type)
+          field.type === 'JSON' && multiSelectTypes.includes(field.meta.type) && field.meta.type !== 'tagbox' 
         "
         [field]="field.name"
         [filterable]="false"

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -487,7 +487,11 @@
               textField="text"
               valueField="value"
               [valuePrimitive]="true"
-              [formControl]="formGroup.get(field.name)"
+              [formControl]="
+                field.name.indexOf('.') === -1
+                  ? formGroup.get(field.name)
+                  : formGroup.get(field.name.substring(0, field.name.indexOf('.')))
+              "
             ></kendo-dropdownlist>
           </ng-container>
         </ng-template>
@@ -495,7 +499,6 @@
         <ng-container
           *ngIf="field.meta.type === 'tagbox' || (field.meta.type === 'referenceData' && !field.meta.choices)"
         >
-        <!-- [data]="getTagboxChoices(field)" -->
           <kendo-multiselect
             [data]="field.meta.choices"
             textField="text"

--- a/libs/safe/src/lib/services/grid/grid.service.ts
+++ b/libs/safe/src/lib/services/grid/grid.service.ts
@@ -82,27 +82,19 @@ export class SafeGridService {
     },
     refDataSubField = false
   ): any[] {
-    // console.log('getFields fields', fields)
-    console.log('getFields options', options)
-    // console.log('getFields metaFields', metaFields)
     return flatDeep(
       fields.map((f) => {
-        console.log('---> f: ', f)
         const fullName: string = prefix ? `${prefix}.${f.name}` : f.name;
         let metaData = get(metaFields, fullName);
-    console.log('metaData ', metaData)
         const canSee = get(metaData, 'permissions.canSee', true);
         const canUpdate = get(metaData, 'permissions.canUpdate', false);
         const hidden: boolean =
           (!isNil(canSee) && !canSee) || options.hidden || false;
         const disabled: boolean = (options.disabled || !canUpdate) && !refDataSubField;
         const isRefData = f.type.endsWith(REFERENCE_DATA_END) || refDataSubField;
-            console.log(' metaData', metaData)
-            console.log(' disabled', disabled)
 
         switch (f.kind) {
           case 'OBJECT': {
-          console.log('----------- OBJECT:', f.name)
             return this.getFields(
               f.fields,
               metaFields,
@@ -116,7 +108,6 @@ export class SafeGridService {
             );
           }
           case 'LIST': {
-          console.log('----------- LIST:', f.name)
             metaData = Object.assign([], metaData);
             if (isRefData) {
               metaData.type = 'referenceData';
@@ -159,7 +150,6 @@ export class SafeGridService {
             };
           }
           default: {
-          console.log('----------- default:', f.name)
             const cachedField = get(layoutFields, fullName);
             const title = f.label ? f.label : prettifyLabel(f.name);
             return {
@@ -405,8 +395,6 @@ export class SafeGridService {
     fields
       .filter((x) => !x.disabled)
       .forEach((field) => {
-        console.log('field', field)
-        console.log('dataItem', dataItem)
         if (
           field.type !== 'JSON' ||
           MULTISELECT_TYPES.includes(field.meta.type)

--- a/libs/safe/src/lib/services/grid/grid.service.ts
+++ b/libs/safe/src/lib/services/grid/grid.service.ts
@@ -404,7 +404,12 @@ export class SafeGridService {
           const fieldName = index !== -1
             ? field.name.substring(0, index)
             : field.name;
-          formGroup[fieldName] = [dataItem[fieldName]];
+          // and its value shouldn't be the object saved, but only the value of the subfield
+          const fieldData = fieldName !== field.name
+            ? field.name.substring(index + 1, field.name.length)
+            : field.name;
+          // TODO: tagbox using reference data: how to get "value field" from red data and set value correctly?
+          formGroup[fieldName] = [dataItem[fieldData] ?? dataItem[fieldName][fieldData]];
         } else {
           if (field.meta.type === 'multipletext') {
             const fieldGroup: any = {};


### PR DESCRIPTION
# Description
Inline edition for dropdown / tagbox questions in grids, displaying the list of available choices as we would see when displaying the ref data in surveyjs.

Ticket on hold:  when we save/edit a record, we send the valueField that was chosen when configuring it to be its code from the reference data. But in the grid, we receive only the information that we want to show in the grid. For example in the dropdown_rd question if i want to display the fields of "Institution" and "GeographicScope", and not the "Code" (which is the valueField of the ref data) the custom query on the back sends me the list of choices for these fields and the current value, but no reference to the "Code" or what the valueField would be for each of my available choices. So we need to update the all.ts in the backend, so the custom query gets the valueField from every ref data.

## Ticket
[AB#68728 - ABC - Ability to do inline selection of reference data](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68728)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
