### PR TITLE
Oort feat/HIT-98 add option to request confirm when auto modifying fields in quick action

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1334,7 +1334,7 @@
 						"create": "Add a button",
 						"defaultName": "Action button",
 						"enable": "Enable",
-						"needConfirmation": "Need confirmation",
+						"requireConfirmation": "Require confirmation",
 						"title": "Quick action buttons",
 						"tooltip": {
 							"attach": "When enabled, you must provide a form and a field of this form. All selected rows will be attached to a record from this form. The user will be able to choose which record using a the given field",

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1328,6 +1328,7 @@
 						"create": "Add a button",
 						"defaultName": "Action button",
 						"enable": "Enable",
+						"needConfirmation": "Need confirmation",
 						"title": "Quick action buttons",
 						"tooltip": {
 							"attach": "When enabled, you must provide a form and a field of this form. All selected rows will be attached to a record from this form. The user will be able to choose which record using a the given field",

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1155,6 +1155,7 @@
 					"metaQueryBuildFailed": "Error building metadata",
 					"metaQueryFetchFailed": "Error fetching metadata: {{error}}",
 					"missingDataset": "Select a dataset in settings",
+					"noRowsSelected": "No rows selected",
 					"queryBuildFailed": "Error building query",
 					"queryFetchFailed": "Error fetching data: {{error}}",
 					"validationFailed": "The following records could not be saved due to validation rules:\n{{errors}}\nPlease edit the record using the 'update' button for more details."

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1222,6 +1222,11 @@
 					"categories": "Categories",
 					"color": "Color",
 					"grid": {
+						"buttons": {
+							"modifySelectedRows": {
+								"confirmation": "Are you sure you want to modify the selected rows?"
+							}
+						},
 						"title": "Gridlines",
 						"x": {
 							"display": "Display horizontal gridlines"

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1171,6 +1171,7 @@
 					"metaQueryBuildFailed": "Erreur lors de la création des métadonnées",
 					"metaQueryFetchFailed": "Erreur lors de la récupération des métadonnées: {{error}}",
 					"missingDataset": "Sélectionner un jeu de données dans les jeux de données",
+					"noRowsSelected": "Aucune ligne sélectionnée",
 					"queryBuildFailed": "Erreur lors de la création de la requête",
 					"queryFetchFailed": "Erreur lors de la récupération des données : {{error}}",
 					"validationFailed": "Les enregistrements suivants n'ont pas pu être sauvegardés car invalides :\n{{errors}}\nMerci de les modifier en utilisant le bouton \"Mettre à jour \" pour plus de détails."

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1344,6 +1344,7 @@
 						"create": "Ajouter un bouton",
 						"defaultName": "Bouton d'action",
 						"enable": "Activer",
+						"needConfirmation": "Confirmation requise",
 						"title": "Bouton d'action rapide",
 						"tooltip": {
 							"attach": "Si activé, vous devez fournir un formulaire et un champ dans ce formulaire. Toutes les lignes sélectionnées seront attachées à un enregistrement de ce formulaire. L'utilisateur pourra choisir cet enregistrement grâce au champ donné.",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1241,7 +1241,7 @@
 					"grid": {
 						"buttons": {
 							"modifySelectedRows": {
-								"confirmation": "Are you sure you want to modify the selected rows?"
+								"confirmation": "Voulez-vous vraiment modifier les lignes sélectionnées?"
 							}
 						},
 						"title": "Grille",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1238,6 +1238,11 @@
 					"categories": "Catégories",
 					"color": "Couleur",
 					"grid": {
+						"buttons": {
+							"modifySelectedRows": {
+								"confirmation": "Are you sure you want to modify the selected rows?"
+							}
+						},
 						"title": "Grille",
 						"x": {
 							"display": "Afficher les lignes horizontales"

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1350,7 +1350,7 @@
 						"create": "Ajouter un bouton",
 						"defaultName": "Bouton d'action",
 						"enable": "Activer",
-						"needConfirmation": "Confirmation requise",
+						"requireConfirmation": "Exiger une confirmation",
 						"title": "Bouton d'action rapide",
 						"tooltip": {
 							"attach": "Si activé, vous devez fournir un formulaire et un champ dans ce formulaire. Toutes les lignes sélectionnées seront attachées à un enregistrement de ce formulaire. L'utilisateur pourra choisir cet enregistrement grâce au champ donné.",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1334,7 +1334,7 @@
 						"create": "******",
 						"defaultName": "******",
 						"enable": "******",
-						"needConfirmation": "******",
+						"requireConfirmation": "******",
 						"title": "******",
 						"tooltip": {
 							"attach": "******",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1222,6 +1222,11 @@
 					"categories": "******",
 					"color": "******",
 					"grid": {
+						"buttons": {
+							"modifySelectedRows": {
+								"confirmation": "******"
+							}
+						},
 						"title": "******",
 						"x": {
 							"display": "******"

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1328,6 +1328,7 @@
 						"create": "******",
 						"defaultName": "******",
 						"enable": "******",
+						"needConfirmation": "******",
 						"title": "******",
 						"tooltip": {
 							"attach": "******",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1155,6 +1155,7 @@
 					"metaQueryBuildFailed": "******",
 					"metaQueryFetchFailed": "****** {{error}}",
 					"missingDataset": "******",
+					"noRowsSelected": "******",
 					"queryBuildFailed": "******",
 					"queryFetchFailed": "****** {{error}}",
 					"validationFailed": "****** {{errors}} ******"

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -169,13 +169,12 @@
           *ngIf="formGroup.value.modifySelectedRows"
           class="sub-parameters flex flex-col"
         >
-          <ui-checkbox 
-            class="margin-top-need-confirmation-checkbox"
-            formControlName="needConfirmation">
+          <ui-toggle class="mt-1" formControlName="requireConfirmation">
             <ng-container ngProjectAs="label">{{
-              'components.widget.settings.grid.buttons.needConfirmation' | translate
+              'components.widget.settings.grid.buttons.requireConfirmation'
+                | translate
             }}</ng-container>
-          </ui-checkbox>
+          </ui-toggle>
           <form
             [formGroup]="$any(modification)"
             *ngFor="let modification of modificationsArray.controls; index as i"

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -506,5 +506,10 @@
         <input formControlName="value" type="string" />
       </div>
     </ng-container>
+    <ui-toggle formControlName="needConfimation">
+      <ng-container ngProjectAs="label">{{
+        'components.widget.settings.grid.buttons.needConfirmation' | translate
+      }}</ng-container>
+    </ui-toggle>
   </div>
 </ng-template>

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -169,6 +169,13 @@
           *ngIf="formGroup.value.modifySelectedRows"
           class="sub-parameters flex flex-col"
         >
+          <ui-checkbox 
+            class="margin-top-need-confirmation-checkbox"
+            formControlName="needConfirmation">
+            <ng-container ngProjectAs="label">{{
+              'components.widget.settings.grid.buttons.needConfirmation' | translate
+            }}</ng-container>
+          </ui-checkbox>
           <form
             [formGroup]="$any(modification)"
             *ngFor="let modification of modificationsArray.controls; index as i"
@@ -506,10 +513,5 @@
         <input formControlName="value" type="string" />
       </div>
     </ng-container>
-    <ui-toggle formControlName="needConfimation">
-      <ng-container ngProjectAs="label">{{
-        'components.widget.settings.grid.buttons.needConfirmation' | translate
-      }}</ng-container>
-    </ui-toggle>
   </div>
 </ng-template>

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.scss
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.scss
@@ -1,6 +1,6 @@
 .update-row {
   align-items: end;
-  margin-top: 24px;
+  margin-top: 4px;
 }
 
 .radio-row {
@@ -14,4 +14,8 @@
   padding-left: 24px;
   display: flex;
   flex-direction: column;
+}
+
+.margin-top-need-confirmation-checkbox {
+  margin-top: 4px;
 }

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.scss
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.scss
@@ -15,7 +15,3 @@
   display: flex;
   flex-direction: column;
 }
-
-.margin-top-need-confirmation-checkbox {
-  margin-top: 4px;
-}

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -113,6 +113,20 @@ export class ButtonConfigComponent
     }
 
     this.formGroup
+      ?.get('needConfirmation')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((value) => {
+        if (value) {
+          this.formGroup
+            ?.get('needConfirmation')
+            ?.setValidators(Validators.required);
+        } else {
+          this.formGroup?.get('needConfirmation')?.clearValidators();
+        }
+        this.formGroup?.get('needConfirmation')?.updateValueAndValidity();
+      });
+
+    this.formGroup
       ?.get('prefillForm')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((value) => {
@@ -169,20 +183,6 @@ export class ButtonConfigComponent
           this.formGroup?.controls.publish.setValue(false);
         }
       });
-
-    // this.formGroup
-    // ?.get('askConfirmation')
-    // ?.valueChanges.pipe(takeUntil(this.destroy$))
-    // .subscribe((value) => {
-    //   if (value) {
-    //     this.formGroup
-    //       ?.get('confirmationText')
-    //       ?.setValidators(Validators.required);
-    //   } else {
-    //     this.formGroup?.get('confirmationText')?.clearValidators();
-    //   }
-    //   this.formGroup?.get('confirmationText')?.updateValueAndValidity();
-    // });
 
     this.formGroup
       ?.get('modifySelectedRows')

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -317,16 +317,6 @@ export class ButtonConfigComponent
           this.formGroup?.get('selectAll')?.updateValueAndValidity();
         }
       });
-
-    this.formGroup
-      ?.get('selectPage')
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe((selectPage: boolean) => {
-        if (selectPage) {
-          this.formGroup?.controls.selectAll.setValue(false);
-          this.formGroup?.get('selectAll')?.updateValueAndValidity();
-        }
-      });
   }
 
   /** Set list of resources user can attach a record to */

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -170,6 +170,20 @@ export class ButtonConfigComponent
         }
       });
 
+      // this.formGroup
+      // ?.get('askConfirmation')
+      // ?.valueChanges.pipe(takeUntil(this.destroy$))
+      // .subscribe((value) => {
+      //   if (value) {
+      //     this.formGroup
+      //       ?.get('confirmationText')
+      //       ?.setValidators(Validators.required);
+      //   } else {
+      //     this.formGroup?.get('confirmationText')?.clearValidators();
+      //   }
+      //   this.formGroup?.get('confirmationText')?.updateValueAndValidity();
+      // });
+
     this.formGroup
       ?.get('modifySelectedRows')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
@@ -293,6 +307,17 @@ export class ButtonConfigComponent
           this.formGroup?.get('selectPage')?.updateValueAndValidity();
         }
       });
+
+      this.formGroup
+      ?.get('selectPage')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((selectPage: boolean) => {
+        if (selectPage) {
+          this.formGroup?.controls.selectAll.setValue(false);
+          this.formGroup?.get('selectAll')?.updateValueAndValidity();
+        }
+      });
+  
 
     this.formGroup
       ?.get('selectPage')

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -112,19 +112,19 @@ export class ButtonConfigComponent
         });
     }
 
-    this.formGroup
-      ?.get('needConfirmation')
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe((value) => {
-        if (value) {
-          this.formGroup
-            ?.get('needConfirmation')
-            ?.setValidators(Validators.required);
-        } else {
-          this.formGroup?.get('needConfirmation')?.clearValidators();
-        }
-        this.formGroup?.get('needConfirmation')?.updateValueAndValidity();
-      });
+    // this.formGroup
+    //   ?.get('requireConfirmation')
+    //   ?.valueChanges.pipe(takeUntil(this.destroy$))
+    //   .subscribe((value) => {
+    //     if (value) {
+    //       this.formGroup
+    //         ?.get('requireConfirmation')
+    //         ?.setValidators(Validators.required);
+    //     } else {
+    //       this.formGroup?.get('requireConfirmation')?.clearValidators();
+    //     }
+    //     this.formGroup?.get('requireConfirmation')?.updateValueAndValidity();
+    //   });
 
     this.formGroup
       ?.get('prefillForm')

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -170,19 +170,19 @@ export class ButtonConfigComponent
         }
       });
 
-      // this.formGroup
-      // ?.get('askConfirmation')
-      // ?.valueChanges.pipe(takeUntil(this.destroy$))
-      // .subscribe((value) => {
-      //   if (value) {
-      //     this.formGroup
-      //       ?.get('confirmationText')
-      //       ?.setValidators(Validators.required);
-      //   } else {
-      //     this.formGroup?.get('confirmationText')?.clearValidators();
-      //   }
-      //   this.formGroup?.get('confirmationText')?.updateValueAndValidity();
-      // });
+    // this.formGroup
+    // ?.get('askConfirmation')
+    // ?.valueChanges.pipe(takeUntil(this.destroy$))
+    // .subscribe((value) => {
+    //   if (value) {
+    //     this.formGroup
+    //       ?.get('confirmationText')
+    //       ?.setValidators(Validators.required);
+    //   } else {
+    //     this.formGroup?.get('confirmationText')?.clearValidators();
+    //   }
+    //   this.formGroup?.get('confirmationText')?.updateValueAndValidity();
+    // });
 
     this.formGroup
       ?.get('modifySelectedRows')
@@ -308,7 +308,7 @@ export class ButtonConfigComponent
         }
       });
 
-      this.formGroup
+    this.formGroup
       ?.get('selectPage')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((selectPage: boolean) => {
@@ -317,7 +317,6 @@ export class ButtonConfigComponent
           this.formGroup?.get('selectAll')?.updateValueAndValidity();
         }
       });
-  
 
     this.formGroup
       ?.get('selectPage')

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -46,7 +46,7 @@ export const createButtonFormGroup = (value: any) => {
     ],
     autoSave: [value && value.autoSave ? value.autoSave : false],
     modifySelectedRows: [value ? value.modifySelectedRows : false],
-    needConfirmation: [value ? value.needConfirmation : false],
+    requireConfirmation: [value ? value.requireConfirmation : false],
     modifications: fb.array(
       value && value.modifications && value.modifications.length
         ? value.modifications.map((x: any) =>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -24,7 +24,6 @@ const fb = new FormBuilder();
  * @returns new form group for the floating button.
  */
 export const createButtonFormGroup = (value: any) => {
-  console.log('needConfirmation', value.needConfirmation);
   const formGroup = fb.group({
     show: [value && value.show ? value.show : false, Validators.required],
     name: [
@@ -47,9 +46,7 @@ export const createButtonFormGroup = (value: any) => {
     ],
     autoSave: [value && value.autoSave ? value.autoSave : false],
     modifySelectedRows: [value ? value.modifySelectedRows : false],
-    needConfirmation: [
-      value && value.needConfirmation ? value.needConfirmation : false,
-    ],
+    needConfirmation: [value ? value.needConfirmation : false],
     modifications: fb.array(
       value && value.modifications && value.modifications.length
         ? value.modifications.map((x: any) =>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -46,6 +46,7 @@ export const createButtonFormGroup = (value: any) => {
     ],
     autoSave: [value && value.autoSave ? value.autoSave : false],
     modifySelectedRows: [value ? value.modifySelectedRows : false],
+    needConfirmation: true,
     modifications: fb.array(
       value && value.modifications && value.modifications.length
         ? value.modifications.map((x: any) =>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -24,6 +24,7 @@ const fb = new FormBuilder();
  * @returns new form group for the floating button.
  */
 export const createButtonFormGroup = (value: any) => {
+  console.log('needConfirmation', value.needConfirmation);
   const formGroup = fb.group({
     show: [value && value.show ? value.show : false, Validators.required],
     name: [
@@ -46,7 +47,9 @@ export const createButtonFormGroup = (value: any) => {
     ],
     autoSave: [value && value.autoSave ? value.autoSave : false],
     modifySelectedRows: [value ? value.modifySelectedRows : false],
-    needConfirmation: true,
+    needConfirmation: [
+      value && value.needConfirmation ? value.needConfirmation : false,
+    ],
     modifications: fb.array(
       value && value.modifications && value.modifications.length
         ? value.modifications.map((x: any) =>

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -532,9 +532,9 @@ export class GridWidgetComponent
           { error: true }
         );
       } else {
-        if (options.needConfirmation) {
-          this.confirmService
-            .openConfirmModal({
+        if (options.requireConfirmation) {
+          const confirm = await firstValueFrom(
+            this.confirmService.openConfirmModal({
               title: this.translate.instant(
                 'components.widget.settings.chart.grid.buttons.modifySelectedRows.confirmation'
               ),
@@ -542,28 +542,22 @@ export class GridWidgetComponent
                 'components.confirmModal.confirm'
               ),
               confirmVariant: 'primary',
-            })
-            .closed.pipe(takeUntil(this.destroy$))
-            .subscribe(async (confirm: any) => {
-              if (confirm) {
-                await this.promisedRowsModifications(
-                  options.modifications,
-                  this.grid.selectedRows
-                );
-                this.grid.reloadData();
-              }
-            });
+            }).closed
+          );
+
+          if (confirm) {
+            await this.promisedRowsModifications(
+              options.modifications,
+              this.grid.selectedRows
+            );
+          }
         } else {
           await this.promisedRowsModifications(
             options.modifications,
             this.grid.selectedRows
           );
-          this.grid.reloadData();
         }
       }
-
-      // We need this return to avoid the grid to reload and miss selected rows when modal is open
-      return;
     }
 
     this.grid.reloadData();

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -377,6 +377,9 @@ export class GridWidgetComponent
     }
     // Auto modify the selected rows
     if (options.modifySelectedRows) {
+      //todo: show modal
+      console.log('aaas', options)
+
       await this.promisedRowsModifications(
         options.modifications,
         this.grid.selectedRows

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -526,26 +526,37 @@ export class GridWidgetComponent
 
     // Auto modify the selected rows
     if (options.modifySelectedRows) {
-      this.confirmService
-        .openConfirmModal({
-          title: this.translate.instant(
-            'components.widget.settings.chart.grid.buttons.modifySelectedRows.confirmation'
+      if (this.grid.selectedRows.length === 0) {
+        this.snackBar.openSnackBar(
+          this.translate.instant(
+            'components.widget.grid.errors.noRowsSelected'
           ),
-          confirmText: this.translate.instant(
-            'components.confirmModal.confirm'
-          ),
-          confirmVariant: 'primary',
-        })
-        .closed.pipe(takeUntil(this.destroy$))
-        .subscribe(async (confirm: any) => {
-          if (confirm) {
-            await this.promisedRowsModifications(
-              options.modifications,
-              this.grid.selectedRows
-            );
-            this.grid.reloadData();
-          }
-        });
+          { error: true }
+        );
+      } else {
+        if (options.needConfirmation) {
+          this.confirmService
+            .openConfirmModal({
+              title: this.translate.instant(
+                'components.widget.settings.chart.grid.buttons.modifySelectedRows.confirmation'
+              ),
+              confirmText: this.translate.instant(
+                'components.confirmModal.confirm'
+              ),
+              confirmVariant: 'primary',
+            })
+            .closed.pipe(takeUntil(this.destroy$))
+            .subscribe(async (confirm: any) => {
+              if (confirm) {
+                await this.promisedRowsModifications(
+                  options.modifications,
+                  this.grid.selectedRows
+                );
+                this.grid.reloadData();
+              }
+            });
+        }
+      }
 
       // We need this return to avoid the grid to reload and miss selected rows when modal is open
       return;

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -378,7 +378,7 @@ export class GridWidgetComponent
     // Auto modify the selected rows
     if (options.modifySelectedRows) {
       //todo: show modal
-      console.log('aaas', options)
+      console.log('aaas', options);
 
       await this.promisedRowsModifications(
         options.modifications,

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -274,8 +274,6 @@ export class GridWidgetComponent
    * @param options action options.
    */
   public async onQuickAction(options: any): Promise<void> {
-    console.log('onQuickAction', options);
-    console.log('this.grid.selectedRows', this.grid.selectedRows);
     // Select all the records in the grid
     if (options.selectAll) {
       const query = this.queryBuilder.graphqlQuery(
@@ -555,6 +553,12 @@ export class GridWidgetComponent
                 this.grid.reloadData();
               }
             });
+        } else {
+          await this.promisedRowsModifications(
+            options.modifications,
+            this.grid.selectedRows
+          );
+          this.grid.reloadData();
         }
       }
 


### PR DESCRIPTION
# Description

Inside a grid, we have the option to set up quick action buttons, one of which is called 'auto modify selected rows.' For this one, I added an option to choose whether confirmation is needed when the user clicks the button.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-98

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?


## Screenshots


https://github.com/ReliefApplications/oort-frontend/assets/24783896/c457fb7e-56cc-455c-b3be-ac2a70b7e960



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
