### PR TITLE
fix/HIT-138-corrupted-file-grid-details

### DIFF
--- a/libs/shared/src/lib/components/record-modal/record-modal.component.ts
+++ b/libs/shared/src/lib/components/record-modal/record-modal.component.ts
@@ -165,25 +165,17 @@ export class RecordModalComponent
    * Initializes the form
    */
   private initSurvey() {
-    this.data.isTemporary
-      ? (this.survey = this.formBuilderService.createSurvey(
-          this.form?.structure || '',
-          this.form?.metadata,
-          this.record
-        ))
-      : (this.survey = this.formBuilderService.createSurvey(
-          this.form?.structure || '',
-          this.form?.metadata
-        ));
-
+    this.survey = this.formBuilderService.createSurvey(
+      this.form?.structure || '',
+      this.form?.metadata,
+      this.record
+    );
     addCustomFunctions({
       record: this.record,
       authService: this.authService,
       apollo: this.apollo,
       form: this.form,
     });
-
-    this.survey.data = this.record.data;
 
     this.survey.mode = 'display';
     // After the survey is created we add common callback to survey events
@@ -192,6 +184,7 @@ export class RecordModalComponent
       this.selectedPageIndex,
       {}
     );
+    this.survey.data = this.record.data;
 
     if (this.data.compareTo) {
       this.surveyNext = this.formBuilderService.createSurvey(

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -172,6 +172,7 @@ export class FormBuilderService {
     this.formHelpersService.addApplicationVariables(survey);
     this.formHelpersService.setWorkflowContextVariable(survey);
     if (record) {
+      this.recordId = record.id;
       this.formHelpersService.addRecordIDVariable(survey, record);
     }
     survey.onAfterRenderQuestion.add(


### PR DESCRIPTION
# Description
Fix corrupted file when downloaded from grid details modal and file not available for download on grid update record modal on the 2.1.x-oort branch

## Useful links
- Please insert link to ticket: https://oortcloud.atlassian.net/browse/HIT-138

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Using a form with a file questions as a resource for a grid widget, try to download the file from a record from the details modal and the update record modal.

## Screenshots
[file.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/4bf268db-1474-4648-a612-0b0235a8f45e)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
