### PR TITLE
Feat/ab#74663 open settings when creating new widget

### DIFF
--- a/libs/safe/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/safe/src/lib/components/widget-grid/widget-grid.component.ts
@@ -177,8 +177,29 @@ export class SafeWidgetGridComponent
    *
    * @param e new widget.
    */
-  onAdd(e: any): void {
+  async onAdd(e: any): Promise<void> {
     this.add.emit(e);
+    if (e) {
+      const tile = JSON.parse(JSON.stringify(e));
+      if (tile) {
+        //open settings automatically
+        const { SafeTileDataComponent } = await import(
+          './floating-options/menu/tile-data/tile-data.component'
+        );
+        const dialogRef = this.dialog.open(SafeTileDataComponent, {
+          disableClose: true,
+          data: {
+            tile: tile,
+            template: this.dashboardService.findSettingsTemplate(tile),
+          },
+        });
+        dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((res: any) => {
+          if (res) {
+            this.edit.emit({ type: 'data', id: this.widgets[this.widgets.length - 1].id, options: res });
+          }
+        });
+      }
+    }
   }
 
   /**

--- a/libs/safe/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/safe/src/lib/components/widget-grid/widget-grid.component.ts
@@ -193,11 +193,17 @@ export class SafeWidgetGridComponent
             template: this.dashboardService.findSettingsTemplate(tile),
           },
         });
-        dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((res: any) => {
-          if (res) {
-            this.edit.emit({ type: 'data', id: this.widgets[this.widgets.length - 1].id, options: res });
-          }
-        });
+        dialogRef.closed
+          .pipe(takeUntil(this.destroy$))
+          .subscribe((res: any) => {
+            if (res) {
+              this.edit.emit({
+                type: 'data',
+                id: this.widgets[this.widgets.length - 1].id,
+                options: res,
+              });
+            }
+          });
       }
     }
   }

--- a/libs/safe/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/safe/src/lib/components/widget-grid/widget-grid.component.ts
@@ -178,7 +178,6 @@ export class SafeWidgetGridComponent
    * @param e new widget.
    */
   async onAdd(e: any): Promise<void> {
-    this.add.emit(e);
     if (e) {
       const tile = JSON.parse(JSON.stringify(e));
       if (tile) {
@@ -197,11 +196,14 @@ export class SafeWidgetGridComponent
           .pipe(takeUntil(this.destroy$))
           .subscribe((res: any) => {
             if (res) {
-              this.edit.emit({
-                type: 'data',
-                id: this.widgets[this.widgets.length - 1].id,
-                options: res,
-              });
+              this.add.emit(e);
+              setTimeout(() => {
+                this.edit.emit({
+                  type: 'data',
+                  id: this.widgets[this.widgets.length - 1].id,
+                  options: res,
+                });
+              }, 500);
             }
           });
       }

--- a/libs/safe/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/safe/src/lib/components/widget-grid/widget-grid.component.ts
@@ -173,7 +173,8 @@ export class SafeWidgetGridComponent
   }
 
   /**
-   * Emits addition event.
+   * Open settings component for widget edition.
+   * Emits addition event if edition should be saved.
    *
    * @param e new widget.
    */
@@ -181,7 +182,7 @@ export class SafeWidgetGridComponent
     if (e) {
       const tile = JSON.parse(JSON.stringify(e));
       if (tile) {
-        //open settings automatically
+        /** Open settings dialog component from the widget.  */
         const { SafeTileDataComponent } = await import(
           './floating-options/menu/tile-data/tile-data.component'
         );
@@ -194,16 +195,13 @@ export class SafeWidgetGridComponent
         });
         dialogRef.closed
           .pipe(takeUntil(this.destroy$))
-          .subscribe((res: any) => {
-            if (res) {
-              this.add.emit(e);
-              setTimeout(() => {
-                this.edit.emit({
-                  type: 'data',
-                  id: this.widgets[this.widgets.length - 1].id,
-                  options: res,
-                });
-              }, 500);
+          .subscribe((value: any) => {
+            // Should save the value, and so, add the widget to the grid
+            if (value) {
+              this.add.emit({
+                ...tile,
+                settings: value,
+              });
             }
           });
       }


### PR DESCRIPTION
# Description

Improved user flow  when adding a new widget from dashboard, now it opens the settings.

## Useful links

[User story](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/74663)
[Improvement ticket for implementation](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/75272)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested creating new widgets of all types and testing if after it's created it opens the settings and when saving the settings is correctly applied to the widget.

## Screenshots

![Peek 18-09-2023 09-21](https://github.com/ReliefApplications/oort-frontend/assets/56398308/920109e9-185f-4352-bb80-e61045ae72ef)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
