### PR TITLE
bugfix/AB#72067_ABC-cannot-expand-accordion

### DIFF
--- a/libs/ui/src/lib/expansion-panel/expansion-panel.component.scss
+++ b/libs/ui/src/lib/expansion-panel/expansion-panel.component.scss
@@ -3,6 +3,5 @@ div.accordion-item {
 }
 
 div.accordion-content {
-  // todo: check hidden
-  @apply p-5 hidden border-l border-r border-b border-gray-200 overflow-hidden;
+  @apply p-5 border-l border-r border-b border-gray-200 overflow-hidden;
 }


### PR DESCRIPTION
# Description

fix: accordion item not expanding by deleting the hidden class from the accordion-item

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/72067)
- Please insert link to back-end branch if any
- Please insert any useful link ( documentation you used for example )

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to screenshots below

## Screenshots

Working expansion panels:

https://github.com/ReliefApplications/oort-frontend/assets/123092672/c047e960-3c9d-4134-b40a-d00dcac9ca83


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
