### PR TITLE
OORT-feat/OORT-671-readOnly-for-add-record

### DIFF
--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -30,7 +30,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { SafeUnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component';
 import { SafeFormHelpersService } from '../../services/form-helper/form-helper.service';
 import { SnackbarService } from '@oort-front/ui';
-import { cloneDeep, isNil } from 'lodash';
+import { cloneDeep } from 'lodash';
 
 /**
  * This component is used to display forms
@@ -129,14 +129,11 @@ export class SafeFormComponent
     this.survey.onValueChanged.add(this.valueChange.bind(this));
     this.survey.onComplete.add(this.onComplete);
 
-    // Unset readOnly fields if it's the record creation
-    // It's a requirement to let all fields been editable during addition of records
-    if (!isNil(this.record)) {
-      this.form.fields?.forEach((field) => {
-        if (field.readOnly && this.survey.getQuestionByName(field.name))
-          this.survey.getQuestionByName(field.name).readOnly = true;
-      });
-    }
+    // Set readOnly fields
+    this.form.fields?.forEach((field) => {
+      if (field.readOnly && this.survey.getQuestionByName(field.name))
+        this.survey.getQuestionByName(field.name).readOnly = true;
+    });
     // Fetch cached data from local storage
     this.storageId = `record:${this.record ? 'update' : ''}:${this.form.id}`;
     const storedData = localStorage.getItem(this.storageId);


### PR DESCRIPTION
# Description
Remove for OORT the requirement to let all fields been editable during the addition of records.

## Useful links

- Please insert link to ticket: [OORT-671: readOnly for questions and form pages](https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/3?selectedIssue=OORT-671)

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
When adding a new record to a form with a question with the readOnly set, being enable to edit the question.

## Screenshots
[readonly-add-record.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/94593dc1-9284-4edf-8528-0e7a4a03fb29)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
