### PR TITLE
fix/OORT-662-grid-search-resource-questions

### DIFF
--- a/libs/safe/src/lib/services/grid/grid.service.ts
+++ b/libs/safe/src/lib/services/grid/grid.service.ts
@@ -84,6 +84,10 @@ export class SafeGridService {
       fields.map((f) => {
         const fullName: string = prefix ? `${prefix}.${f.name}` : f.name;
         let metaData = get(metaFields, fullName);
+        metaData = {
+          ...metaData,
+          name: fullName,
+        };
         const canSee = get(metaData, 'permissions.canSee', true);
         const canUpdate = get(metaData, 'permissions.canUpdate', false);
         const hidden: boolean =


### PR DESCRIPTION
# Description
Search in grid not working for text fields if it's from a resource question, because in the filters in the request the subfield `field_name` was used instead of the full name of the subfield, for example `resource_name.field_name` should be used instead of just `field_name`

## Useful links

- Please insert link to ticket: [OORT-662: Grid search not working for resource questions](https://oortcloud.atlassian.net/browse/OORT-662)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Searching in grids for texts presents in resource questions.

## Screenshots
![search1](https://github.com/ReliefApplications/oort-frontend/assets/28535394/615085c0-b9be-4e98-91c8-d41002ced569)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
