### PR TITLE
OORT-feat/IM-62_make-it-grid-respects-the-chosen-language

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -423,7 +423,6 @@ export class CoreGridComponent
                 }
                 const fields = this.settings?.query?.fields || [];
                 const defaultLayoutFields = this.defaultLayout.fields || {};
-
                 this.fields = this.gridService.getFields(
                   fields,
                   this.metaFields,

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -792,8 +792,6 @@ export class CoreGridComponent
     // TODO = check what to do there
     this.onPageChange({ skip: 0, take: this.pageSize });
     this.selectedRows = [];
-    console.log(this.updatedItems);
-    console.log(this.items);
     this.refresh$.next(true);
   }
 

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -321,6 +321,9 @@ export class CoreGridComponent
       .subscribe(() => {
         if (this.dataQuery) this.reloadData();
       });
+    this.translate.onLangChange.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.configureGrid();
+    });
   }
 
   /**
@@ -420,6 +423,7 @@ export class CoreGridComponent
                 }
                 const fields = this.settings?.query?.fields || [];
                 const defaultLayoutFields = this.defaultLayout.fields || {};
+
                 this.fields = this.gridService.getFields(
                   fields,
                   this.metaFields,
@@ -796,8 +800,6 @@ export class CoreGridComponent
     // TODO = check what to do there
     this.onPageChange({ skip: 0, take: this.pageSize });
     this.selectedRows = [];
-    console.log(this.updatedItems);
-    console.log(this.items);
     // this.updatedItems = [];
     this.refresh$.next(true);
   }


### PR DESCRIPTION
# Description

When creating the translation of a form field, if you select the specific language in the platform, it did not update automaticly in the grid; however, after this update, it will.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=IM-62

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Seeing if the translation works after selecting a specific language on the platform.

## Screenshots

Before:
 

https://github.com/ReliefApplications/oort-frontend/assets/24783896/266e6cea-f2bb-4e61-b543-aaeabc1a6353



After:



https://github.com/ReliefApplications/oort-frontend/assets/24783896/99807539-4c42-4402-b03e-9e84190331d7




# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
