### PR TITLE
fix/AB#69129_Filters-not-working-with-date

### DIFF
--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -361,10 +361,45 @@ export class SafeGridComponent
    * @param filter Filter event.
    */
   public onFilterChange(filter: CompositeFilterDescriptor): void {
+    // format filter before sending
+    this.formatFilter(filter);
     if (!this.loadingRecords) {
       this.filter = filter;
       this.filterChange.emit(filter);
     }
+  }
+
+  /**
+   * Format filter before sending.
+   * Adjust date filters to remove timezone.
+   *
+   * @param filter Filter value.
+   */
+  private formatFilter(filter: any) {
+    filter.filters.forEach((filter: any) => {
+      // if there are sub filters
+      if (filter.filters) {
+        this.formatFilter(filter);
+      } else if (filter.value instanceof Date) {
+        const currentDate = filter.value;
+        const hoursToAdjustTimezone = Math.floor(
+          (currentDate as Date).getTimezoneOffset() / 60
+        );
+        const minutesToAdjustTimezone =
+          (currentDate as Date).getTimezoneOffset() % 60;
+
+        const dateObj = new Date(currentDate);
+        dateObj.setHours(dateObj.getHours() - hoursToAdjustTimezone);
+        dateObj.setMinutes(dateObj.getMinutes() - minutesToAdjustTimezone);
+        // Convert the modified date back to the original format
+        const modifiedDateString = dateObj
+          .toISOString()
+          .replace('T00:00:00.000Z', '');
+        const modifiedDate = new Date(modifiedDateString);
+
+        filter.value = modifiedDate;
+      }
+    });
   }
 
   /**

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -361,9 +361,9 @@ export class SafeGridComponent
    * @param filter Filter event.
    */
   public onFilterChange(filter: CompositeFilterDescriptor): void {
-    // format filter before sending
-    this.formatFilter(filter);
     if (!this.loadingRecords) {
+      // format filter timezones before sending
+      this.formatFiltersTimezones(filter);
       this.filter = filter;
       this.filterChange.emit(filter);
     }
@@ -375,11 +375,11 @@ export class SafeGridComponent
    *
    * @param filter Filter value.
    */
-  private formatFilter(filter: any) {
+  private formatFiltersTimezones(filter: any) {
     filter.filters.forEach((subFilter: any) => {
       // if there are sub filters
       if (subFilter.filters) {
-        this.formatFilter(subFilter);
+        this.formatFiltersTimezones(subFilter);
       } else if (subFilter.value instanceof Date) {
         const currentDate = subFilter.value;
         const hoursToAdjustTimezone = Math.floor(
@@ -391,13 +391,8 @@ export class SafeGridComponent
         const dateObj = new Date(currentDate);
         dateObj.setHours(dateObj.getHours() - hoursToAdjustTimezone);
         dateObj.setMinutes(dateObj.getMinutes() - minutesToAdjustTimezone);
-        // Convert the modified date back to the original format
-        const modifiedDateString = dateObj
-          .toISOString()
-          .replace('T00:00:00.000Z', '');
-        const modifiedDate = new Date(modifiedDateString);
 
-        subFilter.value = modifiedDate;
+        subFilter.value = dateObj;
       }
     });
   }

--- a/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -376,12 +376,12 @@ export class SafeGridComponent
    * @param filter Filter value.
    */
   private formatFilter(filter: any) {
-    filter.filters.forEach((filter: any) => {
+    filter.filters.forEach((subFilter: any) => {
       // if there are sub filters
-      if (filter.filters) {
-        this.formatFilter(filter);
-      } else if (filter.value instanceof Date) {
-        const currentDate = filter.value;
+      if (subFilter.filters) {
+        this.formatFilter(subFilter);
+      } else if (subFilter.value instanceof Date) {
+        const currentDate = subFilter.value;
         const hoursToAdjustTimezone = Math.floor(
           (currentDate as Date).getTimezoneOffset() / 60
         );
@@ -397,7 +397,7 @@ export class SafeGridComponent
           .replace('T00:00:00.000Z', '');
         const modifiedDate = new Date(modifiedDateString);
 
-        filter.value = modifiedDate;
+        subFilter.value = modifiedDate;
       }
     });
   }


### PR DESCRIPTION
# Description

This branch is a way to re-add modifications done in this PR : https://github.com/ReliefApplications/ems-frontend/pull/1741 and later deleted for scope reasons. These modifications allow the user to filter by date without taking timezones into account.

There was a second issue mentioned in the ticket (quick filters not working with dates in specific conditions) but I was not able to reproduce this bug even though a video showing the bug was linked to the ticket

## Useful links

- Link to ticket : https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/69129

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested on local with own database, with UAT database and directly on UAT environment
- [x] Tested with different resources including the exact one used in the WHO video

## Screenshots

The time zone issue is fixed (here shown on local environment with UAT database) : 
![ticket69129_notimeZoneIssue](https://github.com/ReliefApplications/ems-frontend/assets/103029022/6061df98-736c-4406-8647-3eb9f90a8095)

The bug when filtering with 2 fields cannot be reproduced even on UAT (the timezone bug here is still showing because we are on UAT environment) : 

![ticket69129_cannotReproduce](https://github.com/ReliefApplications/ems-frontend/assets/103029022/827a2a0e-431e-4ce0-93dc-8726213a82a3)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
