### PR TITLE
fix/AB#71534_remove-all-records-in-resources-question

### DIFF
--- a/libs/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -383,7 +383,7 @@ export class SafeFormModalComponent
         mutation: EDIT_RECORD,
         variables: {
           id,
-          data: survey.data,
+          data: this.formHelpersService.getSurveyData(survey),
           template: this.data.template,
         },
       })

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -271,7 +271,7 @@ export class SafeFormComponent
         mutation: EDIT_RECORD,
         variables: {
           id: recordId,
-          data: this.survey.data,
+          data: this.formHelpersService.getSurveyData(this.survey),
           template:
             this.form.id !== this.record?.form?.id ? this.form.id : null,
         },
@@ -282,7 +282,7 @@ export class SafeFormComponent
         mutation: ADD_RECORD,
         variables: {
           form: this.form.id,
-          data: this.survey.data,
+          data: this.formHelpersService.getSurveyData(this.survey),
         },
       });
     }

--- a/libs/safe/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/safe/src/lib/services/form-helper/form-helper.service.ts
@@ -305,7 +305,6 @@ export class SafeFormHelpersService {
 
     // We want to include empty arrays multiple option questions
     survey.getAllQuestions().forEach((question) => {
-      console.log(question.getType());
       if (
         multipleOptionTypes.includes(question.getType()) &&
         question.visible

--- a/libs/safe/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/safe/src/lib/services/form-helper/form-helper.service.ts
@@ -291,4 +291,32 @@ export class SafeFormHelpersService {
 
     await Promise.all(promises);
   }
+
+  /**
+   * Gets survey data from the survey and adds empty arrays multiple option questions
+   *
+   * @param survey The survey to get the data from
+   * @returns The survey data
+   */
+  public getSurveyData(survey: Survey.SurveyModel): Record<string, any> {
+    const data = survey.data;
+
+    const multipleOptionTypes = ['checkbox', 'tagbox', 'resources'];
+
+    // We want to include empty arrays multiple option questions
+    survey.getAllQuestions().forEach((question) => {
+      console.log(question.getType());
+      if (
+        multipleOptionTypes.includes(question.getType()) &&
+        question.visible
+      ) {
+        const name = question.name;
+        if (!data[name]) {
+          data[name] = [];
+        }
+      }
+    });
+
+    return data;
+  }
 }

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -751,11 +751,12 @@ export const init = (
         if (parentElement) {
           const instance: SafeCoreGridComponent =
             buildRecordsGrid(question, parentElement.firstChild) || undefined;
-          instance.removeRowIds.subscribe((ids) => {
-            question.value = question.value.filter(
-              (id: string) => !ids.includes(id)
-            );
-          });
+          if (instance)
+            instance.removeRowIds.subscribe((ids) => {
+              question.value = question.value.filter(
+                (id: string) => !ids.includes(id)
+              );
+            });
           if ((question.survey as SurveyModel).mode !== 'display') {
             el.parentElement.querySelector('#actionsButtons')?.remove();
             const actionsButtons = document.createElement('div');


### PR DESCRIPTION
# Description

The bug was caused because when getting the survey data, surveyJS considers empty array as undefined values, so it didn't send the data to the server in the first place. Thought there would be a configuration about that, but I don't think so, so I just go through all questions and if it's one with an array value and isn't present in the `survey.data`, add it as an empty array

## Useful links
* [SA-HQ- All signals - Resources data is not removing on update signal record](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/71534)
* [Forum post with an answer from SurveyJS support team](https://surveyjs.answerdesk.io/ticket/details/t10005/re-forcing-empty-value-to-be-included-in-survey-data)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By recreating the [steps to reproduce](https://dev.azure.com/WHOHQ/2888b816-2d79-49ef-a86e-561e6cd456a0/_apis/wit/attachments/3466dd91-def1-4b45-b8f7-33968885c352) on UAT

## Screenshots

![Peek 2023-07-12 11-40](https://github.com/ReliefApplications/oort-frontend/assets/102038450/e3124f77-8ad6-4ce3-9f47-7a818356a6e5)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
