### PR TITLE
Bug/ab#67008 force scroll to top in dashboard

### DIFF
--- a/libs/ui/src/lib/sidenav/sidenav-container.component.html
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.html
@@ -12,7 +12,7 @@
     </div>
   </ng-container>
   <!-- CONTENT -->
-  <div class="flex-1 overflow-y-auto" #content>
+  <div class="flex-1 overflow-y-auto" #contentContainer>
     <div
       [ngClass]="{
         'visible bg-black opacity-50': showSidenav[0] && mode[0] === 'over',
@@ -20,7 +20,7 @@
       }"
       class="block w-full overflow-y-auto min-h-full transition-visibility duration-500 transition-all ease-in-out absolute inset-0 pointer-events-none z-[998]"
     ></div>
-    <div class="py-[32px] overflow-y-auto h-full px-[24px]" #container>
+    <div class="py-[32px] overflow-y-auto h-full px-[24px]" #contentWrapper>
       <ng-content select="content"></ng-content>
     </div>
   </div>

--- a/libs/ui/src/lib/sidenav/sidenav-container.component.html
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.html
@@ -20,7 +20,7 @@
       }"
       class="block w-full overflow-y-auto min-h-full transition-visibility duration-500 transition-all ease-in-out absolute inset-0 pointer-events-none z-[998]"
     ></div>
-    <div class="py-[32px] overflow-y-auto h-full px-[24px]">
+    <div class="py-[32px] overflow-y-auto h-full px-[24px]" #container>
       <ng-content select="content"></ng-content>
     </div>
   </div>

--- a/libs/ui/src/lib/sidenav/sidenav-container.component.ts
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.ts
@@ -26,9 +26,9 @@ import { filter } from 'rxjs/operators';
 })
 export class SidenavContainerComponent implements AfterViewInit, OnDestroy {
   @ContentChildren(SidenavDirective) uiSidenavDirective!: SidenavDirective[];
-  @ViewChild('content') content!: ElementRef;
+  @ViewChild('contentContainer') contentContainer!: ElementRef;
   @ViewChildren('sidenav') sidenav!: QueryList<any>;
-  @ViewChild('container') container!: ElementRef;
+  @ViewChild('contentWrapper') contentWrapper!: ElementRef;
 
   public showSidenav: boolean[] = [];
   public mode: SidenavTypes[] = [];
@@ -52,9 +52,12 @@ export class SidenavContainerComponent implements AfterViewInit, OnDestroy {
     private router: Router
   ) {
     this.router.events
-      .pipe(filter((event) => event instanceof NavigationEnd))
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntil(this.destroy$)
+      )
       .subscribe(() => {
-        this.container.nativeElement.scroll({
+        this.contentWrapper.nativeElement.scroll({
           top: 0,
           left: 0,
           behavior: 'smooth',
@@ -125,7 +128,7 @@ export class SidenavContainerComponent implements AfterViewInit, OnDestroy {
    */
   private setTransitionForContent() {
     this.animationClasses.forEach((aClass) => {
-      this.renderer.addClass(this.content.nativeElement, aClass);
+      this.renderer.addClass(this.contentContainer.nativeElement, aClass);
       this.sidenav.forEach((side) => {
         this.renderer.addClass(side.nativeElement, aClass);
       });

--- a/libs/ui/src/lib/sidenav/sidenav-container.component.ts
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.ts
@@ -10,9 +10,11 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
 import { SidenavDirective } from './sidenav.directive';
 import { Subject, takeUntil } from 'rxjs';
 import { SidenavPositionTypes, SidenavTypes } from './types/sidenavs';
+import { filter } from 'rxjs/operators';
 
 /**
  * UI Sidenav component
@@ -26,6 +28,7 @@ export class SidenavContainerComponent implements AfterViewInit, OnDestroy {
   @ContentChildren(SidenavDirective) uiSidenavDirective!: SidenavDirective[];
   @ViewChild('content') content!: ElementRef;
   @ViewChildren('sidenav') sidenav!: QueryList<any>;
+  @ViewChild('container') container!: ElementRef;
 
   public showSidenav: boolean[] = [];
   public mode: SidenavTypes[] = [];
@@ -40,12 +43,24 @@ export class SidenavContainerComponent implements AfterViewInit, OnDestroy {
    * @param renderer Renderer2
    * @param cdr ChangeDetectorRef
    * @param el elementRef
+   * @param router Angular router
    */
   constructor(
     private renderer: Renderer2,
     private cdr: ChangeDetectorRef,
-    public el: ElementRef
-  ) {}
+    public el: ElementRef,
+    private router: Router
+  ) {
+    this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe(() => {
+        this.container.nativeElement.scroll({
+          top: 0,
+          left: 0,
+          behavior: 'smooth',
+        });
+      });
+  }
 
   ngAfterViewInit() {
     // Initialize width and show sidenav value


### PR DESCRIPTION
# Description

Switching between dashboards made the scroll buggy so I forced a scroll to top to prevent users to scroll manually after switching from a dashboard to another

## Useful links

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67008

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It's scrolling to top when changing pages in app

## Screenshots

# Checklist:

( * == Mandatory ) 

- [X] * The pull request is linked to an existing milestone ( if possible )
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
