### PR TITLE
OORT-fix/IM-45_workflow-context-withm-multiple-grids

### DIFF
--- a/libs/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -454,7 +454,7 @@ export class SafeGridWidgetComponent
           this.dashboardService.dashboard$
         );
         if (!dashboard?.id) return;
-        this.workflowService.addToContext(
+        this.workflowService.setContext(
           dashboard.id,
           this.settings.id,
           this.grid.selectedRows

--- a/libs/safe/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/safe/src/lib/services/form-builder/form-builder.service.ts
@@ -108,7 +108,7 @@ export class SafeFormBuilderService {
 
     // Add custom variables
     this.formHelpersService.addUserVariables(survey);
-    this.formHelpersService.addWorkflowVariables(survey);
+    this.formHelpersService.setWorkflowContextVariable(survey);
     if (record) {
       this.formHelpersService.addRecordIDVariable(survey, record);
     }
@@ -215,10 +215,14 @@ export class SafeFormBuilderService {
         survey.openOnQuestionValuesPage
       );
       const page = survey.getPageByName(question.value);
-      selectedPageIndex.next(page.visibleIndex);
+      if (page) {
+        selectedPageIndex.next(page.visibleIndex);
+      }
     } else if (survey.openOnPage) {
       const page = survey.getPageByName(survey.openOnPage);
-      selectedPageIndex.next(page.visibleIndex);
+      if (page) {
+        selectedPageIndex.next(page.visibleIndex);
+      }
     }
     survey.onClearFiles.add((_, options: any) => this.onClearFiles(options));
     survey.onUploadFiles.add((_, options: any) =>

--- a/libs/safe/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/safe/src/lib/services/form-helper/form-helper.service.ts
@@ -341,19 +341,11 @@ export class SafeFormHelpersService {
    *
    * @param survey Survey instance
    */
-  public addWorkflowVariables = (survey: Survey.SurveyModel) => {
+  public setWorkflowContextVariable = (survey: Survey.SurveyModel) => {
     firstValueFrom(this.workflowService.workflowContext$).then((context) => {
-      const dashboardIds = Object.keys(context || {});
-      dashboardIds.forEach((dashboardId) => {
-        const widgets = Object.keys(context[dashboardId] || {});
-        widgets.forEach((widgetId) => {
-          const selectedIds = context[dashboardId][widgetId];
-          survey.setVariable(
-            `workflow_${dashboardId}_${widgetId}`,
-            selectedIds
-          );
-        });
-      });
+      if (!context) return;
+      const { dashboard, widget, rows } = context;
+      survey.setVariable(`workflow_${dashboard}_${widget}`, rows);
     });
   };
 

--- a/libs/safe/src/lib/services/workflow/workflow.service.ts
+++ b/libs/safe/src/lib/services/workflow/workflow.service.ts
@@ -19,17 +19,12 @@ import { SafeApplicationService } from '../application/application.service';
 import { TranslateService } from '@ngx-translate/core';
 import { SnackbarService } from '@oort-front/ui';
 
-/**
- * Defines the type for workflow context.
- * Contains the ids of selected rows for each grid when the 'Next step' button is clicked.
- */
+/** Defines the type for workflow context. */
 type WorkflowContext = {
-  // each key is a dashboard id
-  [key: string]: {
-    // each key is a widget id
-    [key: string]: string[];
-  };
-};
+  dashboard: string;
+  widget: string;
+  rows: string[];
+} | null;
 
 /**
  * Workflow service. Handles modification of workflow ( step addition / step name update ) and some workflow actions.
@@ -48,7 +43,7 @@ export class SafeWorkflowService {
   public nextStep = new EventEmitter<void>();
 
   /** Current workflow context */
-  private workflowContext = new BehaviorSubject<WorkflowContext>({});
+  private workflowContext = new BehaviorSubject<WorkflowContext>(null);
   /** @returns Current workflow context as observable */
   get workflowContext$(): Observable<WorkflowContext> {
     return this.workflowContext.asObservable();
@@ -214,22 +209,15 @@ export class SafeWorkflowService {
    * @param widgetId widget id
    * @param rows selected rows
    */
-  public addToContext(
+  public setContext(
     dashboardId: string,
     widgetId: string,
     rows: string[]
   ): void {
-    // If necessary to send full workflow context
-    // const context = this.workflowContext.getValue();
-    // if (!context[dashboardId]) {
-    //   context[dashboardId] = {};
-    // }
-    // context[dashboardId][widgetId] = rows;
-    const context = {
-      [dashboardId]: {
-        [widgetId]: rows,
-      },
-    };
-    this.workflowContext.next(context);
+    this.workflowContext.next({
+      dashboard: dashboardId,
+      widget: widgetId,
+      rows,
+    });
   }
 }

--- a/libs/safe/src/lib/services/workflow/workflow.service.ts
+++ b/libs/safe/src/lib/services/workflow/workflow.service.ts
@@ -219,11 +219,17 @@ export class SafeWorkflowService {
     widgetId: string,
     rows: string[]
   ): void {
-    const context = this.workflowContext.getValue();
-    if (!context[dashboardId]) {
-      context[dashboardId] = {};
-    }
-    context[dashboardId][widgetId] = rows;
+    // If necessary to send full workflow context
+    // const context = this.workflowContext.getValue();
+    // if (!context[dashboardId]) {
+    //   context[dashboardId] = {};
+    // }
+    // context[dashboardId][widgetId] = rows;
+    const context = {
+      [dashboardId]: {
+        [widgetId]: rows,
+      },
+    };
     this.workflowContext.next(context);
   }
 }


### PR DESCRIPTION
# Description
Issue with the workflow context (getWorkflowContext custom function) when working with multiple grids in the same dashboard: the first value is always set in the question form

## Useful links

[- Please insert link to ticket](https://oortcloud.atlassian.net/jira/software/projects/IM/boards/5?selectedIssue=IM-45)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
- Create a workflow where the first step is a dashboard and the second step is a form
- In the dashboard step add 2 grids of the same resource and action buttons to got to the next step of the workflow
- In the form, set a question that uses the getWorkflowContext to get its default value and creates an expression that gets the value for the first grid or of the second grid

## Screenshots
[context-workflow.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/01cc14e5-c12d-4c94-b293-7243670f0607)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
