### PR TITLE
fix/AB#71542_field-value-null-when-closing-expand-modal

### DIFF
--- a/libs/safe/src/lib/components/ui/core-grid/expanded-comment/expanded-comment.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/expanded-comment/expanded-comment.component.html
@@ -11,7 +11,7 @@
     </div>
   </ng-container>
   <ng-container ngProjectAs="actions">
-    <ui-button uiDialogClose>
+    <ui-button [uiDialogClose]="null">
       {{ 'common.close' | translate }}
     </ui-button>
     <ui-button

--- a/libs/ui/src/lib/tooltip/tooltip.directive.ts
+++ b/libs/ui/src/lib/tooltip/tooltip.directive.ts
@@ -77,7 +77,6 @@ export class TooltipDirective implements OnDestroy {
    * Destroy the tooltip and stop its display
    */
   private removeHint() {
-    console.log(this.document.body);
     if (this.document.body.contains(this.elToolTip)) {
       this.renderer.removeChild(this.document.body, this.elToolTip);
     }


### PR DESCRIPTION
# Description

A simple fix to prevent cell values set to null after closing expand modal

## Useful links
[SA - HQ - Save button on field value window should be disabled on GRID)](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/71542)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

See bellow

## Screenshots
![Peek 2023-07-12 11-40](https://github.com/ReliefApplications/oort-frontend/assets/102038450/4e8b7d4c-8b4d-4ffa-abf7-dd293b434917)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
