### PR TITLE
Feat 2.0.x/abc#71765 select no available choices option

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -130,6 +130,7 @@
 		"modifiedOn": "Modified On",
 		"name": "Name",
 		"next": "Next",
+		"noOptions": "No available choices",
 		"notifications": {
 			"accessDenied": "You don't have permission to see the {{type}}.",
 			"accessNotProvided": "No access provided to this {{type}}. {{error}}",

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -130,6 +130,7 @@
 		"modifiedOn": "Modifié le ",
 		"name": "Nom",
 		"next": "Suivant",
+		"noOptions": "Aucun choix disponible",
 		"notifications": {
 			"accessDenied": "Vous n'avez pas la permission pour accéder à cet objet de type {{type}}.",
 			"accessNotProvided": "Pas d'accès fourni à cet objet de type {{type}}. {{error}}",

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -130,6 +130,7 @@
 		"modifiedOn": "******",
 		"name": "******",
 		"next": "******",
+		"noOptions": "******",
 		"notifications": {
 			"accessDenied": "****** {{type}} ******",
 			"accessNotProvided": "****** {{type}} ****** {{error}}",

--- a/libs/ui/src/lib/select-menu/select-menu.component.html
+++ b/libs/ui/src/lib/select-menu/select-menu.component.html
@@ -48,8 +48,9 @@
       }"
       class="shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm ease-in-out duration-100 w-full overflow-auto rounded-md bg-white text-base"
     >
-      <!-- Elements of the list -->
+      <!-- Display the elements of the list -->
       <ng-content *ngIf="optionList.length"></ng-content>
+      <!-- Display a message to indicate the list is empty -->
       <div
         *ngIf="!optionList.length"
         class="h-24 flex flex-col gap-2 justify-center items-center"

--- a/libs/ui/src/lib/select-menu/select-menu.component.html
+++ b/libs/ui/src/lib/select-menu/select-menu.component.html
@@ -49,7 +49,15 @@
       class="shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm ease-in-out duration-100 w-full overflow-auto rounded-md bg-white text-base"
     >
       <!-- Elements of the list -->
-      <ng-content></ng-content>
+      <ng-content *ngIf="optionList.length"></ng-content>
+      <div
+        *ngIf="!optionList.length"
+        class="h-24 flex justify-center items-center"
+      >
+        <p>
+          {{ 'common.noOptions' | translate }}
+        </p>
+      </div>
     </ul>
   </div>
 </ng-template>

--- a/libs/ui/src/lib/select-menu/select-menu.component.html
+++ b/libs/ui/src/lib/select-menu/select-menu.component.html
@@ -52,9 +52,10 @@
       <ng-content *ngIf="optionList.length"></ng-content>
       <div
         *ngIf="!optionList.length"
-        class="h-24 flex justify-center items-center"
+        class="h-24 flex flex-col gap-2 justify-center items-center"
       >
-        <p>
+        <ui-icon icon="error_outline" variant="grey"></ui-icon>
+        <p class="text-neutral-400 font-medium">
           {{ 'common.noOptions' | translate }}
         </p>
       </div>

--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -30,7 +30,6 @@ import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { DOCUMENT } from '@angular/common';
 import { isNil } from 'lodash';
-import { TranslateService } from '@ngx-translate/core';
 
 /**
  * UI Select Menu component
@@ -100,7 +99,6 @@ export class SelectMenuComponent
     private renderer: Renderer2,
     private viewContainerRef: ViewContainerRef,
     private overlay: Overlay,
-    private translate: TranslateService,
     @Inject(DOCUMENT) private document: Document
   ) {
     if (this.control) {
@@ -147,9 +145,6 @@ export class SelectMenuComponent
             }
             this.setDisplayTriggerText();
           });
-          if (!this.optionList.length) {
-            this.displayTrigger = this.translate.instant('common.noOptions');
-          }
         },
       });
     if (this.control) {
@@ -164,12 +159,6 @@ export class SelectMenuComponent
         },
       });
     }
-
-    this.translate.onLangChange.subscribe(() => {
-      if (!this.optionList.length) {
-        this.displayTrigger = this.translate.instant('common.noOptions');
-      }
-    });
   }
 
   /**
@@ -320,7 +309,7 @@ export class SelectMenuComponent
    */
   openSelectPanel() {
     //Do nothing if the box is disabled
-    if (this.disabled || !this.optionList.length) {
+    if (this.disabled) {
       return;
     }
     // Open the box + emit outputs

--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -30,6 +30,7 @@ import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { DOCUMENT } from '@angular/common';
 import { isNil } from 'lodash';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * UI Select Menu component
@@ -90,6 +91,7 @@ export class SelectMenuComponent
    * @param renderer Renderer2
    * @param viewContainerRef ViewContainerRef
    * @param overlay Overlay
+   * @param translate Angular translate service
    * @param document document
    */
   constructor(
@@ -98,6 +100,7 @@ export class SelectMenuComponent
     private renderer: Renderer2,
     private viewContainerRef: ViewContainerRef,
     private overlay: Overlay,
+    private translate: TranslateService,
     @Inject(DOCUMENT) private document: Document
   ) {
     if (this.control) {
@@ -144,6 +147,9 @@ export class SelectMenuComponent
             }
             this.setDisplayTriggerText();
           });
+          if (!this.optionList.length) {
+            this.displayTrigger = this.translate.instant('common.noOptions');
+          }
         },
       });
     if (this.control) {
@@ -158,6 +164,12 @@ export class SelectMenuComponent
         },
       });
     }
+
+    this.translate.onLangChange.subscribe(() => {
+      if (!this.optionList.length) {
+        this.displayTrigger = this.translate.instant('common.noOptions');
+      }
+    });
   }
 
   /**
@@ -308,7 +320,7 @@ export class SelectMenuComponent
    */
   openSelectPanel() {
     //Do nothing if the box is disabled
-    if (this.disabled) {
+    if (this.disabled || !this.optionList.length) {
       return;
     }
     // Open the box + emit outputs

--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -90,7 +90,6 @@ export class SelectMenuComponent
    * @param renderer Renderer2
    * @param viewContainerRef ViewContainerRef
    * @param overlay Overlay
-   * @param translate Angular translate service
    * @param document document
    */
   constructor(

--- a/libs/ui/src/lib/select-menu/select-menu.module.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.module.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { SelectMenuComponent } from './select-menu.component';
 import { SelectOptionModule } from './components/select-option.module';
 import { TranslateModule } from '@ngx-translate/core';
+import { IconModule } from '../icon/icon.module';
 
 /**
  * UI Select menu module
@@ -15,6 +16,7 @@ import { TranslateModule } from '@ngx-translate/core';
     ReactiveFormsModule,
     SelectOptionModule,
     TranslateModule,
+    IconModule,
   ],
   exports: [SelectMenuComponent, SelectOptionModule],
 })

--- a/libs/ui/src/lib/select-menu/select-menu.module.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.module.ts
@@ -3,13 +3,19 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { SelectMenuComponent } from './select-menu.component';
 import { SelectOptionModule } from './components/select-option.module';
+import { TranslateModule } from '@ngx-translate/core';
 
 /**
  * UI Select menu module
  */
 @NgModule({
   declarations: [SelectMenuComponent],
-  imports: [CommonModule, ReactiveFormsModule, SelectOptionModule],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SelectOptionModule,
+    TranslateModule,
+  ],
   exports: [SelectMenuComponent, SelectOptionModule],
 })
 export class SelectMenuModule {}


### PR DESCRIPTION
# Description

Setting default text to "No available choices" when there is no option for a select. 

## Useful links

Ticket: [71765 - ABC - Add "no available choices" text when no content is available in a select](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/71765)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tried to load an empty select and checked if the display was correct. I also checked that the text is set again if values are added and then removed.

## Screenshots

![peek3](https://github.com/ReliefApplications/oort-frontend/assets/65243509/34d01354-c751-4134-bee7-b53e0e9268fd)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
