### PR TITLE
OORT-feat/IM-83_Add-option-to-make-records-unselectable-in-resources-question

### DIFF
--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -400,6 +400,14 @@ export const init = (
         visibleIndex: 3,
       });
       Survey.Serializer.addProperty('resources', {
+        name: 'canDeselectRecords:boolean',
+        category: 'Custom Questions',
+        dependsOn: 'resource',
+        default: false,
+        visibleIf: visibleIfResource,
+        visibleIndex: 3,
+      });
+      Survey.Serializer.addProperty('resources', {
         name: 'alwaysCreateRecord:boolean',
         category: 'Custom Questions',
         dependsOn: ['resource', 'addRecord'],
@@ -900,7 +908,7 @@ export const init = (
           convert: question.convert,
           update: question.update,
           inlineEdition: question.inlineEdition,
-          remove: true,
+          remove: question.canDeselectRecords,
         },
       });
     }

--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -403,7 +403,7 @@ export const init = (
         name: 'canDeselectRecords:boolean',
         category: 'Custom Questions',
         dependsOn: 'resource',
-        default: false,
+        default: true,
         visibleIf: visibleIfResource,
         visibleIndex: 3,
       });


### PR DESCRIPTION
# Description

Adds a new property to the resources question called ‘Can deselect records’ (category custom questions).
If enabled, the user can remove selected records from the grid (current behavior)
If disabled, they shouldn’t be able to (new feature)

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=IM-83

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Checking if the property "Can deselect records" is true allows the button "remove", and if it is false, it does not allow.

## Screenshots

https://github.com/ReliefApplications/oort-frontend/assets/24783896/310bd91e-a42a-48a8-b886-e8d32fec94cf

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
