### PR TITLE
HIT-feat/HIT-125_Add-ability-to-add-tooltip-to-widget-headers

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1149,6 +1149,11 @@
 				},
 				"other": "Other"
 			},
+			"display": {
+				"tooltip": {
+					"placeholder": "Enter a value for tooltip"
+				}
+			},
 			"expand": "Expand",
 			"grid": {
 				"actions": {
@@ -2025,7 +2030,8 @@
 				"border": "Show widget border",
 				"searchable": "Allow search",
 				"sortable": "Allow sorting",
-				"title": "Widget display"
+				"title": "Widget display",
+				"tooltip": "Show tooltip"
 			},
 			"map": {
 				"defaultTitle": "Map Widget",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1164,6 +1164,11 @@
 				},
 				"other": "Autre"
 			},
+			"display": {
+				"tooltip": {
+					"placeholder": "Entrez une valeur pour l'info-bulle"
+				}
+			},
 			"expand": "Étendre",
 			"grid": {
 				"actions": {
@@ -2041,7 +2046,8 @@
 				"border": "Afficher la bordure du widget",
 				"searchable": "Autoriser la recherche",
 				"sortable": "Autoriser le tri",
-				"title": "Affichage des widgets"
+				"title": "Affichage des widgets",
+				"tooltip": "afficher l'info-bulle"
 			},
 			"map": {
 				"defaultTitle": "Widget Carte",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1149,6 +1149,11 @@
 				},
 				"other": "******"
 			},
+			"display": {
+				"tooltip": {
+					"placeholder": "******"
+				}
+			},
 			"expand": "******",
 			"grid": {
 				"actions": {
@@ -2025,7 +2030,8 @@
 				"border": "******",
 				"searchable": "******",
 				"sortable": "******",
-				"title": "******"
+				"title": "******",
+				"tooltip": "******"
 			},
 			"map": {
 				"defaultTitle": "******",

--- a/libs/shared/src/lib/components/widget-grid/floating-options/floating-options.component.html
+++ b/libs/shared/src/lib/components/widget-grid/floating-options/floating-options.component.html
@@ -1,14 +1,5 @@
 <div class="flex space-x-0">
   <ui-button
-    *ngIf="this.widget.settings.widgetDisplay.showTooltip"
-    [isIcon]="true"
-    icon="info"
-    variant="grey"
-    [uiTooltip]="this.widget.settings.widgetDisplay.tooltip"
-  >
-  </ui-button>
-
-  <ui-button
     [isIcon]="true"
     icon="more_vert"
     [uiMenuTriggerFor]="menu"

--- a/libs/shared/src/lib/components/widget-grid/floating-options/floating-options.component.html
+++ b/libs/shared/src/lib/components/widget-grid/floating-options/floating-options.component.html
@@ -1,11 +1,23 @@
-<ui-button
-  [isIcon]="true"
-  icon="more_vert"
-  [uiMenuTriggerFor]="menu"
-  variant="grey"
-  [uiTooltip]="'common.options' | translate"
->
-</ui-button>
+<div class="flex space-x-0">
+  <ui-button
+    *ngIf="this.widget.settings.widgetDisplay.showTooltip"
+    [isIcon]="true"
+    icon="info"
+    variant="grey"
+    [uiTooltip]="this.widget.settings.widgetDisplay.tooltip"
+  >
+  </ui-button>
+
+  <ui-button
+    [isIcon]="true"
+    icon="more_vert"
+    [uiMenuTriggerFor]="menu"
+    variant="grey"
+    [uiTooltip]="'common.options' | translate"
+  >
+  </ui-button>
+</div>
+
 <ui-menu #menu>
   <button
     uiMenuItem

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
@@ -68,6 +68,15 @@
         variant="grey"
       >
       </ui-icon>
+      <!-- Widget tooltip -->
+      <ui-icon
+        *ngIf="widget.settings?.widgetDisplay?.showTooltip"
+        icon="info"
+        class="absolute top-2 right-10 z-[1100]"
+        variant="grey"
+        [uiTooltip]="widget.settings.widgetDisplay.tooltip"
+      >
+      </ui-icon>
       <!-- Expand button -->
       <ui-button
         *ngIf="!canUpdate && !(widget.component === 'map')"

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
@@ -8,6 +8,14 @@
         'models.widget.display.border' | translate
       }}</ng-container>
     </ui-toggle>
+    <ui-toggle formControlName="showTooltip">
+      <ng-container ngProjectAs="label">{{ 'models.widget.display.tooltip' | translate }}</ng-container>
+    </ui-toggle>
+    <ng-container *ngIf="formGroup.get('widgetDisplay.showTooltip')?.value">
+      <ui-textarea formControlName="tooltip" [placeholder]="'components.widget.display.tooltip.placeholder' | translate"
+        [minRows]="1" [maxRows]="3" name="textarea">
+      </ui-textarea>
+    </ng-container>
   </ng-container>
   <!-- Other specific options for each widget type -->
   <ng-content></ng-content>

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { ToggleModule } from '@oort-front/ui';
+import { ToggleModule, TextareaModule } from '@oort-front/ui';
 
 /** Component for selecting the widget display options */
 @Component({
@@ -13,6 +13,7 @@ import { ToggleModule } from '@oort-front/ui';
     FormsModule,
     ReactiveFormsModule,
     ToggleModule,
+    TextareaModule,
     TranslateModule,
   ],
   templateUrl: './display-settings.component.html',

--- a/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
@@ -7,6 +7,8 @@ import { get } from 'lodash';
  * @param form widget form
  * @param settings settings to apply
  * @param settings.showBorder show border setting
+ * @param setting.showTooltip show tooltip setting
+ * @param setting.tooltip custom tooltip to show in widget
  * @param settings.style custom style of the widget
  * @param specificControls specific controls to add to the form, on a widget basis
  * @returns form with the common fields
@@ -18,12 +20,16 @@ export const extendWidgetForm = <
   form: FormGroup<T>,
   settings?: {
     showBorder?: boolean;
+    showTooltip?: boolean;
+    tooltip?: string;
     style?: string;
   },
   specificControls?: T2
 ) => {
   const controls = {
     showBorder: new FormControl(get(settings, 'showBorder', true)),
+    showTooltip: new FormControl(get(settings, 'showTooltip', false)),
+    tooltip: new FormControl(get(settings, 'tooltip', '')),
     style: new FormControl(get(settings, 'style', '')),
   };
   Object.assign(controls, specificControls);
@@ -34,6 +40,8 @@ export const extendWidgetForm = <
       widgetDisplay: FormGroup<
         {
           showBorder: FormControl<boolean>;
+          showTooltip: FormControl<boolean>;
+          tooltip: FormControl<string>;
           style: FormControl<string>;
         } & T2
       >;


### PR DESCRIPTION
# Description

New option in the widget display tab to allow the user to enter a tooltip that would be displayed when they hover the icon in the widget header.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-125

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Setting a new tooltip and testing if it appears in header of widget.

## Screenshots


https://github.com/ReliefApplications/ems-frontend/assets/24783896/917516e4-d7a2-431c-8569-df0181c4a4ca


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
