### PR TITLE
feat/AB#78337_Regression-Added-field-is-not-getting-removed-on-click-of-remove-icon(X)-on-history-section-of-record

### DIFF
--- a/libs/safe/src/lib/components/record-history/record-history.component.html
+++ b/libs/safe/src/lib/components/record-history/record-history.component.html
@@ -36,7 +36,7 @@
       <label>{{ 'components.history.field.select' | translate }}</label>
       <ui-select-menu
         (selectedOption)="applyFilter($event)"
-        [value]="filterFields"
+        [ngModel]="filterFields"
         [multiselect]="true"
       >
         <ui-select-option

--- a/libs/safe/src/lib/components/record-history/record-history.module.ts
+++ b/libs/safe/src/lib/components/record-history/record-history.module.ts
@@ -14,6 +14,7 @@ import { SafeDateModule } from '../../pipes/date/date.module';
 import { IndicatorsModule } from '@progress/kendo-angular-indicators';
 import { SafeEmptyModule } from '../ui/empty/empty.module';
 import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule } from '@angular/forms';
 
 /**
  * SafeRecordHistoryModule is a class used to manage all the modules and components
@@ -34,6 +35,7 @@ import { ReactiveFormsModule } from '@angular/forms';
     SelectMenuModule,
     ReactiveFormsModule,
     FormWrapperModule,
+    FormsModule,
   ],
   exports: [SafeRecordHistoryComponent],
 })


### PR DESCRIPTION
# Description

Clearing the history filter did not updated the dropdown

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78337)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/15035750/6670a442-b0c7-4019-b834-0d7d184a821d

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules