### PR TITLE
Fix/ab#76504 aggregation not displaying in grid configurations after be reseted

### DIFF
--- a/libs/shared/src/lib/components/aggregation/aggregation-table/aggregation-table.component.ts
+++ b/libs/shared/src/lib/components/aggregation/aggregation-table/aggregation-table.component.ts
@@ -21,7 +21,7 @@ import { Dialog } from '@angular/cdk/dialog';
 })
 export class AggregationTableComponent
   extends UnsubscribeComponent
-  implements OnInit, OnChanges
+  implements OnInit
 {
   /** Can select new aggregations or not */
   @Input() canAdd = true;
@@ -57,12 +57,6 @@ export class AggregationTableComponent
       });
   }
 
-  ngOnChanges(): void {
-    const defaultValue = this.selectedAggregations?.value;
-    this.setAllAggregations();
-    this.setSelectedAggregations(defaultValue);
-  }
-
   /**
    * Sets the list of all aggregations from resource / form.
    */
@@ -96,6 +90,7 @@ export class AggregationTableComponent
         .sort(
           (a, b) => value.indexOf(a.id || '') - value.indexOf(b.id || '')
         ) || [];
+    
   }
 
   /**

--- a/libs/shared/src/lib/components/aggregation/aggregation-table/aggregation-table.component.ts
+++ b/libs/shared/src/lib/components/aggregation/aggregation-table/aggregation-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Layout } from '../../../models/layout.model';
 import { Form } from '../../../models/form.model';
 import { Resource } from '../../../models/resource.model';
@@ -90,7 +90,6 @@ export class AggregationTableComponent
         .sort(
           (a, b) => value.indexOf(a.id || '') - value.indexOf(b.id || '')
         ) || [];
-    
   }
 
   /**


### PR DESCRIPTION
# Description

Fixed: after adding a aggregation to the grid settings and then remove it and set another one, the aggregations template is not being displayed, only if reopening the settings.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/76504)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested creating a grid, setting an aggregation, saving, changing to another aggregation and verifying if now the aggregations template is being displayed.

## Screenshots

![Peek 05-10-2023 14-04](https://github.com/ReliefApplications/oort-frontend/assets/56398308/0729e490-0ac6-49a2-92a4-2938904e7a28)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
