### PR TITLE
feat/AB#75506_better-use-of-at-param-in-filters

### DIFF
--- a/apps/back-office/src/app/application/pages/archive/archive.component.ts
+++ b/apps/back-office/src/app/application/pages/archive/archive.component.ts
@@ -77,7 +77,6 @@ export class ArchiveComponent extends UnsubscribeComponent implements OnInit {
       )
       .subscribe({
         next: ({ data }) => {
-          // console.log(data);
           if (data) {
             this.pages =
               (data.application.pages || []).map((page) => {

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1865,8 +1865,10 @@
 				"selectDisplayField": "Select display field",
 				"selectOrigin": "Select context origin"
 			},
+			"contextFilter": "Context filter",
 			"dashboardFilter": "Dashboard filter",
 			"deactivateFiltering": "Deactivate filtering",
+			"historicalDate": "Historical Date",
 			"share": "Share Dashboard",
 			"tooltip": {
 				"useDashboardFilterEditor": "Use dashboard filter editor",

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1891,9 +1891,11 @@
 			"contextFilter": "Context filter",
 			"dashboardFilter": "Dashboard filter",
 			"deactivateFiltering": "Deactivate filtering",
-			"historicalDate": "Historical Date",
+			"historicalDate": "Get dataset at",
 			"share": "Share Dashboard",
 			"tooltip": {
+				"dashboardFilter": "You can use fields from the dashboard filter as well as static values to filter the dataset.",
+				"historicalDate": "You can use a field from the dashboard filter to query dataset at a specific date.\nIndicate which field to use, by using this syntax: {{filter.<name>}}.",
 				"useDashboardFilterEditor": "Use dashboard filter editor",
 				"useDefaultEditor": "Use default editor"
 			}

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1904,12 +1904,14 @@
 				"selectDisplayField": "Sélectionnez le champ d'affichage",
 				"selectOrigin": "Sélectionnez la source de données"
 			},
-			"contextFilter": "Filtre de contexte",
-			"dashboardFilter": "Filtre de tableaux de bord",
+			"contextFilter": "Filtre contextuel",
+			"dashboardFilter": "Filtre du tableau de bord",
 			"deactivateFiltering": "Désactiver le filtre",
-			"historicalDate": "Date historique",
+			"historicalDate": "Récupérer les données historiques",
 			"share": "Partager le tableau de bord",
 			"tooltip": {
+				"dashboardFilter": "Vous pouvez utiliser les champs du filtre du tableau de bord, ou utiliser des valeurs statiques.",
+				"historicalDate": "Vous pouvez récupérer les données à une date spécifique en utilisant un champ du filtre du tableau de board.\nVeuillez alors utiliser cette syntaxe : {{filter.<nom>}}.",
 				"useDashboardFilterEditor": "Utiliser l'éditeur de tableaux de bord",
 				"useDefaultEditor": "Utiliser l'éditeur par défaut"
 			}

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1881,8 +1881,10 @@
 				"selectDisplayField": "Sélectionnez le champ d'affichage",
 				"selectOrigin": "Sélectionnez la source de données"
 			},
+			"contextFilter": "Filtre de contexte",
 			"dashboardFilter": "Filtre de tableaux de bord",
 			"deactivateFiltering": "Désactiver le filtre",
+			"historicalDate": "Date historique",
 			"share": "Partager le tableau de bord",
 			"tooltip": {
 				"useDashboardFilterEditor": "Utiliser l'éditeur de tableaux de bord",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1894,6 +1894,8 @@
 			"historicalDate": "******",
 			"share": "******",
 			"tooltip": {
+				"dashboardFilter": "******",
+				"historicalDate": "****** {{filter.<name>}} ******",
 				"useDashboardFilterEditor": "******",
 				"useDefaultEditor": "******"
 			}

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1865,8 +1865,10 @@
 				"selectDisplayField": "******",
 				"selectOrigin": "******"
 			},
+			"contextFilter": "******",
 			"dashboardFilter": "******",
 			"deactivateFiltering": "******",
+			"historicalDate": "******",
 			"share": "******",
 			"tooltip": {
 				"useDashboardFilterEditor": "******",

--- a/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
+++ b/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
@@ -124,9 +124,7 @@ export class AggregationGridComponent
             JSON.parse(this.contextFilters)
           )
         : undefined,
-      this.contextService.isFilterEnabled.getValue() && this.at
-        ? this.contextService.atArgumentValue(this.at)
-        : undefined
+      this.at ? this.contextService.atArgumentValue(this.at) : undefined
     );
     this.dataQuery.valueChanges.pipe(takeUntil(this.destroy$)).subscribe({
       next: ({ data, loading }) => {

--- a/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
+++ b/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
@@ -51,7 +51,10 @@ export class AggregationGridComponent
 
   @Input() resourceId!: string;
   @Input() aggregation!: Aggregation;
+  /** Context filters to be used with dashboard filters */
   @Input() contextFilters: string | undefined;
+  /** Version at to be used with dashboard filters */
+  @Input() at: string | undefined;
 
   /** @returns The column menu */
   get columnMenu(): { columnChooser: boolean; filter: boolean } {
@@ -120,6 +123,9 @@ export class AggregationGridComponent
         ? this.contextService.injectDashboardFilterValues(
             JSON.parse(this.contextFilters)
           )
+        : undefined,
+      this.contextService.isFilterEnabled.getValue() && this.at
+        ? this.contextService.atArgumentValue(this.at)
         : undefined
     );
     this.dataQuery.valueChanges.pipe(takeUntil(this.destroy$)).subscribe({

--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -350,23 +350,34 @@ export class DashboardFilterComponent
    * @param value value to check if is a date
    * @returns If value is a date or not, and if it's the formatted value (questionName: formatted)
    */
-  public isDate(
+  private isDate(
     questionName: string,
     value: any
   ): { isDate: boolean; formattedValue?: string } {
     const checkDate = (str: any) => {
-      if (str === null || str === undefined) {
-        return false; // Handle null or undefined input
+      if (typeof str === 'string') {
+        // Checks the date or datetime in the input string
+        // (datetimes are formatted as date)
+        const datePart = str.match(
+          /\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}\.\d{3}Z)?/
+        );
+        if (!datePart) {
+          return false; // Invalid format
+        }
+        // Check if date is valid
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const [y, M, d, h, m, s] = str.split(/[- : T Z]/);
+        return y && parseFloat(M) <= 12 && parseFloat(d) <= 31 ? true : false;
+      } else {
+        // Don't check objects (time questions included)
+        return false;
       }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [y, M, d, h, m, s] = str.split(/[- : T Z]/);
-      return y && M <= 12 && d <= 31 ? true : false;
     };
     if (checkDate(value)) {
       const date = new Date(value);
       const formatted = new DatePipe(this.dateTranslate).transform(
         date,
-        'short'
+        'shortDate'
       );
       return { isDate: true, formattedValue: `${questionName}: ${formatted}` };
     } else {
@@ -427,6 +438,8 @@ export class DashboardFilterComponent
       .reduce(function (acc, question) {
         acc = {
           ...acc,
+          // isPrimitiveValue property is just for the tagbox/dropdown/checkbox/radio questions
+          // So if undefined, we can just skip it if for the other type of fields
           [question.name]: question.isPrimitiveValue ?? true,
         };
         return acc;

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -393,6 +393,9 @@ export class CoreGridComponent
             sortField: this.sortField || undefined,
             sortOrder: this.sortOrder,
             styles: this.style,
+            at: this.settings.at
+              ? this.contextService.atArgumentValue(this.settings.at)
+              : undefined,
           },
           fetchPolicy: 'no-cache',
           nextFetchPolicy: 'cache-first',
@@ -1318,6 +1321,9 @@ export class CoreGridComponent
         sortField: this.sortField || undefined,
         sortOrder: this.sortOrder,
         styles: this.style,
+        ...(this.settings.at && {
+          at: this.contextService.atArgumentValue(this.settings.at),
+        }),
       })
       .then(() => (this.loading = false));
   }

--- a/libs/shared/src/lib/components/ui/map/interfaces/layer-settings.type.ts
+++ b/libs/shared/src/lib/components/ui/map/interfaces/layer-settings.type.ts
@@ -59,6 +59,7 @@ export interface LayerFormData {
   };
   sublayers?: string[];
   contextFilters: string;
+  at: string;
 }
 
 export type LayerLabel = {

--- a/libs/shared/src/lib/components/widgets/chart-settings/chart-forms.ts
+++ b/libs/shared/src/lib/components/widgets/chart-settings/chart-forms.ts
@@ -329,6 +329,7 @@ export const createChartWidgetForm = (id: any, value: any) =>
     chart: createChartForm(get(value, 'chart')),
     resource: [get(value, 'resource', null), Validators.required],
     contextFilters: [get(value, 'contextFilters', DEFAULT_CONTEXT_FILTER)],
+    at: [get(value, 'at', '')],
   });
 
 /**

--- a/libs/shared/src/lib/components/widgets/chart-settings/chart-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/chart-settings/chart-settings.component.html
@@ -38,7 +38,7 @@
   <ui-tab>
     <ng-container ngProjectAs="label">
       <ui-icon icon="filter_list" [size]="24"></ui-icon>
-      <span>{{ 'models.dashboard.dashboardFilter' | translate }}</span>
+      <span>{{ 'models.dashboard.contextFilter' | translate }}</span>
     </ng-container>
     <ng-template uiTabContent>
       <shared-contextual-filters-settings

--- a/libs/shared/src/lib/components/widgets/chart/chart.component.ts
+++ b/libs/shared/src/lib/components/widgets/chart/chart.component.ts
@@ -157,6 +157,9 @@ export class ChartComponent extends UnsubscribeComponent implements OnChanges {
                 ? this.contextService.injectDashboardFilterValues(
                     JSON.parse(this.settings.contextFilters)
                   )
+                : undefined,
+              this.settings.at
+                ? this.contextService.atArgumentValue(this.settings.at)
                 : undefined
             );
             if (this.dataQuery) {

--- a/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.html
@@ -1,6 +1,18 @@
-<ngx-monaco-editor
-  class="!h-full min-h-[500px]"
-  (onInit)="initEditor($event)"
-  [options]="editorOptions"
-  [formControl]="$any(form.get('contextFilters'))"
-></ngx-monaco-editor>
+<div class="grid gap-x-2">
+  <!-- Dashboard filter -->
+  <h2>{{ 'models.dashboard.dashboardFilter' | translate }}</h2>
+  <div class="grow overflow-y-auto overflow-x-hidden w-full">
+    <ngx-monaco-editor
+      class="!h-full min-h-[450px]"
+      (onInit)="initEditor($event)"
+      [options]="editorOptions"
+      [formControl]="$any(form.get('contextFilters'))"
+    ></ngx-monaco-editor>
+  </div>
+
+  <!-- Historical date (version at) -->
+  <h2 class="mt-2">{{ 'models.dashboard.historicalDate' | translate }}</h2>
+  <div uiFormFieldDirective>
+    <input [formControl]="$any(form.get('at'))" type="string" />
+  </div>
+</div>

--- a/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.html
@@ -1,18 +1,41 @@
-<div class="grid gap-x-2">
-  <!-- Dashboard filter -->
-  <h2>{{ 'models.dashboard.dashboardFilter' | translate }}</h2>
-  <div class="grow overflow-y-auto overflow-x-hidden w-full">
-    <ngx-monaco-editor
-      class="!h-full min-h-[450px]"
-      (onInit)="initEditor($event)"
-      [options]="editorOptions"
-      [formControl]="$any(form.get('contextFilters'))"
-    ></ngx-monaco-editor>
-  </div>
-
+<div class="flex flex-col gap-4 h-full">
   <!-- Historical date (version at) -->
-  <h2 class="mt-2">{{ 'models.dashboard.historicalDate' | translate }}</h2>
-  <div uiFormFieldDirective>
-    <input [formControl]="$any(form.get('at'))" type="string" />
+  <div class="flex flex-col">
+    <h2>
+      {{ 'models.dashboard.historicalDate' | translate }}
+      <ui-icon
+        icon="info_outline"
+        class="cursor-pointer ml-1"
+        variant="grey"
+        [size]="18"
+        uiSuffix
+        [uiTooltip]="'models.dashboard.tooltip.historicalDate' | translate"
+      ></ui-icon>
+    </h2>
+    <div uiFormFieldDirective>
+      <input [formControl]="$any(form.get('at'))" type="string" />
+    </div>
+  </div>
+  <!-- Dashboard filter -->
+  <div class="flex-1 flex flex-col">
+    <h2>
+      {{ 'models.dashboard.dashboardFilter' | translate
+      }}<ui-icon
+        icon="info_outline"
+        class="cursor-pointer ml-1"
+        variant="grey"
+        [size]="18"
+        uiSuffix
+        [uiTooltip]="'models.dashboard.tooltip.dashboardFilter' | translate"
+      ></ui-icon>
+    </h2>
+    <div class="grow overflow-y-auto overflow-x-hidden w-full">
+      <ngx-monaco-editor
+        class="!h-full min-h-[450px]"
+        (onInit)="initEditor($event)"
+        [options]="editorOptions"
+        [formControl]="$any(form.get('contextFilters'))"
+      ></ngx-monaco-editor>
+    </div>
   </div>
 </div>

--- a/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.ts
@@ -2,12 +2,21 @@ import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { FormWrapperModule } from '@oort-front/ui';
 
 /** Component to define the contextual filters of a widget or a map layer */
 @Component({
   selector: 'shared-contextual-filters-settings',
   standalone: true,
-  imports: [CommonModule, MonacoEditorModule, FormsModule, ReactiveFormsModule],
+  imports: [
+    CommonModule,
+    MonacoEditorModule,
+    FormsModule,
+    ReactiveFormsModule,
+    TranslateModule,
+    FormWrapperModule,
+  ],
   templateUrl: './contextual-filters-settings.component.html',
   styleUrls: ['./contextual-filters-settings.component.scss'],
 })

--- a/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { FormWrapperModule } from '@oort-front/ui';
+import { FormWrapperModule, IconModule, TooltipModule } from '@oort-front/ui';
 
 /** Component to define the contextual filters of a widget or a map layer */
 @Component({
@@ -16,6 +16,8 @@ import { FormWrapperModule } from '@oort-front/ui';
     ReactiveFormsModule,
     TranslateModule,
     FormWrapperModule,
+    IconModule,
+    TooltipModule,
   ],
   templateUrl: './contextual-filters-settings.component.html',
   styleUrls: ['./contextual-filters-settings.component.scss'],

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -69,7 +69,7 @@
   <ui-tab>
     <ng-container ngProjectAs="label">
       <ui-icon icon="filter_list" [size]="24"></ui-icon>
-      <span>{{ 'models.dashboard.dashboardFilter' | translate }}</span>
+      <span>{{ 'models.dashboard.contextFilter' | translate }}</span>
     </ng-container>
     <ng-template uiTabContent>
       <shared-contextual-filters-settings

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -151,6 +151,7 @@ export const createGridWidgetFormGroup = (id: string, configuration: any) => {
     contextFilters: [
       get(configuration, 'contextFilters', DEFAULT_CONTEXT_FILTER),
     ],
+    at: get(configuration, 'at', ''),
   });
   return formGroup;
 };

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.html
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.html
@@ -65,6 +65,7 @@
     [resourceId]="settings.resource"
     [aggregation]="aggregation"
     [contextFilters]="widget.settings.contextFilters"
+    [at]="widget.settings.at"
   ></shared-aggregation-grid>
 </ng-template>
 

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.html
@@ -237,7 +237,7 @@
       <ui-tab *ngIf="form.get('datasource')" [disabled]="!isDatasourceValid">
         <ng-container ngProjectAs="label">
           <ui-icon icon="filter_list" [size]="24"></ui-icon>
-          <span>{{ 'models.dashboard.dashboardFilter' | translate }}</span>
+          <span>{{ 'models.dashboard.contextFilter' | translate }}</span>
         </ng-container>
         <ng-template uiTabContent>
           <shared-contextual-filters-settings

--- a/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
@@ -102,6 +102,7 @@ export const createLayerForm = (value?: LayerModel) => {
     contextFilters: new FormControl(
       get(value, 'contextFilters', DEFAULT_CONTEXT_FILTER)
     ),
+    at: new FormControl(get(value, 'at', null)),
   });
   if (type !== 'GroupLayer') {
     formGroup.get('datasource.type')?.valueChanges.subscribe((geometryType) => {

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -71,7 +71,7 @@
     <ui-tab>
       <ng-container ngProjectAs="label">
         <ui-icon icon="filter_list" [size]="24"></ui-icon>
-        <span>{{ 'models.dashboard.dashboardFilter' | translate }}</span>
+        <span>{{ 'models.dashboard.contextFilter' | translate }}</span>
       </ng-container>
       <ng-template uiTabContent>
         <shared-contextual-filters-settings

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -74,6 +74,7 @@ const createSummaryCardForm = (def: any) => {
     contextFilters: new FormControl(
       get(settings, 'contextFilters', DEFAULT_CONTEXT_FILTER)
     ),
+    at: new FormControl(get(settings, 'at', '')),
   });
 
   const isUsingAggregation = !!get(settings, 'card.aggregation', null);

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -204,13 +204,25 @@ export class SummaryCardComponent
     this.contextService.filter$
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(() => {
-        this.setupDynamicCards();
+        this.onPage({
+          pageSize: DEFAULT_PAGE_SIZE,
+          skip: 0,
+          previousPageIndex: 0,
+          pageIndex: 0,
+          totalItems: 0,
+        });
       });
 
     this.contextService.isFilterEnabled$
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(() => {
-        this.setupDynamicCards();
+        this.onPage({
+          pageSize: DEFAULT_PAGE_SIZE,
+          skip: 0,
+          previousPageIndex: 0,
+          pageIndex: 0,
+          totalItems: 0,
+        });
       });
   }
 
@@ -319,6 +331,9 @@ export class SummaryCardComponent
           filter: this.queryFilter,
           sortField: this.sortOptions.field,
           sortOrder: this.sortOptions.order,
+          ...(this.settings.at && {
+            at: this.contextService.atArgumentValue(this.settings.at),
+          }),
         })
         .then(this.updateCards.bind(this));
     }
@@ -437,6 +452,9 @@ export class SummaryCardComponent
                 sortField: this.sortOptions.field,
                 sortOrder: this.sortOptions.order,
                 styles: layoutQuery.style || null,
+                ...(this.settings.at && {
+                  at: this.contextService.atArgumentValue(this.settings.at),
+                }),
               },
               fetchPolicy: 'network-only',
               nextFetchPolicy: 'cache-first',
@@ -594,6 +612,9 @@ export class SummaryCardComponent
           sortField: this.sortOptions.field,
           sortOrder: this.sortOptions.order,
           styles: layoutQuery?.style || null,
+          ...(this.settings.at && {
+            at: this.contextService.atArgumentValue(this.settings.at),
+          }),
         })
         .then(this.updateCards.bind(this));
     }
@@ -651,6 +672,9 @@ export class SummaryCardComponent
           filter: this.queryFilter,
           sortField: this.sortOptions.field,
           sortOrder: this.sortOptions.order,
+          ...(this.settings.at && {
+            at: this.contextService.atArgumentValue(this.settings.at),
+          }),
         })
         .then(() => (this.loading = false));
     }

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -493,7 +493,10 @@ export class SummaryCardComponent
       card.aggregation,
       DEFAULT_PAGE_SIZE,
       0,
-      this.contextService.injectDashboardFilterValues(this.contextFilters)
+      this.contextService.injectDashboardFilterValues(this.contextFilters),
+      this.widget.settings.at
+        ? this.contextService.atArgumentValue(this.widget.settings.at)
+        : undefined
     );
 
     this.dataQuery.valueChanges

--- a/libs/shared/src/lib/models/layer.model.ts
+++ b/libs/shared/src/lib/models/layer.model.ts
@@ -151,6 +151,7 @@ export interface LayerModel {
   createdAt: Date;
   updatedAt: Date;
   contextFilters?: string;
+  at?: string;
 }
 
 /** Model for AddLayerMutationResponse object */

--- a/libs/shared/src/lib/services/aggregation/aggregation.service.ts
+++ b/libs/shared/src/lib/services/aggregation/aggregation.service.ts
@@ -91,7 +91,7 @@ export class AggregationService {
     aggregation: string,
     mapping?: any,
     contextFilters?: CompositeFilterDescriptor,
-    at?: string
+    at?: Date
   ): Observable<ApolloQueryResult<AggregationDataQueryResponse>> {
     return this.apollo.query<AggregationDataQueryResponse>({
       query: GET_AGGREGATION_DATA,
@@ -122,7 +122,7 @@ export class AggregationService {
     first: number,
     skip: number,
     contextFilters?: CompositeFilterDescriptor,
-    at?: string
+    at?: Date
   ): QueryRef<AggregationDataQueryResponse> {
     return this.apollo.watchQuery<AggregationDataQueryResponse>({
       query: GET_AGGREGATION_DATA,

--- a/libs/shared/src/lib/services/aggregation/aggregation.service.ts
+++ b/libs/shared/src/lib/services/aggregation/aggregation.service.ts
@@ -83,13 +83,15 @@ export class AggregationService {
    * @param aggregation Aggregation definition
    * @param mapping aggregation mapping ( category, field, series )
    * @param contextFilters context filters, if any
+   * @param at 'at' argument value, if any
    * @returns Aggregation query
    */
   aggregationDataQuery(
     resource: string,
     aggregation: string,
     mapping?: any,
-    contextFilters?: CompositeFilterDescriptor
+    contextFilters?: CompositeFilterDescriptor,
+    at?: string
   ): Observable<ApolloQueryResult<AggregationDataQueryResponse>> {
     return this.apollo.query<AggregationDataQueryResponse>({
       query: GET_AGGREGATION_DATA,
@@ -98,6 +100,7 @@ export class AggregationService {
         aggregation,
         mapping,
         contextFilters,
+        at,
       },
     });
   }
@@ -110,6 +113,7 @@ export class AggregationService {
    * @param first size of the page
    * @param skip index of the page
    * @param contextFilters context filters, if any
+   * @param at 'at' argument value, if any
    * @returns Aggregation query
    */
   aggregationDataWatchQuery(
@@ -117,7 +121,8 @@ export class AggregationService {
     aggregation: string,
     first: number,
     skip: number,
-    contextFilters?: CompositeFilterDescriptor
+    contextFilters?: CompositeFilterDescriptor,
+    at?: string
   ): QueryRef<AggregationDataQueryResponse> {
     return this.apollo.watchQuery<AggregationDataQueryResponse>({
       query: GET_AGGREGATION_DATA,
@@ -127,6 +132,7 @@ export class AggregationService {
         first,
         skip,
         contextFilters,
+        at,
       },
     });
   }

--- a/libs/shared/src/lib/services/aggregation/graphql/queries.ts
+++ b/libs/shared/src/lib/services/aggregation/graphql/queries.ts
@@ -37,6 +37,7 @@ export const GET_AGGREGATION_DATA = gql`
     $first: Int
     $skip: Int
     $contextFilters: JSON
+    $at: String
   ) {
     recordsAggregation(
       resource: $resource
@@ -45,6 +46,7 @@ export const GET_AGGREGATION_DATA = gql`
       first: $first
       skip: $skip
       contextFilters: $contextFilters
+      at: $at
     )
   }
 `;

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -152,8 +152,11 @@ export class ContextService {
    * @returns 'at' value
    */
   public atArgumentValue(atField: string): string {
-    const regex = /(?<={{filter\.)(.*?)(?=}})/gim;
-    const atFilterName = atField.match(regex)?.[0] ?? '';
-    return get(this.availableFilterFieldsValue, atFilterName);
+    if (this.isFilterEnabled.getValue()) {
+      const regex = /(?<={{filter\.)(.*?)(?=}})/gim;
+      const atFilterName = atField.match(regex)?.[0] ?? '';
+      return get(this.availableFilterFieldsValue, atFilterName);
+    }
+    return '';
   }
 }

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -24,9 +24,13 @@ export class ContextService {
     value: string;
   }[] = [];
 
+  /** To update/keep the current filter */
   public filter = new BehaviorSubject<Record<string, any>>({});
+  /** To update/keep the current filter structure  */
   public filterStructure = new BehaviorSubject<any>(null);
+  /** To update/keep the current filter position  */
   public filterPosition = new BehaviorSubject<any>(null);
+  /** The current application id */
   private currentApplicationId?: string | null = null;
 
   /** @returns filter value as observable */
@@ -49,11 +53,17 @@ export class ContextService {
     return this.currentApplicationId + ':filterPosition';
   }
 
+  /** Used to update the state of whether the filter is enabled */
   public isFilterEnabled = new BehaviorSubject<boolean>(false);
 
   /** @returns  isFilterEnable value as observable */
   get isFilterEnabled$() {
     return this.isFilterEnabled.asObservable();
+  }
+
+  /** @returns current question values from the filter */
+  get availableFilterFieldsValue(): Record<string, any> {
+    return this.filter.getValue();
   }
 
   /**
@@ -108,14 +118,13 @@ export class ContextService {
     }
 
     const regex = /(?<={{filter\.)(.*?)(?=}})/gim;
-    const availableFilterFields = this.filter.getValue();
 
     if ('field' in filter && filter.field) {
       // If it's a filter descriptor, replace value ( if string )
       if (filter.value && typeof filter.value === 'string') {
         const filterName = filter.value?.match(regex)?.[0];
         if (filterName) {
-          filter.value = get(availableFilterFields, filterName);
+          filter.value = get(this.availableFilterFieldsValue, filterName);
         }
       }
     } else if ('filters' in filter && filter.filters) {
@@ -134,5 +143,17 @@ export class ContextService {
         });
     }
     return filter;
+  }
+
+  /**
+   * Get the 'at' argument value from the filter field selected
+   *
+   * @param atField filter field that should be used as 'at' param
+   * @returns 'at' value
+   */
+  public atArgumentValue(atField: string): string {
+    const regex = /(?<={{filter\.)(.*?)(?=}})/gim;
+    const atFilterName = atField.match(regex)?.[0] ?? '';
+    return get(this.availableFilterFieldsValue, atFilterName);
   }
 }

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -151,12 +151,14 @@ export class ContextService {
    * @param atField filter field that should be used as 'at' param
    * @returns 'at' value
    */
-  public atArgumentValue(atField: string): string {
+  public atArgumentValue(atField: string): Date | undefined {
     if (this.isFilterEnabled.getValue()) {
       const regex = /(?<={{filter\.)(.*?)(?=}})/gim;
       const atFilterName = atField.match(regex)?.[0] ?? '';
-      return get(this.availableFilterFieldsValue, atFilterName);
+      if (get(this.availableFilterFieldsValue, atFilterName)) {
+        return new Date(get(this.availableFilterFieldsValue, atFilterName));
+      }
     }
-    return '';
+    return undefined;
   }
 }

--- a/libs/shared/src/lib/services/map/graphql/queries.ts
+++ b/libs/shared/src/lib/services/map/graphql/queries.ts
@@ -99,6 +99,7 @@ export const GET_LAYER_BY_ID = gql`
       }
       sublayers
       contextFilters
+      at
     }
   }
 `;

--- a/libs/shared/src/lib/services/map/map-layers.service.ts
+++ b/libs/shared/src/lib/services/map/map-layers.service.ts
@@ -347,11 +347,17 @@ export class MapLayersService {
           JSON.parse(layer.contextFilters)
         )
       : {};
+    const at = layer.at
+      ? this.contextService.atArgumentValue(layer.at)
+      : undefined;
     const params = new HttpParams({
       fromObject: omitBy(
         {
           ...layer.datasource,
           contextFilters: JSON.stringify(contextFilters),
+          ...(at && {
+            at: at.toString(),
+          }),
         },
         isNil
       ),

--- a/libs/shared/src/lib/services/query-builder/query-builder.service.ts
+++ b/libs/shared/src/lib/services/query-builder/query-builder.service.ts
@@ -20,6 +20,7 @@ interface QueryVariables {
   sortOrder?: string;
   display?: boolean;
   styles?: any;
+  at?: Date;
 }
 
 /** Interface for a query response */
@@ -337,15 +338,16 @@ export class QueryBuilderService {
    */
   public graphqlQuery(name: string, fields: string[] | string) {
     return gql<QueryResponse, QueryVariables>`
-    query GetCustomQuery($first: Int, $skip: Int, $filter: JSON, $sortField: String, $sortOrder: String, $display: Boolean, $styles: JSON) {
+    query GetCustomQuery($first: Int, $skip: Int, $filter: JSON, $sortField: String, $sortOrder: String, $display: Boolean, $styles: JSON, $at: Date) {
       ${name}(
-      first: $first,
-      skip: $skip,
-      sortField: $sortField,
-      sortOrder: $sortOrder,
-      filter: $filter,
+      first: $first
+      skip: $skip
+      sortField: $sortField
+      sortOrder: $sortOrder
+      filter: $filter
       display: $display
       styles: $styles
+      at: $at
       ) {
         edges {
           node {


### PR DESCRIPTION
# Description
- Created shared method to set valueName automaticaly for both form builder and dashboard filter builder in the form-helper service
- "Dashboard filter" tab renamed to "Context filter" and added input to save new 'at' argument in the contextual-filters-settings component
- Fixed onValueChange method in dashboard-filter component: dashboard filter heard was always empty when field didn't have the isPrimitiveValue property. Also added a method to check if the field is a date, and if so format output in the filter heard to be `<label of question>: <date as it should appears with date pipe>`
- Added in the context service a new method: atArgumentValue, to get the filter field selected and retrieve from the filters the value for the 'at' argument to be used in the recordsAggregation querie
- Update adding the 'at' param the getAggregationData() for: grid, summary cards and charts (@TODO: check if need edit/update something for map layers) 

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/75506)
- [Please insert link to back-end branch if any](https://github.com/ReliefApplications/oort-backend/pull/752)
- Please insert any useful link ( documentation you used for example )

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots
Set the value name is automated for dashboard filter:
[value_name.webm](https://github.com/ReliefApplications/oort-frontend/assets/28535394/1f608a88-164a-4e5d-b6aa-cf9410498d0d)

Context field tab with new input field for 'at' argument:
![context-filter](https://github.com/ReliefApplications/oort-frontend/assets/28535394/c42795bf-bd13-4b94-b68c-634046ce3053)

Date value formated in filter headers:
![format-date](https://github.com/ReliefApplications/oort-frontend/assets/28535394/437f9eda-87c6-409a-a87f-636d21fd0194)

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
