### PR TITLE
feat/OORT-667_next-on-form-submit

### DIFF
--- a/apps/back-office/src/app/application/pages/form/form.component.ts
+++ b/apps/back-office/src/app/application/pages/form/form.component.ts
@@ -1,7 +1,7 @@
 import { Apollo } from 'apollo-angular';
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { Subscription, firstValueFrom } from 'rxjs';
 import {
   Form,
   Page,
@@ -295,6 +295,13 @@ export class FormComponent extends SafeUnsubscribeComponent implements OnInit {
   onComplete(e: { completed: boolean; hideNewRecord?: boolean }): void {
     this.completed = e.completed;
     this.hideNewRecord = e.hideNewRecord || false;
+
+    // Checks if should go to next step if in an workflow
+    firstValueFrom(this.workflowService.workflow$).then((workflow) => {
+      if (workflow?.nextStepOnSave) {
+        this.workflowService.nextStep.emit();
+      }
+    });
   }
 
   /**

--- a/apps/back-office/src/app/application/pages/workflow/components/add-step/add-step.component.html
+++ b/apps/back-office/src/app/application/pages/workflow/components/add-step/add-step.component.html
@@ -22,7 +22,7 @@
           (filter)="onFilterDataSource($event)"
           (scrolled)="onScrollDataSource($event)"
         ></safe-forms-dropdown>
-        <ui-divider [text]="'or'"></ui-divider>
+        <ui-divider [text]="'common.or' | translate"></ui-divider>
         <!-- New form -->
         <ui-button
           class="mt-4 self-center"

--- a/apps/back-office/src/app/application/pages/workflow/workflow.component.ts
+++ b/apps/back-office/src/app/application/pages/workflow/workflow.component.ts
@@ -95,6 +95,12 @@ export class WorkflowComponent
       this.workflowService.loadWorkflow(this.id);
     });
 
+    this.workflowService.nextStep
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.goToNextStep();
+      });
+
     this.workflowService.workflow$
       .pipe(takeUntil(this.destroy$))
       .subscribe((workflow: Workflow | null) => {

--- a/libs/safe/src/lib/models/workflow.model.ts
+++ b/libs/safe/src/lib/models/workflow.model.ts
@@ -15,4 +15,5 @@ export interface Workflow {
   canSee?: boolean;
   canUpdate?: boolean;
   canDelete?: boolean;
+  nextStepOnSave?: boolean;
 }

--- a/libs/safe/src/lib/services/workflow/graphql/queries.ts
+++ b/libs/safe/src/lib/services/workflow/graphql/queries.ts
@@ -12,6 +12,7 @@ export const GET_WORKFLOW_BY_ID = gql`
       createdAt
       modifiedAt
       canUpdate
+      nextStepOnSave
       permissions {
         canSee {
           id

--- a/libs/safe/src/lib/services/workflow/workflow.service.ts
+++ b/libs/safe/src/lib/services/workflow/workflow.service.ts
@@ -1,5 +1,5 @@
 import { Apollo } from 'apollo-angular';
-import { Injectable } from '@angular/core';
+import { EventEmitter, Injectable } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { BehaviorSubject, Observable } from 'rxjs';
 import {
@@ -32,6 +32,8 @@ export class SafeWorkflowService {
   get workflow$(): Observable<Workflow | null> {
     return this.workflow.asObservable();
   }
+
+  public nextStep = new EventEmitter<void>();
 
   /**
    * Workflow service. Handles modification of workflow ( step addition / step name update ) and some workflow actions.


### PR DESCRIPTION
# Description

This PR adds the ability to make it so if you're in a workflow and submits a survey, you're automatically sent to the next step of the workflow. No UI for now.

## Useful links

- Ticket: [New trigger fro next page on workflow](https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/3?selectedIssue=OORT-667)
- Back-end PR:  [feat/OORT-667_next-on-form-submit](https://github.com/ReliefApplications/oort-backend/pull/712)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By manually setting the nextStepOnSave of a workflow to true in the DB directly and then submitting a survey on a form in it.

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
