### PR TITLE
feat: add user variables on form

### DIFF
--- a/libs/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -15,7 +15,7 @@ import { SafeReferenceDataService } from '../../services/reference-data/referenc
 import { Form } from '../../models/form.model';
 import { renderGlobalProperties } from '../../survey/render-global-properties';
 import { SnackbarService } from '@oort-front/ui';
-
+import { SafeFormHelpersService } from '../../services/form-helper/form-helper.service';
 /**
  * Array containing the different types of questions.
  * Commented types are not yet implemented.
@@ -104,12 +104,14 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
    * @param snackBar This is the service that will be used to display the snackbar.
    * @param translate Angular translate service
    * @param referenceDataService Reference data service
+   * @param formHelpersService Shared form helper service.
    */
   constructor(
     public dialog: Dialog,
     private snackBar: SnackbarService,
     private translate: TranslateService,
-    private referenceDataService: SafeReferenceDataService
+    private referenceDataService: SafeReferenceDataService,
+    private formHelpersService: SafeFormHelpersService
   ) {
     // translate the editor in the same language as the interface
     SurveyCreator.localization.currentLocale = this.translate.currentLang;
@@ -169,6 +171,12 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
       'surveyCreatorContainer',
       creatorOptions
     );
+
+    this.surveyCreator.onTestSurveyCreated.add((_: any, options: any) => {
+      const survey: Survey.SurveyModel = options.survey;
+      this.formHelpersService.addUserVariables(survey);
+    });
+
     this.surveyCreator.haveCommercialLicense = true;
     this.surveyCreator.text = structure;
     this.surveyCreator.saveSurveyFunc = this.saveMySurvey;

--- a/libs/safe/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/safe/src/lib/services/form-builder/form-builder.service.ts
@@ -11,6 +11,7 @@ import { Metadata } from '../../models/metadata.model';
 import { SafeRestService } from '../rest/rest.service';
 import { BehaviorSubject } from 'rxjs';
 import { SnackbarService } from '@oort-front/ui';
+import { SafeFormHelpersService } from '../form-helper/form-helper.service';
 
 /**
  * Shared form builder service.
@@ -28,13 +29,15 @@ export class SafeFormBuilderService {
    * @param apollo Apollo service
    * @param snackBar Service used to show a snackbar.
    * @param restService This is the service that is used to make http requests.
+   * @param formHelpersService Shared form helper service.
    */
   constructor(
     private referenceDataService: SafeReferenceDataService,
     private translate: TranslateService,
     private apollo: Apollo,
     private snackBar: SnackbarService,
-    private restService: SafeRestService
+    private restService: SafeRestService,
+    private formHelpersService: SafeFormHelpersService
   ) {}
 
   /**
@@ -53,6 +56,7 @@ export class SafeFormBuilderService {
     record?: Record
   ): Survey.SurveyModel {
     const survey = new Survey.Model(structure);
+    this.formHelpersService.addUserVariables(survey);
     survey.onAfterRenderQuestion.add(
       renderGlobalProperties(this.referenceDataService)
     );

--- a/libs/safe/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/safe/src/lib/services/form-helper/form-helper.service.ts
@@ -14,6 +14,7 @@ import { DialogRef } from '@angular/cdk/dialog';
 import { SnackbarService } from '@oort-front/ui';
 import localForage from 'localforage';
 import { cloneDeep } from 'lodash';
+import { SafeAuthService } from '../auth/auth.service';
 
 /**
  * Shared survey helper service.
@@ -29,12 +30,14 @@ export class SafeFormHelpersService {
    * @param snackBar This is the service that allows you to display a snackbar.
    * @param confirmService This is the service that will be used to display confirm window.
    * @param translate This is the service that allows us to translate the text in our application.
+   * @param authService Shared auth service
    */
   constructor(
     public apollo: Apollo,
     private snackBar: SnackbarService,
     private confirmService: SafeConfirmService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private authService: SafeAuthService
   ) {}
 
   /**
@@ -313,4 +316,27 @@ export class SafeFormHelpersService {
 
     await Promise.all(promises);
   }
+
+  /**
+   * Registration of new custom variables for the survey.
+   * Custom variables can be used in the logic fields.
+   *
+   * @param survey Survey instance
+   */
+  public addUserVariables = (survey: Survey.SurveyModel) => {
+    const user = this.authService.user.getValue();
+
+    // set user variables
+    survey.setVariable('user.firstName', user?.firstName ?? '');
+    survey.setVariable('user.lastName', user?.lastName ?? '');
+    survey.setVariable('user.email', user?.username ?? '');
+
+    // Allow us to do some cool stuff like
+    // {user.roles} contains '62e3e676c9bcb900656c95c9'
+    survey.setVariable('user.roles', user?.roles?.map((r) => r.id || '') ?? []);
+
+    // Allow us to select the current user
+    // as a default question for Users question type
+    survey.setVariable('user.id', user?.id || '');
+  };
 }


### PR DESCRIPTION
# Description

This PR adds user information as variables into the survey

## Ticket
[EIOS - logged user info as expressions](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68748)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By setting up an expression type question with the expressions `user.firstName`, `user.lastName`, `user.email`, `user.id` and `user.roles`

## Screenshots
![image](https://github.com/ReliefApplications/oort-frontend/assets/102038450/996919c9-31bf-49bc-ab94-e5f55f2ba58f)

Users question with default value of {user.id} that is disabled
![image](https://github.com/ReliefApplications/oort-frontend/assets/102038450/1cc172b0-1237-44c5-ba98-b87e19b87c78)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
