### PR TITLE
fix/web-widgets-build-and-serve fix: remove not existing scss file fr…

### DIFF
--- a/apps/web-widgets/src/app/styles/_ui.scss
+++ b/apps/web-widgets/src/app/styles/_ui.scss
@@ -10,11 +10,12 @@
 
 /* All the needed fonts for the web component */
 @import 'libs/styles/src/lib/tailwind/tailwind.scss';
-@import 'libs/styles/src/lib/shared/shared.scss';
-@import 'libs/shared/src/lib/style/styles.scss';
+@import 'libs/styles/src/lib/kendo/theme.scss';
 @import 'libs/shared/src/lib/style/widgets.scss';
+@import 'libs/shared/src/lib/style/styles.scss';
 @import 'libs/shared/src/lib/style/survey.scss';
-@import 'libs/shared/src/lib/style/theme.scss';
+@import 'libs/styles/src/lib/shared/shared.scss';
+
 
 /* Definition of the scss properties in the shadow root host element, won't affect any other element outside shadow-root */
 @import 'variables.scss';

--- a/apps/web-widgets/src/app/widgets/form-widget/components/form.module.ts
+++ b/apps/web-widgets/src/app/widgets/form-widget/components/form.module.ts
@@ -1,13 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormComponent } from './form.component';
-import { FormModule } from '@oort-front/shared';
+import { FormModule as SharedFormModule } from '@oort-front/shared';
 import { ButtonModule, SpinnerModule } from '@oort-front/ui';
 
 /** Form module. */
 @NgModule({
   declarations: [FormComponent],
-  imports: [CommonModule, FormModule, ButtonModule, SpinnerModule],
+  imports: [CommonModule, SharedFormModule, ButtonModule, SpinnerModule],
   exports: [FormComponent],
 })
 export class FormModule {}


### PR DESCRIPTION
# Description

fix: remove not existing scss file from the web-widgets library, plus added missing one for kendo in the style library
fix: change the shared lib form module as there was a name duplication in the form.module of the web-widgets lib

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
