### PR TITLE
Ab#75576 remove expand option for map widgets

### DIFF
--- a/libs/shared/src/lib/components/widget-grid/floating-options/floating-options.component.html
+++ b/libs/shared/src/lib/components/widget-grid/floating-options/floating-options.component.html
@@ -19,7 +19,7 @@
     <ui-icon icon="palette" variant="grey"></ui-icon>
     <span>{{ 'components.widget.styling' | translate }}</span>
   </button>
-  <button uiMenuItem (click)="onClick('Expand')">
+  <button uiMenuItem (click)="onClick('Expand')" *ngIf="canExpand">
     <ui-icon icon="open_in_full" variant="grey"></ui-icon>
     <span>{{ 'components.widget.expand' | translate }}</span>
   </button>

--- a/libs/shared/src/lib/components/widget-grid/floating-options/floating-options.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/floating-options/floating-options.component.ts
@@ -18,6 +18,7 @@ import { UnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.compon
 export class FloatingOptionsComponent extends UnsubscribeComponent {
   // === WIDGET ===
   @Input() widget: any;
+  @Input() canExpand = true;
 
   // === EMIT ACTION SELECTED ===
   @Output() edit: EventEmitter<any> = new EventEmitter();

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
@@ -46,6 +46,7 @@
         *ngIf="canUpdate"
         class="absolute top-0 right-0 z-[1100]"
         [widget]="widget"
+        [canExpand]="!(widget.component === 'map')"
         (edit)="onEditWidget($event)"
         (delete)="onDeleteWidget($event)"
         (expand)="onExpandWidget($event)"

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
@@ -70,7 +70,7 @@
       </ui-icon>
       <!-- Expand button -->
       <ui-button
-        *ngIf="!canUpdate"
+        *ngIf="!canUpdate && !(widget.component === 'map')"
         [isIcon]="true"
         icon="open_in_full"
         variant="grey"


### PR DESCRIPTION
# Description

Added a boolean canExpand for floating options: maps have canExpand set to false and voila.

## Useful links
[
- Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/75576)

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Went on both back and front office: expand option removed for both.

## Screenshots

![Screenshot from 2023-09-22 13-25-25](https://github.com/ReliefApplications/oort-frontend/assets/59645813/ccbb1d07-ad66-44a7-b162-7b8a6a377f6b)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings

