### PR TITLE
Bug/ab#69081 group layer visibility range not working

### DIFF
--- a/libs/safe/src/lib/components/ui/map/layer.ts
+++ b/libs/safe/src/lib/components/ui/map/layer.ts
@@ -265,42 +265,27 @@ export class Layer implements LayerModel {
             this.layerService
           )
         : [];
-      console.log(
-        'sublayer init 1',
-        this._sublayers,
-        options.sublayers,
-        options
-      );
       for (const sublayer of this._sublayers) {
-        console.log(
-          sublayer?.layerDefinition?.minZoom,
-          sublayer?.layerDefinition?.maxZoom,
-          '/',
-          options.layerDefinition.minZoom,
-          options.layerDefinition.maxZoom
-        );
         if (
-          (sublayer?.layerDefinition?.minZoom ?? 0) >=
-            options.layerDefinition.minZoom &&
-          (sublayer?.layerDefinition?.minZoom ?? 0) <=
-            options.layerDefinition.maxZoom &&
-          (sublayer?.layerDefinition?.maxZoom ?? 0) >=
-            options.layerDefinition.minZoom &&
-          (sublayer?.layerDefinition?.maxZoom ?? 0) <=
-            options.layerDefinition.maxZoom
+          sublayer &&
+          sublayer.layerDefinition &&
+          sublayer.layerDefinition.maxZoom &&
+          sublayer.layerDefinition.minZoom &&
+          options.layerDefinition
         ) {
-          sublayer.visibility = true;
-        } else {
-          sublayer.visibility = false;
-        } // la valeur n'est pas mis à jour lors du zoom dans la map, uniquement à l'initialisation
+          if (
+            sublayer.layerDefinition.maxZoom > options.layerDefinition.maxZoom
+          ) {
+            sublayer.layerDefinition.maxZoom = options.layerDefinition.maxZoom;
+          }
+          if (
+            sublayer.layerDefinition.minZoom < options.layerDefinition.minZoom
+          ) {
+            sublayer.layerDefinition.minZoom = options.layerDefinition.minZoom;
+          }
+        }
       }
-      if (options.layerDefinition.minZoom) this.sublayersLoaded.next(true);
-      console.log(
-        'sublayer init 2',
-        this._sublayers,
-        options.sublayers,
-        options
-      );
+      this.sublayersLoaded.next(true);
     }
   }
 

--- a/libs/safe/src/lib/components/ui/map/layer.ts
+++ b/libs/safe/src/lib/components/ui/map/layer.ts
@@ -265,8 +265,42 @@ export class Layer implements LayerModel {
             this.layerService
           )
         : [];
-
-      this.sublayersLoaded.next(true);
+      console.log(
+        'sublayer init 1',
+        this._sublayers,
+        options.sublayers,
+        options
+      );
+      for (const sublayer of this._sublayers) {
+        console.log(
+          sublayer?.layerDefinition?.minZoom,
+          sublayer?.layerDefinition?.maxZoom,
+          '/',
+          options.layerDefinition.minZoom,
+          options.layerDefinition.maxZoom
+        );
+        if (
+          (sublayer?.layerDefinition?.minZoom ?? 0) >=
+            options.layerDefinition.minZoom &&
+          (sublayer?.layerDefinition?.minZoom ?? 0) <=
+            options.layerDefinition.maxZoom &&
+          (sublayer?.layerDefinition?.maxZoom ?? 0) >=
+            options.layerDefinition.minZoom &&
+          (sublayer?.layerDefinition?.maxZoom ?? 0) <=
+            options.layerDefinition.maxZoom
+        ) {
+          sublayer.visibility = true;
+        } else {
+          sublayer.visibility = false;
+        } // la valeur n'est pas mis à jour lors du zoom dans la map, uniquement à l'initialisation
+      }
+      if (options.layerDefinition.minZoom) this.sublayersLoaded.next(true);
+      console.log(
+        'sublayer init 2',
+        this._sublayers,
+        options.sublayers,
+        options
+      );
     }
   }
 


### PR DESCRIPTION
# Description

Sublayers have zoom range as well as group layers
We need to display sublayers only if the current map zoom is inside the range of it group layer

I made sublayers zoom matching group zoom in case it's overlapping

## Ticket

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/69081

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I zoomed in and out to check if the sublayer is displaying outside it group range and it doesn't anymore.

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/9751045/f0e99a53-e3a9-4a7b-a5e1-22ab4e88bf10)

![image](https://github.com/ReliefApplications/oort-frontend/assets/9751045/12156da4-46c3-49c2-a8db-506dd0de0c28)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
