### PR TITLE
choices titles from fast entry

### DIFF
--- a/libs/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -488,7 +488,7 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
           );
         }
       } else {
-        // As we already have the reference data value to get the choices, we dont want to save them again with the form structure
+        // As we already have the reference data value to get the choices, we don't want to save them again with the form structure
         question.choices = [];
       }
     }
@@ -508,20 +508,27 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges {
       });
     }
     if (question.getType() === 'matrix') {
-      question.columns.forEach(
-        (x: any) => (x.value = this.toSnakeCase(x.value || x.text || x))
-      );
-      question.rows.forEach(
-        (x: any) => (x.value = this.toSnakeCase(x.value || x.text || x))
-      );
+      question.columns.forEach((x: any) => {
+        const snakeCaseValue = this.toSnakeCase(x.value || x.text || x);
+        x.text = x.text || x.value;
+        x.value = snakeCaseValue;
+      });
+      question.rows.forEach((x: any) => {
+        const snakeCaseValue = this.toSnakeCase(x.value || x.text || x);
+        x.text = x.text || x.value;
+        x.value = snakeCaseValue;
+      });
     }
     if (question.getType() === 'matrixdropdown') {
       question.columns.forEach((x: any) => {
-        x.name = this.toSnakeCase(x.name || x.title || x);
+        const snakeCaseName = this.toSnakeCase(x.name || x.title || x);
         x.title = x.title || x.name || x;
+        x.name = snakeCaseName;
       });
       question.rows.forEach((x: any) => {
-        x.value = this.toSnakeCase(x.value || x.text || x);
+        const snakeCaseValue = this.toSnakeCase(x.value || x.text || x);
+        x.text = x.text || x.value;
+        x.value = snakeCaseValue;
       });
     }
     if (['resource', 'resources'].includes(question.getType())) {


### PR DESCRIPTION
# Description

This PR fixes an issue that caused choices entered from the fast editor to have their values snake_cased, making it hard to quickly create new rows. This PR addresses it by setting the title of the row to be equal of the value before snake-case, if empty

## Ticket
[Choices titles from fast entry editor](https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/3?selectedIssue=OORT-656)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
See below

## Screenshots

![Peek 2023-07-12 11-40](https://github.com/ReliefApplications/oort-frontend/assets/102038450/a705c2f0-dd22-4a68-bbf7-903e5f8a7fe7)


# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
