### PR TITLE
Oort feat im 64 add a delete translation option

### DIFF
--- a/libs/safe/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/safe/src/lib/components/form-builder/form-builder.component.ts
@@ -398,6 +398,31 @@ export class SafeFormBuilderComponent implements OnInit, OnChanges, OnDestroy {
    * Custom SurveyJS method, save the form when edited.
    */
   saveMySurvey = () => {
+    function removeKeyFromJSON(obj: Object, keyToRemove: any) {
+      if (Array.isArray(obj)) {
+        for (let i = 0; i < obj.length; i++) {
+          removeKeyFromJSON(obj[i], keyToRemove);
+        }
+      } else if (typeof obj === 'object' && obj !== null) {
+        for (const prop in obj) {
+          if (prop === keyToRemove) {
+            delete obj[prop as keyof Object];
+          } else {
+            removeKeyFromJSON(obj[prop as keyof Object], keyToRemove);
+          }
+        }
+      }
+    }
+    if (this.surveyCreator.survey.deleteUnusedTranslations == 'Yes') {
+      this.surveyCreator.translation.locales
+        .filter(
+          (x: any) =>
+            !this.surveyCreator.translation.getSelectedLocales().includes(x)
+        )
+        .forEach((locale: any) => {
+          removeKeyFromJSON(this.surveyCreator.JSON, locale);
+        });
+    }
     this.validateValueNames()
       .then((canCreate: boolean) => {
         if (canCreate) {

--- a/libs/safe/src/lib/survey/global-properties/others.ts
+++ b/libs/safe/src/lib/survey/global-properties/others.ts
@@ -5,6 +5,8 @@ import {
 } from 'survey-angular';
 import { Question } from '../types';
 import * as Survey from 'survey-angular';
+import { surveyStrings } from 'entries/angular';
+import { SurveyCreator } from 'survey-creator';
 
 /**
  * Add support for custom properties to the survey
@@ -102,6 +104,14 @@ export const init = (Survey: any, environment: any): void => {
       );
       choicesCallback(pages);
     },
+  });
+  // Adds a property to the survey settings to delete or not unticket translations in the translations tab from the JSON Object
+  serializer.addProperty('survey', {
+    name: 'deleteUnusedTranslations',
+    category: 'general',
+    type: 'dropdown',
+    choices: ['Yes', 'No'],
+    default: 'No',
   });
 };
 

--- a/libs/safe/src/lib/survey/global-properties/others.ts
+++ b/libs/safe/src/lib/survey/global-properties/others.ts
@@ -5,8 +5,6 @@ import {
 } from 'survey-angular';
 import { Question } from '../types';
 import * as Survey from 'survey-angular';
-import { surveyStrings } from 'entries/angular';
-import { SurveyCreator } from 'survey-creator';
 
 /**
  * Add support for custom properties to the survey


### PR DESCRIPTION
# Description

Added a "delete unused translations" in the general tab of properties of a survey. When its set to "Yes", any unmarked translations in the translations tab will be deleted, and when its set to "No" the Json containing it won't be deleted.

## Useful links

[- Please insert link to ticket](https://oortcloud.atlassian.net/jira/software/projects/IM/boards/5?selectedIssue=IM-64)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Set the option "delete unused translations" to "Yes" and save survey with any unmarked translations in the translations tab. All translations for the unmarked languages should be deleted.

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/39497117/54d4b4ac-30f8-42c2-b408-c43c98d5e809)
![image](https://github.com/ReliefApplications/oort-frontend/assets/39497117/c5211695-19d6-42b9-a8d7-23b9be077c13)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
