### PR TITLE
AB#79743: Improve UI of display settings in chart widgets

### DIFF
--- a/libs/shared/src/lib/components/widgets/chart-settings/series-settings/series-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/chart-settings/series-settings/series-settings.component.html
@@ -5,15 +5,14 @@
       <label>
         {{ 'components.widget.settings.chart.series.title' | translate }}
       </label>
-      <ui-select-menu [formControl]="selectedSerie">
+      <ui-select-menu [formControl]="selectedSerie" [placeholder]="'components.widget.settings.chart.other'| translate">
         <ui-select-option
           *ngFor="let serie of formArray.value"
           [value]="serie.serie"
         >
-          {{
-            serie.serie || 'components.widget.settings.chart.other' | translate
-          }}
+          {{ serie.serie || 'components.widget.settings.chart.other' | translate }} 
         </ui-select-option>
+        
       </ui-select-menu>
     </div>
     <!-- Serie Visibility -->
@@ -42,8 +41,8 @@
         <label>
           {{ 'components.widget.settings.chart.series.fill' | translate }}
         </label>
-        <ui-select-menu formControlName="fill">
-          <ui-select-option>
+        <ui-select-menu formControlName="fill" [placeholder]="'components.widget.settings.chart.auto' | translate">
+          <ui-select-option value="auto">
             {{ 'components.widget.settings.chart.auto' | translate }}
           </ui-select-option>
           <ui-select-option *ngFor="let type of fillTypes" [value]="type">

--- a/libs/shared/src/lib/components/widgets/chart-settings/series-settings/series-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/chart-settings/series-settings/series-settings.component.html
@@ -5,14 +5,18 @@
       <label>
         {{ 'components.widget.settings.chart.series.title' | translate }}
       </label>
-      <ui-select-menu [formControl]="selectedSerie" [placeholder]="'components.widget.settings.chart.other'| translate">
+      <ui-select-menu
+        [formControl]="selectedSerie"
+        [placeholder]="'components.widget.settings.chart.other' | translate"
+      >
         <ui-select-option
           *ngFor="let serie of formArray.value"
           [value]="serie.serie"
         >
-          {{ serie.serie || 'components.widget.settings.chart.other' | translate }} 
+          {{
+            serie.serie || 'components.widget.settings.chart.other' | translate
+          }}
         </ui-select-option>
-        
       </ui-select-menu>
     </div>
     <!-- Serie Visibility -->
@@ -41,7 +45,10 @@
         <label>
           {{ 'components.widget.settings.chart.series.fill' | translate }}
         </label>
-        <ui-select-menu formControlName="fill" [placeholder]="'components.widget.settings.chart.auto' | translate">
+        <ui-select-menu
+          formControlName="fill"
+          [placeholder]="'components.widget.settings.chart.auto' | translate"
+        >
           <ui-select-option value="auto">
             {{ 'components.widget.settings.chart.auto' | translate }}
           </ui-select-option>
@@ -60,7 +67,10 @@
               | translate
           }}
         </label>
-        <ui-select-menu formControlName="interpolation">
+        <ui-select-menu
+          formControlName="interpolation"
+          [placeholder]="'components.widget.settings.chart.auto' | translate"
+        >
           <ui-select-option>
             {{ 'components.widget.settings.chart.auto' | translate }}
           </ui-select-option>
@@ -84,7 +94,10 @@
               | translate
           }}
         </label>
-        <ui-select-menu formControlName="stepped">
+        <ui-select-menu
+          formControlName="stepped"
+          [placeholder]="'components.widget.settings.chart.auto' | translate"
+        >
           <ui-select-option>
             {{ 'components.widget.settings.chart.auto' | translate }}
           </ui-select-option>


### PR DESCRIPTION
# Description

Implemented default value in the series and fill fields

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories/?workitem=79743)

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] Navigated between the listbox options on the screen. The test was carried out on a column-type chart.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/55603259/6f40d586-0fd1-460c-96c1-b83c4a08ffd4


Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
