### PR TITLE
Oort fix/im 57 translation of date questions

### DIFF
--- a/apps/back-office/src/app/app.module.ts
+++ b/apps/back-office/src/app/app.module.ts
@@ -1,5 +1,10 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule, ErrorHandler, APP_INITIALIZER } from '@angular/core';
+import {
+  NgModule,
+  ErrorHandler,
+  APP_INITIALIZER,
+  LOCALE_ID,
+} from '@angular/core';
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -38,6 +43,10 @@ import { PureAbility } from '@casl/ability';
 // Register local translations for dates
 registerLocaleData(localeFr);
 registerLocaleData(localeEn);
+
+// Imports to translate datepickers
+import '@progress/kendo-angular-intl/locales/en/all';
+import '@progress/kendo-angular-intl/locales/fr/all';
 
 import { PopupService } from '@progress/kendo-angular-popup';
 import { ResizeBatchService } from '@progress/kendo-angular-common';
@@ -109,6 +118,10 @@ export const httpTranslateLoader = (http: HttpClient) =>
     MonacoEditorModule.forRoot(),
   ],
   providers: [
+    {
+      provide: LOCALE_ID,
+      useValue: localStorage.getItem('lang'),
+    },
     {
       provide: 'environment',
       useValue: environment,

--- a/apps/front-office/src/app/app.module.ts
+++ b/apps/front-office/src/app/app.module.ts
@@ -1,5 +1,10 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule, APP_INITIALIZER, ErrorHandler } from '@angular/core';
+import {
+  NgModule,
+  APP_INITIALIZER,
+  ErrorHandler,
+  LOCALE_ID,
+} from '@angular/core';
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -69,6 +74,10 @@ import {
 import { Router } from '@angular/router';
 import * as Sentry from '@sentry/angular-ivy';
 
+// Imports to translate datepickers
+import '@progress/kendo-angular-intl/locales/en/all';
+import '@progress/kendo-angular-intl/locales/fr/all';
+
 /**
  * Initialize authentication in the platform.
  * Configuration in environment file.
@@ -117,6 +126,10 @@ export const httpTranslateLoader = (http: HttpClient) =>
     DateInputsModule,
   ],
   providers: [
+    {
+      provide: LOCALE_ID,
+      useValue: localStorage.getItem('lang'),
+    },
     {
       provide: 'environment',
       useValue: environment,

--- a/apps/web-widgets/src/app/app.module.ts
+++ b/apps/web-widgets/src/app/app.module.ts
@@ -4,6 +4,7 @@ import {
   ElementRef,
   Injector,
   NgModule,
+  LOCALE_ID,
 } from '@angular/core';
 import { createCustomElement } from '@angular/elements';
 import { BrowserModule } from '@angular/platform-browser';
@@ -30,6 +31,9 @@ import {
   TranslateModule,
   TranslateService,
 } from '@ngx-translate/core';
+// Imports to translate datepickers
+import '@progress/kendo-angular-intl/locales/en/all';
+import '@progress/kendo-angular-intl/locales/fr/all';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { MessageService } from '@progress/kendo-angular-l10n';
 import {
@@ -103,6 +107,10 @@ const provideOverlay = (_platform: Platform): AppOverlayContainer =>
     GraphQLModule,
   ],
   providers: [
+    {
+      provide: LOCALE_ID,
+      useValue: localStorage.getItem('lang'),
+    },
     {
       provide: 'environment',
       useValue: environment,

--- a/libs/safe/src/lib/components/preferences-modal/preferences-modal.component.ts
+++ b/libs/safe/src/lib/components/preferences-modal/preferences-modal.component.ts
@@ -20,6 +20,7 @@ import {
   IconModule,
 } from '@oort-front/ui';
 import { DIALOG_DATA } from '@angular/cdk/dialog';
+import { CldrIntlService, IntlService } from '@progress/kendo-angular-intl';
 
 /** Preferences Dialog Data */
 interface PreferencesDialogData {
@@ -64,12 +65,14 @@ export class SafePreferencesModalComponent implements OnInit {
    * @param formBuilder This is the service that will be used to build forms.
    * @param translate This is the Angular service that translates text
    * @param dateTranslate Shared service for Date Translation
+   * @param kendoIntl Kendo internationalization service
    */
   constructor(
     @Inject(DIALOG_DATA) public data: PreferencesDialogData,
     private formBuilder: UntypedFormBuilder,
     private translate: TranslateService,
-    private dateTranslate: SafeDateTranslateService
+    private dateTranslate: SafeDateTranslateService,
+    private kendoIntl: IntlService
   ) {
     // find the current language
     this.currLang = this.translate.currentLang || this.translate.defaultLang;
@@ -102,6 +105,7 @@ export class SafePreferencesModalComponent implements OnInit {
       .get('language')
       ?.valueChanges.subscribe((lang: any) => {
         this.translate.use(lang);
+        (this.kendoIntl as CldrIntlService).localeId = lang;
       });
   }
 


### PR DESCRIPTION
# Description

Now when a user set its preferences to another language the kendo date-pickers which he might encounter on forms will be translated to the language selected. It sometimes is necessary to reload the page for this to take change.

Useful links

## Useful links

(https://oortcloud.atlassian.net/browse/IM-57)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

-Create a form with a single input of a date, date-time, etc which contains a picker and save it.
-Enter the form as to test it and change your language in the prefences modal. Reload the page if necessary.
-The calendar should be translated.

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/39497117/3f06709f-3982-4948-9a7a-d5f495d7d8d3)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
