### PR TITLE
OORT-feat/IM-28-replace-grid-actions-menu-if-single-action

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1302,6 +1302,9 @@
 							"publish": "When enabled, you must provide a channel. All selected rows will be sent as a single publication on the specified channel. Everyone listening to this channel can receive the records"
 						}
 					},
+					"display": {
+						"showSingleActionAsButton": "Show single action as button"
+					},
 					"hint": {
 						"actions": {
 							"add": "If authorized, user can add new records using selected template",

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1318,6 +1318,9 @@
 							"publish": "Si activé, vous devez fournir un canal de diffusion. Toutes les lignes sélectionnées seront envoyées en tant que notification unique sur le canal spécifié. Quiconque écoutant sur ce canal pourra recevoir ces enregistrements."
 						}
 					},
+					"display": {
+						"showSingleActionAsButton": "Afficher une seule action sous forme de bouton"
+					},
 					"hint": {
 						"actions": {
 							"add": "L'utilisateur peut ajouter de nouveaux enregistrements avec le modèle choisi, s'il en a la permission",

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1302,6 +1302,9 @@
 							"publish": "******"
 						}
 					},
+					"display": {
+						"showSingleActionAsButton": "******"
+					},
 					"hint": {
 						"actions": {
 							"add": "******",

--- a/libs/safe/src/lib/components/query-builder/query-builder-forms.ts
+++ b/libs/safe/src/lib/components/query-builder/query-builder-forms.ts
@@ -167,6 +167,7 @@ export const createQueryForm = (
 export const createDisplayForm = (value: any): UntypedFormGroup =>
   formBuilder.group({
     showFilter: [value?.showFilter],
+    actionsColWidth: [value?.actionsColWidth || 86],
     sort: [value?.sort || []],
     fields: [value?.fields || null],
     filter: [value?.filter || null],

--- a/libs/safe/src/lib/components/ui/core-grid/core-grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/core-grid.component.html
@@ -30,5 +30,6 @@
   [widget]="widget"
   [canUpdate]="canUpdate"
   [canAdd]="canCreateRecords"
+  [actionsWidth]="defaultLayout.actionsColWidth ?? 86"
 >
 </safe-grid>

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -36,7 +36,7 @@
       editable ||
       filterable ||
       admin ||
-      hasEnabledActions
+      enabledActions.length > 0
     "
     kendoGridToolbarTemplate
     position="top"
@@ -972,10 +972,10 @@
     </kendo-grid-column>
     <!-- ROW ACTIONS -->
     <kendo-grid-column
-      *ngIf="hasEnabledActions"
+      *ngIf="enabledActions.length > 0"
       [columnMenu]="false"
-      [width]="86"
-      [resizable]="false"
+      [minResizableWidth]="86"
+      [width]="actionsWidth"
       [sticky]="true"
     >
       <ng-template
@@ -985,6 +985,9 @@
       >
         <safe-grid-row-actions
           [item]="dataItem"
+          [singleActionAsButton]="
+            !!widget?.settings?.widgetDisplay?.showSingleActionAsButton
+          "
           [actions]="actions"
           (action)="action.emit($event)"
         >

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -549,7 +549,6 @@ export class SafeGridComponent
 
   /** @returns Current grid layout. */
   get layout(): GridLayout {
-    console.log(this.grid?.columns);
     return {
       fields: this.visibleFields,
       sort: this.sort,

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -59,6 +59,9 @@ import { SafeUnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe
 const matches = (el: any, selector: any) =>
   (el.matches || el.msMatchesSelector).call(el, selector);
 
+/** Row actions. */
+export const rowActions = ['update', 'delete', 'history', 'convert'];
+
 /** Component for grid widgets */
 @Component({
   selector: 'safe-grid',
@@ -111,8 +114,6 @@ export class SafeGridComponent
   public gradientSettings = GRADIENT_SETTINGS;
   public editing = false;
 
-  private readonly rowActions = ['update', 'delete', 'history', 'convert'];
-
   // === ACTIONS ===
   @Input() actions = {
     add: false,
@@ -134,7 +135,7 @@ export class SafeGridComponent
         Object.keys(this.actions).filter((key: string) =>
           get(this.actions, key, false)
         ),
-        this.rowActions
+        rowActions
       ).length > 0
     );
   }

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -60,7 +60,13 @@ const matches = (el: any, selector: any) =>
   (el.matches || el.msMatchesSelector).call(el, selector);
 
 /** Row actions. */
-export const rowActions = ['update', 'delete', 'history', 'convert'];
+export const rowActions = [
+  'update',
+  'delete',
+  'history',
+  'convert',
+  'remove',
+] as const;
 
 /** Component for grid widgets */
 @Component({
@@ -86,6 +92,7 @@ export class SafeGridComponent
 
   // === DATA ===
   @Input() fields: any[] = [];
+  @Input() actionsWidth = 86;
   @Input() data: GridDataResult = { data: [], total: 0 };
   @Input() loadingRecords = false;
   @Input() loadingSettings = true;
@@ -129,14 +136,12 @@ export class SafeGridComponent
   @Output() action = new EventEmitter();
 
   /** @returns A boolean indicating if actions are enabled */
-  get hasEnabledActions(): boolean {
-    return (
-      intersection(
-        Object.keys(this.actions).filter((key: string) =>
-          get(this.actions, key, false)
-        ),
-        rowActions
-      ).length > 0
+  get enabledActions() {
+    return intersection(
+      Object.keys(this.actions).filter((key: string) =>
+        get(this.actions, key, false)
+      ),
+      rowActions
     );
   }
 
@@ -544,11 +549,13 @@ export class SafeGridComponent
 
   /** @returns Current grid layout. */
   get layout(): GridLayout {
+    console.log(this.grid?.columns);
     return {
       fields: this.visibleFields,
       sort: this.sort,
       filter: this.filter,
       showFilter: this.showFilter,
+      actionsColWidth: this.grid?.columns?.last.width ?? 86,
     };
   }
 
@@ -794,7 +801,7 @@ export class SafeGridComponent
   }
 
   /**
-   * Calls layout format from utils.ts to get the formated fields
+   * Calls layout format from utils.ts to get the formatted fields
    *
    * @param name Content of the field as a string
    * @param field Field data

--- a/libs/safe/src/lib/components/ui/core-grid/models/grid-layout.model.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/models/grid-layout.model.ts
@@ -11,4 +11,5 @@ export interface GridLayout {
   filter?: CompositeFilterDescriptor;
   sort?: SortDescriptor[];
   showFilter?: boolean;
+  actionsColWidth?: number;
 }

--- a/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.html
@@ -1,5 +1,5 @@
 <button
-  *ngIf="display && actionLength > 1"
+  *ngIf="display && (availableActions.length > 1 || !singleActionAsButton)"
   kendoButton
   class="text-center"
   icon="more-vertical"
@@ -7,12 +7,14 @@
   [uiMenuTriggerFor]="menu"
 ></button>
 <button
-  *ngIf="display && actionLength === 1"
+  *ngIf="display && availableActions.length === 1 && singleActionAsButton"
+  id="single-action-button"
   kendoButton
   class="text-center"
-  (click)="singleAction.hasPermission ?  action.emit({ action: singleAction.name, item: item }) : ''"
+  (click)="action.emit({ action: availableActions[0].action, item })"
 >
-  {{ singleAction.translationKey | translate }}
+  {{ availableActions[0].translationKey | translate }}
+  <div id="single-action-title"></div>
 </button>
 <ui-menu #menu>
   <button

--- a/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.html
@@ -19,37 +19,47 @@
 <ui-menu #menu>
   <button
     *ngIf="actions.update && item.canUpdate"
+    id="update-action-button"
     uiMenuItem
     (click)="action.emit({ action: 'update', item: item })"
   >
     {{ 'common.update' | translate }}
+    <div id="update-action-label"></div>
   </button>
   <button
     *ngIf="actions.history"
+    id="history-action-button"
     uiMenuItem
     (click)="action.emit({ action: 'history', item: item })"
   >
     {{ 'common.history' | translate }}
+    <div id="history-action-label"></div>
   </button>
   <button
     *ngIf="actions.convert && item.canUpdate"
+    id="convert-action-button"
     uiMenuItem
     (click)="action.emit({ action: 'convert', item: item })"
   >
     {{ 'models.record.convert' | translate }}
+    <div id="convert-action-label"></div>
   </button>
   <button
     *ngIf="actions.delete && item.canDelete"
+    id="delete-action-button"
     uiMenuItem
     (click)="action.emit({ action: 'delete', item: item })"
   >
     {{ 'common.delete' | translate }}
+    <div id="delete-action-label"></div>
   </button>
   <button
     *ngIf="actions.remove"
+    id="remove-action-button"
     uiMenuItem
     (click)="action.emit({ action: 'remove', item: item })"
   >
     {{ 'components.widget.settings.grid.actions.remove' | translate }}
+    <div id="remove-action-label"></div>
   </button>
 </ui-menu>

--- a/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.html
@@ -1,11 +1,19 @@
 <button
-  *ngIf="display"
+  *ngIf="display && actionLength > 1"
   kendoButton
   class="text-center"
   icon="more-vertical"
   [look]="'flat'"
   [uiMenuTriggerFor]="menu"
 ></button>
+<button
+  *ngIf="display && actionLength === 1"
+  kendoButton
+  class="text-center"
+  (click)="singleAction.hasPermission ?  action.emit({ action: singleAction.name, item: item }) : ''"
+>
+  {{ singleAction.translationKey | translate }}
+</button>
 <ui-menu #menu>
   <button
     *ngIf="actions.update && item.canUpdate"

--- a/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.html
+++ b/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.html
@@ -14,7 +14,7 @@
   (click)="action.emit({ action: availableActions[0].action, item })"
 >
   {{ availableActions[0].translationKey | translate }}
-  <div id="single-action-title"></div>
+  <div id="single-action-label"></div>
 </button>
 <ui-menu #menu>
   <button

--- a/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.ts
@@ -1,4 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { rowActions } from '../grid/grid.component';
+import { get, intersection } from 'lodash';
 
 /** Component for grid row actions */
 @Component({
@@ -28,5 +30,64 @@ export class SafeGridRowActionsComponent {
       (this.item.canDelete && this.actions.delete) ||
       (this.item.canUpdate && (this.actions.update || this.actions.convert))
     );
+  }
+
+  /** @returns The number of actions active for the row */
+  get actionLength(): number {
+    return intersection(
+      Object.keys(this.actions).filter((key: string) =>
+        get(this.actions, key, false)
+      ),
+      rowActions
+    ).length;
+  }
+
+  /** @returns Object for single action with action name, if is allowed and the translation key*/
+  get singleAction(): {
+    name: string;
+    hasPermission: boolean;
+    translationKey: string;
+  } {
+    if (this.actionLength === 1) {
+      const actionReturn = {
+        name: '',
+        hasPermission: false,
+        translationKey: '',
+      };
+      Object.entries(this.actions).forEach((action: any) => {
+        if (rowActions.includes(action[0]) && action[1]) {
+          actionReturn.name = action[0];
+          // Actions that has a button in the menu
+          switch (action[0]) {
+            case 'update':
+              actionReturn.hasPermission = action[1] && this.item.canUpdate;
+              actionReturn.translationKey = 'common.update';
+              break;
+            case 'delete':
+              actionReturn.hasPermission = action[1] && this.item.canDelete;
+              actionReturn.translationKey = 'common.delete';
+              break;
+            case 'history':
+              actionReturn.hasPermission = action[1];
+              actionReturn.translationKey = 'common.history';
+              break;
+            case 'convert':
+              actionReturn.hasPermission = action[1] && this.item.canUpdate;
+              actionReturn.translationKey = 'models.record.convert';
+              break;
+            case 'remove':
+              actionReturn.hasPermission = action[1];
+              actionReturn.translationKey =
+                'components.widget.settings.grid.actions.remove';
+              break;
+            default:
+              actionReturn.hasPermission = false;
+              break;
+          }
+        }
+      });
+      return actionReturn;
+    }
+    return { name: '', hasPermission: false, translationKey: '' };
   }
 }

--- a/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/row-actions/row-actions.component.ts
@@ -2,6 +2,15 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { rowActions } from '../grid/grid.component';
 import { get, intersection } from 'lodash';
 
+/** Translation keys for each of the row action types */
+const ACTIONS_TRANSLATIONS: Record<(typeof rowActions)[number], string> = {
+  update: 'common.update',
+  delete: 'common.delete',
+  history: 'common.history',
+  convert: 'models.record.convert',
+  remove: 'components.widget.settings.grid.actions.remove',
+};
+
 /** Component for grid row actions */
 @Component({
   selector: 'safe-grid-row-actions',
@@ -20,6 +29,7 @@ export class SafeGridRowActionsComponent {
     convert: false,
     remove: false,
   };
+  @Input() singleActionAsButton = false;
   @Output() action = new EventEmitter();
 
   /** @returns A boolean indicating if the component must be shown */
@@ -33,61 +43,16 @@ export class SafeGridRowActionsComponent {
   }
 
   /** @returns The number of actions active for the row */
-  get actionLength(): number {
+  get availableActions() {
     return intersection(
       Object.keys(this.actions).filter((key: string) =>
         get(this.actions, key, false)
       ),
       rowActions
-    ).length;
-  }
-
-  /** @returns Object for single action with action name, if is allowed and the translation key*/
-  get singleAction(): {
-    name: string;
-    hasPermission: boolean;
-    translationKey: string;
-  } {
-    if (this.actionLength === 1) {
-      const actionReturn = {
-        name: '',
-        hasPermission: false,
-        translationKey: '',
-      };
-      Object.entries(this.actions).forEach((action: any) => {
-        if (rowActions.includes(action[0]) && action[1]) {
-          actionReturn.name = action[0];
-          // Actions that has a button in the menu
-          switch (action[0]) {
-            case 'update':
-              actionReturn.hasPermission = action[1] && this.item.canUpdate;
-              actionReturn.translationKey = 'common.update';
-              break;
-            case 'delete':
-              actionReturn.hasPermission = action[1] && this.item.canDelete;
-              actionReturn.translationKey = 'common.delete';
-              break;
-            case 'history':
-              actionReturn.hasPermission = action[1];
-              actionReturn.translationKey = 'common.history';
-              break;
-            case 'convert':
-              actionReturn.hasPermission = action[1] && this.item.canUpdate;
-              actionReturn.translationKey = 'models.record.convert';
-              break;
-            case 'remove':
-              actionReturn.hasPermission = action[1];
-              actionReturn.translationKey =
-                'components.widget.settings.grid.actions.remove';
-              break;
-            default:
-              actionReturn.hasPermission = false;
-              break;
-          }
-        }
-      });
-      return actionReturn;
-    }
-    return { name: '', hasPermission: false, translationKey: '' };
+    ).map((action: string) => ({
+      action,
+      translationKey:
+        ACTIONS_TRANSLATIONS[action as (typeof rowActions)[number]],
+    }));
   }
 }

--- a/libs/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/safe/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -98,6 +98,19 @@
             {{ 'models.widget.display.sortable' | translate }}
           </ng-container>
         </ui-toggle>
+        <ui-toggle
+          *ngIf="formGroup.get('widgetDisplay.showSingleActionAsButton')"
+          [formControl]="
+            $any(formGroup.get('widgetDisplay.showSingleActionAsButton'))
+          "
+        >
+          <ng-container ngProjectAs="label">
+            {{
+              'components.widget.settings.grid.display.showSingleActionAsButton'
+                | translate
+            }}
+          </ng-container>
+        </ui-toggle>
       </safe-display-settings>
     </ng-template>
   </ui-tab>

--- a/libs/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -108,6 +108,13 @@ export class SafeGridSettingsComponent
         sortable: new FormControl(
           get<boolean>(tileSettings, 'widgetDisplay.sortable', false)
         ),
+        showSingleActionAsButton: new FormControl(
+          get<boolean>(
+            tileSettings,
+            'widgetDisplay.showSingleActionAsButton',
+            false
+          )
+        ),
       }
     );
 


### PR DESCRIPTION
# Description
Replace the 'three dots' at the end of the row in a grid if there is only a single action (write the action itself, eg update that redirects to the form directly) for the action button.

## Useful links

[- Please insert link to ticket](https://oortcloud.atlassian.net/jira/software/projects/IM/boards/5?selectedIssue=IM-28)

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
In the grid settings, select a single action that is available in the row actions menu and see instated of the 3 dots menu, the button for the action

## Screenshots
![1](https://github.com/ReliefApplications/oort-frontend/assets/28535394/3d90a8ac-51be-4fd7-a791-0c4df0d6595c)
![2](https://github.com/ReliefApplications/oort-frontend/assets/28535394/971f3609-dc81-4231-8bde-6b5b37163845)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
