### PR TITLE
Removed actions if survey is in display mode

### DIFF
--- a/libs/safe/src/lib/survey/components/resources.ts
+++ b/libs/safe/src/lib/survey/components/resources.ts
@@ -884,7 +884,10 @@ export const init = (
         },
       },
     };
-    if (!question.readOnlyGrid) {
+    if (
+      !question.readOnlyGrid &&
+      (question.survey as SurveyModel).mode !== 'display'
+    ) {
       Object.assign(settings, {
         actions: {
           delete: question.canDelete,


### PR DESCRIPTION
# Description

Added a condition for actions to check if the survey is in display mode.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78451/)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Cannot edit anymore when going on 'details' in a grid for a resources question in grid mode.

## Screenshots



# Checklist:

![Screenshot from 2023-11-02 15-24-18](https://github.com/ReliefApplications/ems-frontend/assets/59645813/5d9dff94-540a-405a-89f6-65349f32c915)

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
