### PR TITLE
AB#79775: reordering tabs in tabWidget

### DIFF
--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
@@ -129,7 +129,7 @@ export class WidgetGridComponent
         this.colsNumber = this.setColsNumber(
           this._host.nativeElement.innerWidth
         );
-        this.setGridOptions();
+        this.setGridOptions(true);
       });
     this.setGridOptions();
   }

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
@@ -129,7 +129,7 @@ export class WidgetGridComponent
         this.colsNumber = this.setColsNumber(
           this._host.nativeElement.innerWidth
         );
-        this.setGridOptions(true);
+        this.setGridOptions();
       });
     this.setGridOptions();
   }

--- a/libs/shared/src/lib/components/widgets/tabs-settings/tab-main/tab-main.component.ts
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tab-main/tab-main.component.ts
@@ -33,6 +33,7 @@ export class TabMainComponent {
         label: 'New tab',
       })
     );
+    this.tabGroup.selectedIndex = this.tabs.length - 1;
     event.stopPropagation();
   }
 
@@ -43,9 +44,7 @@ export class TabMainComponent {
    */
   onDeleteTab(index: number): void {
     this.tabs.removeAt(index);
-    if (this.tabs.length > 0) {
-      this.tabGroup.selectedIndex = 0;
-    }
+    this.tabGroup.selectedIndex = index === 0 ? 0 : index - 1;
   }
 
   /**
@@ -56,24 +55,23 @@ export class TabMainComponent {
   onReorder(event: CdkDragDrop<string[]>): void {
     const previous = event.previousIndex;
     const current = event.currentIndex;
-    if (previous === current) {
-      return;
-    }
-    const previousControl = this.tabs.at(previous);
-    this.tabs.removeAt(previous);
-    this.tabs.insert(current, previousControl);
-    const previousTabIndex = this.tabGroup.selectedIndex || 0;
-    let selectedIndex = 0;
-    if (previous === previousTabIndex) {
-      selectedIndex = current;
-    } else {
-      if (previous > current && current <= previousTabIndex) {
-        selectedIndex = previousTabIndex + 1;
+    if (previous !== current) {
+      const previousControl = this.tabs.at(previous);
+      this.tabs.removeAt(previous);
+      this.tabs.insert(current, previousControl);
+      const previousTabIndex = this.tabGroup.selectedIndex || 0;
+      let selectedIndex = 0;
+      if (previous === previousTabIndex) {
+        selectedIndex = current;
+      } else {
+        if (previous > current && current <= previousTabIndex) {
+          selectedIndex = previousTabIndex + 1;
+        }
+        if (previous < current && current >= previousTabIndex) {
+          selectedIndex = previousTabIndex - 1;
+        }
       }
-      if (previous < current && current >= previousTabIndex) {
-        selectedIndex = previousTabIndex - 1;
-      }
+      this.tabGroup.selectedIndex = selectedIndex;
     }
-    this.tabGroup.selectedIndex = selectedIndex;
   }
 }

--- a/libs/shared/src/lib/components/widgets/tabs-settings/tab-main/tab-main.component.ts
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tab-main/tab-main.component.ts
@@ -74,6 +74,6 @@ export class TabMainComponent {
         selectedIndex = previousTabIndex - 1;
       }
     }
-    this.tabGroup.tabs.get(selectedIndex)?.openTab.emit();
+    this.tabGroup.selectedIndex = selectedIndex;
   }
 }

--- a/libs/ui/src/lib/tabs/tabs.component.ts
+++ b/libs/ui/src/lib/tabs/tabs.component.ts
@@ -130,22 +130,20 @@ export class TabsComponent implements AfterViewInit, OnDestroy, OnChanges {
    * @param tab tab to display
    */
   showContent(tab: TabComponent) {
-    if (tab.index !== this.selectedIndex || !this.tabBodyHost.hasAttached()) {
-      this.selectedIndex = tab.index;
-      this.setSelectedTab();
+    this.selectedIndex = tab.index;
+    this.setSelectedTab();
 
-      // Clean up previous displayed content
-      this.triggerAnimation = false;
+    // Clean up previous displayed content
+    this.triggerAnimation = false;
 
-      // Creates the content element thanks to the hidden html content of the tab component
-      // Timeout so the animation has the time to render (elsewhere it can't cause delete then create is instantaneous)
-      setTimeout(() => {
-        this.triggerAnimation = true;
-        this.openedTab.emit(tab);
-      }, 100);
-      // Emits the current selected index
-      this.selectedIndexChange.emit(this.selectedIndex);
-    }
+    // Creates the content element thanks to the hidden html content of the tab component
+    // Timeout so the animation has the time to render (elsewhere it can't cause delete then create is instantaneous)
+    setTimeout(() => {
+      this.triggerAnimation = true;
+      this.openedTab.emit(tab);
+    }, 100);
+    // Emits the current selected index
+    this.selectedIndexChange.emit(this.selectedIndex);
   }
 
   /**
@@ -172,7 +170,12 @@ export class TabsComponent implements AfterViewInit, OnDestroy, OnChanges {
       tab.openTab
         .pipe(takeUntil(this.reorder$), takeUntil(this.destroy$))
         .subscribe(() => {
-          this.showContent(tab);
+          if (
+            tab.index !== this.selectedIndex ||
+            !this.tabBodyHost.hasAttached()
+          ) {
+            this.showContent(tab);
+          }
           this.selectedIndex = index;
         });
     });


### PR DESCRIPTION
# Description

The tab ordering problem occurred because the screen's selectedIndex variable was not updated correctly.

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories/?workitem=79775)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] The test was carried out by switching between tabs and observing the behavior.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/55603259/9f5e9fbd-ba5c-43cb-9d5d-d31936654263


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
