### PR TITLE
Fix 2.x/ab#74676 db global scrollbar style

### DIFF
--- a/libs/safe/src/lib/style/styles.scss
+++ b/libs/safe/src/lib/style/styles.scss
@@ -151,6 +151,10 @@ body {
 body {
   margin: 0;
   overflow: hidden;
+
+  scrollbar-width: auto;
+  scrollbar-gutter: stable;
+  scrollbar-color: #d4d4d9 white;
 }
 
 // Widgets

--- a/libs/safe/src/lib/style/styles.scss
+++ b/libs/safe/src/lib/style/styles.scss
@@ -152,7 +152,7 @@ body {
   margin: 0;
   overflow: hidden;
 
-  scrollbar-width: auto;
+  scrollbar-width: thin;
   scrollbar-gutter: stable;
   scrollbar-color: #d4d4d9 white;
 }

--- a/libs/ui/src/style/styles.scss
+++ b/libs/ui/src/style/styles.scss
@@ -145,6 +145,10 @@ body {
   margin: 0;
   font-family: Roboto, 'Helvetica Neue', sans-serif;
   overflow: hidden;
+
+  scrollbar-width: auto;
+  scrollbar-gutter: stable;
+  scrollbar-color: #d4d4d9 white;
 }
 
 .widget-header {

--- a/libs/ui/src/style/styles.scss
+++ b/libs/ui/src/style/styles.scss
@@ -146,7 +146,7 @@ body {
   font-family: Roboto, 'Helvetica Neue', sans-serif;
   overflow: hidden;
 
-  scrollbar-width: auto;
+  scrollbar-width: thin;
   scrollbar-gutter: stable;
   scrollbar-color: #d4d4d9 white;
 }


### PR DESCRIPTION
# Description

Standardize scrollbar style between webkit supported browsers and mozilla.
New properties were added to the front and back offices style files.

Mozilla scrollbars are managed by the browser, so it could look different depending on the used browser. We can only manage colors and size.

## Useful links

- [#74676 DB - Style not getting applied in Firefox browser](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/74676)
- [Mozilla scrollbar properties](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Opened WHO in the firefox browser and checked the scrollbar style

## Screenshots

###Before
![Screenshot from 2023-09-13 11-46-49](https://github.com/ReliefApplications/oort-frontend/assets/94831019/29c229ad-0799-4e9d-bac0-19f48253048c)

###After
![Screenshot from 2023-09-13 11-46-55](https://github.com/ReliefApplications/oort-frontend/assets/94831019/8c2b5472-5535-41fd-b646-7418bbc76e52)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
