### PR TITLE
fix/AB#71655-filter-applied-only-saved-aggregation-twice

### DIFF
--- a/libs/safe/src/lib/components/filter/filter-row/filter-row.component.ts
+++ b/libs/safe/src/lib/components/filter/filter-row/filter-row.component.ts
@@ -125,7 +125,10 @@ export class FilterRowComponent
         type?.operators?.includes(x.value)
       );
       if (init) {
-        this.form.get('operator')?.setValue(type?.defaultOperator);
+        /** If type undefined, use as default 'eq' operator and not undefined. */
+        this.form
+          .get('operator')
+          ?.setValue(type?.defaultOperator ?? FILTER_OPERATORS[0].value);
       } else {
         this.form.get('operator')?.setValue(this.form.value.operator);
       }


### PR DESCRIPTION
# Description
When building a filter stage for aggregation, the fields sent to the form-group and form-row didn't have the editor proprieties, so when adding a new form array to the form group the `operator` was always undefined. But if the filter stage already existed, when updating the aggregation the form group created uses the default value 'eq' for the operator so the form-group and form-row component didn't nullify the field `operator` and the chart data was correctly displayed. 

## Useful links

[- Please insert link to ticket
](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/71655)

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Create a chart
2. Create aggregation with filter stage
3. Save aggregation and save chart
4. The chart will show the filtered data

## Screenshots
[aggreg-filter.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/32d2afe3-b990-4ee2-8d95-fa9ea73d0a31)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
