### PR TITLE
AB#79164 ABC-indicate core questions in red in templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ Thumbs.db
 # Doc generated while running storybook
 libs/shared/documentation.json
 libs/ui/documentation.json
+
+# Widgets build
+widgets/

--- a/libs/shared/src/lib/style/styles.scss
+++ b/libs/shared/src/lib/style/styles.scss
@@ -33,7 +33,7 @@ ui-checkbox {
 
 // === Form builder ===
 .core-question {
-  h5 {
+  .sd-question__title {
     @apply text-red-400 #{!important};
   }
 }

--- a/libs/shared/src/lib/style/styles.scss
+++ b/libs/shared/src/lib/style/styles.scss
@@ -33,7 +33,9 @@ ui-checkbox {
 
 // === Form builder ===
 .core-question {
-  @apply text-red-400;
+  h5 {
+    @apply text-red-400 #{!important};
+  }
 }
 
 // .multiline-tooltip {


### PR DESCRIPTION
# Description

A functionality has been restored where questions in template forms will show their core fields in red.
All code was in place but on of the surveyjs updates probably rendered it ineffective.
The solution consisted on updating the class so the style could target an inside element.

## Useful links

- [AB#79164](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/79164/)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Create a template form and check that core fields are correctly styled
- [x] Create a field on the template and make sure it isn't displayed as a core field.

## Screenshots

![Screenshot 2023-11-15 115730](https://github.com/ReliefApplications/ems-frontend/assets/94831019/590e4151-0a77-4148-9525-1637ac06051d)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
