### PR TITLE
OORT-feat/IM-95_Ability-to-set-the-'save'-text-when-submitting-a-form

### DIFF
--- a/libs/shared/src/lib/components/form/form.component.html
+++ b/libs/shared/src/lib/components/form/form.component.html
@@ -49,7 +49,7 @@
       >{{ 'common.next' | translate }}</ui-button
     >
   </ng-container>
-  <ui-button variant="primary" category="secondary" (click)="submit()">{{
-    'common.save' | translate
-  }}</ui-button>
+  <ui-button variant="primary" category="secondary" (click)="submit()">
+    {{ (survey.saveButtonText === 'Save') ? ('common.save' | translate) : survey.saveButtonText}}
+  </ui-button>
 </div>

--- a/libs/shared/src/lib/components/form/form.component.html
+++ b/libs/shared/src/lib/components/form/form.component.html
@@ -50,6 +50,9 @@
     >
   </ng-container>
   <ui-button variant="primary" category="secondary" (click)="submit()">
-    {{ (survey.saveButtonText === 'Save') ? ('common.save' | translate) : survey.saveButtonText}}
+    {{
+      survey.saveButtonText ||
+        ('common.save' | translate : survey.saveButtonText)
+    }}
   </ui-button>
 </div>

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -132,9 +132,8 @@ export const init = (Survey: any, environment: any): void => {
     name: 'saveButtonText',
     type: 'string',
     category: 'general',
-    default: 'Save',
     visibleIndex: 2,
-    isRequired: true,
+    isRequired: false,
   });
 
   // Add ability to conditionally allow dynamic panel add new panel

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -128,6 +128,14 @@ export const init = (Survey: any, environment: any): void => {
     ],
     default: false,
   });
+  serializer.addProperty('survey', {
+    name: 'saveButtonText',
+    type: 'string',
+    category: 'general',
+    default: 'Save',
+    visibleIndex: 2,
+    isRequired: true,
+  });
 
   // Add ability to conditionally allow dynamic panel add new panel
   serializer.addProperty('paneldynamic', {


### PR DESCRIPTION
# Description

Ability to set the 'save' text when submitting a form.
The default value is 'save.' If it is set to the default value, it will be translated according to the platform's language. However, if it has been changed, it will remain as the new value.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=IM-95

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Changing the text of save button and checking if it changes correspondingly

## Screenshots

![changing text](https://github.com/ReliefApplications/oort-frontend/assets/24783896/2099bd0d-5d1f-4606-b526-198b00fe16ad)


![form send text](https://github.com/ReliefApplications/oort-frontend/assets/24783896/b5ec9a6c-d60e-4e80-9006-7e552a3f81a4)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
