### PR TITLE
fix/AB#72835-search-doesn’t-update-new-page-form

### DIFF
--- a/apps/back-office/src/app/application/pages/add-page/graphql/queries.ts
+++ b/apps/back-office/src/app/application/pages/add-page/graphql/queries.ts
@@ -5,8 +5,18 @@ import { Form } from '@oort-front/safe';
 
 /** Graphql request for getting forms */
 export const GET_FORMS = gql`
-  query GetFormNames($first: Int, $afterCursor: ID, $sortField: String) {
-    forms(first: $first, afterCursor: $afterCursor, sortField: $sortField) {
+  query GetFormNames(
+    $first: Int
+    $afterCursor: ID
+    $sortField: String
+    $filter: JSON
+  ) {
+    forms(
+      first: $first
+      afterCursor: $afterCursor
+      sortField: $sortField
+      filter: $filter
+    ) {
       edges {
         node {
           id

--- a/apps/back-office/src/app/application/pages/workflow/graphql/queries.ts
+++ b/apps/back-office/src/app/application/pages/workflow/graphql/queries.ts
@@ -5,8 +5,18 @@ import { Form } from '@oort-front/safe';
 
 /** Graphql request for getting forms */
 export const GET_FORMS = gql`
-  query GetFormNames($first: Int, $afterCursor: ID, $sortField: String) {
-    forms(first: $first, afterCursor: $afterCursor, sortField: $sortField) {
+  query GetFormNames(
+    $first: Int
+    $afterCursor: ID
+    $sortField: String
+    $filter: JSON
+  ) {
+    forms(
+      first: $first
+      afterCursor: $afterCursor
+      sortField: $sortField
+      filter: $filter
+    ) {
       edges {
         node {
           id


### PR DESCRIPTION
# Description
Query GET_FORMS used in the add page and in the add step components missing filter param, so the search was not being queried to update the graphql-select

## Useful links

- Please insert link to ticket:  [AB#72835 - ABC - Search does not apply when adding new page as a form ( or new step as a form )
](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/72835)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Searching and changing the search value in the graphql-select when trying to add a new form as page or as step

## Screenshots
[form.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/93775acc-fd6b-465f-bbb8-3660ae1c6381)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
