### PR TITLE
bugfix/date-filter-alignment-in-tab-filter

### DIFF
--- a/libs/safe/src/lib/components/query-builder/date-filter-editor/date-filter-editor.component.html
+++ b/libs/safe/src/lib/components/query-builder/date-filter-editor/date-filter-editor.component.html
@@ -1,4 +1,4 @@
-<div uiFormFieldDirective *ngIf="!useExpression">
+<div uiFormFieldDirective [defaultMargin]="false" *ngIf="!useExpression">
   <label>{{ 'common.value.one' | translate }}</label>
   <div [uiDateWrapper]="calendar">
     <input
@@ -9,7 +9,7 @@
     <ui-date-picker #calendar> </ui-date-picker>
   </div>
 </div>
-<div uiFormFieldDirective *ngIf="useExpression">
+<div uiFormFieldDirective [defaultMargin]="false" *ngIf="useExpression">
   <label>{{ 'common.value.one' | translate }}</label>
   <input
     uiTooltip="YYYY/MM/DD"

--- a/libs/safe/src/lib/components/query-builder/date-filter-editor/date-filter-editor.component.scss
+++ b/libs/safe/src/lib/components/query-builder/date-filter-editor/date-filter-editor.component.scss
@@ -1,4 +1,4 @@
 :host {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
 }


### PR DESCRIPTION
# Description

 fix: use flex-end and default margin false to the date field in the tab-filter component in order to align the element to the rest of the y axis

## Useful links

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to screenshots below

## Screenshots

Previoulsy
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/5bc86b9c-e103-47ec-98c0-ca3fc7a25e7c)

Now
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/63818256-cb86-417d-a7da-57076179fd2c)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
