### PR TITLE
feat/AB#72018-search-record-in-context-datasource-resource

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.html
@@ -140,6 +140,8 @@
           <ui-graphql-select
             [query]="recordsQuery"
             [formControl]="contextId"
+            [filterable]="true"
+            (searchChange)="onSearchChange($event)"
             path="records"
             valueField="id"
             textField="data.{{ dashboard.page.context.displayField }}"

--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
@@ -846,4 +846,32 @@ export class DashboardComponent
       subscription?.unsubscribe();
     });
   }
+
+  /**
+   * Update query based on text search.
+   *
+   * @param search Search text from the graphql select
+   */
+  public onSearchChange(search: string): void {
+    const context = this.dashboard?.page?.context;
+    if (!context) return;
+    if ('resource' in context) {
+      this.recordsQuery.refetch({
+        variables: {
+          first: ITEMS_PER_PAGE,
+          id: context.resource,
+        },
+        filter: {
+          logic: 'and',
+          filters: [
+            {
+              field: context.displayField,
+              operator: 'contains',
+              value: search,
+            },
+          ],
+        },
+      });
+    }
+  }
 }


### PR DESCRIPTION
# Description
Added the filterable option to the graphql select to the record select when the context datasource is coming from a resource.

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/72018

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Add to a dashboard a context using a resource as datasource and when selecting the record, use the search bar in the select element to filter the options.

## Screenshots

[filter-resource-record.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/4e061c76-a807-40a6-8a99-c34a8f296f64)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
