### PR TITLE
Fix/ab#75167 prefill user data after saved one

### DIFF
--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -164,11 +164,15 @@ export class SafeFormComponent
         //verify if have defaultValueExpression
         if (question.defaultValueExpression) {
           //get the defaultExpression in the right format
-          const questionDefaultExpression = question.defaultValueExpression.replace('{', '').replace('}', '');
+          const questionDefaultExpression = question.defaultValueExpression
+            .replace('{', '')
+            .replace('}', '');
           //verify if the defaultExpression is setted in variables
           if (this.survey.getVariable(questionDefaultExpression)) {
             //update the question value with the variable
-            question.updateValueFromSurvey(this.survey.getVariable(questionDefaultExpression));
+            question.updateValueFromSurvey(
+              this.survey.getVariable(questionDefaultExpression)
+            );
           }
         }
       });
@@ -232,11 +236,15 @@ export class SafeFormComponent
       //verify if have defaultValueExpression
       if (question.defaultValueExpression) {
         //get the defaultExpression in the right format
-        const questionDefaultExpression = question.defaultValueExpression.replace('{', '').replace('}', '');
+        const questionDefaultExpression = question.defaultValueExpression
+          .replace('{', '')
+          .replace('}', '');
         //verify if the defaultExpression is setted in variables
         if (this.survey.getVariable(questionDefaultExpression)) {
           //update the question value with the variable
-          question.updateValueFromSurvey(this.survey.getVariable(questionDefaultExpression));
+          question.updateValueFromSurvey(
+            this.survey.getVariable(questionDefaultExpression)
+          );
         }
       }
     });

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -157,25 +157,7 @@ export class SafeFormComponent
 
     if (cachedData) {
       this.survey.data = cachedData;
-      this.formHelpersService.addUserVariables(this.survey);
-      const surveyQuestion = this.survey.getAllQuestions();
-      //get all questions
-      surveyQuestion.forEach((question: any) => {
-        //verify if have defaultValueExpression
-        if (question.defaultValueExpression) {
-          //get the defaultExpression in the right format
-          const questionDefaultExpression = question.defaultValueExpression
-            .replace('{', '')
-            .replace('}', '');
-          //verify if the defaultExpression is setted in variables
-          if (this.survey.getVariable(questionDefaultExpression)) {
-            //update the question value with the variable
-            question.updateValueFromSurvey(
-              this.survey.getVariable(questionDefaultExpression)
-            );
-          }
-        }
-      });
+      this.setUserVariables();
     } else if (this.form.uniqueRecord && this.form.uniqueRecord.data) {
       this.survey.data = this.form.uniqueRecord.data;
       this.modifiedAt = this.form.uniqueRecord.modifiedAt || null;
@@ -225,10 +207,9 @@ export class SafeFormComponent
   }
 
   /**
-   * Reset the survey to empty
+   * Set user variables
    */
-  public reset(): void {
-    this.survey.clear();
+  private setUserVariables(): void {
     this.formHelpersService.addUserVariables(this.survey);
     const surveyQuestion = this.survey.getAllQuestions();
     //get all questions
@@ -248,6 +229,14 @@ export class SafeFormComponent
         }
       }
     });
+  } 
+
+  /**
+   * Reset the survey to empty
+   */
+  public reset(): void {
+    this.survey.clear();
+    this.setUserVariables();
     this.temporaryFilesStorage = {};
     this.survey.showCompletedPage = false;
     this.save.emit({ completed: false });

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -157,6 +157,21 @@ export class SafeFormComponent
 
     if (cachedData) {
       this.survey.data = cachedData;
+      this.formHelpersService.addUserVariables(this.survey);
+      const surveyQuestion = this.survey.getAllQuestions();
+      //get all questions
+      surveyQuestion.forEach((question: any) => {
+        //verify if have defaultValueExpression
+        if (question.defaultValueExpression) {
+          //get the defaultExpression in the right format
+          const questionDefaultExpression = question.defaultValueExpression.replace('{', '').replace('}', '');
+          //verify if the defaultExpression is setted in variables
+          if (this.survey.getVariable(questionDefaultExpression)) {
+            //update the question value with the variable
+            question.updateValueFromSurvey(this.survey.getVariable(questionDefaultExpression));
+          }
+        }
+      });
     } else if (this.form.uniqueRecord && this.form.uniqueRecord.data) {
       this.survey.data = this.form.uniqueRecord.data;
       this.modifiedAt = this.form.uniqueRecord.modifiedAt || null;
@@ -210,6 +225,21 @@ export class SafeFormComponent
    */
   public reset(): void {
     this.survey.clear();
+    this.formHelpersService.addUserVariables(this.survey);
+    const surveyQuestion = this.survey.getAllQuestions();
+    //get all questions
+    surveyQuestion.forEach((question: any) => {
+      //verify if have defaultValueExpression
+      if (question.defaultValueExpression) {
+        //get the defaultExpression in the right format
+        const questionDefaultExpression = question.defaultValueExpression.replace('{', '').replace('}', '');
+        //verify if the defaultExpression is setted in variables
+        if (this.survey.getVariable(questionDefaultExpression)) {
+          //update the question value with the variable
+          question.updateValueFromSurvey(this.survey.getVariable(questionDefaultExpression));
+        }
+      }
+    });
     this.temporaryFilesStorage = {};
     this.survey.showCompletedPage = false;
     this.save.emit({ completed: false });

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -157,7 +157,7 @@ export class SafeFormComponent
 
     if (cachedData) {
       this.survey.data = cachedData;
-      this.setUserVariables();
+      // this.setUserVariables();
     } else if (this.form.uniqueRecord && this.form.uniqueRecord.data) {
       this.survey.data = this.form.uniqueRecord.data;
       this.modifiedAt = this.form.uniqueRecord.modifiedAt || null;
@@ -207,40 +207,19 @@ export class SafeFormComponent
   }
 
   /**
-   * Set user variables
-   */
-  private setUserVariables(): void {
-    this.formHelpersService.addUserVariables(this.survey);
-    const surveyQuestion = this.survey.getAllQuestions();
-    //get all questions
-    surveyQuestion.forEach((question: any) => {
-      //verify if have defaultValueExpression
-      if (question.defaultValueExpression) {
-        //get the defaultExpression in the right format
-        const questionDefaultExpression = question.defaultValueExpression
-          .replace('{', '')
-          .replace('}', '');
-        //verify if the defaultExpression is setted in variables
-        if (this.survey.getVariable(questionDefaultExpression)) {
-          //update the question value with the variable
-          question.updateValueFromSurvey(
-            this.survey.getVariable(questionDefaultExpression)
-          );
-        }
-      }
-    });
-  }
-
-  /**
    * Reset the survey to empty
    */
   public reset(): void {
     this.survey.clear();
-    this.setUserVariables();
+    /** Reset custom variables */
+    this.formHelpersService.addUserVariables(this.survey);
+    /** Force reload of the survey so default value are being applied */
+    this.survey.fromJSON(this.survey.toJSON());
     this.temporaryFilesStorage = {};
     this.survey.showCompletedPage = false;
     this.save.emit({ completed: false });
     this.survey.render();
+    console.log(this.survey);
     setTimeout(() => (this.surveyActive = true), 100);
   }
 

--- a/libs/safe/src/lib/components/form/form.component.ts
+++ b/libs/safe/src/lib/components/form/form.component.ts
@@ -229,7 +229,7 @@ export class SafeFormComponent
         }
       }
     });
-  } 
+  }
 
   /**
    * Reset the survey to empty


### PR DESCRIPTION
# Description

Fixed prefill user data when using "new record" after having saved one.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/75167)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested creating a form with some fields with default value expressions as described in the ticket and adding a record and then clicking in "new record" and verifying if the fields were prefilled.

## Screenshots

![Peek 15-09-2023 17-02](https://github.com/ReliefApplications/oort-frontend/assets/56398308/3e0e425b-9a9e-436b-bfcb-e4b5ed223a65)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
