### PR TITLE
feat/AB#78059_ABC-replace-widget-new-ids-with-uuid

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
@@ -113,14 +113,6 @@ export class DashboardComponent
   /** Is edition active */
   public editionActive = true;
 
-  /** @returns get newest widget id from existing ids */
-  get newestId(): number {
-    const widgets = this.widgets?.slice() || [];
-    return widgets.length === 0
-      ? 0
-      : Math.max(...widgets.map((x: any) => x.id)) + 1;
-  }
-
   /** @returns type of context element */
   get contextType() {
     if (this.dashboard?.page?.context) {
@@ -394,7 +386,6 @@ export class DashboardComponent
    */
   onAdd(e: any): void {
     const widget = JSON.parse(JSON.stringify(e));
-    widget.id = this.newestId;
     this.widgets = [...this.widgets, widget];
     this.autoSaveChanges();
     if (this.timeoutListener) {

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
@@ -19,6 +19,7 @@ import { DashboardService } from '../../services/dashboard/dashboard.service';
 import { WidgetComponent } from '../widget/widget.component';
 import { takeUntil } from 'rxjs';
 import { UnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component';
+import { v4 as uuidv4 } from 'uuid';
 
 /** Maximum height of the widget in row units when loading grid */
 const MAX_ROW_SPAN_LOADING = 4;
@@ -224,6 +225,8 @@ export class WidgetGridComponent
           .subscribe((value: any) => {
             // Should save the value, and so, add the widget to the grid
             if (value) {
+              // Add the new id once the widget add is confirmed
+              tile.id = uuidv4();
               this.add.emit({
                 ...tile,
                 settings: value,

--- a/libs/shared/src/lib/components/widget/widget.component.ts
+++ b/libs/shared/src/lib/components/widget/widget.component.ts
@@ -16,7 +16,6 @@ import { EditorComponent } from '../widgets/editor/editor.component';
 import { GridWidgetComponent } from '../widgets/grid/grid.component';
 import { MapWidgetComponent } from '../widgets/map/map.component';
 import { SummaryCardComponent } from '../widgets/summary-card/summary-card.component';
-import { v4 as uuidv4 } from 'uuid';
 import get from 'lodash/get';
 import { RestService } from '../../services/rest/rest.service';
 import { DOCUMENT } from '@angular/common';
@@ -56,8 +55,15 @@ export class WidgetComponent implements OnInit, OnDestroy {
 
   private customStyle?: HTMLStyleElement;
 
-  @HostBinding()
-  id = `widget-${uuidv4()}`;
+  /**
+   * Bind current element with the widget id
+   *
+   * @returns current element's id based in the current widget
+   */
+  @HostBinding('id')
+  get id() {
+    return `widget-${this.widget.id}`;
+  }
 
   @ViewChild('widgetContent')
   widgetContentComponent!:


### PR DESCRIPTION
# Description

feat: use uuidv4 to set widget id 
feat: move new widget id assignation inside the widget component to narrow the scope of the properties to the current property holder 
fix: use current widget id for the html holding it fixing the auto scroll on widget add

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78059)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please refer to video below

## Screenshots

New id configuration with an already created dashboard when working with widgets:

https://github.com/ReliefApplications/ems-frontend/assets/123092672/39d0ce9d-6936-41ce-980a-eb17a98ddec0


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
