### PR TITLE
Few improvements on the survey builder

### DIFF
--- a/libs/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -159,7 +159,7 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
   private setFormBuilder(structure: string) {
     const creatorOptions = {
       showEmbededSurveyTab: false,
-      showJSONEditorTab: false,
+      showJSONEditorTab: true,
       generateValidJSON: true,
       showTranslationTab: true,
       questionTypes: QUESTION_TYPES,

--- a/libs/safe/src/lib/survey/components/resource.ts
+++ b/libs/safe/src/lib/survey/components/resource.ts
@@ -40,8 +40,16 @@ const addRecordToSurveyContext = (
   question: QuestionResource,
   recordID: string
 ) => {
-  if (!recordID) return;
   const survey = question.survey as SurveyModel;
+  if (!recordID) {
+    // get survey variables
+    survey.getVariableNames().forEach((variable) => {
+      // remove variable if starts with question name
+      if (variable.startsWith(`${question.name}.`))
+        survey.setVariable(variable, null);
+    });
+    return;
+  }
   // get record from cache
   const record = loadedRecords.get(recordID);
   if (!record) return;

--- a/libs/safe/src/lib/utils/custom-functions.ts
+++ b/libs/safe/src/lib/utils/custom-functions.ts
@@ -191,6 +191,12 @@ const addCustomFunctions = (
       });
     }
   );
+
+  // Get length of an array
+  survey.FunctionFactory.Instance.register('length', (params: any[]) => {
+    if (!Array.isArray(params[0])) return 0;
+    return params[0].length;
+  });
 };
 
 export default addCustomFunctions;


### PR DESCRIPTION
# Description

* Adds a length function to be used in survey builder
* Enables the JSON tab on the survey builder
* Adds variables with field values of selected record from resources question

## Ticket
No ticket for this PR

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

See bellow

## Screenshots

Expression in question 2: `length(listRowsWithColValue("question1", "items_donated", true))`

![image](https://github.com/ReliefApplications/oort-frontend/assets/102038450/89595574-24e5-4340-a186-78ce476f2d5a)

`{ariplane.manufacturer}` is the expression used in the GIF below, considering that `airplane` is the question name and `manufacturer` is a field of the `Airplanes` form
![Peek 2023-07-12 11-40](https://github.com/ReliefApplications/oort-frontend/assets/102038450/c94d3d37-c63b-4131-bdad-4540d280c45b)

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
