### PR TITLE
fix/survey-questions-readonly

### DIFF
--- a/libs/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -232,6 +232,16 @@ export class SafeFormModalComponent
       this.temporaryFilesStorage
     );
 
+    // Set questions readOnly propriety
+    const structure = JSON.parse(this.form?.structure || '');
+    const pages = structure.pages;
+    pages.forEach((page: any) => {
+      page.elements?.forEach((question: any) => {
+        this.survey.getQuestionByName(question.name).readOnly =
+          question.readOnly ?? false;
+      });
+    });
+
     if (this.data.recordId && this.record) {
       addCustomFunctions(Survey, this.authService, this.record);
       this.survey.data = this.isMultiEdition ? null : this.record.data;
@@ -246,6 +256,16 @@ export class SafeFormModalComponent
     }
     this.survey.render(this.formContainer.nativeElement);
     // this.survey.render(this.containerId);
+    // this.pages.getValue().forEach((page: any) => {
+    //   console.log('page', page)
+    //   page.questions?.forEach((question: any) => {
+    //     const q = this.survey.getQuestionByName(question.name)
+    //     console.log('question',  q.name, question.readOnly, question.isReadOnly)
+    //     this.survey.getQuestionByName(question.name).readOnly = question.isReadyOnly ?? false;
+    //     console.log('question',  q.name, q.readOnly, q.isReadOnly)
+
+    //   });
+    // });
     this.loading = false;
   }
 

--- a/libs/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -236,7 +236,7 @@ export class SafeFormModalComponent
     const structure = JSON.parse(this.form?.structure || '');
     const pages = structure.pages;
     const initReadOnly = (elements: any): void => {
-      elements?.forEach((question: any) => {
+      elements.forEach((question: any) => {
         if (question.elements) {
           // If question is a panel type that has sub-questions
           initReadOnly(question.elements);
@@ -245,12 +245,14 @@ export class SafeFormModalComponent
           initReadOnly(question.templateElements);
         } else if (this.survey.getQuestionByName(question.name)) {
           this.survey.getQuestionByName(question.name).readOnly =
-            question?.readOnly ?? false;
+            question.readOnly ?? false;
         }
       });
     };
     pages.forEach((page: any) => {
-      initReadOnly(page.elements);
+      if (page.elements) {
+        initReadOnly(page.elements);
+      }
     });
 
     if (this.data.recordId && this.record) {

--- a/libs/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -233,8 +233,24 @@ export class SafeFormModalComponent
     );
 
     // Set questions readOnly propriety
-    this.survey.getAllQuestions().forEach((question) => {
-      question.readOnly ||= false;
+    const structure = JSON.parse(this.form?.structure || '');
+    const pages = structure.pages;
+    const initReadOnly = (elements: any): void => {
+      elements?.forEach((question: any) => {
+        if (question.elements) {
+          // If question is a panel type that has sub-questions
+          initReadOnly(question.elements);
+        } else if (question.templateElements) {
+          // If question is a paneldynamic type that has sub-questions
+          initReadOnly(question.templateElements);
+        } else if (this.survey.getQuestionByName(question.name)) {
+          this.survey.getQuestionByName(question.name).readOnly =
+            question?.readOnly ?? false;
+        }
+      });
+    };
+    pages.forEach((page: any) => {
+      initReadOnly(page.elements);
     });
 
     if (this.data.recordId && this.record) {

--- a/libs/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -233,13 +233,8 @@ export class SafeFormModalComponent
     );
 
     // Set questions readOnly propriety
-    const structure = JSON.parse(this.form?.structure || '');
-    const pages = structure.pages;
-    pages.forEach((page: any) => {
-      page.elements?.forEach((question: any) => {
-        this.survey.getQuestionByName(question.name).readOnly =
-          question.readOnly ?? false;
-      });
+    this.survey.getAllQuestions().forEach((question) => {
+      question.readOnly ||= false;
     });
 
     if (this.data.recordId && this.record) {
@@ -255,17 +250,6 @@ export class SafeFormModalComponent
       };
     }
     this.survey.render(this.formContainer.nativeElement);
-    // this.survey.render(this.containerId);
-    // this.pages.getValue().forEach((page: any) => {
-    //   console.log('page', page)
-    //   page.questions?.forEach((question: any) => {
-    //     const q = this.survey.getQuestionByName(question.name)
-    //     console.log('question',  q.name, question.readOnly, question.isReadOnly)
-    //     this.survey.getQuestionByName(question.name).readOnly = question.isReadyOnly ?? false;
-    //     console.log('question',  q.name, q.readOnly, q.isReadOnly)
-
-    //   });
-    // });
     this.loading = false;
   }
 

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -134,14 +134,12 @@ export class SafeFormComponent
     this.survey.onValueChanged.add(this.valueChange.bind(this));
     this.survey.onComplete.add(this.onComplete);
 
-    // Unset readOnly fields if it's the record creation
-    if (!this.record) {
-      this.form.fields?.forEach((field) => {
-        if (field.readOnly) {
-          this.survey.getQuestionByName(field.name).readOnly = false;
-        }
-      });
-    }
+    // Set questions readOnly propriety
+    this.form.fields?.forEach((field) => {
+      if (field.readOnly) {
+        this.survey.getQuestionByName(field.name).readOnly = field.readOnly;
+      }
+    });
     // Fetch cached data from local storage
     this.storageId = `record:${this.record ? 'update' : ''}:${this.form.id}`;
     const storedData = localStorage.getItem(this.storageId);

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -136,10 +136,8 @@ export class SafeFormComponent
 
     // Set questions readOnly propriety
     this.form.fields?.forEach((field) => {
-      if (field.readOnly) {
-        this.survey.getQuestionByName(field.name).readOnly =
-          field.readOnly ?? false;
-      }
+      this.survey.getQuestionByName(field.name).readOnly =
+        field.readOnly ?? false;
     });
     // Fetch cached data from local storage
     this.storageId = `record:${this.record ? 'update' : ''}:${this.form.id}`;

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -137,7 +137,8 @@ export class SafeFormComponent
     // Set questions readOnly propriety
     this.form.fields?.forEach((field) => {
       if (field.readOnly) {
-        this.survey.getQuestionByName(field.name).readOnly = field.readOnly;
+        this.survey.getQuestionByName(field.name).readOnly =
+          field.readOnly ?? false;
       }
     });
     // Fetch cached data from local storage


### PR DESCRIPTION
# Description
Question isReadyOnly propriety never working, even if on a page without any logic configurations. Read only for questions only working when page also was in a read-only state
The issue didn't exist in the test survey but in the add a new record, update record, and update record in the grid modal

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Creating questions that assume the readOnly state at different times and seeing them behave as they should.

## Screenshots
![ro-add](https://github.com/ReliefApplications/oort-frontend/assets/28535394/f8b29db3-3ae9-47b5-aef2-72b91096ddb0)

![ro-grid](https://github.com/ReliefApplications/oort-frontend/assets/28535394/14b07aa8-fd16-4c1c-9f57-49e534827540)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
