### PR TITLE
OORT-feat/IM-21-temporary-records-optional

### DIFF
--- a/libs/safe/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/safe/src/lib/components/form-modal/form-modal.component.ts
@@ -55,6 +55,7 @@ interface DialogData {
   prefillRecords?: Record[];
   prefillData?: any;
   askForConfirm?: boolean;
+  alwaysCreateRecord?: boolean;
 }
 /**
  * Defines the default Dialog data

--- a/libs/safe/src/lib/components/resource-modal/resource-modal.component.ts
+++ b/libs/safe/src/lib/components/resource-modal/resource-modal.component.ts
@@ -53,38 +53,43 @@ export class SafeResourceModalComponent extends SafeFormModalComponent {
    * @param survey current survey
    */
   public override async onUpdate(survey: any): Promise<void> {
-    if (this.data.recordId) {
-      await this.formHelpersService.uploadFiles(
-        survey,
-        this.temporaryFilesStorage,
-        this.form?.id
-      );
-      if (this.isMultiEdition) {
-        this.updateMultipleData(this.data.recordId, survey);
-      } else {
-        this.updateData(this.data.recordId, survey);
-      }
+    // If question propriety alwaysCreateRecord set to true, don't use override method and create new record
+    if (this.data.alwaysCreateRecord) {
+      super.onUpdate(survey);
     } else {
-      await this.formHelpersService.uploadFiles(
-        survey,
-        this.temporaryFilesStorage,
-        this.form?.id
-      );
-      const temporaryId = uuidv4();
-      await localForage.setItem(
-        temporaryId.toString(),
-        JSON.stringify({ data: survey.data, template: this.data.template })
-      ); //We save the question temporarily before applying the mutation.
-      this.ngZone.run(() => {
-        this.dialogRef.close({
-          template: this.data.template,
-          data: {
-            id: temporaryId,
-            data: survey.data,
-          },
-        } as any);
-      });
+      if (this.data.recordId) {
+        await this.formHelpersService.uploadFiles(
+          survey,
+          this.temporaryFilesStorage,
+          this.form?.id
+        );
+        if (this.isMultiEdition) {
+          this.updateMultipleData(this.data.recordId, survey);
+        } else {
+          this.updateData(this.data.recordId, survey);
+        }
+      } else {
+        await this.formHelpersService.uploadFiles(
+          survey,
+          this.temporaryFilesStorage,
+          this.form?.id
+        );
+        const temporaryId = uuidv4();
+        await localForage.setItem(
+          temporaryId.toString(),
+          JSON.stringify({ data: survey.data, template: this.data.template })
+        ); //We save the question temporarily before applying the mutation.
+        this.ngZone.run(() => {
+          this.dialogRef.close({
+            template: this.data.template,
+            data: {
+              id: temporaryId,
+              data: survey.data,
+            },
+          } as any);
+        });
+      }
+      survey.showCompletedPage = true;
     }
-    survey.showCompletedPage = true;
   }
 }

--- a/libs/safe/src/lib/survey/components/resource.ts
+++ b/libs/safe/src/lib/survey/components/resource.ts
@@ -300,6 +300,13 @@ export const init = (
         visibleIndex: 3,
       });
       serializer.addProperty('resource', {
+        name: 'alwaysCreateRecord:boolean',
+        category: 'Custom Questions',
+        dependsOn: ['resource', 'addRecord'],
+        visibleIf: (obj: null | QuestionResource) => !!obj && !!obj.addRecord,
+        visibleIndex: 3,
+      });
+      serializer.addProperty('resource', {
         name: 'addTemplate',
         category: 'Custom Questions',
         dependsOn: ['addRecord', 'resource'],
@@ -612,6 +619,7 @@ export const init = (
         this.filters = [];
         this.resourceFieldsName = [];
         question.addRecord = false;
+        question.alwaysCreateRecord = false;
         question.addTemplate = null;
         question.prefillWithCurrentRecord = false;
       }

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -429,6 +429,19 @@ export const init = (
         visibleIndex: 3,
       });
       Survey.Serializer.addProperty('resources', {
+        name: 'alwaysCreateRecord:boolean',
+        category: 'Custom Questions',
+        dependsOn: ['resource', 'addRecord'],
+        visibleIf: (obj: any) => {
+          if (!obj.resource || !obj.addRecord) {
+            return false;
+          } else {
+            return true;
+          }
+        },
+        visibleIndex: 3,
+      });
+      Survey.Serializer.addProperty('resources', {
         name: 'addTemplate',
         category: 'Custom Questions',
         dependsOn: ['addRecord', 'resource'],
@@ -750,6 +763,7 @@ export const init = (
         filters = [];
         this.resourceFieldsName = [];
         question.addRecord = false;
+        question.alwaysCreateRecord = false;
         question.addTemplate = null;
         question.prefillWithCurrentRecord = false;
       }

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -432,13 +432,7 @@ export const init = (
         name: 'alwaysCreateRecord:boolean',
         category: 'Custom Questions',
         dependsOn: ['resource', 'addRecord'],
-        visibleIf: (obj: any) => {
-          if (!obj.resource || !obj.addRecord) {
-            return false;
-          } else {
-            return true;
-          }
-        },
+        visibleIf: (obj: any) => !!obj.resource && !!obj.addRecord,
         visibleIndex: 3,
       });
       Survey.Serializer.addProperty('resources', {

--- a/libs/safe/src/lib/survey/components/utils.ts
+++ b/libs/safe/src/lib/survey/components/utils.ts
@@ -97,6 +97,7 @@ export const buildAddButton = (
           disableClose: true,
           data: {
             template: question.addTemplate,
+            alwaysCreateRecord: question.alwaysCreateRecord,
             locale: question.resource.value,
             askForConfirm: false,
             ...(question.prefillWithCurrentRecord && {

--- a/libs/safe/src/lib/survey/types.ts
+++ b/libs/safe/src/lib/survey/types.ts
@@ -56,6 +56,7 @@ export interface QuestionResource
   displayField: null | string;
   relatedName?: string;
   addRecord?: boolean;
+  alwaysCreateRecord?: boolean;
   canSearch?: boolean;
   addTemplate?: any;
   placeholder?: string;


### PR DESCRIPTION
# Description
For resource/resources questions: added a new optional propriety "alwaysCreateRecord" so when creating new records inside a record creation, we don’t use the temporary record logic used today that creates the “child' record only after saving the form that saves the “parent“ record, but instead we call the addRecord mutation immediately. 

## Useful links

[- Please insert link to ticket](https://oortcloud.atlassian.net/browse/IM-21)

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Created a resource question with addRecord and alwaysCreateRecord propriety sets to true: when creating the "child" record, we can see that the addRecord mutation is applied instead of the temporaryFilesStorage logic
Created a resource question with addRecord set to true, but without the alwaysCreateRecord: the "child" record is saved in the temporaryFilesStorage and created after we save the survey and two addRecord mutations is fired (one for the "child" record and another for the"parent")

## Screenshots
[temporary-record-optinal.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/d4c28422-a4f4-4081-afa2-97d005668ff0)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
