### PR TITLE
fix/AB#71766-history-overflow-hidden

### DIFF
--- a/libs/ui/src/lib/sidenav/sidenav-container.component.html
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.html
@@ -4,9 +4,10 @@
   <ng-container *ngFor="let sidenav of uiSidenavDirective; let i = index">
     <div
       #sidenav
-      class="will-change-transform h-full overflow-y-auto bg-white translate-x-0"
+      class="will-change-transform overflow-y-auto bg-white translate-x-0"
       [attr.data-sidenav-show]="showSidenav[i]"
       [ngClass]="resolveSidenavClasses(i)"
+      [style.height]="height"
     >
       <div class="flex flex-col h-full"></div>
     </div>

--- a/libs/ui/src/lib/sidenav/sidenav-container.component.ts
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.ts
@@ -37,6 +37,7 @@ export class SidenavContainerComponent implements AfterViewInit, OnDestroy {
   private destroy$ = new Subject<void>();
   animationClasses = ['transition-all', 'duration-500', 'ease-in-out'] as const;
 
+  /** @returns height of element */
   get height() {
     return `${this.el.nativeElement.offsetHeight}px`;
   }

--- a/libs/ui/src/lib/sidenav/sidenav-container.component.ts
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.ts
@@ -37,6 +37,10 @@ export class SidenavContainerComponent implements AfterViewInit, OnDestroy {
   private destroy$ = new Subject<void>();
   animationClasses = ['transition-all', 'duration-500', 'ease-in-out'] as const;
 
+  get height() {
+    return `${this.el.nativeElement.offsetHeight}px`;
+  }
+
   /**
    * UI Sidenav constructor
    *
@@ -107,6 +111,7 @@ export class SidenavContainerComponent implements AfterViewInit, OnDestroy {
       classes.push('border-gray-200');
     }
     if (this.mode[index] === 'over') {
+      classes.push('h-full');
       classes.push('left-0');
       classes.push('top-0');
       classes.push('fixed');


### PR DESCRIPTION
# Description
In the layout component, when we open the right sidenav and when the onResize event is detected, the new method setRightSidenavHeight() manually set the right sidenav max height and overflow proprieties to avoid hidden overflow issues, using the ui-sidenav-container height to calc the max-height available to the record History component

## Useful links

- Please insert link to ticket: [AB#71766 - ABC - History overflow hidden](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/71766)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Opening the history details of a record in the grid widget and using the scroll bar to see the complete history details without any overflow issue.

## Screenshots
![historysidenav](https://github.com/ReliefApplications/oort-frontend/assets/28535394/b693dcc4-63c3-45af-9e60-4fcd042ef778)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
