### PR TITLE
feat/AB#80051_enable-buttons-in-resource-records-view-empty

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
+++ b/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
@@ -1,69 +1,69 @@
 <!-- Header -->
 <ng-container *ngIf="!loading; else loadingTmpl">
-  <ng-container *ngIf="!empty; else emptyTmpl">
-    <div class="flex justify-end mb-6">
-      <!-- Actions -->
-      <div class="flex gap-2 items-center flex-wrap justify-end">
-        <ui-button
-          *ngIf="resource.canUpdate && !showDeletedRecords"
-          icon="search_off"
-          category="primary"
-          variant="danger"
-          (click)="onSwitchView($event)"
-        >
-          {{ 'components.records.showArchived' | translate }}
-        </ui-button>
-        <ui-button
-          *ngIf="resource.canUpdate && showDeletedRecords"
-          icon="restore_page"
-          category="primary"
-          variant="success"
-          (click)="onSwitchView($event)"
-        >
-          {{ 'components.records.showActive' | translate }}
-        </ui-button>
-        <ui-button
-          icon="file_download"
-          category="secondary"
-          variant="primary"
-          [uiMenuTriggerFor]="menu"
-        >
-          {{
-            'common.downloadObject'
-              | translate : { name: 'common.record.few' | translate }
-          }}
-        </ui-button>
-        <ui-menu #menu>
-          <button uiMenuItem (click)="onDownload('csv')">.csv</button>
-          <button uiMenuItem (click)="onDownload('xlsx')">.xlsx</button>
-        </ui-menu>
-        <ui-button
-          icon="file_upload"
-          category="secondary"
-          variant="primary"
-          [uiTooltip]="'components.records.upload.hint' | translate"
-          (click)="showUpload = !showUpload"
-          cdkOverlayOrigin
-          #uploadTrigger="cdkOverlayOrigin"
-        >
-          {{
-            'common.uploadObject'
-              | translate : { name: 'common.record.few' | translate }
-          }}
-        </ui-button>
-        <ng-template
-          cdkConnectedOverlay
-          [cdkConnectedOverlayOrigin]="uploadTrigger"
-          [cdkConnectedOverlayOpen]="showUpload"
-        >
-          <app-upload-menu
-            (close)="showUpload = false"
-            (upload)="uploadFileData($event)"
-            (download)="onDownloadTemplate()"
-          ></app-upload-menu>
-        </ng-template>
-      </div>
+  <div class="flex justify-end mb-6">
+    <!-- Actions -->
+    <div class="flex gap-2 items-center flex-wrap justify-end">
+      <ui-button
+        *ngIf="resource.canUpdate && !showDeletedRecords"
+        icon="search_off"
+        category="primary"
+        variant="danger"
+        (click)="onSwitchView($event)"
+      >
+        {{ 'components.records.showArchived' | translate }}
+      </ui-button>
+      <ui-button
+        *ngIf="resource.canUpdate && showDeletedRecords"
+        icon="restore_page"
+        category="primary"
+        variant="success"
+        (click)="onSwitchView($event)"
+      >
+        {{ 'components.records.showActive' | translate }}
+      </ui-button>
+      <ui-button
+        icon="file_download"
+        category="secondary"
+        variant="primary"
+        [uiMenuTriggerFor]="menu"
+      >
+        {{
+          'common.downloadObject'
+            | translate : { name: 'common.record.few' | translate }
+        }}
+      </ui-button>
+      <ui-menu #menu>
+        <button uiMenuItem (click)="onDownload('csv')">.csv</button>
+        <button uiMenuItem (click)="onDownload('xlsx')">.xlsx</button>
+      </ui-menu>
+      <ui-button
+        icon="file_upload"
+        category="secondary"
+        variant="primary"
+        [uiTooltip]="'components.records.upload.hint' | translate"
+        (click)="showUpload = !showUpload"
+        cdkOverlayOrigin
+        #uploadTrigger="cdkOverlayOrigin"
+      >
+        {{
+          'common.uploadObject'
+            | translate : { name: 'common.record.few' | translate }
+        }}
+      </ui-button>
+      <ng-template
+        cdkConnectedOverlay
+        [cdkConnectedOverlayOrigin]="uploadTrigger"
+        [cdkConnectedOverlayOpen]="showUpload"
+      >
+        <app-upload-menu
+          (close)="showUpload = false"
+          (upload)="uploadFileData($event)"
+          (download)="onDownloadTemplate()"
+        ></app-upload-menu>
+      </ng-template>
     </div>
+  </div>
+  <ng-container *ngIf="!empty; else emptyTmpl">
     <!-- Table container -->
     <div class="overflow-x-hidden shadow-2lg">
       <!-- Table scroll container -->


### PR DESCRIPTION
# Description
Action buttons in resource records views always available even  when page empty.

## Useful links
- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/80051

## Type of change
 [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Select a resource with zero records, in the Resource page, go to the records tab and see all the buttons available.

## Screenshots
![image](https://github.com/ReliefApplications/ems-frontend/assets/28535394/7b97fffe-10dc-4e5a-9432-6c7c5749cbb2)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
