### PR TITLE
AB78827_change_widget_size_inside_of_tabs

### DIFF
--- a/libs/shared/src/lib/components/widgets/tabs-settings/tab-settings/tab-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tab-settings/tab-settings.component.ts
@@ -141,7 +141,13 @@ export class TabSettingsComponent implements OnDestroy {
    * @param e event
    */
   onAdd(e: any): void {
-    const widget = cloneDeep(e);
+    const widget = {
+      ...cloneDeep(e),
+      cols:
+        e.cols > 4
+          ? this.widgetGridComponent.colsNumber
+          : Math.floor(this.widgetGridComponent.colsNumber / 2), //set the number of columns so that each widget fills half of the widget grid in width, or all the width for wide widgets (grid and tabs)
+    };
     const widgets = this.structure?.value.slice() || [];
     this.structure?.setValue([...widgets, widget]);
     if (this.timeoutListener) {

--- a/libs/shared/src/lib/components/widgets/tabs-settings/tabs-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tabs-settings.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnDestroy,
   OnInit,
   Output,
 } from '@angular/core';
@@ -25,7 +26,7 @@ import { takeUntil } from 'rxjs';
 })
 export class TabsSettingsComponent
   extends UnsubscribeComponent
-  implements OnInit, AfterViewInit
+  implements OnInit, AfterViewInit, OnDestroy
 {
   /** Settings */
   public widgetForm!: FormGroup;
@@ -53,5 +54,15 @@ export class TabsSettingsComponent
       .subscribe(() => {
         this.change.emit(this.widgetForm);
       });
+  }
+
+  override ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this.widgetForm.value.tabs.forEach((tab: any) => {
+      if (tab.structure.length == 1) {
+        //if only one widget, we set its height to the height of the tabs widget
+        tab.structure[0].rows = this.widget.rows;
+      }
+    });
   }
 }


### PR DESCRIPTION

# Description

- If there is only one widget, upon closing the settings, its height is set to match the height of the tabs widget. 
- When adding a new widget, its width is determined based on whether it is a small widget, in which case it is set to half the size of the tabs, or a large widget, such as a grid or tabs, in which case it occupies the full size of the tabs.

/!\ Not sure about behaviour, since we edit height on saving, not ideal but I think there is no way to know if the user wants to have only one widget

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78827/)

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Created tabs with several widgets.

## Screenshots

![Screenshot from 2023-11-08 14-29-54](https://github.com/ReliefApplications/ems-frontend/assets/59645813/2e0d6506-62ab-410d-bc36-0a82bd0a6b07)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

