### PR TITLE
fix/AB#78622_upload-records-error-with-big-files

### DIFF
--- a/apps/back-office/src/app/components/upload-menu/upload-menu.component.html
+++ b/apps/back-office/src/app/components/upload-menu/upload-menu.component.html
@@ -1,14 +1,12 @@
 <div
   class="flex flex-col items-center shadow-lg bg-white rounded p-2 ring-1 ring-gray-900/5 mb-2"
 >
-  <div
-    class="flex justify-between gap-2 flex-wrap items-center mb-2"
-  >
+  <div class="flex justify-between gap-2 flex-wrap items-center mb-2">
     <kendo-upload
       class="flex-1"
       #fileReader
       name="Upload XLSX"
-      [restrictions]="{ maxFileSize }"
+      [restrictions]="{ maxFileSize: maxFileSize * 1024 * 1024 }"
       (upload)="onUpload($event)"
       accept=".xlsx"
       [multiple]="false"
@@ -22,7 +20,10 @@
       {{ 'common.downloadTemplate' | translate }}
     </ui-button>
   </div>
-  <div>
-    {{ 'common.notifications.file.upload.maxFileSize' | translate : { size: maxFileSize } }}
-  </div>
+  <span class="text-gray-700 text-xs">
+    {{
+      'common.notifications.file.upload.maxFileSize'
+        | translate : { size: maxFileSize }
+    }}
+  </span>
 </div>

--- a/apps/back-office/src/app/components/upload-menu/upload-menu.component.html
+++ b/apps/back-office/src/app/components/upload-menu/upload-menu.component.html
@@ -1,21 +1,28 @@
 <div
-  class="flex justify-between gap-2 flex-wrap items-center shadow-lg bg-white rounded p-2 ring-1 ring-gray-900/5 mb-2"
+  class="flex flex-col items-center shadow-lg bg-white rounded p-2 ring-1 ring-gray-900/5 mb-2"
 >
-  <kendo-upload
-    class="flex-1"
-    #fileReader
-    name="Upload XLSX"
-    data-max-size="5120"
-    (upload)="onUpload($event)"
-    accept=".xlsx"
-    [multiple]="false"
+  <div
+    class="flex justify-between gap-2 flex-wrap items-center mb-2"
   >
-  </kendo-upload>
-  <ui-button
-    variant="primary"
-    category="tertiary"
-    (click)="onDownloadTemplate()"
-  >
-    {{ 'common.downloadTemplate' | translate }}
-  </ui-button>
+    <kendo-upload
+      class="flex-1"
+      #fileReader
+      name="Upload XLSX"
+      [restrictions]="{ maxFileSize }"
+      (upload)="onUpload($event)"
+      accept=".xlsx"
+      [multiple]="false"
+    >
+    </kendo-upload>
+    <ui-button
+      variant="primary"
+      category="tertiary"
+      (click)="onDownloadTemplate()"
+    >
+      {{ 'common.downloadTemplate' | translate }}
+    </ui-button>
+  </div>
+  <div>
+    {{ 'common.notifications.file.upload.maxFileSize' | translate : { size: maxFileSize } }}
+  </div>
 </div>

--- a/apps/back-office/src/app/components/upload-menu/upload-menu.component.ts
+++ b/apps/back-office/src/app/components/upload-menu/upload-menu.component.ts
@@ -24,7 +24,7 @@ export class UploadMenuComponent {
   /** Close event emitter */
   // eslint-disable-next-line @angular-eslint/no-output-native
   @Output() close: EventEmitter<null> = new EventEmitter();
-  /** File size limit, in bytes */
+  /** File size limit, in MB */
   public maxFileSize: number;
   /** Show upload menu */
   private show = true;

--- a/apps/back-office/src/app/components/upload-menu/upload-menu.component.ts
+++ b/apps/back-office/src/app/components/upload-menu/upload-menu.component.ts
@@ -1,4 +1,10 @@
-import { Component, EventEmitter, HostListener, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Inject,
+  Output,
+} from '@angular/core';
 import { UploadEvent } from '@progress/kendo-angular-upload';
 
 /**
@@ -12,12 +18,14 @@ import { UploadEvent } from '@progress/kendo-angular-upload';
 })
 export class UploadMenuComponent {
   /** Upload event emitter */
-  @Output() upload = new EventEmitter<UploadEvent>();
+  @Output() upload = new EventEmitter<File>();
   /** Download event emitter, for template */
   @Output() download = new EventEmitter();
   /** Close event emitter */
   // eslint-disable-next-line @angular-eslint/no-output-native
   @Output() close: EventEmitter<null> = new EventEmitter();
+  /** File size limit, in bytes */
+  public maxFileSize: number;
   /** Show upload menu */
   private show = true;
 
@@ -37,6 +45,16 @@ export class UploadMenuComponent {
   }
 
   /**
+   * Upload Menu to be displayed in overlay container.
+   * Contains file upload and template download.
+   *
+   * @param environment environment
+   */
+  constructor(@Inject('environment') environment: any) {
+    this.maxFileSize = environment.maxFileSize;
+  }
+
+  /**
    * Handles upload event.
    * Event is transmitted by the component to other components.
    *
@@ -44,7 +62,8 @@ export class UploadMenuComponent {
    */
   onUpload(e: UploadEvent): void {
     e.preventDefault();
-    this.upload.emit(e);
+    const file = e.files[0].rawFile;
+    this.upload.emit(file);
   }
 
   /**

--- a/apps/back-office/src/app/dashboard/pages/form-records/form-records.component.html
+++ b/apps/back-office/src/app/dashboard/pages/form-records/form-records.component.html
@@ -66,7 +66,7 @@
       >
         <app-upload-menu
           (close)="showUpload = false"
-          (upload)="onFileChange($event)"
+          (upload)="uploadFileData($event)"
           (download)="onDownloadTemplate()"
         ></app-upload-menu>
       </ng-template>

--- a/apps/back-office/src/app/dashboard/pages/form-records/form-records.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/form-records/form-records.component.ts
@@ -378,16 +378,6 @@ export class FormRecordsComponent
   }
 
   /**
-   * Take file from upload event and call upload method.
-   *
-   * @param event Upload event.
-   */
-  onFileChange(event: any): void {
-    const file = event.files[0].rawFile;
-    this.uploadFileData(file);
-  }
-
-  /**
    * Upload file and indicate status of request.
    *
    * @param file file to upload.
@@ -406,9 +396,8 @@ export class FormRecordsComponent
           this.showUpload = false;
         }
       },
-      error: (error: any) => {
-        console.log(error);
-        this.snackBar.openSnackBar(error.error, { error: true });
+      error: () => {
+        // The error message has already been handled in DownloadService
         this.showUpload = false;
       },
     });

--- a/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
+++ b/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
@@ -58,7 +58,7 @@
         >
           <app-upload-menu
             (close)="showUpload = false"
-            (upload)="onFileChange($event)"
+            (upload)="uploadFileData($event)"
             (download)="onDownloadTemplate()"
           ></app-upload-menu>
         </ng-template>

--- a/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
@@ -77,7 +77,7 @@ export class RecordsTabComponent
    * @param snackBar Shared snackbar service
    * @param confirmService Shared confirm service
    * @param downloadService Service used to download.
-      */
+   */
   constructor(
     private apollo: Apollo,
     private translate: TranslateService,

--- a/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
@@ -77,7 +77,7 @@ export class RecordsTabComponent
    * @param snackBar Shared snackbar service
    * @param confirmService Shared confirm service
    * @param downloadService Service used to download.
-   */
+      */
   constructor(
     private apollo: Apollo,
     private translate: TranslateService,
@@ -312,16 +312,6 @@ export class RecordsTabComponent
   }
 
   /**
-   * Detects changes on the file.
-   *
-   * @param event new file event.
-   */
-  onFileChange(event: any): void {
-    const file = event.files[0].rawFile;
-    this.uploadFileData(file);
-  }
-
-  /**
    * Calls rest endpoint to upload new records for the resource.
    *
    * @param file File to upload.
@@ -335,8 +325,8 @@ export class RecordsTabComponent
           this.showUpload = false;
         }
       },
-      error: (error: any) => {
-        this.snackBar.openSnackBar(error.error, { error: true });
+      error: () => {
+        // The error message has already been handled in DownloadService
         this.showUpload = false;
       },
     });

--- a/apps/back-office/src/environments/environment.shared.ts
+++ b/apps/back-office/src/environments/environment.shared.ts
@@ -3,7 +3,7 @@
  */
 export const sharedEnvironment = {
   module: 'backoffice',
-  maxFileSize: 7 * 1024 * 1024,
+  maxFileSize: 7, // transformed into MB later, just indicate number of MB there
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   version: require('../../../../package.json').version,
   esriApiKey:

--- a/apps/back-office/src/environments/environment.shared.ts
+++ b/apps/back-office/src/environments/environment.shared.ts
@@ -3,6 +3,7 @@
  */
 export const sharedEnvironment = {
   module: 'backoffice',
+  maxFileSize: 7 * 1024 * 1024,
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   version: require('../../../../package.json').version,
   esriApiKey:

--- a/apps/back-office/src/environments/environment.type.ts
+++ b/apps/back-office/src/environments/environment.type.ts
@@ -17,4 +17,5 @@ export interface Environment {
   theme: any;
   availableWidgets: string[];
   sentry?: any;
+  maxFileSize?: number;
 }

--- a/apps/front-office/src/environments/environment.shared.ts
+++ b/apps/front-office/src/environments/environment.shared.ts
@@ -3,6 +3,7 @@
  */
 export const sharedEnvironment = {
   module: 'frontoffice',
+  maxFileSize: 7 * 1024 * 1024,
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   version: require('../../../../package.json').version,
   esriApiKey:

--- a/apps/front-office/src/environments/environment.shared.ts
+++ b/apps/front-office/src/environments/environment.shared.ts
@@ -3,7 +3,7 @@
  */
 export const sharedEnvironment = {
   module: 'frontoffice',
-  maxFileSize: 7 * 1024 * 1024,
+  maxFileSize: 7, // transformed into MB later, just indicate number of MB there
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   version: require('../../../../package.json').version,
   esriApiKey:

--- a/apps/front-office/src/environments/environment.type.ts
+++ b/apps/front-office/src/environments/environment.type.ts
@@ -16,4 +16,5 @@ export interface Environment {
   esriApiKey: string;
   theme: any;
   sentry?: any;
+  maxFileSize?: number;
 }

--- a/apps/web-widgets/src/environments/environment.shared.ts
+++ b/apps/web-widgets/src/environments/environment.shared.ts
@@ -2,6 +2,7 @@
  * Shared environment for back-office
  */
 export const sharedEnvironment = {
+  maxFileSize: 7, // transformed into MB later, just indicate number of MB there
   esriApiKey:
     'AAPK6020068836884707b511570bfb55c042Y7JsUDJU7Dg19M1paHAURrcaX7rPUEnxZj1a_-rDCRSrzSSluutrv3vNaDRnpb9N',
 };

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -251,7 +251,7 @@
 				},
 				"upload": {
 					"error": "Something went wrong during the upload",
-					"maxFileSize": "Maximum file size is {{size}} bytes.",
+					"maxFileSize": "Maximum file size is {{size}} MB.",
 					"processing": "Uploading file...",
 					"ready": "File uploaded"
 				}

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -251,6 +251,7 @@
 				},
 				"upload": {
 					"error": "Something went wrong during the upload",
+					"maxFileSize": "Maximum file size is {{size}} bytes.",
 					"processing": "Uploading file...",
 					"ready": "File uploaded"
 				}
@@ -2016,6 +2017,7 @@
 		},
 		"upload": {
 			"dropFilesHere": "Drop files here to upload",
+			"invalidMaxFileSize": "File size too large.",
 			"select": "Select files..."
 		}
 	},

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -251,7 +251,7 @@
 				},
 				"upload": {
 					"error": "Un problème est survenu lors de l'import",
-					"maxFileSize": "La taille maximale du fichier est de {{size}} octets.",
+					"maxFileSize": "La taille maximale du fichier est de {{size}} Mo.",
 					"processing": "Fichier en cours d'importation...",
 					"ready": "Fichier importé"
 				}

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -251,6 +251,7 @@
 				},
 				"upload": {
 					"error": "Un problème est survenu lors de l'import",
+					"maxFileSize": "La taille maximale du fichier est de {{size}} octets.",
 					"processing": "Fichier en cours d'importation...",
 					"ready": "Fichier importé"
 				}
@@ -2038,6 +2039,7 @@
 		},
 		"upload": {
 			"dropFilesHere": "Déposez les fichiers ici pour les importer",
+			"invalidMaxFileSize": "Taille du fichier trop grande.",
 			"select": "Sélectionner les fichiers..."
 		}
 	},

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -251,6 +251,7 @@
 				},
 				"upload": {
 					"error": "******",
+					"maxFileSize": "****** {{size}} ******",
 					"processing": "******",
 					"ready": "******"
 				}
@@ -2016,6 +2017,7 @@
 		},
 		"upload": {
 			"dropFilesHere": "******",
+			"invalidMaxFileSize": "******",
 			"select": "******"
 		}
 	},

--- a/libs/shared/src/lib/components/users/components/invite-users/invite-users.component.html
+++ b/libs/shared/src/lib/components/users/components/invite-users/invite-users.component.html
@@ -17,11 +17,15 @@
         (upload)="onUpload($event)"
         accept=".xlsx"
         [multiple]="false"
+        [restrictions]="{ maxFileSize }"
       >
       </kendo-upload>
       <ui-button (click)="onDownload()" variant="primary" icon="file_download">
         {{ 'common.downloadTemplate' | translate }}
       </ui-button>
+      <div>
+        {{ 'common.notifications.file.upload.maxFileSize' | translate : { size: maxFileSize } }}
+      </div>
     </div>
     <kendo-grid
       [data]="gridData"

--- a/libs/shared/src/lib/components/users/components/invite-users/invite-users.component.html
+++ b/libs/shared/src/lib/components/users/components/invite-users/invite-users.component.html
@@ -17,15 +17,18 @@
         (upload)="onUpload($event)"
         accept=".xlsx"
         [multiple]="false"
-        [restrictions]="{ maxFileSize }"
+        [restrictions]="{ maxFileSize: maxFileSize * 1024 * 1024 }"
       >
       </kendo-upload>
       <ui-button (click)="onDownload()" variant="primary" icon="file_download">
         {{ 'common.downloadTemplate' | translate }}
       </ui-button>
-      <div>
-        {{ 'common.notifications.file.upload.maxFileSize' | translate : { size: maxFileSize } }}
-      </div>
+      <span class="text-gray-700 text-xs">
+        {{
+          'common.notifications.file.upload.maxFileSize'
+            | translate : { size: maxFileSize }
+        }}
+      </span>
     </div>
     <kendo-grid
       [data]="gridData"

--- a/libs/shared/src/lib/components/users/components/invite-users/invite-users.component.ts
+++ b/libs/shared/src/lib/components/users/components/invite-users/invite-users.component.ts
@@ -29,7 +29,7 @@ interface DialogData {
 export class InviteUsersComponent extends UnsubscribeComponent {
   public gridData: GridDataResult = { data: [], total: 0 };
   public formGroup!: ReturnType<typeof this.createFormGroup>;
-  /** File size limit, in bytes */
+  /** File size limit, in MB */
   public maxFileSize: number;
   private editedRowIndex = 0;
   private editionActive = false;

--- a/libs/shared/src/lib/components/users/components/invite-users/invite-users.component.ts
+++ b/libs/shared/src/lib/components/users/components/invite-users/invite-users.component.ts
@@ -29,6 +29,8 @@ interface DialogData {
 export class InviteUsersComponent extends UnsubscribeComponent {
   public gridData: GridDataResult = { data: [], total: 0 };
   public formGroup!: ReturnType<typeof this.createFormGroup>;
+  /** File size limit, in bytes */
+  public maxFileSize: number;
   private editedRowIndex = 0;
   private editionActive = false;
 
@@ -53,6 +55,7 @@ export class InviteUsersComponent extends UnsubscribeComponent {
    * @param dialogRef The reference to a Dialog
    * @param translate The translation service
    * @param data The input data of the component
+   * @param environment environment
    */
   constructor(
     private downloadService: DownloadService,
@@ -61,9 +64,11 @@ export class InviteUsersComponent extends UnsubscribeComponent {
     public dialog: Dialog,
     public dialogRef: DialogRef<InviteUsersComponent>,
     public translate: TranslateService,
-    @Inject(DIALOG_DATA) public data: DialogData
+    @Inject(DIALOG_DATA) public data: DialogData,
+    @Inject('environment') public environment: any
   ) {
     super();
+    this.maxFileSize = environment.maxFileSize;
   }
 
   /**

--- a/libs/shared/src/lib/services/download/download.service.ts
+++ b/libs/shared/src/lib/services/download/download.service.ts
@@ -250,7 +250,8 @@ export class DownloadService {
 
           setTimeout(() => snackBarRef.instance.dismiss(), SNACKBAR_DURATION);
         },
-        error: () => {
+        error: (err) => {
+          console.log(err);
           snackBarSpinner.instance.message = this.translate.instant(
             'common.notifications.file.upload.error'
           );


### PR DESCRIPTION
# Description
Added to the back-office and front-office Environment type the maxFileSize property with the default value of 7 * 1024 * 1024 bytes. Value is used in the kendo-upload of the records and users upload files to limit the max allowed size to the files. If a bigger file is chosen for the user, the kendo component displays an alert message and doesn't upload.

I didn't find a way to get into the downloadService the error status code, the error doesn't have a proper message or status to identify the status to alert the user if the backend file limit is different and smaller than the front-end env limit and there is an error with the size.

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78622

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Upload a file bigger than 7 * 1024 * 1024 bytes to the records form or in the user page invite and see the alert message of file too large in the kendo upload 

## Screenshots
[too-large.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/bedfe13a-c682-4c02-8e2b-df0c5617c89f)

[too-large2.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/d40a90ec-732e-4184-b443-5817f63ca3ad)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
