### PR TITLE
Feat/hit 156 add option to resource/s question to only allow adding new records

### DIFF
--- a/libs/shared/src/lib/survey/components/resource.ts
+++ b/libs/shared/src/lib/survey/components/resource.ts
@@ -209,6 +209,14 @@ export const init = (
         visibleIf: visibleIfResource,
         visibleIndex: 4,
       });
+      Serializer.addProperty('resource', {
+        name: 'canSelectExistingRecords:boolean',
+        category: 'general',
+        dependsOn: 'resource',
+        default: true,
+        visibleIf: visibleIfResource,
+        visibleIndex: 3,
+      });
 
       // Build set available grid fields button
       serializer.addProperty('resource', {
@@ -257,7 +265,7 @@ export const init = (
         name: 'canSearch:boolean',
         category: 'Custom Questions',
         dependsOn: ['resource'],
-        default: true,
+        default: false,
         visibleIf: visibleIfResource,
         visibleIndex: 3,
       });
@@ -566,9 +574,10 @@ export const init = (
         question.addTemplate = null;
         question.prefillWithCurrentRecord = false;
       }
+      if (!question.canSelectExistingRecords) question.canSearch = false;
     },
     populateChoices: (question: QuestionResource): void => {
-      if (question.resource) {
+      if (question.resource && question.canSelectExistingRecords) {
         getResourceRecordsById({ id: question.resource, filters }).subscribe(
           ({ data }) => {
             const choices = mapQuestionChoices(data, question);


### PR DESCRIPTION
# Description

Adds a new option to resource question to only allow adding new records. If enabled, users would not be able to select existing records.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-156

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?



## Screenshots


https://github.com/ReliefApplications/ems-frontend/assets/24783896/7546c990-8fd5-4a64-9b1c-a77f2e536b8d



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
