### PR TITLE
feat/OORT-665_validate-questions-in-real-time

### DIFF
--- a/libs/safe/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/safe/src/lib/services/form-builder/form-builder.service.ts
@@ -62,6 +62,16 @@ export class SafeFormBuilderService {
     survey.onAfterRenderQuestion.add(
       renderGlobalProperties(this.referenceDataService)
     );
+
+    // For each question, if validateOnValueChange is true, we will add a listener to the value change event
+    survey.getAllQuestions().forEach((question) => {
+      if (question.validateOnValueChange) {
+        question.registerFunctionOnPropertyValueChanged('value', () => {
+          question.validate();
+        });
+      }
+    });
+
     survey.onCompleting.add(() => {
       for (const page of survey.toJSON().pages) {
         if (!page.elements) continue;

--- a/libs/safe/src/lib/survey/global-properties/others.ts
+++ b/libs/safe/src/lib/survey/global-properties/others.ts
@@ -45,6 +45,14 @@ export const init = (Survey: any, environment: any): void => {
       { name: 'enableIf', index: 20 },
     ],
   };
+
+  // Adds a property that makes it so the question is validated on every value change
+  serializer.addProperty('question', {
+    name: 'validateOnValueChange:boolean',
+    category: 'validation',
+    visibleIndex: 4,
+    default: false,
+  });
 };
 
 /**


### PR DESCRIPTION
# Description

This PR adds an option on the validation tab of the survey builder to validate the question on every value change, instead of the default behavior that is just when the survey is submitted
## Useful links

- Ticket: [Validate question on real time](https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/3?selectedIssue=OORT-665)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
See bellow, notice that in the first case, the validation error appeared only when trying to submit the survey

## Screenshots

![Peek 2023-08-17 02-04](https://github.com/ReliefApplications/oort-frontend/assets/102038450/72734eb0-934f-4795-bb6c-9526a8c94de7)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
