### PR TITLE
refactor: improves graphql filtering by handing change detection to s…

### DIFF
--- a/libs/safe/src/lib/survey/global-properties/others.ts
+++ b/libs/safe/src/lib/survey/global-properties/others.ts
@@ -37,7 +37,7 @@ export const init = (Survey: any, environment: any): void => {
     }
   };
 
-  // // Add file option for file columns on matrix questions
+  // Add file option for file columns on matrix questions
   Survey.matrixDropdownColumnTypes.file = {
     properties: ['showPreview', 'imageHeight', 'imageWidth'],
     tabs: [
@@ -45,6 +45,20 @@ export const init = (Survey: any, environment: any): void => {
       { name: 'enableIf', index: 20 },
     ],
   };
+
+  // Adds property that clears the value when condition is met
+  serializer.addProperty('question', {
+    name: 'clearIf:condition',
+    category: 'logic',
+    visibleIndex: 4,
+    default: '',
+    isLocalizable: true,
+    onExecuteExpression: (obj: Question, res: boolean) => {
+      if (res) {
+        obj.value = null;
+      }
+    },
+  });
 };
 
 /**


### PR DESCRIPTION
# Description

This PR includes a few improvements on the choices by URL using POST feature.
* Improve change detection, should work every time you change the dependent fields
* Added a is GraphQL query, that facilitates a bit dealing with escaped characters
* Minor refactoring


## Useful links

- Ticket: [Improve filtering on Country, subnational1 and subnational2](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/72098)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

So it's hard for me to test the exact use case in UAT, but I think I managed to create a situation similar enough to the new requirements:

![Peek 2023-08-17 02-04](https://github.com/ReliefApplications/oort-frontend/assets/102038450/89c031ff-4f7b-4cd2-9b52-451eefec4834)

So I have a text field called `country`, a dropdown `admin1` with the config bellow and `admin2\´ the same, just replacing the "in" with a "nin" in the request 

**URL** https://countries.trevorblades.com/
**Path** data.countries
**Value name** code
**Title name** emoji
**Request body**
```
'query {  countries(filter: {code: {in: [\"' + {country} + '\"]}}) {   code   capital   emoji }  }' 
```

Besides that, used the Logic tab, for both the dropdowns to set them to be disabled if country is empty
And in the new option clear if, selected if country is empty
And in the new is graphql query option, checked it

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
