### PR TITLE
fix/page-form-edit-name

### DIFF
--- a/apps/back-office/src/app/application/pages/form/form.component.ts
+++ b/apps/back-office/src/app/application/pages/form/form.component.ts
@@ -137,7 +137,7 @@ export class FormComponent extends SafeUnsubscribeComponent implements OnInit {
           )
           .subscribe(({ data, loading }) => {
             this.form = data.form;
-            this.canEditName = this.step?.canUpdate || false;
+            this.canEditName = this.page?.canUpdate || false;
             this.applicationId = this.page?.application?.id || '';
             this.loading = loading;
           });


### PR DESCRIPTION
# Description
Impossible to edit page name in an application if page is a form, only possible to edit the name if the form is a step because in the code the step object didn't exist in the case of being a page.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Updating the page name.

## Screenshots
![formpage](https://github.com/ReliefApplications/oort-frontend/assets/28535394/8f6e51cf-7e35-4572-a4a5-82d1ea8b539c)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
