### PR TITLE
feat/IM-23_add-afterRecordDeselection

### DIFF
--- a/libs/safe/src/lib/survey/components/resource.ts
+++ b/libs/safe/src/lib/survey/components/resource.ts
@@ -497,13 +497,19 @@ export const init = (
 
       Survey.Serializer.addProperty('resource', {
         name: 'afterRecordCreation',
-        // type: 'expression',
+        type: 'text',
         category: 'logic',
       });
 
       Survey.Serializer.addProperty('resource', {
         name: 'afterRecordSelection',
-        // type: 'expression',
+        type: 'text',
+        category: 'logic',
+      });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'afterRecordDeselection',
+        type: 'text',
         category: 'logic',
       });
     },

--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -610,13 +610,19 @@ export const init = (
 
       Survey.Serializer.addProperty('resources', {
         name: 'afterRecordCreation',
-        // type: 'expression',
+        type: 'text',
         category: 'logic',
       });
 
       Survey.Serializer.addProperty('resources', {
         name: 'afterRecordSelection',
-        // type: 'expression',
+        type: 'text',
+        category: 'logic',
+      });
+
+      Survey.Serializer.addProperty('resources', {
+        name: 'afterRecordDeselection',
+        type: 'text',
         category: 'logic',
       });
     },

--- a/libs/safe/src/lib/survey/components/utils.ts
+++ b/libs/safe/src/lib/survey/components/utils.ts
@@ -100,12 +100,7 @@ export const buildAddButton = (
             locale: question.resource.value,
             askForConfirm: false,
             ...(question.prefillWithCurrentRecord && {
-              prefillData: {
-                ...question.survey.data,
-                // Special question name, that will be prefilled with the current record id
-                // useful for linking new records to the current one when creating a new record from the resources question
-                owner_resource: question.survey.getVariable('record.id'),
-              },
+              prefillData: question.survey.data,
             }),
           },
           height: '98%',


### PR DESCRIPTION
# Description

This PR refactors the part in the code where we handled `afterRecordCreation` and `afterRecordSelection` and also added `afterRecordDeselection` option.

* A new syntax is now also valid, being a JSON with the data to be sent in the `editRecord` mutation
* Drops support to `owner_resource` solution, as this one is way more flexible and can accomplish the same result 

## Useful links

- Please insert link to ticket: [Figure out how to save records of individuals even when families separate](https://oortcloud.atlassian.net/jira/software/projects/IM/boards/5?selectedIssue=IM-23)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By setting up a resources question in the Family form, with afterRecordCreation and afterRecordSelection set to` { "owner_resource": {record.id} }` and afterRecordDeselection set to `{ "owner_resource": null }`. After that, tested from the family form, creating a new family member, selecting existing one and deselecting one that is selected. After that, check the Person records to see if the `owner_resource` was successfully updated. 


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
