### PR TITLE
bugfix/74388_add-clear-button-for-date-pickers-in-survey-on-first-load

### DIFF
--- a/libs/safe/src/lib/survey/widgets/text-widget.ts
+++ b/libs/safe/src/lib/survey/widgets/text-widget.ts
@@ -177,10 +177,12 @@ export const init = (Survey: any, domService: DomService): void => {
               }
             });
             if (question.value) {
-              pickerInstance.value = getDateDisplay(
-                question.value,
-                question.inputType
+              pickerInstance.writeValue(
+                getDateDisplay(question.value, question.inputType)
               );
+              //The register on change event only triggers from the calendar UI selection, therefor we have to manually show the clear button in first load
+              // https://www.telerik.com/kendo-angular-ui/components/dateinputs/api/DatePickerComponent/#toc-valuechange
+              button.classList.remove('hidden');
             }
             if (question.min) {
               pickerInstance.min = getDateDisplay(


### PR DESCRIPTION
# Description

feat: remove hidden class from date picker clear button on first load if picker contains any value, as the valueChange event only triggers from the calendar UI, not on setting a value into the date picker 
refactor: use the writeValue default built in method of kendo date picker in order to avoid any strange misbehavior on setting value

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/74388)
- [Useful link, about the valueChange event](https://www.telerik.com/kendo-angular-ui/components/dateinputs/api/DatePickerComponent/#toc-valuechange)

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Open a record containing a date picker with a default/already set value and clear button will show now in the input

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
