### PR TITLE
feat/OORT-666-make-error-messages-appear-for-longer rebased to 2.1.x

### DIFF
--- a/libs/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -405,7 +405,10 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges, OnDestroy {
         }
       })
       .catch((error) => {
-        this.snackBar.openSnackBar(error.message, { error: true });
+        this.snackBar.openSnackBar(error.message, {
+          error: true,
+          duration: 15000,
+        });
       });
   };
 

--- a/libs/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -399,8 +399,10 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges, OnDestroy {
    */
   saveMySurvey = () => {
     this.validateValueNames()
-      .then(() => {
-        this.save.emit(this.surveyCreator.text);
+      .then((canCreate: boolean) => {
+        if (canCreate) {
+          this.save.emit(this.surveyCreator.text);
+        }
       })
       .catch((error) => {
         this.snackBar.openSnackBar(error.message, { error: true });
@@ -409,31 +411,44 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges, OnDestroy {
 
   /**
    * Makes sure that value names are existent and snake case, to not cause backend problems.
+   *
+   * @returns if the validation is approved and can create the survey
    */
-  private async validateValueNames(): Promise<void> {
+  private async validateValueNames(): Promise<boolean> {
     this.relatedNames = [];
     const survey = new Survey.SurveyModel(this.surveyCreator.JSON);
-    survey.pages.forEach((page: Survey.PageModel) => {
-      page.questions.forEach((question: Survey.Question) =>
-        this.setQuestionNames(question, page)
+    const canCreate = survey.pages.every((page: Survey.PageModel) => {
+      const verifiedQuestions = page.questions.every(
+        (question: Survey.Question) => this.setQuestionNames(question, page)
       );
-      // Search for duplicated value names
-      const duplicatedFields = difference(
-        page.questions,
-        uniqBy(page.questions, 'valueName')
-      );
-      if (duplicatedFields.length > 0) {
-        throw new Error(
-          this.translate.instant(
-            'pages.formBuilder.errors.dataFieldDuplicated',
-            {
-              name: duplicatedFields[0].valueName,
-            }
-          )
+      if (verifiedQuestions) {
+        // If questions verified, search for duplicated value names
+        const duplicatedFields = difference(
+          page.questions,
+          uniqBy(page.questions, 'valueName')
         );
+        if (duplicatedFields.length > 0) {
+          this.snackBar.openSnackBar(
+            this.translate.instant(
+              'pages.formBuilder.errors.dataFieldDuplicated',
+              {
+                name: duplicatedFields[0].valueName,
+              }
+            ),
+            {
+              error: true,
+              duration: 15000,
+            }
+          );
+          return false;
+        }
+      } else {
+        return false;
       }
+      return true;
     });
     this.surveyCreator.JSON = survey.toJSON();
+    return canCreate;
   }
 
   /**
@@ -461,15 +476,17 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   /**
-   * Recursively set the question names of the form.
+   * Recursively set the question names of the form and depending on
+   * the question type, check additional required fields.
    *
    * @param question The question of the form whose name we need to set
    * @param page The page of the form
+   * @returns if question name and additional required fields are valid
    */
   private setQuestionNames(
     question: Survey.Question,
     page: Survey.PageModel
-  ): void {
+  ): boolean {
     // create the valueName of the element in snake case
     if (!question.valueName) {
       if (question.title) {
@@ -477,20 +494,30 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges, OnDestroy {
       } else if (question.name) {
         question.valueName = this.toSnakeCase(question.name);
       } else {
-        throw new Error(
+        this.snackBar.openSnackBar(
           this.translate.instant('pages.formBuilder.errors.missingName', {
             page: page.name,
-          })
+          }),
+          {
+            error: true,
+            duration: 15000,
+          }
         );
+        return false;
       }
     } else {
       if (!this.isSnakeCase(question.valueName)) {
-        throw new Error(
+        this.snackBar.openSnackBar(
           this.translate.instant('pages.formBuilder.errors.snakecase', {
             name: question.valueName,
             page: page.name,
-          })
+          }),
+          {
+            error: true,
+            duration: 15000,
+          }
         );
+        return false;
       }
     }
     // if choices object exists, checks for duplicate values
@@ -503,14 +530,19 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges, OnDestroy {
         const distinctValues = [...new Set(values)];
 
         if (values.length > distinctValues.length) {
-          throw new Error(
+          this.snackBar.openSnackBar(
             this.translate.instant(
               'pages.formBuilder.errors.choices.valueDuplicated',
               {
                 question: question.valueName,
               }
-            )
+            ),
+            {
+              error: true,
+              duration: 15000,
+            }
           );
+          return false;
         }
       } else {
         // As we already have the reference data value to get the choices, we dont want to save them again with the form structure
@@ -518,19 +550,31 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges, OnDestroy {
       }
     }
     if (question.getType() === 'multipletext') {
-      question.items.forEach((item: any) => {
+      let validQuestion = true;
+      // Check if every item of the questions is valid, otherwise stop loop and function
+      question.items.every((item: any) => {
         if (!item.name && !item.title) {
-          throw new Error(
+          this.snackBar.openSnackBar(
             this.translate.instant(
               'pages.formBuilder.errors.multipletext.missingName',
               {
                 question: question.valueName,
               }
-            )
+            ),
+            {
+              error: true,
+              duration: 15000,
+            }
           );
+          validQuestion = false;
+          return false;
         }
         item.name = this.toSnakeCase(item.name);
+        return true;
       });
+      if (!validQuestion) {
+        return false;
+      }
     }
     if (question.getType() === 'matrix') {
       question.columns.forEach(
@@ -553,66 +597,91 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges, OnDestroy {
       if (question.relatedName) {
         question.relatedName = this.toSnakeCase(question.relatedName);
         if (this.relatedNames.includes(question.relatedName)) {
-          throw new Error(
+          this.snackBar.openSnackBar(
             this.translate.instant(
               'components.formBuilder.errors.duplicatedRelatedName',
               {
                 question: question.name,
                 page: page.name,
               }
-            )
+            ),
+            {
+              error: true,
+              duration: 15000,
+            }
           );
+          return false;
         } else {
           this.relatedNames.push(question.relatedName);
         }
       } else {
-        throw new Error(
+        this.snackBar.openSnackBar(
           this.translate.instant(
             'components.formBuilder.errors.missingRelatedName',
             {
               question: question.name,
               page: page.name,
             }
-          )
+          ),
+          {
+            error: true,
+            duration: 15000,
+          }
         );
+        return false;
       }
-
       if (question.addRecord && !question.addTemplate) {
-        throw new Error(
+        this.snackBar.openSnackBar(
           this.translate.instant(
             'components.formBuilder.errors.missingTemplate',
             {
               question: question.name,
               page: page.name,
             }
-          )
+          ),
+          {
+            error: true,
+            duration: 15000,
+          }
         );
+        return false;
       }
 
       // Error if the user selected Display As Grid without adding an available field.
       if (question.displayAsGrid && !question.gridFieldsSettings) {
-        throw new Error(
+        this.snackBar.openSnackBar(
           this.translate.instant(
             'components.formBuilder.errors.missingGridField',
             {
               question: question.name,
               page: page.name,
             }
-          )
+          ),
+          {
+            error: true,
+            duration: 15000,
+          }
         );
+        return false;
       }
     }
     // Check that at least an application is selected in the properties of users and owner question
     if (['users', 'owner'].includes(question.getType())) {
       if (!question.applications) {
-        throw new Error(
+        this.snackBar.openSnackBar(
           this.translate.instant('pages.formBuilder.errors.selectApplication', {
             question: question.name,
             page: page.name,
-          })
+          }),
+          {
+            error: true,
+            duration: 15000,
+          }
         );
+        return false;
       }
     }
+    return true;
   }
 
   /**


### PR DESCRIPTION
# Description
The `throw new Error()` used in the form builder to display errors messages and stop the code flow when an incorrect criterion to the survey creation was found don't have a costume duration time to increase the time it stays in the screen. 
And how the alternative, the snackbar service, don't stop the saveMySurvey() call or sub-calls to the other methods with any return, in addition to replacing the `Error()` constructor with `snackBar.openSnackBar` to show error messages longer, I also changed the `validateValueNames()`, `saveMySurvey()` and `setQuestionNames` methods to return booleans in case an error was detected and the code need to be interrupted 

## Useful links

- Please insert link to ticket: [Make error messages appear for longer](https://oortcloud.atlassian.net/browse/OORT-666)

## Type of change
- [X] Improvement (refactor or addition to existing functionality)


# How Has This Been Tested?
Creating and editing surveys, causing error scenarios where error messages should appear (such as resource question without relatedName or without template, when necessary), and when without errors managing to save the survey without problems

## Screenshots
[message-error.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/26389e62-b727-4dfa-8690-8266cc3fb3fc)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
