### PR TITLE
fix/AB#76111_block_buttons_not_taking_all_width

### DIFF
--- a/libs/ui/src/lib/button/button.component.scss
+++ b/libs/ui/src/lib/button/button.component.scss
@@ -1,6 +1,6 @@
 :host {
   display: block;
-  width: max-content !important;
+  width: max-content;
 }
 
 :host button > * {

--- a/libs/ui/src/lib/button/button.component.ts
+++ b/libs/ui/src/lib/button/button.component.ts
@@ -63,7 +63,7 @@ export class ButtonComponent {
   /** @returns general resolved classes and variant for button*/
   get resolveButtonClasses(): string[] {
     const classes = [];
-    if (this.isBlock) classes.push('w-full');
+    if (this.isBlock) classes.push('!w-full');
     classes.push(this.isIcon ? 'ui-button-icon' : 'ui-button');
     classes.push(this.category);
     classes.push(this.size);


### PR DESCRIPTION
# Description

Fixed: buttons with the 'isBlock' property set to true don't take all available space.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/76111)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested accessing the buttons with the property 'isBlock" and verifying if the style is working correctly.

## Screenshots

![Captura de tela de 2023-10-02 09-05-46](https://github.com/ReliefApplications/oort-frontend/assets/56398308/147ffc16-f70f-4498-89d5-8fc49a59816e)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
