### PR TITLE
feat/AB#78157_improve_block_style

### DIFF
--- a/apps/back-office/src/app/application/pages/add-page/add-page.component.html
+++ b/apps/back-office/src/app/application/pages/add-page/add-page.component.html
@@ -9,7 +9,7 @@
         formControlName="type"
         [contentTypes]="contentTypes"
       ></shared-content-choice>
-      <ui-divider class="m-8" [text]="'common.or' | translate"></ui-divider>
+      <ui-divider class="m-8 w-full" [text]="'common.or' | translate"></ui-divider>
       <!-- Select a type of widget -->
       <h2>{{ 'pages.application.addPage.startFromWidget' | translate }}</h2>
       <shared-widget-choice

--- a/libs/shared/src/lib/components/applications-archive/applications-archive.component.html
+++ b/libs/shared/src/lib/components/applications-archive/applications-archive.component.html
@@ -48,7 +48,7 @@
                 <ui-icon icon="restore_page" variant="grey"></ui-icon>
                 {{ 'common.archive.restore' | translate }}
               </button>
-              <ui-divider></ui-divider>
+              <ui-divider class="py-1"></ui-divider>
               <button uiMenuItem (click)="onDelete(element)">
                 <ui-icon icon="delete" variant="danger"></ui-icon>
                 {{ 'common.archive.delete' | translate }}

--- a/libs/ui/src/lib/divider/divider.component.scss
+++ b/libs/ui/src/lib/divider/divider.component.scss
@@ -1,6 +1,7 @@
 :host {
-  @apply block w-full;
+  display: block;
 }
+
 .divider-container {
   @apply flex justify-center;
 }

--- a/libs/ui/src/lib/divider/divider.component.scss
+++ b/libs/ui/src/lib/divider/divider.component.scss
@@ -1,3 +1,6 @@
+:host {
+  @apply block w-full;
+}
 .divider-container {
   @apply flex justify-center;
 }


### PR DESCRIPTION
# Description

Improved ui-divider style by adding display block and width full to it.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78157)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested accessing in the application where it's used ui-divider and checking if it's working correctly.

## Screenshots

![Captura de tela de 2023-10-27 10-34-49](https://github.com/ReliefApplications/ems-frontend/assets/56398308/082fea8c-a6d3-478a-a030-5126f8120dd1)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
