### PR TITLE
Bug on records modal / page visibility

### DIFF
--- a/libs/safe/src/lib/components/form-modal/form-modal.component.html
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.html
@@ -13,7 +13,7 @@
         [selectedIndex]="(selectedPageIndex$ | async)!"
         (selectedIndexChange)="onShowPage($event)"
       >
-        <ui-tab *ngFor="let page of pages$ | async">
+        <ui-tab *ngFor="let page of survey?.visiblePages ?? []">
           <ng-container ngProjectAs="label">
             {{ page.title ? page.title : page.name }}
             <ui-icon
@@ -38,7 +38,7 @@
     <ui-button (click)="onClose()" variant="danger">{{
       'common.cancel' | translate
     }}</ui-button>
-    <ng-container *ngIf="pages$ | async as pages">
+    <ng-container *ngIf="survey?.visiblePages as pages">
       <ui-button
         category="secondary"
         variant="primary"

--- a/libs/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -106,10 +106,6 @@ export class SafeFormModalComponent
     new BehaviorSubject<number>(0);
   /** Selected page index as observable */
   public selectedPageIndex$ = this.selectedPageIndex.asObservable();
-  /** Available pages*/
-  private pages = new BehaviorSubject<any[]>([]);
-  /** Pages as observable */
-  public pages$ = this.pages.asObservable();
 
   /**
    * The constructor function is a special function that is called when a new instance of the class is
@@ -220,14 +216,12 @@ export class SafeFormModalComponent
   private initSurvey(): void {
     this.survey = this.formBuilderService.createSurvey(
       this.form?.structure || '',
-      this.pages,
       this.form?.metadata,
       this.record
     );
     // After the survey is created we add common callback to survey events
     this.formBuilderService.addEventsCallBacksToSurvey(
       this.survey,
-      this.pages,
       this.selectedPageIndex,
       this.temporaryFilesStorage
     );

--- a/libs/safe/src/lib/components/form/form.component.html
+++ b/libs/safe/src/lib/components/form/form.component.html
@@ -17,7 +17,7 @@
   [selectedIndex]="(selectedPageIndex$ | async)!"
   (selectedIndexChange)="onShowPage($event)"
 >
-  <ui-tab *ngFor="let page of pages$ | async">
+  <ui-tab *ngFor="let page of survey?.visiblePages ?? []">
     <ng-container ngProjectAs="label">
       {{ page.title ? page.title : page.name }}
       <ui-icon
@@ -33,7 +33,7 @@
 <div #formContainer></div>
 <!-- Form actions -->
 <div *ngIf="surveyActive" class="flex justify-end gap-2 mt-4 flex-wrap">
-  <ng-container *ngIf="pages$ | async as pages">
+  <ng-container *ngIf="survey?.visiblePages as pages">
     <ui-button
       *ngIf="pages.length > 1"
       [disabled]="survey.isFirstPage"

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -71,10 +71,6 @@ export class SafeFormComponent
     new BehaviorSubject<number>(0);
   /** Selected page index as observable */
   public selectedPageIndex$ = this.selectedPageIndex.asObservable();
-  /** Available pages*/
-  private pages = new BehaviorSubject<any[]>([]);
-  /** Pages as observable */
-  public pages$ = this.pages.asObservable();
 
   /**
    * The constructor function is a special function that is called when a new instance of the class is
@@ -115,14 +111,12 @@ export class SafeFormComponent
 
     this.survey = this.formBuilderService.createSurvey(
       JSON.stringify(structure),
-      this.pages,
       this.form.metadata,
       this.record
     );
     // After the survey is created we add common callback to survey events
     this.formBuilderService.addEventsCallBacksToSurvey(
       this.survey,
-      this.pages,
       this.selectedPageIndex,
       this.temporaryFilesStorage
     );

--- a/libs/safe/src/lib/components/record-modal/record-modal.component.html
+++ b/libs/safe/src/lib/components/record-modal/record-modal.component.html
@@ -17,7 +17,7 @@
         [selectedIndex]="(selectedPageIndex$ | async)!"
         (selectedIndexChange)="onShowPage($event)"
       >
-        <ui-tab *ngFor="let page of pages$ | async">
+        <ui-tab *ngFor="let page of survey?.visiblePages ?? []">
           <ng-container ngProjectAs="label">{{
             page.title ? page.title : page.name
           }}</ng-container>
@@ -70,7 +70,7 @@
         {{ 'common.close' | translate }}
       </ui-button>
 
-      <ng-container *ngIf="pages$ | async as pages">
+      <ng-container *ngIf="survey.visiblePages as pages">
         <ui-button
           category="secondary"
           variant="primary"

--- a/libs/safe/src/lib/components/record-modal/record-modal.component.ts
+++ b/libs/safe/src/lib/components/record-modal/record-modal.component.ts
@@ -93,10 +93,6 @@ export class SafeRecordModalComponent
     new BehaviorSubject<number>(0);
   /** Selected page index as observable */
   public selectedPageIndex$ = this.selectedPageIndex.asObservable();
-  /** Available pages*/
-  private pages = new BehaviorSubject<any[]>([]);
-  /** Pages as observable */
-  public pages$ = this.pages.asObservable();
 
   /**
    * The constructor function is a special function that is called when a new instance of the class is
@@ -184,13 +180,11 @@ export class SafeRecordModalComponent
     this.data.isTemporary
       ? (this.survey = this.formBuilderService.createSurvey(
           this.form?.structure || '',
-          this.pages,
           this.form?.metadata,
           this.record
         ))
       : (this.survey = this.formBuilderService.createSurvey(
           this.form?.structure || '',
-          this.pages,
           this.form?.metadata
         ));
 
@@ -201,7 +195,6 @@ export class SafeRecordModalComponent
     // After the survey is created we add common callback to survey events
     this.formBuilderService.addEventsCallBacksToSurvey(
       this.survey,
-      this.pages,
       this.selectedPageIndex,
       {}
     );
@@ -210,7 +203,6 @@ export class SafeRecordModalComponent
     if (this.data.compareTo) {
       this.surveyNext = this.formBuilderService.createSurvey(
         this.form?.structure || '',
-        this.pages,
         this.form?.metadata,
         this.record
       );
@@ -219,7 +211,6 @@ export class SafeRecordModalComponent
       // After the survey is created we add common callback to survey events
       this.formBuilderService.addEventsCallBacksToSurvey(
         this.surveyNext,
-        this.pages,
         this.selectedPageIndex,
         {}
       );

--- a/libs/safe/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/safe/src/lib/services/form-builder/form-builder.service.ts
@@ -44,14 +44,12 @@ export class SafeFormBuilderService {
    * Creates new survey from the structure and add on complete expression to it.
    *
    * @param structure form structure
-   * @param pages Pages of the current survey
    * @param fields list of fields used to check if the fields should be hidden or disabled
    * @param record record that'll be edited, if any
    * @returns New survey
    */
   createSurvey(
     structure: string,
-    pages: BehaviorSubject<any[]>,
     fields: Metadata[] = [],
     record?: RecordModel
   ): Survey.SurveyModel {
@@ -128,7 +126,6 @@ export class SafeFormBuilderService {
     survey.showNavigationButtons = 'none';
     survey.showProgressBar = 'off';
     survey.focusFirstQuestionAutomatic = false;
-    this.setPages(survey, pages);
     return survey;
   }
 
@@ -137,13 +134,11 @@ export class SafeFormBuilderService {
    * and temporary files storage
    *
    * @param survey Survey where to add the callbacks
-   * @param pages Pages of the current survey
    * @param selectedPageIndex Current page of the survey
    * @param temporaryFilesStorage Temporary files saved while executing the survey
    */
   public addEventsCallBacksToSurvey(
     survey: Survey.SurveyModel,
-    pages: BehaviorSubject<any[]>,
     selectedPageIndex: BehaviorSubject<number>,
     temporaryFilesStorage: Record<string, Array<File>>
   ) {
@@ -157,37 +152,10 @@ export class SafeFormBuilderService {
     survey.onUpdateQuestionCssClasses.add((_, options: any) =>
       this.onSetCustomCss(options)
     );
-    survey.onPageVisibleChanged.add(() => {
-      this.setPages(survey, pages);
-    });
-    survey.onSettingQuestionErrors.add(() => {
-      this.setPages(survey, pages);
-    });
     survey.onCurrentPageChanged.add((survey: Survey.SurveyModel) => {
       survey.checkErrorsMode = survey.isLastPage ? 'onComplete' : 'onNextPage';
       selectedPageIndex.next(survey.currentPageNo);
     });
-  }
-
-  /**
-   * Set the pages of the survey
-   *
-   * @param survey Current survey
-   * @param pages Page number emitter
-   */
-  private setPages(
-    survey: Survey.SurveyModel,
-    pages: BehaviorSubject<any[]>
-  ): void {
-    const pageList = [];
-    if (survey) {
-      for (const page of survey.pages) {
-        if (page.isVisible) {
-          pageList.push(page);
-        }
-      }
-    }
-    pages.next(pageList);
   }
 
   /**


### PR DESCRIPTION

# Description

This PR fixes a bug on the record modal by simplifying the logic with the page visibility. Instead of doing all that ourselves, just use the `survey.visiblePages` propertly

## Ticket
[Records details on gird are showing incorrect pages](https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/3?selectedIssue=OORT-655)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
See below (also tested on record update modal and form component on BO)

## Screenshots

prod (few pages missing)
![image](https://github.com/ReliefApplications/oort-frontend/assets/102038450/f6030e3f-745c-49b4-82dc-a6fa50d88551)

fix
![image](https://github.com/ReliefApplications/oort-frontend/assets/102038450/1ef38a60-977b-4346-889c-622973834ca0)



# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
