### PR TITLE
Added options to show/hide close button and ask for confirmation when trying to close a record modal

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -77,6 +77,7 @@
 			"one": "Column"
 		},
 		"comma": "comma",
+		"confirmClose": "Do you really wanna close the editor?",
 		"copy": "Copy",
 		"create": "Create",
 		"createdOn": "Created on",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -77,6 +77,7 @@
 			"one": "Colonne"
 		},
 		"comma": "virgule",
+		"confirmClose": "Voulez-vous vraiment fermer l'éditeur ?",
 		"copy": "Copier",
 		"create": "Créer",
 		"createdOn": "Date de création",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -77,6 +77,7 @@
 			"one": "******"
 		},
 		"comma": "******",
+		"confirmClose": "******",
 		"copy": "******",
 		"create": "******",
 		"createdOn": "******",

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.html
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.html
@@ -42,7 +42,11 @@
     </div>
   </ng-container>
   <ng-container ngProjectAs="actions">
-    <ui-button uiDialogClose>
+    <ui-button
+      (click)="close()"
+      cdkFocusInitial
+      *ngIf="survey?.showCloseButtonOnModal"
+    >
       {{ 'common.close' | translate }}
     </ui-button>
     <ng-container *ngIf="survey?.visiblePages ?? [] as pages">

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -285,6 +285,29 @@ export class FormModalComponent
   }
 
   /**
+   * Closes the dialog asking for confirmation if needed.
+   */
+  public close(): void {
+    if (this.survey.confirmOnModalClose) {
+      const dialogRef = this.confirmService.openConfirmModal({
+        title: this.translate.instant('common.close'),
+        content: this.translate.instant('common.confirmClose'),
+        confirmText: this.translate.instant('components.confirmModal.confirm'),
+        confirmVariant: 'primary',
+      });
+      dialogRef.closed
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((value: any) => {
+          if (value) {
+            this.dialogRef.close();
+          }
+        });
+    } else {
+      this.dialogRef.close();
+    }
+  }
+
+  /**
    * Creates the record, or update it if provided.
    *
    * @param survey Survey instance.

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -124,7 +124,41 @@ export const init = (environment: any): void => {
     default: false,
     visibleIndex: 2,
   });
-
+  // Adds a property to the survey settings to show or hide the close button on record modal
+  serializer.addProperty('survey', {
+    name: 'showCloseButtonOnModal',
+    category: 'general',
+    type: 'dropdown',
+    choices: [
+      {
+        value: true,
+        text: 'Yes',
+      },
+      {
+        value: false,
+        text: 'No',
+      },
+    ],
+    default: true,
+  });
+  // Adds a property to the survey settings to ask for confirmation on closing the record modal
+  serializer.addProperty('survey', {
+    name: 'confirmOnModalClose',
+    category: 'general',
+    type: 'dropdown',
+    choices: [
+      {
+        value: true,
+        text: 'Yes',
+      },
+      {
+        value: false,
+        text: 'No',
+      },
+    ],
+    default: false,
+    visibleIf: (survey: SurveyModel) => survey.showCloseButtonOnModal,
+  });
   // Property to allow customization of the save button label
   serializer.addProperty('survey', {
     name: 'saveButtonText',


### PR DESCRIPTION
# Description

Added showCloseButtonOnModal and confirmOnModalClose properties which define if the close button will be showing or not and if a confirmation dialog is to be shown when closing the record modal when you update a record from a grid widget.

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-172

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Create a grid widget from a resource and set the new properties to the survey in question. Then, try the new changes by updating a record from the grid.

## Screenshots

![image](https://github.com/ReliefApplications/ems-frontend/assets/39497117/a0264c34-b20c-4d43-93de-a9adcf54512b)
![chrome-capture-2023-10-14](https://github.com/ReliefApplications/ems-frontend/assets/39497117/02f33112-e6a9-4c87-a0f8-591f37c09a14)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings