### PR TITLE
feat/AB#73245_enhance_styling_summary_card_button

### DIFF
--- a/libs/ui/src/lib/button/button.component.scss
+++ b/libs/ui/src/lib/button/button.component.scss
@@ -160,7 +160,10 @@
   }
 }
 
-button.ui-button:disabled,
-button.ui-button-icon:disabled {
+button.ui-button:disabled {
   @apply text-neutral-400 bg-neutral-500 bg-opacity-20;
+}
+
+button.ui-button-icon:disabled {
+  @apply text-neutral-400 bg-opacity-20;
 }


### PR DESCRIPTION
# Description

Fixed the style of button when it's a icon and is disabled, now the disabled icon buttons doesn't have background on it.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/73245)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested verifying in the application, in grid type of display button if now disabled button icons doesn't have a background color.

## Screenshots

![Peek 23-08-2023 11-01](https://github.com/ReliefApplications/oort-frontend/assets/56398308/ced9a182-cd8d-40fe-bd34-39b22b401c20)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
