### PR TITLE
Ab#78899 fix resources readonly

### DIFF
--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -745,7 +745,7 @@ export const init = (
     instance.multiSelect = true;
     const promises: any[] = [];
     const settings = await processNewCreatedRecords(question, true, promises);
-    if (!question.readOnlyGrid) {
+    if (!question.readOnly) {
       Object.assign(settings, {
         actions: {
           delete: question.canDelete,


### PR DESCRIPTION
# Description

Bug in the PR is in fact not a bug, but saw a bug for the resources question: when editing record, we could update the records from the resources, which should be disabled. This PR should do that.
Changed logic to get resources question readonly => from readOnlyGrid to readOnly.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78899/)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create resources question in a form. When adding records to the form, it should be possible to do actions from the question (update record, delete...). When modifying the record from Form => View records => Update record, these actions should not be possible.

## Screenshots

![Screenshot from 2023-11-08 17-01-43](https://github.com/ReliefApplications/ems-frontend/assets/59645813/3ece537a-d216-4cec-b6f7-7c4f10f84b65)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
