### PR TITLE
feat/AB#75646-grid-actions-from-summary-card

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1485,6 +1485,10 @@
 					"tooltip": {
 						"template": "Select a template for addition and edition of records",
 						"useRecordId": "Url will contain id of the item, in order to redirect to contextual page, if configured"
+					},
+					"warnings": {
+						"add": "Please select a template",
+						"general": "Warning: actions contain errors"
 					}
 				},
 				"iconPicker": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1501,6 +1501,10 @@
 					"tooltip": {
 						"template": "Sélectionnez un modèle à utiliser pour l'ajout et l'édition des enregistrements",
 						"useRecordId": "L'url de redirection contiendra l'identifiant de l'élément, afin de naviguer à une page contextuelle, si configurée"
+					},
+					"warnings": {
+						"add": "Veuillez sélectionner un modèle",
+						"general": "Attention: les actions contiennent des erreurs"
 					}
 				},
 				"iconPicker": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1485,6 +1485,10 @@
 					"tooltip": {
 						"template": "******",
 						"useRecordId": "******"
+					},
+					"warnings": {
+						"add": "******",
+						"general": "******"
 					}
 				},
 				"iconPicker": {

--- a/libs/shared/src/lib/components/widgets/common/tab-actions/tab-actions.component.html
+++ b/libs/shared/src/lib/components/widgets/common/tab-actions/tab-actions.component.html
@@ -22,7 +22,10 @@
             ></ui-icon>
             <!-- Icon with warning if any -->
             <ui-icon
-              *ngIf="action.toolTipWarning && templateWarning"
+              *ngIf="
+                formGroup.get('actions')?.get(action.name)?.invalid &&
+                action.toolTipWarning
+              "
               class="ml-1 cursor-help self-center"
               variant="danger"
               icon="warning"
@@ -79,7 +82,7 @@
             {{
               'components.widget.settings.grid.actions.useRecordId' | translate
             }}<ui-icon
-              class="ml-1 cursor-help "
+              class="ml-1 cursor-help"
               variant="grey"
               icon="info_outline"
               [size]="18"

--- a/libs/shared/src/lib/components/widgets/common/tab-actions/tab-actions.component.html
+++ b/libs/shared/src/lib/components/widgets/common/tab-actions/tab-actions.component.html
@@ -20,6 +20,16 @@
               [uiTooltip]="action.tooltip | translate"
               uiTooltipPosition="right"
             ></ui-icon>
+            <!-- Icon with warning if any -->
+            <ui-icon
+              *ngIf="action.toolTipWarning && templateWarning"
+              class="ml-1 cursor-help self-center"
+              variant="danger"
+              icon="warning"
+              [size]="18"
+              [uiTooltip]="action.toolTipWarning | translate"
+              uiTooltipPosition="right"
+            ></ui-icon>
           </ng-container>
         </ui-toggle>
       </div>

--- a/libs/shared/src/lib/components/widgets/common/tab-actions/tab-actions.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/tab-actions/tab-actions.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { ApplicationService } from '../../../../services/application/application.service';
 import { Application } from '../../../../models/application.model';
@@ -18,9 +18,8 @@ export class TabActionsComponent
   extends UnsubscribeComponent
   implements OnInit
 {
+  /** Widget reactive form group */
   @Input() formGroup!: UntypedFormGroup;
-  /** To show the tooltip warning icon next to the tab name */
-  public templateWarning = false;
   /** Show select page id and checkbox for record id */
   public showSelectPage = false;
   /** Available pages from the application */
@@ -74,8 +73,6 @@ export class TabActionsComponent
       tooltip: 'components.widget.settings.grid.hint.actions.navigateToPage',
     },
   ];
-  /** Alerts parent component on warning status changes */
-  @Output() warnings = new EventEmitter();
 
   /**
    * Constructor of the grid component
@@ -97,15 +94,6 @@ export class TabActionsComponent
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((val: boolean) => {
         this.showSelectPage = val;
-      });
-
-    // If addRecord actin enabled but missing template, show warning
-    this.checkTemplateWarning();
-    this.formGroup.controls.actions
-      .get('addRecord')
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.checkTemplateWarning();
       });
   }
 
@@ -137,21 +125,5 @@ export class TabActionsComponent
     return page.type === ContentType.form
       ? `${application.id}/${page.type}/${page.id}`
       : `${application.id}/${page.type}/${page.content}`;
-  }
-
-  /**
-   * Checks if If addRecord action is enabled but missing template to display warning
-   */
-  private checkTemplateWarning(): void {
-    this.templateWarning =
-      !(
-        this.formGroup.get('template')?.value ||
-        this.formGroup.get('card.template')?.value
-      ) && this.formGroup.controls.actions.get('addRecord')?.value;
-    if (this.templateWarning) {
-      this.warnings.emit(true);
-    } else {
-      this.warnings.emit(false);
-    }
   }
 }

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -35,9 +35,19 @@
       <span>{{
         'components.widget.settings.grid.actions.title' | translate
       }}</span>
+      <!-- Icon with warning if any -->
+      <ui-icon
+        *ngIf="actionsWarnings"
+        class="ml-1 cursor-help self-center"
+        variant="danger"
+        icon="warning"
+        [size]="18"
+        [uiTooltip]="'components.widget.settings.grid.warnings.general' | translate"
+        uiTooltipPosition="right"
+      ></ui-icon>
     </ng-container>
     <ng-template uiTabContent>
-      <shared-tab-actions [formGroup]="formGroup"></shared-tab-actions>
+      <shared-tab-actions [formGroup]="formGroup" (warnings)="actionsWarnings = $event"></shared-tab-actions>
     </ng-template>
   </ui-tab>
   <!-- BUTTONS -->

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -37,7 +37,7 @@
       }}</span>
       <!-- Icon with warning if any -->
       <ui-icon
-        *ngIf="actionsWarnings"
+        *ngIf="formGroup.get('actions')?.invalid"
         class="ml-1 cursor-help self-center"
         variant="danger"
         icon="warning"
@@ -47,7 +47,7 @@
       ></ui-icon>
     </ng-container>
     <ng-template uiTabContent>
-      <shared-tab-actions [formGroup]="formGroup" (warnings)="actionsWarnings = $event"></shared-tab-actions>
+      <shared-tab-actions [formGroup]="formGroup"></shared-tab-actions>
     </ng-template>
   </ui-tab>
   <!-- BUTTONS -->

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -28,7 +28,6 @@ import { createGridWidgetFormGroup } from './grid-settings.forms';
 import { DistributionList } from '../../../models/distribution-list.model';
 import { UnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.component';
 import { takeUntil } from 'rxjs/operators';
-import { extendWidgetForm } from '../common/display-settings/extendWidgetForm';
 import { AggregationService } from '../../../services/aggregation/aggregation.service';
 
 /**
@@ -63,14 +62,11 @@ export class GridSettingsComponent
 
   // === DATASET AND TEMPLATES ===
   public templates: Form[] = [];
-  private allQueries: any[] = [];
   public filteredQueries: any[] = [];
   public resource: Resource | null = null;
 
   /** Stores the selected tab */
   public selectedTab = 0;
-  /** To show the tooltip warning icon if grid actions has warnings */
-  public actionsWarnings = false;
 
   /** @returns application templates */
   get appTemplates(): any[] {
@@ -104,10 +100,7 @@ export class GridSettingsComponent
   /** Build the settings form, using the widget saved parameters. */
   ngOnInit(): void {
     const tileSettings = this.tile.settings;
-    this.formGroup = extendWidgetForm(
-      createGridWidgetFormGroup(this.tile.id, tileSettings),
-      tileSettings?.widgetDisplay
-    );
+    this.formGroup = createGridWidgetFormGroup(this.tile.id, tileSettings);
 
     this.change.emit(this.formGroup);
 
@@ -184,15 +177,6 @@ export class GridSettingsComponent
     if (this.formGroup.get('layouts')?.value.length > 0) {
       this.formGroup.controls.aggregations.clearValidators();
     }
-
-    // Subscribe to form template changes to display warning if necessary
-    this.checkActionsWarning();
-    this.formGroup
-      .get('template')
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.checkActionsWarning();
-      });
 
     this.initSortFields();
   }
@@ -366,15 +350,5 @@ export class GridSettingsComponent
           }
         });
     }
-  }
-
-  /**
-   * Checks if If addRecord action is enabled but missing template to display warning
-   */
-  private checkActionsWarning(): void {
-    console.log('checkTemplateWarning');
-    this.actionsWarnings =
-      !this.formGroup.get('template')?.value &&
-      this.formGroup.get('actions.addRecord')?.value;
   }
 }

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -69,6 +69,8 @@ export class GridSettingsComponent
 
   /** Stores the selected tab */
   public selectedTab = 0;
+  /** To show the tooltip warning icon if grid actions has warnings */
+  public actionsWarnings = false;
 
   /** @returns application templates */
   get appTemplates(): any[] {
@@ -182,6 +184,15 @@ export class GridSettingsComponent
     if (this.formGroup.get('layouts')?.value.length > 0) {
       this.formGroup.controls.aggregations.clearValidators();
     }
+
+    // Subscribe to form template changes to display warning if necessary
+    this.checkActionsWarning();
+    this.formGroup
+      .get('template')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.checkActionsWarning();
+      });
 
     this.initSortFields();
   }
@@ -355,5 +366,15 @@ export class GridSettingsComponent
           }
         });
     }
+  }
+
+  /**
+   * Checks if If addRecord action is enabled but missing template to display warning
+   */
+  private checkActionsWarning(): void {
+    console.log('checkTemplateWarning');
+    this.actionsWarnings =
+      !this.formGroup.get('template')?.value &&
+      this.formGroup.get('actions.addRecord')?.value;
   }
 }

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -73,9 +73,19 @@
           'components.widget.settings.summaryCard.card.gridActions.title'
             | translate
         }}</span>
+        <!-- Icon with warning if any -->
+        <ui-icon
+          *ngIf="actionsWarnings"
+          class="ml-1 cursor-help self-center"
+          variant="danger"
+          icon="warning"
+          [size]="18"
+          [uiTooltip]="'components.widget.settings.grid.warnings.general' | translate"
+          uiTooltipPosition="right"
+        ></ui-icon>
       </ng-container>
       <ng-template uiTabContent>
-        <shared-tab-actions [formGroup]="tileForm"></shared-tab-actions>
+        <shared-tab-actions [formGroup]="tileForm" (warnings)="actionsWarnings = $event"></shared-tab-actions>
       </ng-template>
     </ui-tab>
     <!-- Card display settings -->

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -75,7 +75,7 @@
         }}</span>
         <!-- Icon with warning if any -->
         <ui-icon
-          *ngIf="actionsWarnings"
+          *ngIf="tileForm.get('actions')?.invalid"
           class="ml-1 cursor-help self-center"
           variant="danger"
           icon="warning"
@@ -85,7 +85,7 @@
         ></ui-icon>
       </ng-container>
       <ng-template uiTabContent>
-        <shared-tab-actions [formGroup]="tileForm" (warnings)="actionsWarnings = $event"></shared-tab-actions>
+        <shared-tab-actions [formGroup]="tileForm"></shared-tab-actions>
       </ng-template>
     </ui-tab>
     <!-- Card display settings -->

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -131,6 +131,8 @@ export class SummaryCardSettingsComponent
   public fields: any[] = [];
   public activeTabIndex: number | undefined;
   public templates: Form[] = [];
+  /** To show the tooltip warning icon if grid actions has warnings */
+  public actionsWarnings = false;
 
   /**
    * Summary Card Settings component.
@@ -198,6 +200,15 @@ export class SummaryCardSettingsComponent
       });
 
     this.getTemplates();
+
+    // Subscribe to form template changes to display warning if necessary
+    this.checkActionsWarning();
+    this.tileForm
+      .get('card.template')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.checkActionsWarning();
+      });
   }
 
   /**
@@ -390,5 +401,15 @@ export class SummaryCardSettingsComponent
   handleAggregationChange(aggregation: Aggregation | null) {
     this.selectedAggregation = aggregation;
     this.getCustomAggregation();
+  }
+
+  /**
+   * Checks if If addRecord action is enabled but missing template to display warning
+   */
+  private checkActionsWarning(): void {
+    this.actionsWarnings =
+      (!this.tileForm?.get('card.template')?.value &&
+        this.tileForm?.get('actions.addRecord')?.value) ??
+      false;
   }
 }

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.forms.ts
@@ -1,0 +1,124 @@
+import {
+  AbstractControl,
+  FormArray,
+  FormBuilder,
+  FormControl,
+  ValidationErrors,
+} from '@angular/forms';
+import get from 'lodash/get';
+import { createGridActionsFormGroup } from '../grid-settings/grid-settings.forms';
+import { extendWidgetForm } from '../common/display-settings/extendWidgetForm';
+
+/** Creating a new instance of the FormBuilder class. */
+const fb = new FormBuilder();
+
+/**
+ * Create a summary card form from definition
+ *
+ * @param id id of the widget
+ * @param configuration Widget configuration
+ * @returns Summary card widget form
+ */
+export const createSummaryCardForm = (id: string, configuration: any) => {
+  const formGroup = fb.group(
+    {
+      id,
+      title: get<string>(configuration, 'title', ''),
+      card: createCardForm(get(configuration, 'card', null)),
+      sortFields: new FormArray([]),
+      contextFilters: get<string>(
+        configuration,
+        'contextFilters',
+        DEFAULT_CONTEXT_FILTER
+      ),
+      actions: createGridActionsFormGroup(configuration),
+      at: get<string>(configuration, 'at', ''),
+    },
+    {
+      validators: [templateRequiredWhenAddRecord],
+    }
+  );
+
+  const isUsingAggregation = !!get(configuration, 'card.aggregation', null);
+  const searchable = isUsingAggregation
+    ? false
+    : get<boolean>(configuration, 'widgetDisplay.searchable', false);
+
+  const extendedForm = extendWidgetForm(
+    formGroup,
+    configuration?.widgetDisplay,
+    {
+      searchable: new FormControl(searchable),
+      usePagination: new FormControl(
+        get<boolean>(configuration, 'widgetDisplay.usePagination', false)
+      ),
+    }
+  );
+
+  // disable searchable if aggregation is selected
+  if (isUsingAggregation)
+    extendedForm.get('widgetDisplay.searchable')?.disable();
+
+  return extendedForm;
+};
+
+// todo: put in common
+/** Default context filter value. */
+const DEFAULT_CONTEXT_FILTER = `{
+  "logic": "and",
+  "filters": []
+}`;
+
+/**
+ * Validators for checking that a template is selected when configuring "add record" action.
+ *
+ * @param group form group
+ * @returns validation errors
+ */
+export const templateRequiredWhenAddRecord = (
+  group: AbstractControl
+): ValidationErrors | null => {
+  const templateControl = group.get('card.template');
+  const addRecordControl = group.get('actions.addRecord');
+
+  if (templateControl && addRecordControl) {
+    const templateValue = templateControl.value;
+    const addRecordValue = addRecordControl.value;
+
+    if (addRecordValue && !templateValue) {
+      addRecordControl.setErrors({
+        missingTemplate: true,
+      });
+      return {
+        actions: {
+          addRecord: {
+            missingTemplate: true,
+          },
+        },
+      };
+    } else {
+      addRecordControl.setErrors(null);
+    }
+  }
+  return null;
+};
+
+/**
+ * Create a card form
+ *
+ * @param value card value, optional
+ * @returns card as form group
+ */
+const createCardForm = (value?: any) => {
+  return fb.group({
+    title: get<string>(value, 'title', 'New Card'),
+    resource: get<string | null>(value, 'resource', null),
+    template: get<string | null>(value, 'template', null),
+    layout: get<string | null>(value, 'layout', null),
+    aggregation: get<string | null>(value, 'aggregation', null),
+    html: get<string | null>(value, 'html', null),
+    showDataSourceLink: get<boolean>(value, 'showDataSourceLink', false),
+    useStyles: get<boolean>(value, 'useStyles', true),
+    wholeCardStyles: get<boolean>(value, 'wholeCardStyles', false),
+  });
+};


### PR DESCRIPTION
# Description
In a grid or summary card widget, if the  "add new record" option in the enable actions tab is selected and a template is not, add a icon warning displayed by the side of the "add new record" action and by the side of the tab name, so when opening the widget the warning icon is already visible in these cases

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/75646

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Select the "add new record" option in the enable actions tab in a grid or summary card widget. If a template is not selected, an icon warning is displayed by the side of the "add new record" action and by the side of the tab name, so when opening the widget the warning icon is already visible in these cases

## Screenshots
In summary cards:
[summary-card.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/ac237e04-3ef8-4845-bf10-cd003fafa422)

In grids:
[grid.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/59d17083-cc02-433c-989e-9b983fb36f90)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
