### PR TITLE
IM-89 - Added the enable actions title functionality

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1340,6 +1340,7 @@
 						}
 					},
 					"display": {
+						"displayActionsTitle": "Display actions title",
 						"showSingleActionAsButton": "Show single action as button"
 					},
 					"hint": {

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1340,7 +1340,7 @@
 						}
 					},
 					"display": {
-						"displayActionsTitle": "Display actions title",
+						"actionsTitle": "Display actions title",
 						"showSingleActionAsButton": "Show single action as button"
 					},
 					"hint": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1356,6 +1356,7 @@
 						}
 					},
 					"display": {
+						"displayActionsTitle": "Afficher le titre des actions",
 						"showSingleActionAsButton": "Afficher une seule action sous forme de bouton"
 					},
 					"hint": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1356,7 +1356,7 @@
 						}
 					},
 					"display": {
-						"displayActionsTitle": "Afficher le titre des actions",
+						"actionsTitle": "Afficher le titre des actions",
 						"showSingleActionAsButton": "Afficher une seule action sous forme de bouton"
 					},
 					"hint": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1340,7 +1340,7 @@
 						}
 					},
 					"display": {
-						"displayActionsTitle": "******",
+						"actionsTitle": "******",
 						"showSingleActionAsButton": "******"
 					},
 					"hint": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1340,6 +1340,7 @@
 						}
 					},
 					"display": {
+						"displayActionsTitle": "******",
 						"showSingleActionAsButton": "******"
 					},
 					"hint": {

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -1192,6 +1192,11 @@
       [width]="actionsWidth"
       [resizable]="false"
       [sticky]="true"
+      [title]="
+        widget.settings.widgetDisplay.enableActionsTitle
+          ? widget.settings.widgetDisplay.actionsTitle
+          : ''
+      "
     >
       <ng-template
         kendoGridCellTemplate

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -111,6 +111,28 @@
             }}
           </ng-container>
         </ui-toggle>
+        <ui-toggle
+          *ngIf="formGroup.get('widgetDisplay.enableActionsTitle')"
+          [formControl]="
+            $any(formGroup.get('widgetDisplay.enableActionsTitle'))
+          "
+        >
+          <ng-container ngProjectAs="label">
+            {{
+              'components.widget.settings.grid.display.displayActionsTitle'
+                | translate
+            }}
+          </ng-container>
+        </ui-toggle>
+        <div
+          uiFormFieldDirective
+          *ngIf="formGroup.get('widgetDisplay.enableActionsTitle')?.value"
+        >
+          <input
+            type="string"
+            [formControl]="$any(formGroup.get('widgetDisplay.actionsTitle'))"
+          />
+        </div>
       </shared-display-settings>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -111,27 +111,31 @@
             }}
           </ng-container>
         </ui-toggle>
-        <ui-toggle
-          *ngIf="formGroup.get('widgetDisplay.enableActionsTitle')"
-          [formControl]="
-            $any(formGroup.get('widgetDisplay.enableActionsTitle'))
-          "
-        >
-          <ng-container ngProjectAs="label">
-            {{
-              'components.widget.settings.grid.display.displayActionsTitle'
-                | translate
-            }}
-          </ng-container>
-        </ui-toggle>
-        <div
-          uiFormFieldDirective
-          *ngIf="formGroup.get('widgetDisplay.enableActionsTitle')?.value"
-        >
-          <input
-            type="string"
-            [formControl]="$any(formGroup.get('widgetDisplay.actionsTitle'))"
-          />
+        <div class="flex gap-2 items-center">
+          <ui-toggle
+            *ngIf="formGroup.get('widgetDisplay.enableActionsTitle')"
+            [formControl]="
+              $any(formGroup.get('widgetDisplay.enableActionsTitle'))
+            "
+          >
+            <ng-container ngProjectAs="label">
+              {{
+                'components.widget.settings.grid.display.actionsTitle'
+                  | translate
+              }}
+            </ng-container>
+          </ui-toggle>
+          <div
+            class="!mb-0"
+            uiFormFieldDirective
+            *ngIf="formGroup.get('widgetDisplay.enableActionsTitle')?.value"
+          >
+            <input
+              type="string"
+              [formControl]="$any(formGroup.get('widgetDisplay.actionsTitle'))"
+              [placeholder]="'common.title' | translate"
+            />
+          </div>
         </div>
       </shared-display-settings>
     </ng-template>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -116,6 +116,12 @@ export class GridSettingsComponent
             false
           )
         ),
+        enableActionsTitle: new FormControl(
+          get<boolean>(tileSettings, 'widgetDisplay.enableActionsTitle', false)
+        ),
+        actionsTitle: new FormControl(
+          get<string>(tileSettings, 'widgetDisplay.actionsTitle', '')
+        ),
       }
     );
 

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.module.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.module.ts
@@ -11,6 +11,7 @@ import {
   TabsModule,
   ToggleModule,
   TooltipModule,
+  FormWrapperModule,
 } from '@oort-front/ui';
 import { DisplaySettingsComponent } from '../common/display-settings/display-settings.component';
 import { SortingSettingsModule } from '../common/sorting-settings/sorting-settings.module';
@@ -23,6 +24,7 @@ import { ContextualFiltersSettingsComponent } from '../common/contextual-filters
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
+    FormWrapperModule,
     TabsModule,
     TranslateModule,
     IconModule,


### PR DESCRIPTION
# Description

Within a grid widget's Settings -> Widget Display there should now be a new toggle named displayActionsTitle which can be used to set a title for the actions header.

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/IM/boards/5?selectedIssue=IM-89

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Enabling the displayActionsTitle toggle sets an input field to visible which can be used to set a title for the actions row. Disabling it removes the input field and sets the title to an empty string.

## Screenshots

![image](https://github.com/ReliefApplications/oort-frontend/assets/39497117/7d8b6087-f424-48ce-894e-9a52c59b960a)
![image](https://github.com/ReliefApplications/oort-frontend/assets/39497117/d5abd8ee-198e-4430-94dc-106c30e8faf7)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings