### PR TITLE
OORT-fix/IM-3-custom-function-to-change-pages

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -1107,6 +1107,7 @@
 			"grid": {
 				"actions": {
 					"detail": "Open detail",
+					"downloadReport": "Download",
 					"history": "Show history"
 				},
 				"errors": {

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -1122,6 +1122,7 @@
 			"grid": {
 				"actions": {
 					"detail": "Ouvrir le détail",
+					"downloadReport": "Télécharger",
 					"history": "Voir l'historique"
 				},
 				"empty": "Aucun enregistrement détecté pour cette configuration de réseau",

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -1107,6 +1107,7 @@
 			"grid": {
 				"actions": {
 					"detail": "******",
+					"downloadReport": "******",
 					"history": "******"
 				},
 				"errors": {

--- a/libs/safe/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/safe/src/lib/services/form-builder/form-builder.service.ts
@@ -209,17 +209,19 @@ export class SafeFormBuilderService {
     selectedPageIndex: BehaviorSubject<number>,
     temporaryFilesStorage: Record<string, Array<File>>
   ) {
-    // Open survey on a specific page (openOnQuestionValuesPage has priority over openOnPage)
-    if (survey.openOnQuestionValuesPage) {
-      const question = survey.getQuestionByName(
-        survey.openOnQuestionValuesPage
-      );
-      const page = survey.getPageByName(question.value);
-      selectedPageIndex.next(page.visibleIndex);
-    } else if (survey.openOnPage) {
-      const page = survey.getPageByName(survey.openOnPage);
-      selectedPageIndex.next(page.visibleIndex);
-    }
+    survey.onAfterRenderSurvey.add(() => {
+      // Open survey on a specific page (openOnQuestionValuesPage has priority over openOnPage)
+      if (survey.openOnQuestionValuesPage) {
+        const question = survey.getQuestionByName(
+          survey.openOnQuestionValuesPage
+        );
+        const page = survey.getPageByName(question.value);
+        selectedPageIndex.next(page.visibleIndex);
+      } else if (survey.openOnPage) {
+        const page = survey.getPageByName(survey.openOnPage);
+        selectedPageIndex.next(page.visibleIndex);
+      }
+    });
     survey.onClearFiles.add((_, options: any) => this.onClearFiles(options));
     survey.onUploadFiles.add((_, options: any) =>
       this.onUploadFiles(temporaryFilesStorage, options)


### PR DESCRIPTION
# Description
When using the openOnQuestionValuesPage survey configuration to start it on a page, depending on the expression used in the question the criteria were incorrectly calculated and the survey started on the wrong page, when it should wait for the survey to finish being started and rendered to have the correct value from page

## Useful links
[- Please insert link to ticket](https://oortcloud.atlassian.net/browse/IM-3)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots
[open-page.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/a58a2f41-1d31-44a7-b675-cb127940ef78)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
