### PR TITLE
Fix 2.1.x/db#69081 group layer visibility range not working

### DIFF
--- a/libs/safe/src/lib/components/ui/map/layer.ts
+++ b/libs/safe/src/lib/components/ui/map/layer.ts
@@ -782,7 +782,7 @@ export class Layer implements LayerModel {
     } else {
       // Classic visibility check based on zoom
       const currZoom = map.getZoom();
-      const [maxZoom, minZoom] = this.getMinMaxZoom(map);
+      const [minZoom, maxZoom] = this.getMinMaxZoom(map);
       if (currZoom > maxZoom || currZoom < minZoom) {
         map.removeLayer(layer);
       } else {
@@ -804,20 +804,18 @@ export class Layer implements LayerModel {
   }
 
   /**
-   * Get maximum and minimum zoom based on layer and group layer
+   * Get minimum and maximum zoom based on layer and group layer
    *
    * @param map Leaflet map
-   * @returns maximum and minimum zoom
+   * @returns minimum and maximum zoom
    */
   public getMinMaxZoom(map: L.Map) {
-    let maxZoom = 0;
-    let minZoom = 0;
+    let minZoom = this.layerDefinition?.minZoom || map.getMinZoom();
+    let maxZoom = this.layerDefinition?.maxZoom || map.getMaxZoom();
 
     if (this.parentLayer) {
       const parentMaxZoom = this.parentLayer.maxZoom || map.getMaxZoom();
       const parentMinZoom = this.parentLayer.minZoom || map.getMinZoom();
-      maxZoom = this.layerDefinition?.maxZoom || map.getMaxZoom();
-      minZoom = this.layerDefinition?.minZoom || map.getMinZoom();
 
       if (parentMaxZoom < maxZoom) {
         maxZoom = parentMaxZoom;
@@ -825,11 +823,8 @@ export class Layer implements LayerModel {
       if (parentMinZoom > minZoom) {
         minZoom = parentMinZoom;
       }
-    } else {
-      maxZoom = this.layerDefinition?.maxZoom || map.getMaxZoom();
-      minZoom = this.layerDefinition?.minZoom || map.getMinZoom();
     }
-    return [maxZoom, minZoom];
+    return [minZoom, maxZoom];
   }
 
   /**
@@ -841,7 +836,7 @@ export class Layer implements LayerModel {
    */
   public onZoom(map: L.Map, zoom: L.LeafletEvent, layer: L.Layer) {
     const currZoom = zoom.target.getZoom();
-    const [maxZoom, minZoom] = this.getMinMaxZoom(map);
+    const [minZoom, maxZoom] = this.getMinMaxZoom(map);
 
     if (isNil((layer as any).shouldDisplay)) {
       if (currZoom > maxZoom || currZoom < minZoom) {

--- a/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
+++ b/libs/safe/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
@@ -294,9 +294,9 @@ export class EditLayerModalComponent
           this.updateMapLayer({ delete: true });
           // If any of the main properties to fetch the layer changes, set up layer
           if (
-            prev.datasource.geoField !== next.datasource.geoField ||
-            prev.datasource.latitudeField !== next.datasource.latitudeField ||
-            prev.datasource.longitudeField !== next.datasource.longitudeField
+            prev.datasource?.geoField !== next.datasource?.geoField ||
+            prev.datasource?.latitudeField !== next.datasource?.latitudeField ||
+            prev.datasource?.longitudeField !== next.datasource?.longitudeField
           ) {
             this.setUpLayer();
           } else {


### PR DESCRIPTION
# Description

Added a parent layer variable to the layer component which contains the properties of the layer group. When zooming, it will check its maximum and minimum values to set the visibility of the layer.

## Useful links

Ticket: [69081 - DB - Group Layer visibility range not working](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/69081)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tried the zoom function on a personalized map composed of:
- 1 group layer, min zoom: 4, max zoom: 10
- layer 1, belongs to the group layer, min zoom 6, max zoom 9
- layer 2, belongs to the group layer, min zoom 2, max zoom 18

## Screenshots

![peek](https://github.com/ReliefApplications/oort-frontend/assets/65243509/6c7e97b6-9651-4188-96cd-7e56b53b5470)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
