### PR TITLE
feat/AB#78097_implement_way_to_hide_padding_of_widgets

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -2128,6 +2128,7 @@
 			"display": {
 				"border": "Show widget border",
 				"header": "Show widget header",
+				"padding": "Show widget padding",
 				"searchable": "Allow search",
 				"sortable": "Allow sorting",
 				"title": "Widget display"

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -2144,6 +2144,7 @@
 			"display": {
 				"border": "Afficher la bordure du widget",
 				"header": "Afficher l'en-tête du widget",
+				"padding": "Afficher le remplissage du widget",
 				"searchable": "Autoriser la recherche",
 				"sortable": "Autoriser le tri",
 				"title": "Affichage des widgets"

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -2128,6 +2128,7 @@
 			"display": {
 				"border": "******",
 				"header": "******",
+				"padding": "******",
 				"searchable": "******",
 				"sortable": "******",
 				"title": "******"

--- a/libs/shared/src/lib/components/ui/charts/bar-chart/bar-chart.component.html
+++ b/libs/shared/src/lib/components/ui/charts/bar-chart/bar-chart.component.html
@@ -1,4 +1,4 @@
-<div class="h-full p-2" style="background: white">
+<div class="h-full" [ngClass]="{'p-2': showPadding}" style="background: white" id="inner-widget">
   <canvas
     baseChart
     [data]="chartData"

--- a/libs/shared/src/lib/components/ui/charts/bar-chart/bar-chart.component.ts
+++ b/libs/shared/src/lib/components/ui/charts/bar-chart/bar-chart.component.ts
@@ -50,6 +50,8 @@ export class BarChartComponent implements OnChanges {
     palette: DEFAULT_PALETTE,
     stack: false,
   };
+  /** Input decorator for show padding */
+  @Input() showPadding = true;
   /** Input decorator for gap. */
   @Input() gap = 2;
   /** Input decorator for spacing. */

--- a/libs/shared/src/lib/components/ui/charts/line-chart/line-chart.component.html
+++ b/libs/shared/src/lib/components/ui/charts/line-chart/line-chart.component.html
@@ -1,4 +1,4 @@
-<div class="h-full p-2">
+<div class="h-full" [ngClass]="{'p-2': showPadding}" id="inner-widget">
   <canvas
     baseChart
     [data]="chartData"

--- a/libs/shared/src/lib/components/ui/charts/line-chart/line-chart.component.ts
+++ b/libs/shared/src/lib/components/ui/charts/line-chart/line-chart.component.ts
@@ -57,6 +57,8 @@ export class LineChartComponent implements OnChanges {
     palette: DEFAULT_PALETTE,
     axes: null,
   };
+  /** Input decorator for show padding */
+  @Input() showPadding = true;
   /** ViewChild decorator for chart. */
   @ViewChild(BaseChartDirective) chart?: BaseChartDirective;
   /** Options for the chart configuration. */

--- a/libs/shared/src/lib/components/ui/charts/pie-donut-chart/pie-donut-chart.component.html
+++ b/libs/shared/src/lib/components/ui/charts/pie-donut-chart/pie-donut-chart.component.html
@@ -1,4 +1,4 @@
-<div class="h-full p-2">
+<div class="h-full" [ngClass]="{'p-2': showPadding}" id="inner-widget">
   <canvas
     baseChart
     [data]="chartData"

--- a/libs/shared/src/lib/components/ui/charts/pie-donut-chart/pie-donut-chart.component.ts
+++ b/libs/shared/src/lib/components/ui/charts/pie-donut-chart/pie-donut-chart.component.ts
@@ -47,6 +47,8 @@ export class PieDonutChartComponent implements OnChanges {
   @Input() options: any = {
     palette: DEFAULT_PALETTE,
   };
+  /** Input decorator for show padding */
+  @Input() showPadding = true;
   /** ViewChild decorator for chart. */
   @ViewChild(BaseChartDirective) chart: BaseChartDirective | undefined;
   /** Options for the chart configuration. */

--- a/libs/shared/src/lib/components/widgets/chart-settings/chart-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/chart-settings/chart-settings.component.html
@@ -59,6 +59,7 @@
     <ng-template uiTabContent>
       <shared-display-settings
         [formGroup]="formGroup"
+        widgetType="chart"
       ></shared-display-settings>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/chart/chart.component.html
+++ b/libs/shared/src/lib/components/widgets/chart/chart.component.html
@@ -15,6 +15,7 @@
       *ngIf="settings.chart.type === 'line'"
       [title]="settings.chart.title"
       [legend]="settings.chart.legend"
+      [showPadding]="settings.widgetDisplay.showPadding"
       [series]="series"
       [options]="options"
     ></shared-line-chart>
@@ -25,6 +26,7 @@
       *ngIf="settings.chart.type === 'pie'"
       [title]="settings.chart.title"
       [legend]="settings.chart.legend"
+      [showPadding]="settings.widgetDisplay.showPadding"
       [series]="series"
       [options]="options"
     ></shared-pie-donut-chart>
@@ -35,6 +37,7 @@
       *ngIf="settings.chart.type === 'polar'"
       [title]="settings.chart.title"
       [legend]="settings.chart.legend"
+      [showPadding]="settings.widgetDisplay.showPadding"
       [series]="series"
       [options]="options"
     ></shared-pie-donut-chart>
@@ -45,6 +48,7 @@
       *ngIf="settings.chart.type === 'donut'"
       [title]="settings.chart.title"
       [legend]="settings.chart.legend"
+      [showPadding]="settings.widgetDisplay.showPadding"
       [series]="series"
       [options]="options"
     ></shared-pie-donut-chart>
@@ -55,6 +59,7 @@
       *ngIf="settings.chart.type === 'radar'"
       [title]="settings.chart.title"
       [legend]="settings.chart.legend"
+      [showPadding]="settings.widgetDisplay.showPadding"
       [series]="series"
       [options]="options"
     ></shared-pie-donut-chart>
@@ -65,6 +70,7 @@
       *ngIf="settings.chart.type === 'column'"
       [title]="settings.chart.title"
       [legend]="settings.chart.legend"
+      [showPadding]="settings.widgetDisplay.showPadding"
       [series]="series"
       [options]="options"
     ></shared-bar-chart>
@@ -75,6 +81,7 @@
       *ngIf="settings.chart.type === 'bar'"
       [title]="settings.chart.title"
       [legend]="settings.chart.legend"
+      [showPadding]="settings.widgetDisplay.showPadding"
       [series]="series"
       [options]="options"
     ></shared-bar-chart>

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
@@ -13,6 +13,18 @@
         'models.widget.display.header' | translate
       }}</ng-container>
     </ui-toggle>
+    <ui-toggle 
+      formControlName="showPadding" 
+      *ngIf="
+        widgetType === 'summaryCard' ||
+        widgetType === 'editor' ||
+        widgetType === 'chart'
+      "
+    >
+      <ng-container ngProjectAs="label">
+        {{ 'models.widget.display.padding' | translate }}
+      </ng-container>
+    </ui-toggle>
   </ng-container>
   <!-- Other specific options for each widget type -->
   <ng-content></ng-content>

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input } from '@angular/core';
+import { Attribute, Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { ToggleModule } from '@oort-front/ui';
+import { WidgetType } from '../../types/widget-types';
 
 /** Component for selecting the widget display options */
 @Component({
@@ -20,5 +21,11 @@ import { ToggleModule } from '@oort-front/ui';
 })
 export class DisplaySettingsComponent {
   @Input() formGroup!: FormGroup;
-  @Input() widgetType!: string;
+
+  /**
+   * Shared display settings constructor by widget type
+   *
+   * @param widgetType Type of widget
+   */
+  constructor(@Attribute('widgetType') public widgetType: WidgetType) {}
 }

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
@@ -20,4 +20,5 @@ import { ToggleModule } from '@oort-front/ui';
 })
 export class DisplaySettingsComponent {
   @Input() formGroup!: FormGroup;
+  @Input() widgetType!: string;
 }

--- a/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
@@ -9,6 +9,7 @@ import { get } from 'lodash';
  * @param settings.showBorder show border setting
  * @param settings.showHeader show border header
  * @param settings.style custom style of the widget
+ * @param settings.showPadding show padding of the widget
  * @param specificControls specific controls to add to the form, on a widget basis
  * @returns form with the common fields
  */

--- a/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
@@ -20,6 +20,7 @@ export const extendWidgetForm = <
   settings?: {
     showBorder?: boolean;
     showHeader?: boolean;
+    showPadding?: boolean;
     style?: string;
   },
   specificControls?: T2
@@ -27,6 +28,7 @@ export const extendWidgetForm = <
   const controls = {
     showBorder: new FormControl(get(settings, 'showBorder', true)),
     showHeader: new FormControl(get(settings, 'showHeader', true)),
+    showPadding: new FormControl(get(settings, 'showPadding', true)),
     style: new FormControl(get(settings, 'style', '')),
   };
   Object.assign(controls, specificControls);
@@ -38,6 +40,7 @@ export const extendWidgetForm = <
         {
           showBorder: FormControl<boolean>;
           showHeader: FormControl<boolean>;
+          showPadding: FormControl<boolean>;
           style: FormControl<string>;
         } & T2
       >;

--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.html
@@ -79,6 +79,7 @@
         <div class="flex flex-col">
           <shared-display-settings
             [formGroup]="tileForm"
+            widgetType="editor"
           ></shared-display-settings>
           <ui-divider class="my-2"></ui-divider>
           <div [formGroup]="tileForm">

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.html
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.html
@@ -1,5 +1,10 @@
 <div class="h-full flex flex-col">
-  <div class="flex-1 overflow-auto p-[14px]" (click)="onClick($event)">
+  <div 
+    class="flex-1 overflow-auto"
+    [ngClass]="{'p-[14px]': settings.widgetDisplay.showPadding}"
+    (click)="onClick($event)"
+    id="inner-widget"
+  >
     <div class="w-full h-fit" (click)="onClick($event)">
       <shared-html-widget-content
         [html]="formattedHtml"

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.html
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.html
@@ -1,7 +1,7 @@
 <div class="h-full flex flex-col">
-  <div 
+  <div
     class="flex-1 overflow-auto"
-    [ngClass]="{'p-[14px]': settings.widgetDisplay.showPadding}"
+    [ngClass]="{ 'p-[14px]': settings.widgetDisplay.showPadding ?? true }"
     (click)="onClick($event)"
     id="inner-widget"
   >

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -89,7 +89,7 @@
       <span>{{ 'models.widget.display.title' | translate }}</span>
     </ng-container>
     <ng-template uiTabContent>
-      <shared-display-settings [formGroup]="formGroup">
+      <shared-display-settings [formGroup]="formGroup" widgetType="grid">
       </shared-display-settings>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.html
@@ -42,7 +42,7 @@
       <span>{{ 'models.widget.display.title' | translate }}</span>
     </ng-container>
     <ng-template uiTabContent>
-      <shared-display-settings [formGroup]="tileForm"></shared-display-settings>
+      <shared-display-settings [formGroup]="tileForm" widgetType="map"></shared-display-settings>
     </ng-template>
   </ui-tab>
 </ui-tabs>

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -111,7 +111,7 @@
         <span>{{ 'models.widget.display.title' | translate }}</span>
       </ng-container>
       <ng-template uiTabContent>
-        <shared-display-settings [formGroup]="tileForm">
+        <shared-display-settings [formGroup]="tileForm"  widgetType="summaryCard">
           <!-- Specific settings for summary card -->
           <ui-toggle
             *ngIf="tileForm.get('widgetDisplay.searchable')?.enabled"

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.html
@@ -18,5 +18,6 @@
   [styles]="card.useStyles ? styles : []"
   [wholeCardStyles]="card.wholeCardStyles"
   class="flex-1 overflow-auto p-[14px]"
+  [ngClass]="{'p-[14px]': showPadding}"
 >
 </shared-summary-card-item-content>

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card-item/summary-card-item.component.ts
@@ -12,6 +12,8 @@ import { CardT } from '../summary-card.component';
 })
 export class SummaryCardItemComponent implements OnInit, OnChanges {
   @Input() card!: CardT;
+  /** Input decorator for show padding */
+  @Input() showPadding = true;
   public fields: any[] = [];
   public fieldsValue: any = null;
   public styles: any[] = [];

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -6,7 +6,9 @@
       <kendo-pdf-export #pdf paperSize="A4" margin="2cm">
         <div
           class="summary-card-container k-widget k-tile-layout k-grid-flow-col"
+          [ngClass]="{'p-4': settings.widgetDisplay?.showPadding}"
           style.grid-template-columns="{{ 'repeat(' + colsNumber + ', 1fr)' }}"
+          id="inner-widget"
         >
           <ng-container
             *sharedSkeleton="
@@ -26,6 +28,8 @@
               }}"
               style.grid-row-end="{{ 'span ' + 2 }}"
               [card]="card"
+              [showPadding]="settings.widgetDisplay?.showPadding ?? true"
+              id="inner-widget-card"
             >
             </shared-summary-card-item>
           </ng-container>

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.scss
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.scss
@@ -2,7 +2,6 @@
   display: grid;
   grid-auto-rows: 200px;
   gap: 16px;
-  padding: 16px;
   grid-auto-flow: row;
   background-color: unset;
   max-height: 80vh;

--- a/libs/shared/src/lib/components/widgets/tabs-settings/tabs-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tabs-settings.component.html
@@ -21,7 +21,7 @@
       <span>{{ 'models.widget.display.title' | translate }}</span>
     </ng-container>
     <ng-template uiTabContent>
-      <shared-display-settings [formGroup]="widgetForm">
+      <shared-display-settings [formGroup]="widgetForm"  widgetType="tabs">
       </shared-display-settings>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/types/widget-types.ts
+++ b/libs/shared/src/lib/components/widgets/types/widget-types.ts
@@ -1,0 +1,12 @@
+/**
+ * Widget types
+ */
+export const widgetTypes = [
+  'chart',
+  'editor',
+  'grid',
+  'map',
+  'summaryCard',
+  'tabs',
+] as const;
+export type WidgetType = (typeof widgetTypes)[number];


### PR DESCRIPTION
# Description

Implemented toggle in settings of the widget to hide padding, and also put in the content that has the padding an id= "inner-widget"

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78097)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested creating widgets and testing if we hide the padding the widget is correctly styled with the padding hidded.

## Screenshots

![Peek 26-10-2023 17-15](https://github.com/ReliefApplications/ems-frontend/assets/56398308/3ccb193c-5cf6-41ab-a525-09374f5ed74f)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
