### PR TITLE
Fix 2.1.x/db#69267 fields showing when no layout selected fix

### DIFF
--- a/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.html
+++ b/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.html
@@ -96,7 +96,9 @@
           [isIcon]="true"
           icon="close"
           (click)="
-            formGroup.get('datasource.layout')?.setValue(null); layout = null
+            formGroup.get('datasource.layout')?.setValue(null);
+            layout = null;
+            this.fields.next([]);
           "
         ></ui-button>
       </div>
@@ -123,7 +125,8 @@
           icon="close"
           (click)="
             formGroup.get('datasource.aggregation')?.setValue(null);
-            aggregation = null
+            aggregation = null;
+            this.fields.next([]);
           "
         ></ui-button>
       </div>
@@ -154,7 +157,7 @@
       </div>
 
       <!-- Fields selection -->
-      <ng-container *ngIf="formGroup.get('geoField')?.enabled">
+      <ng-container *ngIf="formGroup.get('geoField')?.enabled && (fields$ | async)?.length! > 0">
         <div uiFormFieldDirective>
           <label>{{
             'components.widget.settings.map.layers.dataSource.geoField'
@@ -181,7 +184,7 @@
         </div>
       </ng-container>
 
-      <ng-container *ngIf="formGroup.get('latitudeField')?.enabled">
+      <ng-container *ngIf="formGroup.get('latitudeField')?.enabled && (fields$ | async)?.length! > 0">
         <div class="flex flex-row justify-between gap-2 flex-wrap">
           <!-- Latitude Field -->
           <div uiFormFieldDirective class="flex-1">


### PR DESCRIPTION
# Description

Fix bug for layer configuration where geolocation / lat-long fields continued to be available when you removed the layout or aggregation.

## Ticket

[69267 DB - Fields issue with layer using aggregation
](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/69267)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Added a layout and removed it, confirmed that the fields are hidden.
- [x] Added an aggregation and removed it, confirmed that the fields are hidden.

## Screenshots

![ezgif com-video-to-gif](https://github.com/ReliefApplications/oort-frontend/assets/94831019/6d58e759-3665-481c-8f77-725808faf5ed)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
