### PR TITLE
fix/AB#79453_widgets-wrong-scroll

### DIFF
--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
@@ -86,7 +86,7 @@ export class WidgetGridComponent
   private gridOptionsTimeoutListener!: NodeJS.Timeout;
   /** Subscribe to structure changes */
   private changesSubscription?: Subscription;
-  /**Register if ngOnChanges has fired to not set setGridOptions twice on init */
+  /** Register if ngOnChanges has fired to not set setGridOptions twice on init */
   private changed = false;
 
   /**

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
@@ -86,6 +86,8 @@ export class WidgetGridComponent
   private gridOptionsTimeoutListener!: NodeJS.Timeout;
   /** Subscribe to structure changes */
   private changesSubscription?: Subscription;
+  /**Register if ngOnChanges has fired to not set setGridOptions twice on init */
+  private changed = false;
 
   /**
    * Indicate if the widget grid can be deactivated or not.
@@ -140,9 +142,13 @@ export class WidgetGridComponent
         Boolean(changes['canUpdate'].currentValue)
     ) {
       this.setLayout();
-      this.gridOptionsTimeoutListener = setTimeout(() => {
-        this.setGridOptions(true);
-      }, 0);
+      // Only triggers the setGridOptions with isDashboardSet true if is not the first registered change
+      if (this.changed) {
+        this.gridOptionsTimeoutListener = setTimeout(() => {
+          this.setGridOptions(true);
+        }, 0);
+      }
+      this.changed = true;
     }
   }
 


### PR DESCRIPTION
# Description
In the shared-widget-grid, only triggers the setGridOptions with isDashboardSet true (used to scroll down to new widgets) if is not the first registered change of the ngOnChanges hook, because it was incorrectly scrolling to the first widget on init.

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/79453

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Opening a tabs widget settings with already a tab and a few widgets in it or dashboard pages with widgets on it, on init they don't scroll down to the first widget anymore

## Screenshots
[scroll.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/191ae91a-d8d7-4edc-a153-e4d408835512)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
