### PR TITLE
Fix 2.1.x/ab#68826 issue zindex geospatial question

### DIFF
--- a/libs/safe/src/lib/style/survey.scss
+++ b/libs/safe/src/lib/style/survey.scss
@@ -59,6 +59,11 @@
   }
 }
 
+::ng-deep .k-combobox,
+::ng-deep .k-multiselect {
+  z-index: 999; //over leaflet, below sidebar
+}
+
 ::ng-deep .sv_main {
   .k-button {
     border-color: rgba(0, 0, 0, 0.08) !important;


### PR DESCRIPTION
# Description

Setting the z-index of dropdown and tag question to display them over the leaflet and below the sidebar. 

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68826

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created a new form with a geospatial question, a tag question and a drop down question respectively, I added enough options for these last two so that the list options are displayed on the input and not below. Then I checked that it didn't overlap the geospatial question and the sidebar (small screen size).

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/65243509/ee22b327-7dd2-4229-9094-b0abfe491d4e)

![image](https://github.com/ReliefApplications/oort-frontend/assets/65243509/2c98cd46-c703-4711-92a2-247143904624)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
