### PR TITLE
feat/AB#78322_Change-settings-icon-of-widgets-to-be-similar-to-the-one-we-have-for-applications

### DIFF
--- a/libs/shared/src/lib/components/widget-grid/widget-actions/widget-actions.component.html
+++ b/libs/shared/src/lib/components/widget-grid/widget-actions/widget-actions.component.html
@@ -2,7 +2,7 @@
   <div class="flex items-center" *ngIf="!collapsed">
     <ui-button
       [isIcon]="true"
-      icon="insert_chart"
+      icon="tune"
       [uiTooltip]="'common.settings' | translate"
       (click)="onClick('settings')"
       [disabled]="!this.widget || !this.widget.settings"
@@ -48,7 +48,7 @@
       (click)="onClick('settings')"
       [disabled]="!this.widget || !this.widget.settings"
     >
-      <ui-icon icon="insert_chart" variant="grey"></ui-icon>
+      <ui-icon icon="tune" variant="grey"></ui-icon>
       <span>{{ 'common.settings' | translate }}</span>
     </button>
     <button uiMenuItem (click)="onClick('style')">


### PR DESCRIPTION
Change the settings icon of widgets to be similar to the one we have for applications

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78322)

## Type of change

Please delete options that are not relevant.
- [x] Improvement (refactor or addition to existing functionality)

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/15035750/8d3972f7-72d9-471d-8eca-87b583e18d7d

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
