### PR TITLE
feat/AB#78580_Wrong-date-is-added-on-moving-signal-record-to-PHI-list,-Ebola-list-&-Interna-dashboard-from-quick-action-on-grid

### DIFF
--- a/libs/safe/src/i18n/en.json
+++ b/libs/safe/src/i18n/en.json
@@ -247,6 +247,7 @@
 			"none": "No Reference Data",
 			"one": "Reference Data"
 		},
+		"remove": "Remove",
 		"resource": {
 			"few": "Resources",
 			"none": "No resource",
@@ -1263,6 +1264,9 @@
 						"create": "Add a button",
 						"defaultName": "Action button",
 						"enable": "Enable",
+						"placeholder": {
+							"modifyValue": "Set as null"
+						},
 						"title": "Quick action buttons",
 						"tooltip": {
 							"attach": "When enabled, you must provide a form and a field of this form. All selected rows will be attached to a record from this form. The user will be able to choose which record using a the given field",

--- a/libs/safe/src/i18n/fr.json
+++ b/libs/safe/src/i18n/fr.json
@@ -247,6 +247,7 @@
 			"none": "Aucune référence de données",
 			"one": "Référence de données"
 		},
+		"remove": "Supprimer",
 		"resource": {
 			"few": "Ressources",
 			"none": "Aucune ressource",
@@ -1270,6 +1271,9 @@
 						"create": "Ajouter un bouton",
 						"defaultName": "Bouton d'action",
 						"enable": "Activer",
+						"placeholder": {
+							"modifyValue": "Supprimer la valeur"
+						},
 						"title": "Bouton d'action rapide",
 						"tooltip": {
 							"attach": "Si activé, vous devez fournir un formulaire et un champ dans ce formulaire. Toutes les lignes sélectionnées seront attachées à un enregistrement de ce formulaire. L'utilisateur pourra choisir cet enregistrement grâce au champ donné.",

--- a/libs/safe/src/i18n/test.json
+++ b/libs/safe/src/i18n/test.json
@@ -247,6 +247,7 @@
 			"none": "******",
 			"one": "******"
 		},
+		"remove": "******",
 		"resource": {
 			"few": "******",
 			"none": "******",
@@ -1263,6 +1264,9 @@
 						"create": "******",
 						"defaultName": "******",
 						"enable": "******",
+						"placeholder": {
+							"modifyValue": "******"
+						},
 						"title": "******",
 						"tooltip": {
 							"attach": "******",

--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -208,7 +208,8 @@
                   modificationTemplate;
                   context: {
                     formGroup: $any(modification),
-                    field: scalarField(modification.value.field)
+                    field: scalarField(modification.value.field),
+                    index: i
                   }
                 "
               ></ng-container>
@@ -429,18 +430,33 @@
 </form>
 
 <!-- Template for auto modification -->
-<ng-template #modificationTemplate let-field="field" let-formGroup="formGroup">
+<ng-template
+  #modificationTemplate
+  let-field="field"
+  let-index="index"
+  let-formGroup="formGroup"
+>
   <div [formGroup]="formGroup">
     <!-- @todo: replace with ngSwitch and better manage all types -->
+
     <ng-container *ngIf="['Int', 'Float'].includes(field.type.name)">
-      <div uiFormFieldDirective>
-        <label>{{
-          'components.widget.settings.grid.buttons.callback.modifyValue'
-            | translate
-        }}</label>
-        <input formControlName="value" type="number" />
+      <div class="flex gap-3 items-end">
+        <div uiFormFieldDirective class="flex-1">
+          <label>{{
+            'components.widget.settings.grid.buttons.callback.modifyValue'
+              | translate
+          }}</label>
+          <input formControlName="value" type="number" placeholder="null" />
+          <ui-button
+            uiSuffix
+            icon="close"
+            [isIcon]="true"
+            (click)="setModificationValueToNull(index)"
+          ></ui-button>
+        </div>
       </div>
     </ng-container>
+
     <ng-container *ngIf="field.type.name === 'Boolean'">
       <div uiFormFieldDirective>
         <label>{{
@@ -452,24 +468,33 @@
           <ui-select-option [value]="true">{{
             'common.true' | translate
           }}</ui-select-option>
-          <ui-select-option [value]="false">{{
+          <ui-select-option value="false">{{
             'common.false' | translate
           }}</ui-select-option>
         </ui-select-menu>
       </div>
     </ng-container>
+
     <ng-container
       *ngIf="
         !['Int', 'Float'].includes(field.type.name) &&
         field.type.name !== 'Boolean'
       "
     >
-      <div uiFormFieldDirective>
-        <label>{{
-          'components.widget.settings.grid.buttons.callback.modifyValue'
-            | translate
-        }}</label>
-        <input formControlName="value" type="string" />
+      <div class="flex gap-3 items-end">
+        <div uiFormFieldDirective class="flex-1">
+          <label>{{
+            'components.widget.settings.grid.buttons.callback.modifyValue'
+              | translate
+          }}</label>
+          <input formControlName="value" type="string" placeholder="null" />
+          <ui-button
+            uiSuffix
+            icon="close"
+            [isIcon]="true"
+            (click)="setModificationValueToNull(index)"
+          ></ui-button>
+        </div>
       </div>
     </ng-container>
   </div>

--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -172,9 +172,9 @@
           <form
             [formGroup]="$any(modification)"
             *ngFor="let modification of modificationsArray.controls; index as i"
-            class="update-row"
+            class="flex gap-2"
           >
-            <div uiFormFieldDirective [defaultMargin]="false">
+            <div uiFormFieldDirective class="flex-1">
               <label>{{
                 'components.widget.settings.grid.buttons.callback.modifyField'
                   | translate
@@ -205,7 +205,7 @@
             >
               <ng-container
                 *ngTemplateOutlet="
-                  modificationTemplate;
+                  modificationTmpl;
                   context: {
                     formGroup: $any(modification),
                     field: scalarField(modification.value.field),
@@ -431,44 +431,56 @@
 
 <!-- Template for auto modification -->
 <ng-template
-  #modificationTemplate
+  #modificationTmpl
   let-field="field"
   let-index="index"
   let-formGroup="formGroup"
 >
-  <div [formGroup]="formGroup">
+  <ng-container [formGroup]="formGroup">
     <!-- @todo: replace with ngSwitch and better manage all types -->
 
     <ng-container *ngIf="['Int', 'Float'].includes(field.type.name)">
-      <div class="flex gap-3 items-end">
-        <div uiFormFieldDirective class="flex-1">
-          <label>{{
-            'components.widget.settings.grid.buttons.callback.modifyValue'
-              | translate
-          }}</label>
-          <input formControlName="value" type="number" placeholder="null" />
-          <ui-button
-            uiSuffix
-            icon="close"
-            [isIcon]="true"
-            (click)="setModificationValueToNull(index)"
-          ></ui-button>
-        </div>
-      </div>
-    </ng-container>
-
-    <ng-container *ngIf="field.type.name === 'Boolean'">
-      <div uiFormFieldDirective>
+      <div uiFormFieldDirective class="flex-1">
         <label>{{
           'components.widget.settings.grid.buttons.callback.modifyValue'
             | translate
         }}</label>
-        <ui-select-menu formControlName="value">
+        <input
+          formControlName="value"
+          type="number"
+          [placeholder]="
+            'components.widget.settings.grid.buttons.placeholder.modifyValue'
+              | translate
+          "
+        />
+        <ui-button
+          uiSuffix
+          icon="close"
+          [isIcon]="true"
+          (click)="setModificationValueToNull(index)"
+          [uiTooltip]="'common.remove' | translate"
+        ></ui-button>
+      </div>
+    </ng-container>
+
+    <ng-container *ngIf="field.type.name === 'Boolean'">
+      <div uiFormFieldDirective class="flex-1">
+        <label>{{
+          'components.widget.settings.grid.buttons.callback.modifyValue'
+            | translate
+        }}</label>
+        <ui-select-menu
+          formControlName="value"
+          [placeholder]="
+            'components.widget.settings.grid.buttons.placeholder.modifyValue'
+              | translate
+          "
+        >
           <ui-select-option>--</ui-select-option>
           <ui-select-option [value]="true">{{
             'common.true' | translate
           }}</ui-select-option>
-          <ui-select-option value="false">{{
+          <ui-select-option [value]="false">{{
             'common.false' | translate
           }}</ui-select-option>
         </ui-select-menu>
@@ -481,21 +493,27 @@
         field.type.name !== 'Boolean'
       "
     >
-      <div class="flex gap-3 items-end">
-        <div uiFormFieldDirective class="flex-1">
-          <label>{{
-            'components.widget.settings.grid.buttons.callback.modifyValue'
+      <div uiFormFieldDirective class="flex-1">
+        <label>{{
+          'components.widget.settings.grid.buttons.callback.modifyValue'
+            | translate
+        }}</label>
+        <input
+          formControlName="value"
+          type="string"
+          [placeholder]="
+            'components.widget.settings.grid.buttons.placeholder.modifyValue'
               | translate
-          }}</label>
-          <input formControlName="value" type="string" placeholder="null" />
-          <ui-button
-            uiSuffix
-            icon="close"
-            [isIcon]="true"
-            (click)="setModificationValueToNull(index)"
-          ></ui-button>
-        </div>
+          "
+        />
+        <ui-button
+          uiSuffix
+          icon="close"
+          [isIcon]="true"
+          (click)="setModificationValueToNull(index)"
+          [uiTooltip]="'common.remove' | translate"
+        ></ui-button>
       </div>
     </ng-container>
-  </div>
+  </ng-container>
 </ng-template>

--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.scss
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.scss
@@ -1,11 +1,3 @@
-.update-row {
-  align-items: end;
-  margin-top: 24px;
-  .mat-form-field {
-    margin-left: 16px;
-  }
-}
-
 .radio-row {
   display: flex;
   flex-direction: row;

--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -370,7 +370,7 @@ export class ButtonConfigComponent
    */
   public setModificationValueToNull(index: number): void {
     const modifications = this.modificationsArray.value;
-    modifications[index].value = '';
+    modifications[index].value = null;
     this.modificationsArray.setValue(modifications);
   }
 

--- a/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -358,9 +358,20 @@ export class ButtonConfigComponent
     this.modificationsArray.push(
       this.formBuilder.group({
         field: ['', Validators.required],
-        value: ['', Validators.required],
+        value: [''],
       })
     );
+  }
+
+  /**
+   * Set the value of a modification to null
+   *
+   * @param index The index of the modification
+   */
+  public setModificationValueToNull(index: number): void {
+    const modifications = this.modificationsArray.value;
+    modifications[index].value = '';
+    this.modificationsArray.setValue(modifications);
   }
 
   /**

--- a/libs/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -7,12 +7,7 @@ import {
   EventEmitter,
   AfterViewInit,
 } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormArray,
-  Validators,
-  FormArray,
-} from '@angular/forms';
+import { UntypedFormGroup, UntypedFormArray, Validators } from '@angular/forms';
 import { QueryBuilderService } from '../../../services/query-builder/query-builder.service';
 import { GET_CHANNELS, GET_GRID_RESOURCE_META } from './graphql/queries';
 import { Application } from '../../../models/application.model';
@@ -242,16 +237,6 @@ export class SafeGridSettingsComponent
           }
         });
     }
-
-    //remove the validator from value field in modification array
-    const floatingButtons = this.formGroup.controls
-      .floatingButtons as FormArray;
-    floatingButtons.controls.forEach((btn: any) => {
-      const modificationsArray = btn.controls.modifications;
-      modificationsArray.controls.forEach((mod: any) => {
-        mod.controls.value.clearValidators();
-      });
-    });
   }
 
   /**

--- a/libs/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -7,7 +7,12 @@ import {
   EventEmitter,
   AfterViewInit,
 } from '@angular/core';
-import { UntypedFormGroup, UntypedFormArray, Validators } from '@angular/forms';
+import {
+  UntypedFormGroup,
+  UntypedFormArray,
+  Validators,
+  FormArray,
+} from '@angular/forms';
 import { QueryBuilderService } from '../../../services/query-builder/query-builder.service';
 import { GET_CHANNELS, GET_GRID_RESOURCE_META } from './graphql/queries';
 import { Application } from '../../../models/application.model';
@@ -237,6 +242,16 @@ export class SafeGridSettingsComponent
           }
         });
     }
+
+    //remove the validator from value field in modification array
+    const floatingButtons = this.formGroup.controls
+      .floatingButtons as FormArray;
+    floatingButtons.controls.forEach((btn: any) => {
+      const modificationsArray = btn.controls.modifications;
+      modificationsArray.controls.forEach((mod: any) => {
+        mod.controls.value.clearValidators();
+      });
+    });
   }
 
   /**

--- a/libs/safe/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/safe/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -48,7 +48,7 @@ export const createButtonFormGroup = (value: any): UntypedFormGroup => {
         ? value.modifications.map((x: any) =>
             fb.group({
               field: [x.field, Validators.required],
-              value: [x.value, Validators.required],
+              value: [x.value],
             })
           )
         : []

--- a/libs/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -479,19 +479,20 @@ export class SafeGridWidgetComponent
     const update: any = {};
     for (const modification of modifications) {
       if (modification.field) {
+        // If no value, set at null
         if (modification.value === undefined || modification.value === '') {
-          modification.value = null;
+          set(update, modification.field, null);
+        } else {
+          set(update, modification.field, modification.value);
         }
-        set(update, modification.field, modification.value);
       }
     }
-    const data = update;
     return firstValueFrom(
       this.apollo.mutate<EditRecordsMutationResponse>({
         mutation: EDIT_RECORDS,
         variables: {
           ids,
-          data,
+          data: update,
           template: get(this.settings, 'template', null),
         },
       })

--- a/libs/safe/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/safe/src/lib/components/widgets/grid/grid.component.ts
@@ -29,7 +29,6 @@ import { SafeGridLayoutService } from '../../../services/grid-layout/grid-layout
 import { SafeConfirmService } from '../../../services/confirm/confirm.service';
 import { Layout } from '../../../models/layout.model';
 import { TranslateService } from '@ngx-translate/core';
-import { cleanRecord } from '../../../utils/cleanRecord';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import { SafeApplicationService } from '../../../services/application/application.service';
@@ -480,10 +479,13 @@ export class SafeGridWidgetComponent
     const update: any = {};
     for (const modification of modifications) {
       if (modification.field) {
+        if (modification.value === undefined || modification.value === '') {
+          modification.value = null;
+        }
         set(update, modification.field, modification.value);
       }
     }
-    const data = cleanRecord(update);
+    const data = update;
     return firstValueFrom(
       this.apollo.mutate<EditRecordsMutationResponse>({
         mutation: EDIT_RECORDS,


### PR DESCRIPTION
# Description

Now grid quick action allows null values and has a button for it

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78580)
- Is similar/related to [this one](https://github.com/ReliefApplications/ems-backend/pull/667)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/15035750/9790c19d-468d-4867-81c9-84c37037f6da


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules