### PR TITLE
OORT-feat/IM-81_add-ability-to-conditionally-allow-or-not-dynamicpanel-add-new-panel

### DIFF
--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -129,14 +129,14 @@ export const init = (Survey: any, environment: any): void => {
     default: false,
   });
 
-  // Add ability to conditionally allow dynamicpanel add new panel
+  // Add ability to conditionally allow dynamic panel add new panel
   serializer.addProperty('paneldynamic', {
-    name: 'Allow new panels expression:expression',
+    name: 'AllowNewPanelsExpression:expression',
     category: 'logic',
     visibleIndex: 7,
     default: '',
     isLocalizable: true,
-    onExecuteExpression: (obj: Question, res: any) => {
+    onExecuteExpression: (obj: Survey.QuestionPanelDynamicModel, res: any) => {
       obj.allowAddPanel = !!res;
     },
   });

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -128,6 +128,18 @@ export const init = (Survey: any, environment: any): void => {
     ],
     default: false,
   });
+
+  // Add ability to conditionally allow dynamicpanel add new panel
+  serializer.addProperty('paneldynamic', {
+    name: 'Allow new panels expression:expression',
+    category: 'logic',
+    visibleIndex: 7,
+    default: '',
+    isLocalizable: true,
+    onExecuteExpression: (obj: Question, res: any) => {
+      obj.allowAddPanel = !!res;
+    },
+  });
 };
 
 /**


### PR DESCRIPTION
# Description

In the configuration of a dynamic panel, there is the option to allow the addition of a new panel or not. I have added a field that can be evaluated and allowed through an expression.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=IM-81

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Checking if the expression is true allows the addition of panels, and if it is false, it does not allow.

## Screenshots


https://github.com/ReliefApplications/oort-frontend/assets/24783896/c961de7c-e0f4-4aa8-9bc6-6674979af239


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules