### PR TITLE
HIT-fix/HIT-109_workflow-access-error-on-FO

### DIFF
--- a/apps/front-office/src/app/application/pages/workflow/workflow.component.ts
+++ b/apps/front-office/src/app/application/pages/workflow/workflow.component.ts
@@ -1,4 +1,3 @@
-import { Apollo } from 'apollo-angular';
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
@@ -35,7 +34,6 @@ export class WorkflowComponent extends UnsubscribeComponent implements OnInit {
   /**
    * Workflow page.
    *
-   * @param apollo Apollo client
    * @param route Angular current route
    * @param snackBar Shared snackbar service
    * @param router Angular router
@@ -43,7 +41,6 @@ export class WorkflowComponent extends UnsubscribeComponent implements OnInit {
    * @param workflowService Shared workflow service
    */
   constructor(
-    private apollo: Apollo,
     private route: ActivatedRoute,
     private snackBar: SnackbarService,
     private router: Router,
@@ -69,7 +66,7 @@ export class WorkflowComponent extends UnsubscribeComponent implements OnInit {
         this.goToNextStep();
       });
 
-    this.workflowService.workflow$.subscribe({
+    this.workflowService.workflow$.pipe(takeUntil(this.destroy$)).subscribe({
       next: (workflow) => {
         if (workflow) {
           this.workflow = workflow;


### PR DESCRIPTION
# Description

Fixes issue where sometimes when navigating in an app, you'd get an error message saying you had no access to that workflow even though you did. (FO only)

## Useful links

- [Please insert link to ticket](https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-109&text=109)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
