### PR TITLE
fix/add-empty-state-for-pulljobs-page

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.component.html
+++ b/apps/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.component.html
@@ -1,133 +1,140 @@
-<!-- Pull jobs add button -->
-<div class="mb-4 flex flex-row justify-end">
-  <ui-button
-    icon="add"
-    category="secondary"
-    variant="primary"
-    (click)="onAdd()"
-  >
-    {{ 'pages.pullJobs.create' | translate }}
-  </ui-button>
-</div>
-
-<!-- Table container -->
-<div class="overflow-x-hidden shadow-2lg">
-  <!-- Table scroll container -->
-  <div class="overflow-x-auto">
-    <table *ngIf="!loading" cdk-table uiTableWrapper [dataSource]="pullJobs">
-      <ng-container cdkColumnDef="name">
-        <th uiCellHeader *cdkHeaderCellDef>
-          {{ 'common.name' | translate }}
-        </th>
-        <td
-          uiCell
-          *cdkCellDef="let element"
-          class="!text-gray-900 !font-medium max-w-[30vw]"
-        >
-          {{ element.name }}
-        </td>
-      </ng-container>
-      <ng-container cdkColumnDef="status">
-        <th uiCellHeader *cdkHeaderCellDef>
-          {{ 'common.status' | translate }}
-        </th>
-        <td uiCell *cdkCellDef="let element">
-          <div uiChipList>
-            <ui-chip
-              class="s!rounded-lg"
-              variant="success"
-              *ngIf="element.status === 'active'"
-            >
-              {{ 'common.status_active' | translate | titlecase }}
-            </ui-chip>
-            <ui-chip
-              class="!rounded-lg"
-              variant="warning"
-              *ngIf="element.status === 'pending'"
-            >
-              {{ 'common.status_pending' | translate | titlecase }}
-            </ui-chip>
-            <ui-chip
-              class="!rounded-lg"
-              variant="danger"
-              *ngIf="element.status === 'archived'"
-            >
-              {{ 'common.status_archived' | translate | titlecase }}
-            </ui-chip>
-          </div>
-        </td>
-      </ng-container>
-      <!-- <ng-container cdkColumnDef="apiConfiguration">
-        <th uiCellHeader *cdkHeaderCellDef>
-          {{ 'common.apiConfiguration.one' | translate }}
-        </th>
-        <td uiCell *cdkCellDef="let element">
-          {{ element.apiConfiguration ? element.apiConfiguration.name : '-' }}
-        </td>
-      </ng-container> -->
-      <ng-container cdkColumnDef="schedule">
-        <th uiCellHeader *cdkHeaderCellDef>
-          {{ 'models.pullJob.nextIteration' | translate }}
-        </th>
-        <td uiCell *cdkCellDef="let element">
-          {{ element.schedule | sharedCronParser | sharedDate : 'short' }}
-        </td>
-      </ng-container>
-      <!-- <ng-container cdkColumnDef="convertTo">
-        <th uiCellHeader *cdkHeaderCellDef>
-          {{ 'components.record.convert.select' | translate }}
-        </th>
-        <td uiCell *cdkCellDef="let element">
-          {{ element.convertTo ? element.convertTo.name : '-' }}
-        </td>
-      </ng-container> -->
-      <ng-container cdkColumnDef="actions" [stickyEnd]="true">
-        <th uiCellHeader *cdkHeaderCellDef class="w-16"></th>
-        <td uiCell *cdkCellDef="let element">
-          <ui-button
-            [isIcon]="true"
-            icon="more_vert"
-            [uiMenuTriggerFor]="menu"
-            (click)="$event.stopPropagation()"
-            [uiTooltip]="'common.options' | translate"
-          >
-          </ui-button>
-          <ui-menu #menu>
-            <button uiMenuItem (click)="onEdit(element)">
-              <ui-icon icon="edit" variant="grey"></ui-icon>
-              {{ 'common.edit' | translate }}
-            </button>
-            <ui-divider class="py-1"></ui-divider>
-            <button uiMenuItem (click)="onDelete(element)">
-              <ui-icon icon="delete" variant="danger"></ui-icon>
-              {{ 'common.delete' | translate }}
-            </button>
-          </ui-menu>
-        </td>
-      </ng-container>
-      <tr cdk-header-row *cdkHeaderRowDef="displayedColumns"></tr>
-      <tr *cdkRowDef="let row; columns: displayedColumns" cdk-row></tr>
-    </table>
-    <!-- Skeleton table when loading -->
-    <shared-skeleton-table
-      *ngIf="loading"
-      [columns]="[
-        'common.name',
-        'common.status',
-        'common.apiConfiguration.one',
-        'components.record.convert.select'
-      ]"
-      [actions]="true"
+<ng-container *ngIf="!loading; else loadingTmpl">
+  <ng-container *ngIf="pullJobs.length">
+    <div class="flex justify-end">
+      <ng-container *ngTemplateOutlet="newPulljob"></ng-container>
+    </div>
+  </ng-container>
+  <ng-template #newPulljob>
+    <ui-button
+      icon="add"
+      category="secondary"
+      variant="primary"
+      (click)="onAdd()"
     >
-    </shared-skeleton-table>
-  </div>
-</div>
-<ui-paginator
-  [disabled]="loading"
-  [pageSize]="pageInfo.pageSize"
-  [pageSizeOptions]="[10, 25, 50]"
-  [totalItems]="pageInfo.length"
-  [ariaLabel]="'components.pullJob.paginator.ariaLabel' | translate"
-  (pageChange)="onPage($event)"
->
-</ui-paginator>
+      {{ 'pages.pullJobs.create' | translate }}
+    </ui-button>
+  </ng-template>
+  <ng-container *ngIf="pullJobs.length; else emptyTmpl">
+    <!-- Table container -->
+    <div class="mt-4 overflow-x-hidden shadow-2lg">
+      <!-- Table scroll container -->
+      <div class="overflow-x-auto">
+        <table cdk-table uiTableWrapper [dataSource]="pullJobs">
+          <ng-container cdkColumnDef="name">
+            <th uiCellHeader *cdkHeaderCellDef>
+              {{ 'common.name' | translate }}
+            </th>
+            <td
+              uiCell
+              *cdkCellDef="let element"
+              class="!text-gray-900 !font-medium max-w-[30vw]"
+            >
+              {{ element.name }}
+            </td>
+          </ng-container>
+          <ng-container cdkColumnDef="status">
+            <th uiCellHeader *cdkHeaderCellDef>
+              {{ 'common.status' | translate }}
+            </th>
+            <td uiCell *cdkCellDef="let element">
+              <div uiChipList>
+                <ui-chip
+                  class="s!rounded-lg"
+                  variant="success"
+                  *ngIf="element.status === 'active'"
+                >
+                  {{ 'common.status_active' | translate | titlecase }}
+                </ui-chip>
+                <ui-chip
+                  class="!rounded-lg"
+                  variant="warning"
+                  *ngIf="element.status === 'pending'"
+                >
+                  {{ 'common.status_pending' | translate | titlecase }}
+                </ui-chip>
+                <ui-chip
+                  class="!rounded-lg"
+                  variant="danger"
+                  *ngIf="element.status === 'archived'"
+                >
+                  {{ 'common.status_archived' | translate | titlecase }}
+                </ui-chip>
+              </div>
+            </td>
+          </ng-container>
+          <!-- <ng-container cdkColumnDef="apiConfiguration">
+            <th uiCellHeader *cdkHeaderCellDef>
+              {{ 'common.apiConfiguration.one' | translate }}
+            </th>
+            <td uiCell *cdkCellDef="let element">
+              {{ element.apiConfiguration ? element.apiConfiguration.name : '-' }}
+            </td>
+          </ng-container> -->
+          <ng-container cdkColumnDef="schedule">
+            <th uiCellHeader *cdkHeaderCellDef>
+              {{ 'models.pullJob.nextIteration' | translate }}
+            </th>
+            <td uiCell *cdkCellDef="let element">
+              {{ element.schedule | sharedCronParser | sharedDate : 'short' }}
+            </td>
+          </ng-container>
+          <!-- <ng-container cdkColumnDef="convertTo">
+            <th uiCellHeader *cdkHeaderCellDef>
+              {{ 'components.record.convert.select' | translate }}
+            </th>
+            <td uiCell *cdkCellDef="let element">
+              {{ element.convertTo ? element.convertTo.name : '-' }}
+            </td>
+          </ng-container> -->
+          <ng-container cdkColumnDef="actions" [stickyEnd]="true">
+            <th uiCellHeader *cdkHeaderCellDef class="w-16"></th>
+            <td uiCell *cdkCellDef="let element">
+              <ui-button
+                [isIcon]="true"
+                icon="more_vert"
+                [uiMenuTriggerFor]="menu"
+                (click)="$event.stopPropagation()"
+                [uiTooltip]="'common.options' | translate"
+              >
+              </ui-button>
+              <ui-menu #menu>
+                <button uiMenuItem (click)="onEdit(element)">
+                  <ui-icon icon="edit" variant="grey"></ui-icon>
+                  {{ 'common.edit' | translate }}
+                </button>
+                <ui-divider class="py-1"></ui-divider>
+                <button uiMenuItem (click)="onDelete(element)">
+                  <ui-icon icon="delete" variant="danger"></ui-icon>
+                  {{ 'common.delete' | translate }}
+                </button>
+              </ui-menu>
+            </td>
+          </ng-container>
+          <tr cdk-header-row *cdkHeaderRowDef="displayedColumns"></tr>
+          <tr *cdkRowDef="let row; columns: displayedColumns" cdk-row></tr>
+        </table>
+      </div>
+    </div>
+    <ui-paginator
+      [disabled]="loading"
+      [pageSize]="pageInfo.pageSize"
+      [pageSizeOptions]="[10, 25, 50]"
+      [totalItems]="pageInfo.length"
+      [ariaLabel]="'components.pullJob.paginator.ariaLabel' | translate"
+      (pageChange)="onPage($event)"
+    >
+    </ui-paginator>
+  </ng-container>
+  <ng-template #emptyTmpl>
+    <!-- Empty indicator -->
+    <shared-empty
+      [title]="'common.pullJob.none' | translate"
+      [footerTemplate]="newPulljob"
+    ></shared-empty>
+  </ng-template>
+</ng-container>
+<ng-template #loadingTmpl>
+  <!-- Loading indicator -->
+  <shared-skeleton-table [columns]="displayedColumns" [actions]="true">
+  </shared-skeleton-table>
+</ng-template>

--- a/apps/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.module.ts
+++ b/apps/back-office/src/app/dashboard/pages/pull-jobs/pull-jobs.module.ts
@@ -7,6 +7,7 @@ import {
   SkeletonTableModule,
   CronParserModule,
   DateModule,
+  EmptyModule,
 } from '@oort-front/shared';
 import { TranslateModule } from '@ngx-translate/core';
 import {
@@ -35,6 +36,7 @@ import {
     ButtonModule,
     TableModule,
     ChipModule,
+    EmptyModule,
     TooltipModule,
   ],
 })


### PR DESCRIPTION
# Description

fix: add empty state to pulljobs page as the other pages containing table lists and actions

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to screenshots below

## Screenshots

with items
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/2fad5d7e-d820-4f5b-ad6c-9d9cfa1b1c17)

Empty state:

Previously
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/25b57e4d-82f0-4a1c-a4cb-adb0544fbace)

Now
![image](https://github.com/ReliefApplications/oort-frontend/assets/123092672/9a372e18-4942-4a9a-b49f-066e80a94586)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
