### PR TITLE
Feat/ab#75323 last update control for maps

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -739,6 +739,12 @@
 						"all": "Map",
 						"current": "Current view"
 					}
+				},
+				"positions": {
+					"bottomleft": "Bottom left",
+					"bottomright": "Bottom right",
+					"topleft": "Top left",
+					"topright": "Top right"
 				}
 			}
 		},
@@ -1376,6 +1382,7 @@
 					"basemap": "Base map",
 					"category": "Map quick layers",
 					"dataset": "Data set selection",
+					"displayLastUpdate": "Display last update time",
 					"edit": {
 						"aggregation": "Aggregation",
 						"cluster": {
@@ -1999,6 +2006,7 @@
 			},
 			"map": {
 				"defaultTitle": "Map Widget",
+				"display": "Map display",
 				"latitude": "Latitude",
 				"longitude": "Longitude",
 				"zoom": "Zoom"

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -753,6 +753,12 @@
 						"all": "Toute la carte",
 						"current": "Vue actuelle"
 					}
+				},
+				"positions": {
+					"bottomleft": "Bas gauche",
+					"bottomright": "Bas droite",
+					"topleft": "Haut gauche",
+					"topright": "Haut droite"
 				}
 			}
 		},
@@ -1392,6 +1398,7 @@
 					"basemap": "Fond de carte",
 					"category": "Catégories rapides",
 					"dataset": "Sélection du jeu de données",
+					"displayLastUpdate": "Afficher la dernière date de modification",
 					"edit": {
 						"aggregation": "Agrégation",
 						"cluster": {
@@ -2015,6 +2022,7 @@
 			},
 			"map": {
 				"defaultTitle": "Widget Carte",
+				"display": "Affichage de la carte",
 				"latitude": "Latitude",
 				"longitude": "Longitude",
 				"zoom": "Zoom"

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -739,6 +739,12 @@
 						"all": "******",
 						"current": "******"
 					}
+				},
+				"positions": {
+					"bottomleft": "******",
+					"bottomright": "******",
+					"topleft": "******",
+					"topright": "******"
 				}
 			}
 		},
@@ -1376,6 +1382,7 @@
 					"basemap": "******",
 					"category": "******",
 					"dataset": "******",
+					"displayLastUpdate": "******",
 					"edit": {
 						"aggregation": "******",
 						"cluster": {
@@ -1999,6 +2006,7 @@
 			},
 			"map": {
 				"defaultTitle": "******",
+				"display": "******",
 				"latitude": "******",
 				"longitude": "******",
 				"zoom": "******"

--- a/libs/shared/src/lib/components/geospatial-map/geospatial-map.component.ts
+++ b/libs/shared/src/lib/components/geospatial-map/geospatial-map.component.ts
@@ -69,6 +69,7 @@ export class GeospatialMapComponent
 
   // === MAP ===
   public mapSettings: MapConstructorSettings = {
+    modifiedAt: { time: undefined, display: false, position: 'bottomleft' },
     initialState: {
       viewpoint: {
         center: {

--- a/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
+++ b/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
@@ -3,6 +3,7 @@
  */
 export interface MapConstructorSettings {
   title?: string;
+  modifiedAt: MapLastModification;
   initialState: {
     viewpoint: {
       center: {
@@ -40,6 +41,13 @@ export enum MapEventType {
 export interface MapEvent {
   type: MapEventType;
   content: any;
+}
+
+/** Interface for the map last update */
+export interface MapLastModification {
+  time: Date | undefined;
+  display: boolean;
+  position: 'topleft' | 'topright' | 'bottomright' | 'bottomleft';
 }
 
 /** Map controls interface */

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -406,8 +406,20 @@ export class MapComponent
 
     // Close layers/bookmarks menu
     this.document.getElementById('layer-control-button-close')?.click();
+    console.log(modifiedAt);
 
-    this.modifiedAt = modifiedAt;
+    if (this.layers.length) {
+      const latestModifiedDate = this.getLatestModifiedDate();
+      if (latestModifiedDate) {
+        this.modifiedAt = {
+          ...modifiedAt,
+          time: latestModifiedDate,
+        };
+      }
+    } else {
+      this.modifiedAt = modifiedAt;
+    }
+
     this.setupMapLayers({ layers, controls, arcGisWebMap, basemap });
     this.setMapControls(controls, initMap);
   }
@@ -1035,5 +1047,24 @@ export class MapComponent
     (this.map as any)['_handlers']?.forEach((handler: L.Handler) => {
       disable ? handler.disable() : handler.enable();
     });
+  }
+
+  /**
+   * Gets the latest modification time among the layers.
+   *
+   * @returns {Date | undefined} The latest modification time, or undefined if no layers have a modification time.
+   */
+  private getLatestModifiedDate(): Date {
+    // Initialize with a very early date
+    let latestModifiedDate = new Date(0);
+    console.log(this.layers);
+    this.layers.forEach((layer) => {
+      const layerModifiedDate = layer.updatedAt;
+      if (layerModifiedDate > latestModifiedDate) {
+        latestModifiedDate = layerModifiedDate;
+      }
+    });
+    console.log('updateDate:', latestModifiedDate);
+    return latestModifiedDate;
   }
 }

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -31,6 +31,7 @@ import {
   MapEventType,
   DefaultMapControls,
   MapControls,
+  MapLastModification,
 } from './interfaces/map.interface';
 import { BASEMAP_LAYERS } from './const/baseMaps';
 // import { timeDimensionGeoJSON } from './test/timedimension-test';
@@ -101,6 +102,7 @@ export class MapComponent
   }
 
   private mapSettingsValue: MapConstructorSettings = {
+    modifiedAt: { time: undefined, display: true, position: 'bottomright' },
     initialState: {
       viewpoint: {
         center: {
@@ -138,6 +140,7 @@ export class MapComponent
   // Search
   public searchControl?: L.Control;
   @Output() search = new EventEmitter();
+  private modifiedAt: MapLastModification | undefined;
 
   // === QUERY UPDATE INFO ===
   public lastUpdate = '';
@@ -302,8 +305,10 @@ export class MapComponent
     const controls = get(mapSettings, 'controls', DefaultMapControls);
     const arcGisWebMap = get(mapSettings, 'arcGisWebMap', undefined);
     const layers = get(mapSettings, 'layers', []);
+    const modifiedAt = get(mapSettings, 'modifiedAt', {});
 
     return {
+      modifiedAt,
       initialState,
       maxBounds,
       basemap,
@@ -324,6 +329,7 @@ export class MapComponent
    */
   private drawMap(initMap: boolean = true): void {
     const {
+      modifiedAt,
       initialState,
       maxBounds,
       basemap,
@@ -401,6 +407,7 @@ export class MapComponent
     // Close layers/bookmarks menu
     this.document.getElementById('layer-control-button-close')?.click();
 
+    this.modifiedAt = modifiedAt;
     this.setupMapLayers({ layers, controls, arcGisWebMap, basemap });
     this.setMapControls(controls, initMap);
   }
@@ -546,6 +553,13 @@ export class MapComponent
     this.mapControlsService.getLegendControl(this.map, controls.legend ?? true);
     // If initializing map: add fixed controls
     if (initMap) {
+      if (this.modifiedAt?.display) {
+        // Add last modified time
+        this.mapControlsService.getLastUpdatedControl(
+          this.map,
+          this.modifiedAt
+        );
+      }
       // Add leaflet fullscreen control
       this.mapControlsService.getFullScreenControl(this.map);
     }

--- a/libs/shared/src/lib/components/widget-grid/floating-options/menu/tile-data/tile-data.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/floating-options/menu/tile-data/tile-data.component.ts
@@ -70,6 +70,7 @@ export class TileDataComponent
    * Closes the modal sending tile form value.
    */
   onSubmit(): void {
+    this.tileForm?.get('modifiedAt.time')?.patchValue(new Date()); //we set the date of the last modification for the map
     this.dialogRef.close(this.tileForm?.getRawValue());
   }
 

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
@@ -19,8 +19,8 @@
         'components.widget.settings.map.displayLastUpdate' | translate
       }}</ng-container>
     </ui-toggle>
-    <ng-container *ngIf="formGroup.get('modifiedAt.display')?.value"
-      ><div uiFormFieldDirective>
+    <ng-container *ngIf="formGroup.get('modifiedAt.display')?.value">
+      <div uiFormFieldDirective>
         <label>{{
           'components.widget.settings.chart.position' | translate
         }}</label>
@@ -32,16 +32,14 @@
             {{ 'components.map.controls.positions.topright' | translate }}
           </ui-select-option>
           <ui-select-option value="bottomleft">
-            {{
-              'components.map.controls.positions.bottomleft' | translate
-            }}</ui-select-option
-          >
+            {{ 'components.map.controls.positions.bottomleft' | translate }}
+          </ui-select-option>
           <ui-select-option value="bottomright">
             {{ 'components.map.controls.positions.bottomright' | translate }}
           </ui-select-option>
         </ui-select-menu>
-      </div></ng-container
-    >
+      </div>
+    </ng-container>
   </ng-container>
   <ng-content></ng-content>
 </form>

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
@@ -10,5 +10,38 @@
     </ui-toggle>
   </ng-container>
   <!-- Other specific options for each widget type -->
+  <!-- === MAP === -->
+  <ng-container *ngIf="widgetType === 'map'" formGroupName="modifiedAt">
+    <ui-divider></ui-divider>
+    <h2>{{ 'models.widget.map.display' | translate }}</h2>
+    <ui-toggle formControlName="display">
+      <ng-container ngProjectAs="label">{{
+        'components.widget.settings.map.displayLastUpdate' | translate
+      }}</ng-container>
+    </ui-toggle>
+    <ng-container *ngIf="formGroup.get('modifiedAt.display')?.value"
+      ><div uiFormFieldDirective>
+        <label>{{
+          'components.widget.settings.chart.position' | translate
+        }}</label>
+        <ui-select-menu class="w-10" formControlName="position">
+          <ui-select-option value="topleft">
+            {{ 'components.map.controls.positions.topleft' | translate }}
+          </ui-select-option>
+          <ui-select-option value="topright">
+            {{ 'components.map.controls.positions.topright' | translate }}
+          </ui-select-option>
+          <ui-select-option value="bottomleft">
+            {{
+              'components.map.controls.positions.bottomleft' | translate
+            }}</ui-select-option
+          >
+          <ui-select-option value="bottomright">
+            {{ 'components.map.controls.positions.bottomright' | translate }}
+          </ui-select-option>
+        </ui-select-menu>
+      </div></ng-container
+    >
+  </ng-container>
   <ng-content></ng-content>
 </form>

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
@@ -27,6 +27,8 @@ import {
   styleUrls: ['./display-settings.component.scss'],
 })
 export class DisplaySettingsComponent {
+  /** Settings form */
   @Input() formGroup!: FormGroup;
+  /** Widget type used to display settings that are specific to the type */
   @Input() widgetType: 'map' | undefined;
 }

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
@@ -2,7 +2,12 @@ import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { ToggleModule } from '@oort-front/ui';
+import {
+  DividerModule,
+  FormWrapperModule,
+  SelectMenuModule,
+  ToggleModule,
+} from '@oort-front/ui';
 
 /** Component for selecting the widget display options */
 @Component({
@@ -11,13 +16,17 @@ import { ToggleModule } from '@oort-front/ui';
   imports: [
     CommonModule,
     FormsModule,
+    FormWrapperModule,
     ReactiveFormsModule,
     ToggleModule,
     TranslateModule,
+    SelectMenuModule,
+    DividerModule,
   ],
   templateUrl: './display-settings.component.html',
   styleUrls: ['./display-settings.component.scss'],
 })
 export class DisplaySettingsComponent {
   @Input() formGroup!: FormGroup;
+  @Input() widgetType: 'map' | undefined;
 }

--- a/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
@@ -33,6 +33,7 @@ const fb = new FormBuilder();
 /** Default map value */
 const DEFAULT_MAP: Nullable<MapConstructorSettings> = {
   title: null,
+  modifiedAt: null,
   basemap: null,
   initialState: {
     viewpoint: {
@@ -499,6 +500,12 @@ export const createMapWidgetFormGroup = (id: any, value?: any): FormGroup => {
   const formGroup = fb.group({
     id,
     title: [get(value, 'title', DEFAULT_MAP.title)],
+    modifiedAt: fb.group({
+      time: [get(value, 'modifiedAt.time', new Date())],
+      display: [get(value, 'modifiedAt.display', true)],
+      position: [get(value, 'modifiedAt.position', 'bottomright')],
+    }),
+
     initialState: fb.group({
       viewpoint: fb.group({
         zoom: [

--- a/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -42,7 +42,7 @@
       <span>{{ 'models.widget.display.title' | translate }}</span>
     </ng-container>
     <ng-template uiTabContent>
-      <shared-display-settings [formGroup]="tileForm"></shared-display-settings>
+      <shared-display-settings [formGroup]="tileForm" [widgetType]="'map'"></shared-display-settings>
     </ng-template>
   </ui-tab>
 </ui-tabs>

--- a/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -83,6 +83,7 @@ export class MapSettingsComponent
     this.change.emit(this.tileForm);
 
     const defaultMapSettings: MapConstructorSettings = {
+      modifiedAt: this.tileForm.get('modifiedAt')?.value,
       basemap: this.tileForm.value.basemap,
       initialState: this.tileForm.get('initialState')?.value,
       controls: this.tileForm.value.controls,
@@ -188,6 +189,7 @@ export class MapSettingsComponent
       (this.currentTab !== 'layer' && tab === 'layer')
     ) {
       this.mapSettings = {
+        modifiedAt: this.tileForm?.get('modifiedAt')?.value,
         basemap: this.tileForm?.value.basemap,
         initialState: this.tileForm?.get('initialState')?.value,
         controls:

--- a/libs/shared/src/lib/services/map/map-controls.service.ts
+++ b/libs/shared/src/lib/services/map/map-controls.service.ts
@@ -21,7 +21,10 @@ import { AVAILABLE_MEASURE_LANGUAGES } from '../../components/ui/map/const/langu
 import { MapSidenavControlsComponent } from '../../components/ui/map/map-sidenav-controls/map-sidenav-controls.component';
 import { legendControl } from '../../components/ui/map/controls/legend.control';
 import { MapZoomComponent } from '../../components/ui/map/map-zoom/map-zoom.component';
-import { MapEvent } from '../../components/ui/map/interfaces/map.interface';
+import {
+  MapEvent,
+  MapLastModification,
+} from '../../components/ui/map/interfaces/map.interface';
 import { MapComponent } from '../../components/ui/map';
 
 /**
@@ -475,6 +478,35 @@ export class MapControlsService {
       corners[vSide + hSide] = L.DomUtil.create('div', className, container);
     }
     createCorner('verticalcenter', 'right');
+  }
+
+  /**
+   * Adds the legend for the last time the map was updated
+   *
+   * @param map Leaflet map
+   * @param modifiedAt last time the settings were closed
+   * @param modifiedAt.time last time update
+   * @param modifiedAt.display should the control be displayed
+   * @param modifiedAt.position position of the control
+   * @returns last updated control
+   */
+  public getLastUpdatedControl(map: any, modifiedAt: MapLastModification) {
+    const customLastUpdatedControl = new L.Control(<any>{
+      position: modifiedAt?.position,
+    });
+    customLastUpdatedControl.onAdd = () => {
+      const div = L.DomUtil.create('div', 'leaflet-control leaflet-bar');
+      div.innerHTML = modifiedAt.time
+        ? `<div id="last-updated-map" class="bg-white px-4 py-2 rounded-md">Last updated on ${new Date(
+            modifiedAt.time
+          ).toLocaleDateString()} at ${new Date(
+            modifiedAt.time
+          ).toLocaleTimeString()}</div>`
+        : 'Last modified time could not be loaded';
+      return div;
+    };
+    map.addControl(customLastUpdatedControl);
+    return customLastUpdatedControl;
   }
 
   // /**


### PR DESCRIPTION
# Description

add a control to the map to know when the last modification was done. Last modification is considered as the last time the settings were SAVED, if the settings are closed it does not change.

## Useful links

[Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/75323)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

create maps, edit settings, play around with the options.

## Screenshots

![Screenshot from 2023-09-25 15-54-14](https://github.com/ReliefApplications/oort-frontend/assets/59645813/190b6fd1-3540-4b47-ac2b-e0ec91ad1a65)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
