### PR TITLE
Bug/ab#68988 filter unavailable on checkbox tagbox

### DIFF
--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -628,7 +628,7 @@
           field.type === 'JSON' && multiSelectTypes.includes(field.meta.type)
         "
         [field]="field.name"
-        [filterable]="false"
+        [filterable]="true"
         [title]="field.title"
         [editable]="false"
         [width]="field.width"


### PR DESCRIPTION
# Description

I made checkbox and tagbox filterable in grid by turning the boolean props on true 👍

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/68988

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Filter are now displayed and usable

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/9751045/fabed742-5521-422c-b5c8-3ab2d5493105)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
