### PR TITLE
OORT-feat/HIT-107_downloading-from-summary-card-downloads-multiple-files

### DIFF
--- a/libs/shared/src/lib/components/widgets/editor/editor.component.html
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.html
@@ -23,7 +23,7 @@
     </div>
   </kendo-tilelayout-item-header>
   <div class="flex-1 overflow-auto p-[14px]" (click)="onClick($event)">
-    <div class="w-full h-fit" (click)="onClick($event)">
+    <div class="w-full h-fit">
       <shared-html-widget-content
         [html]="formattedHtml"
         [style]="formattedStyle"


### PR DESCRIPTION
# Description

Downloading from summary card downloads multiple files, after this update only 1 file is downloaded.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-107

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Checking if only one file is downloaded after pressing the download button.

## Screenshots

Before:

https://github.com/ReliefApplications/ems-frontend/assets/24783896/7b99cb95-aaff-497a-a778-e81f43e7b2d1

After:

https://github.com/ReliefApplications/ems-frontend/assets/24783896/91514b75-38aa-49a9-8070-c015d3035a75


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
