### PR TITLE
OORT-feat/IM-3-custom-function-to-change-pages

### DIFF
--- a/libs/safe/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/safe/src/lib/services/form-builder/form-builder.service.ts
@@ -162,9 +162,15 @@ export class SafeFormBuilderService {
     selectedPageIndex: BehaviorSubject<number>,
     temporaryFilesStorage: Record<string, Array<File>>
   ) {
-    // Open survey on a specific page
-    if (survey.openFormOnPage) {
-      const page = survey.getPageByName(survey.openFormOnPage);
+    // Open survey on a specific page (openOnQuestionValuesPage has priority over openOnPage)
+    if (survey.openOnQuestionValuesPage) {
+      const question = survey.getQuestionByName(
+        survey.openOnQuestionValuesPage
+      );
+      const page = survey.getPageByName(question.value);
+      selectedPageIndex.next(page.visibleIndex);
+    } else if (survey.openOnPage) {
+      const page = survey.getPageByName(survey.openOnPage);
       selectedPageIndex.next(page.visibleIndex);
     }
     survey.onClearFiles.add((_, options: any) => this.onClearFiles(options));

--- a/libs/safe/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/safe/src/lib/services/form-builder/form-builder.service.ts
@@ -162,6 +162,11 @@ export class SafeFormBuilderService {
     selectedPageIndex: BehaviorSubject<number>,
     temporaryFilesStorage: Record<string, Array<File>>
   ) {
+    // Open survey on a specific page
+    if (survey.openFormOnPage) {
+      const page = survey.getPageByName(survey.openFormOnPage);
+      selectedPageIndex.next(page.visibleIndex);
+    }
     survey.onClearFiles.add((_, options: any) => this.onClearFiles(options));
     survey.onUploadFiles.add((_, options: any) =>
       this.onUploadFiles(temporaryFilesStorage, options)

--- a/libs/safe/src/lib/survey/global-properties/others.ts
+++ b/libs/safe/src/lib/survey/global-properties/others.ts
@@ -68,13 +68,28 @@ export const init = (Survey: any, environment: any): void => {
     visibleIndex: 4,
     default: false,
   });
-  // Adds a property to the survey settings to open the form on a specific page, displaying a dropdown with all the page names
+  // Adds a property to the survey settings to open the form on a specific page using the question value
+  // of the selected question (the value must be a page name)
   serializer.addProperty('survey', {
-    name: 'openFormOnPage',
+    name: 'openOnQuestionValuesPage',
     category: 'pages',
     choices: (survey: Survey.Model, choicesCallback: any) => {
-      const pages: string[] = survey.pages.map(
-        (page: Survey.PageModel) => page.name
+      let questions: string[] = [''];
+      survey.pages.forEach((page: Survey.PageModel) => {
+        questions = questions.concat(
+          page.questions.map((question: Survey.Question) => question.name)
+        );
+      });
+      choicesCallback(questions);
+    },
+  });
+  // Adds a property to the survey settings to open the form on a specific page, displaying a dropdown with all the page names
+  serializer.addProperty('survey', {
+    name: 'openOnPage',
+    category: 'pages',
+    choices: (survey: Survey.Model, choicesCallback: any) => {
+      const pages: string[] = [''].concat(
+        survey.pages.map((page: Survey.PageModel) => page.name)
       );
       choicesCallback(pages);
     },

--- a/libs/safe/src/lib/survey/global-properties/others.ts
+++ b/libs/safe/src/lib/survey/global-properties/others.ts
@@ -4,6 +4,7 @@ import {
   QuestionFileModel,
 } from 'survey-angular';
 import { Question } from '../types';
+import * as Survey from 'survey-angular';
 
 /**
  * Add support for custom properties to the survey
@@ -66,6 +67,17 @@ export const init = (Survey: any, environment: any): void => {
     category: 'validation',
     visibleIndex: 4,
     default: false,
+  });
+  // Adds a property to the survey settings to open the form on a specific page, displaying a dropdown with all the page names
+  serializer.addProperty('survey', {
+    name: 'openFormOnPage',
+    category: 'pages',
+    choices: (survey: Survey.Model, choicesCallback: any) => {
+      const pages: string[] = survey.pages.map(
+        (page: Survey.PageModel) => page.name
+      );
+      choicesCallback(pages);
+    },
   });
 };
 


### PR DESCRIPTION
# Description

- Added a new property to the survey settings named "Open on page" that displays a dropdown with all the page names and allows to open the survey on a specific page when initializing the survey.
- A new property to the survey settings named  "Open on question values page" that displays a dropdown with all the questions names and allows to open the survey on a specific page when initializing the survey, using the value of the selected question

## Useful links

[- Please insert link to ticket](https://oortcloud.atlassian.net/browse/IM-3)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Setting the survey property of some surveys to a specific page and when initializing the survey (adding a new record or updating a record in a modal or not) we are taken to the selected page. If the openOnQuestionValuesPage property is also set, it has priority and the value of the selected question is used to select the init page instead. 

## Screenshots
openOnPage: 
[video1.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/e1cc1fec-1dac-479e-8f88-cd82b1ef23c5)
openOnQuestionValuesPage and openOnPage:
[video2.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/731e7d19-e369-4a22-aa09-afde53480c3f)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
