### PR TITLE
 id as survey variable

### DIFF
--- a/libs/safe/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/safe/src/lib/services/form-builder/form-builder.service.ts
@@ -59,6 +59,9 @@ export class SafeFormBuilderService {
     Survey.settings.useCachingForChoicesRestfull = false;
     const survey = new Survey.Model(structure);
     this.formHelpersService.addUserVariables(survey);
+    if (record) {
+      this.formHelpersService.addRecordIDVariable(survey, record);
+    }
     survey.onAfterRenderQuestion.add(
       renderGlobalProperties(this.referenceDataService)
     );

--- a/libs/safe/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/safe/src/lib/services/form-helper/form-helper.service.ts
@@ -344,6 +344,24 @@ export class SafeFormHelpersService {
   };
 
   /**
+   * Registration of new custom variables for the survey.
+   * Custom variables can be used in the logic fields.
+   * This function is used to add the record id and the incremental id to the survey variables
+   *
+   * @param survey Survey instance
+   * @param record Record to add to the survey variables
+   * @param record.id Record id
+   * @param record.incrementalID Record incremental id
+   */
+  public addRecordIDVariable = (
+    survey: Survey.SurveyModel,
+    record: { id?: string; incrementalID?: string }
+  ) => {
+    survey.setVariable('record.id', record.id);
+    survey.setVariable('record.incrementalID', record?.incrementalID ?? '');
+  };
+
+  /**
    * Clears the temporary files storage
    *
    * @param storage Storage to clear

--- a/libs/safe/src/lib/survey/components/utils.ts
+++ b/libs/safe/src/lib/survey/components/utils.ts
@@ -100,7 +100,11 @@ export const buildAddButton = (
             locale: question.resource.value,
             askForConfirm: false,
             ...(question.prefillWithCurrentRecord && {
-              prefillData: question.survey.data,
+              prefillData: {
+                ...question.survey.data,
+                [`owner_${question.resource}`]:
+                  question.survey.getVariable('record.id'),
+              },
             }),
           },
           height: '98%',


### PR DESCRIPTION
# Description

This PR includes some code that adds the record id (if updating a record) as a variable to be used in the survey.
Also, adds a hacky way to have a two way connection between two records if one is created using a resources type question targeting a resource properly configured.

## Useful links

- Ticket: [Add record id to be used as survey variable](https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/3?selectedIssue=OORT-670)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By adding {record.id} as value to an expression type question in a form and seeing that when you're updating a record, it shows correctly.


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
