### PR TITLE
Fix/AB#69896 misalignment between input and wrapper form date picker

### DIFF
--- a/libs/safe/src/lib/style/survey.scss
+++ b/libs/safe/src/lib/style/survey.scss
@@ -29,6 +29,12 @@
   .k-timepicker,
   .k-datetimepicker {
     width: 100%;
+
+    .k-dateinput {
+      .k-input-inner {
+        height: 100% !important;
+      }
+    }
   }
 }
 
@@ -38,6 +44,12 @@
   .k-timepicker,
   .k-datetimepicker {
     width: 100%;
+
+    .k-dateinput {
+      .k-input-inner {
+        height: 100% !important;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
# Description

While testing the app, a minor style issue was spotted on the surveys.
Datepicker fields on the forms had a misalignment between the dateinput field and the wrapper element.

The solution consisted on overwriting the height of that element inside surveys.

## Ticket

[#69896 misalignment between input and wrapper form date picker
](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/69896)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Create a form with a datepicker element and check that it displays correctly

## Screenshots

Before fix: (Small gap at the bottom)
![Screenshot from 2023-07-19 08-40-43](https://github.com/ReliefApplications/oort-frontend/assets/94831019/7dbc7172-f45a-439a-9e17-4d0693c3dd7d)

After fix:
![Screenshot from 2023-07-19 08-39-30](https://github.com/ReliefApplications/oort-frontend/assets/94831019/964d6c5b-7edf-4446-9b46-35b9753bf2b8)


# Checklist:
( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
