### PR TITLE
Fix/ab#70863 abc breadcrumb going outside of bounds

### DIFF
--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -6,8 +6,7 @@
         class="h-5 w-5 flex-shrink-0 text-gray-400"
         viewBox="-5 0 60 60"
         fill="currentColor"
-        aria-hidden="true"
-      >
+        aria-hidden="true">
         <path d="M.293 0l22 22-22 22h1.414l22-22-22-22H.293z" />
       </svg>
     </ng-container>
@@ -16,8 +15,7 @@
         class="h-5 w-5 flex-shrink-0 text-gray-300"
         fill="currentColor"
         viewBox="0 0 20 20"
-        aria-hidden="true"
-      >
+        aria-hidden="true">
         <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
       </svg>
     </ng-container>
@@ -28,8 +26,7 @@
     'border-b border-gray-200 bg-white': display === 'full'
   }"
   class="flex"
-  aria-label="Breadcrumb"
->
+  aria-label="Breadcrumb">
   <ol
     #breadcrumbList
     class="mb-2"
@@ -38,28 +35,24 @@
       'ui-breadcrumbs__simple': display === 'simple',
       'ui-breadcrumbs__contained': display === 'contained',
       'ui-breadcrumbs__full': display === 'full'
-    }"
-  >
+    }">
     <!-- For each breadcrumb in the breadcrumbs list -->
     <li
       *ngFor="let breadcrumb of breadcrumbs; let first = first; let last = last"
-      class="flex"
-    >
+      (mouseenter)="breadcrumb.showLabel = true"
+      (mouseleave)="breadcrumb.showLabel = false"
+      class="flex pr-4">
       <div *ngIf="!first">
         <ng-container *ngTemplateOutlet="separatorTmpl"></ng-container>
       </div>
       <!-- Breadcrumb link -->
       <div
         [ngClass]="{ 'ml-4': !first }"
-        (mouseover)="breadcrumb.showLabel = true"
-        (mouseout)="breadcrumb.showLabel = false"
-        class="flex items-center"
-      >
+        class="flex items-center">
         <a
           *ngIf="breadcrumb.key || breadcrumb.text"
           [routerLink]="[breadcrumb.uri]"
-          class="text-sm font-medium text-gray-500 hover:text-gray-700"
-        >
+          class="text-sm font-medium text-gray-500 hover:text-gray-700">
           <span
             class="whitespace-nowrap"
             *ngIf="
@@ -67,11 +60,9 @@
                 (isBreadcrumbOffLimits &&
                   (first || last || breadcrumb.showLabel));
               else dotTmpl
-            "
-            >{{
-              breadcrumb.key ? (breadcrumb.key | translate) : breadcrumb.text
-            }}</span
-          >
+            ">{{
+            breadcrumb.key ? (breadcrumb.key | translate) : breadcrumb.text
+            }}</span>
           <ng-template #dotTmpl>
             <span class="text-sm font-medium text-gray-500">...</span>
           </ng-template>
@@ -79,8 +70,7 @@
         <!-- Loading indicator if text not set -->
         <kendo-skeleton
           *ngIf="!breadcrumb.key && !breadcrumb.text"
-          width="3em"
-        ></kendo-skeleton>
+          width="3em"></kendo-skeleton>
       </div>
     </li>
   </ol>

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.html
@@ -31,6 +31,7 @@
   aria-label="Breadcrumb"
 >
   <ol
+    #breadcrumbList
     class="mb-2"
     role="list"
     [ngClass]="{
@@ -40,20 +41,40 @@
     }"
   >
     <!-- For each breadcrumb in the breadcrumbs list -->
-    <li *ngFor="let breadcrumb of breadcrumbs; let f = first" class="flex">
-      <div *ngIf="!f">
+    <li
+      *ngFor="let breadcrumb of breadcrumbs; let first = first; let last = last"
+      class="flex"
+    >
+      <div *ngIf="!first">
         <ng-container *ngTemplateOutlet="separatorTmpl"></ng-container>
       </div>
       <!-- Breadcrumb link -->
-      <div [ngClass]="{ 'ml-4': !f }" class="flex items-center">
+      <div
+        [ngClass]="{ 'ml-4': !first }"
+        (mouseover)="breadcrumb.showLabel = true"
+        (mouseout)="breadcrumb.showLabel = false"
+        class="flex items-center"
+      >
         <a
           *ngIf="breadcrumb.key || breadcrumb.text"
           [routerLink]="[breadcrumb.uri]"
           class="text-sm font-medium text-gray-500 hover:text-gray-700"
         >
-          <span>{{
-            breadcrumb.key ? (breadcrumb.key | translate) : breadcrumb.text
-          }}</span>
+          <span
+            class="whitespace-nowrap"
+            *ngIf="
+              !isBreadcrumbOffLimits ||
+                (isBreadcrumbOffLimits &&
+                  (first || last || breadcrumb.showLabel));
+              else dotTmpl
+            "
+            >{{
+              breadcrumb.key ? (breadcrumb.key | translate) : breadcrumb.text
+            }}</span
+          >
+          <ng-template #dotTmpl>
+            <span class="text-sm font-medium text-gray-500">...</span>
+          </ng-template>
         </a>
         <!-- Loading indicator if text not set -->
         <kendo-skeleton

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.scss
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.scss
@@ -1,9 +1,9 @@
 .ui-breadcrumbs__simple {
-  @apply flex items-center space-x-4;
+  @apply flex items-center;
 }
 .ui-breadcrumbs__contained {
-  @apply flex space-x-4 rounded-md bg-white px-6 shadow;
+  @apply flex rounded-md bg-white px-6 shadow;
 }
 .ui-breadcrumbs__full {
-  @apply mx-auto flex w-full max-w-screen-xl space-x-4 px-4 sm:px-6 lg:px-8;
+  @apply mx-auto flex w-full max-w-screen-xl px-4 sm:px-6 lg:px-8;
 }

--- a/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
+++ b/libs/ui/src/lib/breadcrumbs/breadcrumbs.component.ts
@@ -1,8 +1,16 @@
-import { Component, Input } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  HostListener,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
 import { BreadcrumbDisplay } from './types/breadcrumb-display';
 import { BreadcrumbSeparator } from './types/breadcrumb-separator';
 import { Breadcrumb } from './interfaces/breadcrumb.interface';
-
+import { isEqual } from 'lodash';
 /**
  * UI Breadcrumbs Component
  */
@@ -11,8 +19,62 @@ import { Breadcrumb } from './interfaces/breadcrumb.interface';
   templateUrl: './breadcrumbs.component.html',
   styleUrls: ['./breadcrumbs.component.scss'],
 })
-export class BreadcrumbsComponent {
+export class BreadcrumbsComponent implements OnChanges {
   @Input() breadcrumbs: Breadcrumb[] = [];
   @Input() separator: BreadcrumbSeparator = 'slash';
   @Input() display: BreadcrumbDisplay = 'simple';
+
+  @ViewChild('breadcrumbList', { static: true, read: ElementRef })
+  breadcrumbList!: ElementRef<HTMLOListElement>;
+
+  isBreadcrumbOffLimits = false;
+  expandedWidth = 0;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (
+      changes['breadcrumbs'] &&
+      !isEqual(
+        changes['breadcrumbs'].currentValue,
+        changes['breadcrumbs'].previousValue
+      )
+    ) {
+      this.updateOffLimitValue();
+    }
+  }
+
+  /**
+   * Update off limit value for the given breadcrumb
+   */
+  private updateOffLimitValue(): void {
+    this.loadBreadcrumb().then(() => {
+      // Save the width with all the texts visible to handle minimal or full display later
+      this.expandedWidth = this.breadcrumbList?.nativeElement?.clientWidth;
+      // Check if the breadcrumb is within screen limits on load
+      this.isBreadcrumbOffLimits = window.innerWidth < this.expandedWidth;
+    });
+  }
+
+  /**
+   * Keep checking until breadcrumb is fully load
+   */
+  private loadBreadcrumb(): Promise<void> {
+    const checkAgain = (resolve: () => void) => {
+      if (this.breadcrumbs.every((bc) => bc.key || bc.text)) {
+        resolve();
+      } else {
+        setTimeout(() => checkAgain(resolve), 400);
+      }
+    };
+    return new Promise(checkAgain);
+  }
+
+  /**
+   * Change the display depending on windows size.
+   *
+   * @param event Event that implies a change in window size
+   */
+  @HostListener('window:resize', ['$event'])
+  onResize(event: any): void {
+    this.isBreadcrumbOffLimits = event.target.innerWidth < this.expandedWidth;
+  }
 }

--- a/libs/ui/src/lib/breadcrumbs/interfaces/breadcrumb.interface.ts
+++ b/libs/ui/src/lib/breadcrumbs/interfaces/breadcrumb.interface.ts
@@ -5,4 +5,5 @@ export interface Breadcrumb {
   text?: string;
   key?: string;
   queryParams?: any;
+  showLabel: boolean;
 }


### PR DESCRIPTION
# Description

feat: add minimal display when breadcrumb width is off limit using hover effect
feat: add method to check on window resize if breadcrumb text should be displayed or minimal display should be used
fix: property names in html to make it more legible

## Ticket

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/70863)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please refer to videos below

## Screenshots

https://github.com/ReliefApplications/oort-frontend/assets/123092672/e032f99b-3cc3-417a-9b40-b3bd775949d4

https://github.com/ReliefApplications/oort-frontend/assets/123092672/1d1f4322-5b0c-4bb6-8765-de643f3a4a0b


# Checklist:

( * == Mandatory ) 

- [X] * The pull request is linked to an existing milestone
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
