### PR TITLE
AB#78912 - ID appearing instead of the name

### DIFF
--- a/libs/shared/src/lib/components/aggregation/edit-aggregation-modal/edit-aggregation-modal.component.html
+++ b/libs/shared/src/lib/components/aggregation/edit-aggregation-modal/edit-aggregation-modal.component.html
@@ -13,8 +13,8 @@
         </div>
         <div uiFormFieldDirective>
           <label>{{ 'common.resource.one' | translate }}</label>
-          <ui-select-menu [value]="resource.id" [disabled]="true">
-            <ui-select-option [value]="resource.id" [disabled]="true">
+          <ui-select-menu [value]="resource.name" [disabled]="true">
+            <ui-select-option [value]="resource.name" [disabled]="true">
               {{ resource.name }}
             </ui-select-option>
           </ui-select-menu>

--- a/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.html
+++ b/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.html
@@ -46,8 +46,8 @@
     <ng-container *ngIf="formGroup.value.chart.aggregationId">
       <div *ngIf="aggregation" uiFormFieldDirective>
         <label>{{ 'common.aggregation.one' | translate }}</label>
-        <ui-select-menu [disabled]="true" [value]="aggregation.id">
-          <ui-select-option [value]="aggregation.id">{{
+        <ui-select-menu [disabled]="true" [value]="aggregation.name">
+          <ui-select-option [value]="aggregation.name">{{
             aggregation.name
           }}</ui-select-option>
         </ui-select-menu>

--- a/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.html
+++ b/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.html
@@ -29,8 +29,8 @@
       <label>{{
         'components.widget.settings.grid.layouts.select' | translate
       }}</label>
-      <ui-select-menu [disabled]="true" [value]="selectedLayout.id">
-        <ui-select-option [value]="selectedLayout.id">{{
+      <ui-select-menu [disabled]="true" [value]="selectedLayout.name">
+        <ui-select-option [value]="selectedLayout.name">{{
           selectedLayout.name
         }}</ui-select-option>
       </ui-select-menu>

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
@@ -162,8 +162,8 @@
     >
       <div uiFormFieldDirective>
         <label>{{ 'common.aggregation.one' | translate }}</label>
-        <ui-select-menu [disabled]="true" [value]="selectedAggregation.id">
-          <ui-select-option [value]="selectedAggregation.id">{{
+        <ui-select-menu [disabled]="true" [value]="selectedAggregation.name">
+          <ui-select-option [value]="selectedAggregation.name">{{
             selectedAggregation.name
           }}</ui-select-option>
         </ui-select-menu>


### PR DESCRIPTION
# Description

**Problem Description:**
In some cases, the aggregation and layout were being displayed as ID in the listbox.

**To fix:**
I added the correct value, that is, instead of the ID, the name was placed.

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78912)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] In a summary card, add an aggregation. After adding, the name of the aggregation should be displayed.

## Screenshots

Before fix:
![1](https://github.com/ReliefApplications/ems-frontend/assets/55603259/fa5436bb-2149-41bd-9d91-d607165e3f93)

After fix:
![2](https://github.com/ReliefApplications/ems-frontend/assets/55603259/a1ab5d64-5629-4041-98a8-6b9c551a853b)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
