### PR TITLE
AB#79579 ABC Remove auth settings on authcode api conf

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/api-configuration/api-configuration.component.html
+++ b/apps/back-office/src/app/dashboard/pages/api-configuration/api-configuration.component.html
@@ -120,7 +120,7 @@
     </div>
 
     <!-- Authentication settings -->
-    <ng-container *ngIf="apiForm.value.authType !== authType.public">
+    <ng-container *ngIf="apiForm.value.authType === authType.serviceToService || apiForm.value.authType === authType.userToService">
       <h2 class="mt-8">
         {{ 'pages.apiConfiguration.authentication' | translate }}
       </h2>


### PR DESCRIPTION
# Description

Minor visual fix to hide unused authentication settings header on the api configuration when you select the authorizationCode type

## Useful links

- [AB #79579](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/79579)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Create an API with the authorizationCode type and check that the  authentication settings header is not visible
- [x] Check other types and make sure they continue to work as before

## Screenshots

![Screenshot 2023-11-21 113432](https://github.com/ReliefApplications/ems-frontend/assets/94831019/5d306ae2-f49e-4170-b77f-237445e22abc)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes my code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
