### PR TITLE
fix/AB#71542-incorrect-save-option-text-field-grid

### DIFF
--- a/libs/safe/src/lib/components/ui/core-grid/expanded-comment/expanded-comment.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/expanded-comment/expanded-comment.component.html
@@ -1,6 +1,10 @@
 <ui-dialog size="medium" [closable]="true">
-  <ng-container ngProjectAs="content">
+  <!-- Title of the field -->
+  <ng-container ngProjectAs="header">
     <h1>{{ data.title }}</h1>
+  </ng-container>
+  <!-- Edition of the field ( if available ), else, display of the value -->
+  <ng-container ngProjectAs="content">
     <div uiFormFieldDirective class="flex-1">
       <ui-textarea [formControl]="formControl" [minRows]="15" [maxRows]="15">
       </ui-textarea>

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -101,6 +101,7 @@ export class SafeGridComponent
   @Output() export = new EventEmitter();
 
   // === EDITION ===
+  /** If inlineEdition is allowed */
   @Input() editable = false;
   @Input() hasChanges = false;
   @Output() edit: EventEmitter<any> = new EventEmitter();
@@ -706,7 +707,7 @@ export class SafeGridComponent
         value: get(item, field),
         readonly:
           !this.actions.update ||
-          !item.canUpdate ||
+          !this.editable ||
           this.fields.find((val) => val.name === field).meta.readOnly,
       },
       autoFocus: false,


### PR DESCRIPTION
# Description
The expanded modal on grids was checking if the action "Update records" was enabled to be possible to edit the field and save the changes, and not the "Inline edition" action as it should

## Useful links
Please insert link to ticket: [AB#71542 - SA - HQ - Save button on field value window should be disabled on GRID](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/71542)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Disabling the "Inline edition" action in the grid settings, opening the text field in the expanded modal where we don't see the "Save" button anymore, and not being able to edit it 

## Screenshots
![inline](https://github.com/ReliefApplications/oort-frontend/assets/28535394/169406a0-48d2-49af-ad8c-c8cb2732bab1)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
