### PR TITLE
fix/AB#70722-resource-modal-blank-page

### DIFF
--- a/libs/safe/src/lib/services/form/form.service.ts
+++ b/libs/safe/src/lib/services/form/form.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@angular/core';
+import { Inject, Injectable, NgZone } from '@angular/core';
 import * as SurveyKo from 'survey-knockout';
 import * as Survey from 'survey-angular';
 import { initCreatorSettings } from '../../survey/creator';
@@ -30,6 +30,7 @@ export class SafeFormService {
    * @param formBuilder Angular form builder
    * @param authService Shared authentication service
    * @param referenceDataService Reference data service
+   * @param ngZone Angular Service to execute code inside Angular environment
    */
   constructor(
     @Inject('environment') environment: any,
@@ -38,7 +39,8 @@ export class SafeFormService {
     public apollo: Apollo,
     public formBuilder: UntypedFormBuilder,
     public authService: SafeAuthService,
-    public referenceDataService: SafeReferenceDataService
+    public referenceDataService: SafeReferenceDataService,
+    public ngZone: NgZone
   ) {
     this.environment = environment;
     this.setSurveyCreatorInstance();
@@ -65,7 +67,8 @@ export class SafeFormService {
       this.authService,
       this.environment,
       this.referenceDataService,
-      additionalQuestions.customQuestions
+      additionalQuestions.customQuestions,
+      this.ngZone
     );
     // === CREATOR SETTINGS ===
     initCreatorSettings(SurveyKo);
@@ -79,7 +82,8 @@ export class SafeFormService {
       this.authService,
       this.environment,
       this.referenceDataService,
-      additionalQuestions.customQuestions
+      additionalQuestions.customQuestions,
+      this.ngZone
     );
   }
 }

--- a/libs/safe/src/lib/survey/components/resource.ts
+++ b/libs/safe/src/lib/survey/components/resource.ts
@@ -14,6 +14,7 @@ import { buildSearchButton, buildAddButton } from './utils';
 import get from 'lodash/get';
 import { Question, QuestionResource } from '../types';
 import { JsonMetadata, SurveyModel } from 'survey-angular';
+import { NgZone } from '@angular/core';
 
 /**
  * Inits the resource question component of for survey.
@@ -23,13 +24,15 @@ import { JsonMetadata, SurveyModel } from 'survey-angular';
  * @param apollo Apollo client
  * @param dialog Dialog
  * @param formBuilder Angular form service
+ * @param ngZone Angular Service to execute code inside Angular environment
  */
 export const init = (
   Survey: any,
   domService: DomService,
   apollo: Apollo,
   dialog: Dialog,
-  formBuilder: UntypedFormBuilder
+  formBuilder: UntypedFormBuilder,
+  ngZone: NgZone
 ): void => {
   const getResourceById = (data: { id: string }) =>
     apollo.query<GetResourceByIdQueryResponse>({
@@ -600,7 +603,7 @@ export const init = (
         );
         actionsButtons.appendChild(searchBtn);
 
-        const addBtn = buildAddButton(question, false, dialog);
+        const addBtn = buildAddButton(question, false, dialog, ngZone);
         actionsButtons.appendChild(addBtn);
 
         const parentElement = el.querySelector('.safe-qst-content');

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -15,6 +15,7 @@ import { buildSearchButton, buildAddButton } from './utils';
 import { QuestionResource } from '../types';
 import { SurveyModel } from 'survey-angular';
 import localForage from 'localforage';
+import { NgZone } from '@angular/core';
 
 /** Create the list of filter values for resources */
 export const resourcesFilterValues = new BehaviorSubject<
@@ -40,13 +41,15 @@ export const resourceConditions = [
  * @param apollo Apollo client
  * @param dialog Dialog service
  * @param formBuilder Angular form service
+ * @param ngZone Angular Service to execute code inside Angular environment
  */
 export const init = (
   Survey: any,
   domService: DomService,
   apollo: Apollo,
   dialog: Dialog,
-  formBuilder: UntypedFormBuilder
+  formBuilder: UntypedFormBuilder,
+  ngZone: NgZone
 ): void => {
   const getResourceById = (data: { id: string }) =>
     apollo.query<GetResourceByIdQueryResponse>({
@@ -768,7 +771,7 @@ export const init = (
             );
             actionsButtons.appendChild(searchBtn);
 
-            const addBtn = buildAddButton(question, true, dialog);
+            const addBtn = buildAddButton(question, true, dialog, ngZone);
             actionsButtons.appendChild(addBtn);
 
             parentElement.insertBefore(

--- a/libs/safe/src/lib/survey/init.ts
+++ b/libs/safe/src/lib/survey/init.ts
@@ -21,6 +21,7 @@ import * as ReferenceDataProperties from './global-properties/reference-data';
 import * as TooltipProperty from './global-properties/tooltip';
 import { initLocalization } from './localization';
 import { Dialog } from '@angular/cdk/dialog';
+import { NgZone } from '@angular/core';
 
 /**
  * Executes all init methods of custom SurveyJS.
@@ -34,6 +35,7 @@ import { Dialog } from '@angular/cdk/dialog';
  * @param environment injected environment
  * @param referenceDataService Reference data service
  * @param containsCustomQuestions If survey contains custom questions or not
+ * @param ngZone Angular Service to execute code inside Angular environment
  */
 export const initCustomSurvey = (
   Survey: any,
@@ -44,7 +46,8 @@ export const initCustomSurvey = (
   authService: SafeAuthService,
   environment: any,
   referenceDataService: SafeReferenceDataService,
-  containsCustomQuestions: boolean
+  containsCustomQuestions: boolean,
+  ngZone: NgZone
 ): void => {
   // If the survey created does not contain custom questions, we destroy previously set custom questions if so
   if (!containsCustomQuestions) {
@@ -59,8 +62,22 @@ export const initCustomSurvey = (
   if (containsCustomQuestions) {
     CommentWidget.init(Survey);
     // load components (same as widgets, but with less configuration options)
-    ResourceComponent.init(Survey, domService, apollo, dialog, formBuilder);
-    ResourcesComponent.init(Survey, domService, apollo, dialog, formBuilder);
+    ResourceComponent.init(
+      Survey,
+      domService,
+      apollo,
+      dialog,
+      formBuilder,
+      ngZone
+    );
+    ResourcesComponent.init(
+      Survey,
+      domService,
+      apollo,
+      dialog,
+      formBuilder,
+      ngZone
+    );
     OwnerComponent.init(Survey, domService, apollo);
     UsersComponent.init(Survey, domService, apollo);
   }


### PR DESCRIPTION
# Description
Added NgZone service to the SafeFormService, so the add button in the resource and resources questions can run the code that opens the SafeResourceModalComponent in the modal inside Angular's zone,  ensuring that Angular will be aware of changes happening within that code and its components

## Ticket
[AB#70722 - SA - HQ/RO's - Actions within Signal form - Prod - Gives a blank page, but when click in blank page, it will load
](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/70722)
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Testing in resource and resources question, when clicking on 'add new records' the modal loads the form component automatically 

## Screenshots
![resource](https://github.com/ReliefApplications/oort-frontend/assets/28535394/7bc39855-b91b-4b62-bf12-350db0a538a0)
![resources](https://github.com/ReliefApplications/oort-frontend/assets/28535394/4437feef-bc55-46c6-b449-5d97f1459e7e)

# Checklist:

( * == Mandatory ) 

- [X] * The pull request is linked to an existing milestone
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
