### PR TITLE
refactor: use jsonpath for querying choices path

### DIFF
--- a/libs/safe/src/lib/survey/global-properties/choicesByUrl.ts
+++ b/libs/safe/src/lib/survey/global-properties/choicesByUrl.ts
@@ -1,4 +1,5 @@
-import { get, isNil, set } from 'lodash';
+import { isNil, set } from 'lodash';
+import jsonpath from 'jsonpath';
 import {
   ChoicesRestful,
   QuestionSelectBase,
@@ -200,7 +201,7 @@ export const init = (Survey: any): void => {
     if (!this.processedPath) return result;
     const paths = this.getPathes();
     for (let i = 0; i < paths.length; i++) {
-      result = get(result, paths[i]);
+      result = jsonpath.query(result, paths[i]);
       if (!result) return null;
     }
     return result;
@@ -217,7 +218,7 @@ export const init = (Survey: any): void => {
         ?.getAllQuestions()
         ?.map((q) => `{${q.name}}`) || [];
 
-    if (questionTemplates?.some((q) => this.requestBody.includes(q))) {
+    if (questionTemplates?.some((q) => this.requestBody?.includes(q))) {
       return;
     }
 


### PR DESCRIPTION
# Description

Simple change to use jsonpath instead of lodash get on the choicesByUrl paths


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Used the same setup as always (with the countries API), this time I changed the query to the following:
```
query {
 countries(filter: {code: {nin: ["{code}"]}}) {
  code
  capital
  emoji
  languages {
    name
    code
  }
} 
}
```

And I had two questions, one with each of the paths: `data.countries.*` and `data.countries.*.languages.*`

## Screenshots

![Peek 2023-08-30 03-01](https://github.com/ReliefApplications/oort-frontend/assets/102038450/2bd3f89e-dfd6-4bdc-9592-05f7e49d32ae)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
