### PR TITLE
fix/AB#71861_Cannot-scroll-notification-list

### DIFF
--- a/libs/ui/src/lib/menu/menu.component.html
+++ b/libs/ui/src/lib/menu/menu.component.html
@@ -4,7 +4,7 @@
   >
     <div
       (click)="closed.emit()"
-      class="w-56 shrink bg-white text-sm font-normal leading-6 text-gray-900 shadow-lg ring-1 ring-gray-900/5 flex flex-col rounded-lg overflow-hidden py-1"
+      class="w-56 shrink bg-white text-sm font-normal leading-6 text-gray-900 shadow-lg ring-1 ring-gray-900/5 flex flex-col rounded-lg overflow-hidden py-1 overflow-y-auto max-h-96"
     >
       <ng-content></ng-content>
     </div>


### PR DESCRIPTION
# Description

 Add overflow-y-auto and a height limit to the menu component

## Useful links
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/71861

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

https://github.com/ReliefApplications/oort-frontend/assets/15035750/f34ca643-37ab-4d11-a1c9-95f30e42dc1b

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
