### PR TITLE
fix/AB#76466_duplicated_buttons_when_answering_form

### DIFF
--- a/libs/shared/src/lib/components/form/form.component.html
+++ b/libs/shared/src/lib/components/form/form.component.html
@@ -58,25 +58,3 @@
   </ui-fixed-wrapper>
 </ng-container>
 <survey [model]="survey"></survey>
-<!-- Form actions -->
-<div *ngIf="surveyActive" class="flex justify-end gap-2 mt-4 flex-wrap">
-  <ng-container *ngIf="survey?.visiblePages ?? [] as pages">
-    <ui-button
-      *ngIf="pages.length > 1"
-      [disabled]="survey.isFirstPage"
-      variant="primary"
-      (click)="survey.prevPage()"
-      >{{ 'common.previous' | translate }}</ui-button
-    >
-    <ui-button
-      *ngIf="pages.length > 1"
-      [disabled]="survey.isLastPage"
-      variant="primary"
-      (click)="survey.nextPage()"
-      >{{ 'common.next' | translate }}</ui-button
-    >
-  </ng-container>
-  <ui-button variant="primary" category="secondary" (click)="submit()">{{
-    'common.save' | translate
-  }}</ui-button>
-</div>


### PR DESCRIPTION
# Description

Fixed duplicated actions buttons when answering a form.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/76466)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested verifying in the forms answering if now we doesn't have duplicated action buttons.

## Screenshots

![Captura de tela de 2023-10-04 14-22-46](https://github.com/ReliefApplications/oort-frontend/assets/56398308/0c062a03-46a6-4066-abcb-16409ac3c6fb)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
