### PR TITLE
Fix/infinite re render of filter dropdowns in filter stage

### DIFF
--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/field-dropdown/field-dropdown.component.html
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/field-dropdown/field-dropdown.component.html
@@ -1,6 +1,6 @@
 <div uiFormFieldDirective [defaultMargin]="false" class="flex-1 w-44">
   <label>{{ label || 'common.field.one' | translate }}</label>
-  <ui-select-menu [formControl]="fieldControl" #menu>
+  <ui-select-menu [formControl]="fieldControl">
     <ui-select-option *ngIf="nullable">{{
       'common.input.none' | translate
     }}</ui-select-option>

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/field-dropdown/field-dropdown.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/field-dropdown/field-dropdown.component.ts
@@ -5,7 +5,6 @@ import {
   OnChanges,
   QueryList,
   SimpleChanges,
-  ViewChild,
   ViewChildren,
 } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
@@ -34,7 +33,6 @@ export class FieldDropdownComponent implements AfterViewInit, OnChanges {
   @Input() nullable = false;
 
   @ViewChildren('field') fieldComponents!: QueryList<any>;
-  @ViewChild('menu') selectMenu!: any;
   private currentValueUnnested = false;
   public expansionTree: ExpansionTree = {};
 
@@ -42,7 +40,6 @@ export class FieldDropdownComponent implements AfterViewInit, OnChanges {
   public separator = NESTED_FIELD_NAME_SEPARATOR;
 
   ngAfterViewInit(): void {
-    this.selectMenu.forceOptionList(this.fieldComponents);
     if (
       !this.fieldControl.value ||
       !this.fieldControl.value.includes(this.separator)

--- a/libs/ui/src/lib/expansion-panel/expansion-panel.component.ts
+++ b/libs/ui/src/lib/expansion-panel/expansion-panel.component.ts
@@ -7,6 +7,7 @@ import {
   ViewChild,
   Renderer2,
   ElementRef,
+  OnDestroy,
 } from '@angular/core';
 import {
   trigger,
@@ -44,7 +45,7 @@ import { CdkAccordionItem } from '@angular/cdk/accordion';
     ]),
   ],
 })
-export class ExpansionPanelComponent implements AfterViewInit {
+export class ExpansionPanelComponent implements AfterViewInit, OnDestroy {
   /** Boolean indicating whether to display an icon. */
   @Input() displayIcon = true;
   /** Boolean indicating whether the component is disabled. */
@@ -59,6 +60,8 @@ export class ExpansionPanelComponent implements AfterViewInit {
   @ViewChild('accordionItem') accordionItem!: CdkAccordionItem;
   /** Reference to the content container. */
   @ViewChild('contentContainer') contentContainer!: ElementRef;
+
+  private timeoutListener!: NodeJS.Timeout;
 
   /**
    * UI Panel Expansion constructor
@@ -77,7 +80,10 @@ export class ExpansionPanelComponent implements AfterViewInit {
    * Function detects on close and emit
    */
   onClosed() {
-    setTimeout(() => {
+    if (this.timeoutListener) {
+      clearTimeout(this.timeoutListener);
+    }
+    this.timeoutListener = setTimeout(() => {
       this.renderer.addClass(this.contentContainer.nativeElement, 'hidden');
     }, 100);
     this.closePanel.emit(true);
@@ -90,5 +96,11 @@ export class ExpansionPanelComponent implements AfterViewInit {
   onOpened() {
     this.renderer.removeClass(this.contentContainer.nativeElement, 'hidden');
     this.renderer.addClass(this.contentContainer.nativeElement, 'block');
+  }
+
+  ngOnDestroy(): void {
+    if (this.timeoutListener) {
+      clearTimeout(this.timeoutListener);
+    }
   }
 }

--- a/libs/ui/src/lib/graphql-select/graphql-select.component.ts
+++ b/libs/ui/src/lib/graphql-select/graphql-select.component.ts
@@ -371,8 +371,10 @@ export class GraphQLSelectComponent
    */
   onOpenSelect(): void {
     // focus on search input, if filterable
-    if (this.filterable) this.searchInput?.nativeElement.focus();
-    const panel = this.document.getElementById('optionList');
+    if (this.filterable) {
+      this.searchInput?.nativeElement.focus();
+    }
+    const panel = this.document.getElementById('selectList');
     if (this.scrollListener) {
       this.scrollListener();
     }

--- a/libs/ui/src/lib/select-menu/components/select-option.component.html
+++ b/libs/ui/src/lib/select-menu/components/select-option.component.html
@@ -1,17 +1,19 @@
 <li
+  [attr.data-label]="label"
+  [attr.data-value]="getValue"
+  [attr.data-selected]="selected"
+  [attr.data-is-group]="isGroup"
+  [attr.data-is-disabled]="disabled"
   [ngClass]="{
     'bg-primary-300 text-white': !isGroup && selected,
-    'cursor-pointer hover:bg-primary-200 hover:text-white flex items-center text-gray-900 py-[5px] text-sm':
+    'cursor-pointer hover:bg-primary-200 hover:text-white gap-2 flex items-center text-gray-900':
       !isGroup,
-    'text-gray-400 text-xs font-semibold pt-[5px]': isGroup
+    'text-gray-500 pb-2': isGroup
   }"
-  (click)="onChangeFunction()"
-  class="px-2 relative w-full justify-between"
+  class="px-2 py-1 relative pl-2 w-full justify-between"
+  (click)="selected = !selected"
 >
   <!-- Text, changes if selected -->
-  <span class="font-normal truncate">
-    <ng-content></ng-content>
-  </span>
-
+  <ng-content></ng-content>
   <ng-content select="icon"></ng-content>
 </li>

--- a/libs/ui/src/lib/select-menu/components/select-option.component.ts
+++ b/libs/ui/src/lib/select-menu/components/select-option.component.ts
@@ -1,13 +1,12 @@
 import {
   Component,
-  EventEmitter,
   Input,
-  Output,
   ContentChildren,
   forwardRef,
   QueryList,
   ElementRef,
   AfterContentInit,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 
 /**
@@ -17,13 +16,13 @@ import {
   selector: 'ui-select-option',
   templateUrl: './select-option.component.html',
   styleUrls: ['./select-option.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SelectOptionComponent implements AfterContentInit {
   @Input() value!: any;
   @Input() selected = false;
   @Input() isGroup = false;
   @Input() disabled = false;
-  @Output() optionClick = new EventEmitter<boolean>();
 
   @ContentChildren(forwardRef(() => SelectOptionComponent))
   options!: QueryList<SelectOptionComponent>;
@@ -38,19 +37,16 @@ export class SelectOptionComponent implements AfterContentInit {
    */
   constructor(private el: ElementRef) {}
 
-  ngAfterContentInit(): void {
-    this.label =
-      this.el.nativeElement.querySelector('span').firstChild?.textContent ?? '';
+  /**
+   * Set formatted value for list element
+   *
+   * @returns formatted value
+   */
+  get getValue() {
+    return this.value ? JSON.stringify(this.value) : '';
   }
 
-  /**
-   * Emit optionClick output and updates option selected status
-   */
-  onChangeFunction(): void {
-    if (this.isGroup || this.disabled) {
-      return;
-    }
-    this.selected = !this.selected;
-    this.optionClick.emit(this.selected);
+  ngAfterContentInit(): void {
+    this.label = (this.el.nativeElement.firstChild?.textContent ?? '').trim();
   }
 }

--- a/libs/ui/src/lib/select-menu/select-menu.component.html
+++ b/libs/ui/src/lib/select-menu/select-menu.component.html
@@ -51,7 +51,7 @@
 <ng-template #optionPanel>
   <div class="relative w-full">
     <ul
-      id="optionList"
+      id="selectList"
       [ngClass]="{
         'max-h-36 py-1': !isGraphQlSelect,
         'max-h-52': isGraphQlSelect
@@ -62,7 +62,7 @@
       <ng-content></ng-content>
       <!-- Display a message to indicate the list is empty -->
       <div
-        *ngIf="!optionList.length"
+        *ngIf="!currentOptionList?.length"
         class="h-24 flex flex-col gap-2 justify-center items-center"
       >
         <ui-icon icon="error_outline" variant="grey"></ui-icon>

--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -87,6 +87,7 @@ export class SelectMenuComponent
 
   /**
    * Return current option list html elements
+   *
    * @returns list option as html elements
    */
   get currentOptionList() {


### PR DESCRIPTION
# Description

fix/infinite-re-render-of-filter-dropdowns-in-filter-stage
fix: add listener to some timeouts used in the affected components in order to clear them up as needed and avoid memory leaks.
fix: use dynamic listener for select option list click handler in order to not have multiple click subscriptions and query changes open consuming memory and throwing unexpected results.
fix: field dropdown component as it would not need any list forceoptions

## Useful links

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
