### PR TITLE
fix: Keeping current map state when filtering layers with dashboard filters

### DIFF
--- a/libs/safe/src/lib/components/ui/map/layer.ts
+++ b/libs/safe/src/lib/components/ui/map/layer.ts
@@ -522,6 +522,8 @@ export class Layer implements LayerModel {
           return l;
         };
         this.layer = layer;
+        (this.layer as any).origin = 'app-builder';
+        (this.layer as any).id = this.id;
         return this.layer;
 
       default:
@@ -646,6 +648,8 @@ export class Layer implements LayerModel {
               return l;
             };
             this.layer = layer;
+            (this.layer as any).origin = 'app-builder';
+            (this.layer as any).id = this.id;
             return this.layer;
           default:
             switch (get(this.layerDefinition, 'featureReduction.type')) {
@@ -721,6 +725,8 @@ export class Layer implements LayerModel {
                 };
                 clusterGroup.addLayer(clusterLayer);
                 this.layer = clusterGroup;
+                (this.layer as any).origin = 'app-builder';
+                (this.layer as any).id = this.id;
                 return this.layer;
               default:
                 const layer = L.geoJSON(data, geoJSONopts);
@@ -736,6 +742,8 @@ export class Layer implements LayerModel {
                   return l;
                 };
                 this.layer = layer;
+                (this.layer as any).origin = 'app-builder';
+                (this.layer as any).id = this.id;
                 return this.layer;
             }
         }
@@ -808,7 +816,7 @@ export class Layer implements LayerModel {
       if (currZoom > maxZoom || currZoom < minZoom) {
         map.removeLayer(layer);
       } else {
-        if (this.visibility) {
+        if (this.visibility && !(layer as any).deleted) {
           map.addLayer(layer);
         } else {
           map.removeLayer(layer);
@@ -829,7 +837,7 @@ export class Layer implements LayerModel {
     if (legendControl) {
       legendControl.removeLayer(layer);
     }
-    if (!isNil((layer as any).shouldDisplay)) {
+    if (!isNil((layer as any).shouldDisplay) || (layer as any).deleted) {
       // Ensure that we do not subscribe multiple times to zoom event
       if (this.zoomListener) {
         map.off('zoomend', this.zoomListener);

--- a/libs/safe/src/lib/components/ui/map/map.component.ts
+++ b/libs/safe/src/lib/components/ui/map/map.component.ts
@@ -906,7 +906,7 @@ export class MapComponent
     const filters = this.contextService.filter.getValue();
     if (isEqual(filters, this.appliedDashboardFilters)) return;
     this.appliedDashboardFilters = filters;
-    const { layers: layersToGet } = this.extractSettings();
+    const { layers: layersToGet, controls } = this.extractSettings();
 
     // get which layers are currently visible
     const oldLeafletLayers = await Promise.all(
@@ -943,10 +943,12 @@ export class MapComponent
       }
     });
 
-    // remove current layer controls
-    this.layerControlButtons.remove();
+    if (controls.layer) {
+      // remove current layer controls
+      this.layerControlButtons.remove();
 
-    // create new layer controls, from newly created layers
-    this.setLayersControl(flatten(this.basemapTree), l.layers);
+      // create new layer controls, from newly created layers
+      this.setLayersControl(flatten(this.basemapTree), l.layers);
+    }
   }
 }

--- a/libs/safe/src/lib/components/widgets/map-settings/add-layer-modal/add-layer-modal.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/add-layer-modal/add-layer-modal.component.html
@@ -7,7 +7,7 @@
   <ng-container ngProjectAs="content">
     <form class="flex flex-col">
       <!-- API to use -->
-      <div uiFormFieldDirectiveclass="flex-1">
+      <div uiFormFieldDirective class="flex-1">
         <label>{{ 'common.layers' | translate }}</label>
         <ui-graphql-select
           valueField="id"

--- a/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.html
@@ -158,8 +158,10 @@
       <!-- Previously : layerDefinition.drawingInfo.renderer.type -->
       <ui-tab
         *ngIf="
+          form.get('type')?.value !== 'GroupLayer' &&
           form.get('layerDefinition.drawingInfo.renderer.type')?.value !==
-            'heatmap' && form.get('datasource.type')?.value !== 'Polygon'
+            'heatmap' &&
+          form.get('datasource.type')?.value !== 'Polygon'
         "
         [disabled]="!isDatasourceValid"
       >
@@ -232,7 +234,7 @@
         </ng-template>
       </ui-tab>
       <!-- Context filter settings -->
-      <ui-tab>
+      <ui-tab *ngIf="form.get('datasource')" [disabled]="!isDatasourceValid">
         <ng-container ngProjectAs="label">
           <ui-icon icon="filter_list" [size]="24"></ui-icon>
           <span>{{ 'models.dashboard.dashboardFilter' | translate }}</span>


### PR DESCRIPTION
# Description

This PR changed the map component so it keeps the current state (zoom + layers visibility) when applying dashboard filters

## Ticket
[Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/66070/)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

See bellow

## Screenshots
![Peek 2023-05-29 13-51](https://github.com/ReliefApplications/oort-frontend/assets/102038450/f6e9a21b-0279-4df7-aeff-f9007af69fcc)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
