### PR TITLE
fixed sorting tab in summary card settings

### DIFF
--- a/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/safe/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -133,21 +133,22 @@
         </safe-display-settings>
       </ng-template>
     </ui-tab>
-
-    <ng-container ngProjectAs="label">
-      <ui-icon
-        icon="filter_alt"
-        [size]="24"
-        [uiTooltip]="'models.widget.sorting.title' | translate"
-      ></ui-icon>
-      <span>{{ 'models.widget.sorting.title' | translate }}</span>
-    </ng-container>
-    <ng-template uiTabContent>
-      <safe-sorting-settings
-        [fields]="selectedResource?.metadata"
-        [formArray]="$any(tileForm.get('sortFields'))"
-        [formGroup]="tileForm"
-      ></safe-sorting-settings>
-    </ng-template>
+    <ui-tab>
+      <ng-container ngProjectAs="label">
+        <ui-icon
+          icon="filter_alt"
+          [size]="24"
+          [uiTooltip]="'models.widget.sorting.title' | translate"
+        ></ui-icon>
+        <span>{{ 'models.widget.sorting.title' | translate }}</span>
+      </ng-container>
+      <ng-template uiTabContent>
+        <safe-sorting-settings
+          [fields]="selectedResource?.metadata"
+          [formArray]="$any(tileForm.get('sortFields'))"
+          [formGroup]="tileForm"
+        ></safe-sorting-settings>
+      </ng-template>
+    </ui-tab>
   </ui-tabs>
 </ng-container>


### PR DESCRIPTION
# Description

Fixed sorting settings in summary card not displaying and working correctly.

## Useful links

[ticket](url)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested verifying in the  summary card settings if the sorting settings is now displaying and working correctly.

## Screenshots

![Peek 11-09-2023 09-15](https://github.com/ReliefApplications/oort-frontend/assets/56398308/15448839-0c2d-4c4b-92ed-ddf491878e55)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
