### PR TITLE
Fix 2.0.x/ab#70928 dropdown channel initialization bug

### DIFF
--- a/libs/safe/src/lib/components/role-summary/graphql/queries.ts
+++ b/libs/safe/src/lib/components/role-summary/graphql/queries.ts
@@ -13,6 +13,10 @@ export const GET_ROLE = gql`
       id
       title
       description
+      channels {
+        id
+        title
+      }
       permissions {
         id
         type


### PR DESCRIPTION
# Description

Added channels to the getRole query.

## Ticket

[70928 - Channels dropdown not initially set with saved values from DB](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/70928)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I checked that the role channels are well initialized and tried to update them.

## Screenshots

![peek](https://github.com/ReliefApplications/oort-frontend/assets/65243509/c7925071-a1c9-4f27-a6bd-33b6e9e7b493)

# Checklist:

( * == Mandatory ) 

- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules