### PR TITLE
fix/AB#71072_clean_up_filter_logic

### DIFF
--- a/libs/safe/src/lib/survey/widgets/dropdown-widget.ts
+++ b/libs/safe/src/lib/survey/widgets/dropdown-widget.ts
@@ -54,12 +54,7 @@ export const init = (Survey: any, domService: DomService): void => {
       );
 
       question._propertyValueChangedVirtual = () => {
-        updateChoices(
-          dropdownInstance,
-          question,
-          currentSearchValue,
-          Boolean(question.value)
-        );
+        updateChoices(dropdownInstance, question, currentSearchValue);
       };
       question.registerFunctionOnPropertyValueChanged(
         'visibleChoices',
@@ -76,12 +71,7 @@ export const init = (Survey: any, domService: DomService): void => {
         }
       );
       if (question.visibleChoices.length) {
-        updateChoices(
-          dropdownInstance,
-          question,
-          currentSearchValue,
-          Boolean(question.value)
-        );
+        updateChoices(dropdownInstance, question, currentSearchValue);
       }
       el.parentElement?.appendChild(dropdownDiv);
     },

--- a/libs/safe/src/lib/survey/widgets/tagbox-widget.ts
+++ b/libs/safe/src/lib/survey/widgets/tagbox-widget.ts
@@ -90,12 +90,7 @@ export const init = (Survey: any, domService: DomService): void => {
       );
 
       question._propertyValueChangedVirtual = () => {
-        updateChoices(
-          tagboxInstance,
-          question,
-          currentSearchValue,
-          Boolean(question.value)
-        );
+        updateChoices(tagboxInstance, question, currentSearchValue);
       };
       question.registerFunctionOnPropertyValueChanged(
         'visibleChoices',
@@ -109,12 +104,7 @@ export const init = (Survey: any, domService: DomService): void => {
         }
       );
       if (question.visibleChoices.length) {
-        updateChoices(
-          tagboxInstance,
-          question,
-          currentSearchValue,
-          Boolean(question.value)
-        );
+        updateChoices(tagboxInstance, question, currentSearchValue);
       }
       el.parentElement?.appendChild(tagboxDiv);
     },

--- a/libs/safe/src/lib/survey/widgets/utils/common-list-filters.ts
+++ b/libs/safe/src/lib/survey/widgets/utils/common-list-filters.ts
@@ -14,13 +14,11 @@ const DEFAULT_VISIBLE_OPTIONS = 100;
  * @param widget Widget shown in the surveyjs question
  * @param surveyQuestion surveyjs question instance for the given widget
  * @param searchValue search value to filter item list
- * @param hasDefaultValue if question contains a value set
  */
 function updateChoices(
   widget: ComboBoxComponent | MultiSelectComponent,
   surveyQuestion: any,
-  searchValue: string = '',
-  hasDefaultValue: boolean = false
+  searchValue: string = ''
 ) {
   if (searchValue === '') {
     // Without search value uses virtualization
@@ -60,33 +58,6 @@ function updateChoices(
         )
         .slice(0, DEFAULT_VISIBLE_OPTIONS);
       widget.data = dataToShow;
-    }
-  }
-
-  if (hasDefaultValue) {
-    const choicesAux = surveyQuestion.visibleChoices.filter((ch: any) => {
-      const searchValue = typeof ch === 'string' ? ch : ch.value;
-      return widget instanceof ComboBoxComponent
-        ? searchValue === surveyQuestion.value
-        : surveyQuestion.value.includes(searchValue);
-    });
-
-    // Set the default values selected at the start of the list
-    if (choicesAux.length) {
-      widget.data = [
-        ...choicesAux.map((choice: any) =>
-          typeof choice === 'string'
-            ? {
-                text: choice,
-                value: choice,
-              }
-            : {
-                text: choice.text,
-                value: choice.value,
-              }
-        ),
-        ...widget.data,
-      ];
     }
   }
 


### PR DESCRIPTION
# Description

refactor: deleete no needed logic, as at first load all the choices would be available for both kendo widget

## Ticket

[Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/71072)

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * The pull request is linked to an existing milestone
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
