### PR TITLE
fix: files uploaded before addRecord

### DIFF
--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -19,7 +19,7 @@ import {
   EDIT_RECORD,
 } from './graphql/mutations';
 import { Form } from '../../models/form.model';
-import { Record } from '../../models/record.model';
+import { Record as RecordModel } from '../../models/record.model';
 import { BehaviorSubject, takeUntil } from 'rxjs';
 import addCustomFunctions from '../../utils/custom-functions';
 import { SafeAuthService } from '../../services/auth/auth.service';
@@ -45,7 +45,7 @@ export class SafeFormComponent
   implements OnInit, OnDestroy, AfterViewInit
 {
   @Input() form!: Form;
-  @Input() record?: Record;
+  @Input() record?: RecordModel;
   @Output() save: EventEmitter<{
     completed: boolean;
     hideNewRecord?: boolean;
@@ -54,7 +54,7 @@ export class SafeFormComponent
   // === SURVEYJS ===
   public survey!: Survey.SurveyModel;
   public surveyActive = true;
-  private temporaryFilesStorage: any = {};
+  public temporaryFilesStorage: Record<string, Array<File>> = {};
 
   @ViewChild('formContainer') formContainer!: ElementRef;
 
@@ -213,7 +213,9 @@ export class SafeFormComponent
    */
   public reset(): void {
     this.survey.clear();
-    this.temporaryFilesStorage = {};
+    this.formHelpersService.clearTemporaryFilesStorage(
+      this.temporaryFilesStorage
+    );
     this.survey.showCompletedPage = false;
     this.save.emit({ completed: false });
     this.survey.render();
@@ -347,7 +349,9 @@ export class SafeFormComponent
     } else {
       this.survey.clear();
     }
-    this.temporaryFilesStorage = {};
+    this.formHelpersService.clearTemporaryFilesStorage(
+      this.temporaryFilesStorage
+    );
     localStorage.removeItem(this.storageId);
     this.formHelpersService.cleanCachedRecords(this.survey);
     this.isFromCacheData = false;

--- a/libs/safe/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/safe/src/lib/services/form-builder/form-builder.service.ts
@@ -5,7 +5,7 @@ import { SafeReferenceDataService } from '../reference-data/reference-data.servi
 import { renderGlobalProperties } from '../../survey/render-global-properties';
 import { Apollo } from 'apollo-angular';
 import get from 'lodash/get';
-import { Record } from '../../models/record.model';
+import { Record as RecordModel } from '../../models/record.model';
 import { EditRecordMutationResponse, EDIT_RECORD } from './graphql/mutations';
 import { Metadata } from '../../models/metadata.model';
 import { SafeRestService } from '../rest/rest.service';
@@ -53,7 +53,7 @@ export class SafeFormBuilderService {
     structure: string,
     pages: BehaviorSubject<any[]>,
     fields: Metadata[] = [],
-    record?: Record
+    record?: RecordModel
   ): Survey.SurveyModel {
     const survey = new Survey.Model(structure);
     this.formHelpersService.addUserVariables(survey);
@@ -145,7 +145,7 @@ export class SafeFormBuilderService {
     survey: Survey.SurveyModel,
     pages: BehaviorSubject<any[]>,
     selectedPageIndex: BehaviorSubject<number>,
-    temporaryFilesStorage: any
+    temporaryFilesStorage: Record<string, Array<File>>
   ) {
     survey.onClearFiles.add((_, options: any) => this.onClearFiles(options));
     survey.onUploadFiles.add((_, options: any) =>

--- a/libs/safe/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/safe/src/lib/services/form-helper/form-helper.service.ts
@@ -339,4 +339,17 @@ export class SafeFormHelpersService {
     // as a default question for Users question type
     survey.setVariable('user.id', user?.id || '');
   };
+
+  /**
+   * Clears the temporary files storage
+   *
+   * @param storage Storage to clear
+   */
+  public clearTemporaryFilesStorage(
+    storage: Record<string, Array<File>>
+  ): void {
+    Object.keys(storage).forEach((key) => {
+      delete storage[key];
+    });
+  }
 }


### PR DESCRIPTION
# Description

This PR fixes a bug that caused some files to not be uploaded from the form component. The error was happening when the `temporaryFileStorage` was cleared, because it was done by assigning a new object to it, changing it to be a different object than the one passed to the `addEventsCallBacksToSurvey`. 

## Ticket
[68917](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68917)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By creating a record, and then creating another one right after without reloading the page that has a file question


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
