### PR TITLE
Ab#80081 possibility to have fixed width in grid widgets

### DIFF
--- a/libs/shared/src/lib/components/grid-layout/edit-layout-modal/edit-layout-modal.component.html
+++ b/libs/shared/src/lib/components/grid-layout/edit-layout-modal/edit-layout-modal.component.html
@@ -21,6 +21,7 @@
           [templates]="templates"
           [queryName]="data.queryName"
           [layoutPreviewData]="layoutPreviewData"
+          [showColumnWidth]="true"
         ></shared-query-builder>
       </div>
     </form>

--- a/libs/shared/src/lib/components/query-builder/query-builder.component.html
+++ b/libs/shared/src/lib/components/query-builder/query-builder.component.html
@@ -78,6 +78,7 @@
             [form]="$any(form.controls.fields)"
             [fields]="availableFields"
             [showLimit]="true"
+            [showColumnWidth]="showColumnWidth"
           ></shared-tab-fields>
         </ng-template>
       </ui-tab>

--- a/libs/shared/src/lib/components/query-builder/query-builder.component.ts
+++ b/libs/shared/src/lib/components/query-builder/query-builder.component.ts
@@ -55,6 +55,8 @@ export class QueryBuilderComponent
   @Input() showStyle = true;
   @Input() showFilter = true;
   @Input() showSort = true;
+  /** Toggles the column width parameter */
+  @Input() showColumnWidth = false;
 
   // Tab options
   @Input() showLimit = false;

--- a/libs/shared/src/lib/components/query-builder/tab-fields/tab-fields.component.html
+++ b/libs/shared/src/lib/components/query-builder/tab-fields/tab-fields.component.html
@@ -171,7 +171,7 @@
           <label>
             {{ 'components.queryBuilder.fields.column' | translate }}
           </label>
-          <input formControlName="width" type="number" />
+          <input formControlName="width" type="number" min="0" />
         </div>
       </div>
       <!-- Display format -->

--- a/libs/shared/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
+++ b/libs/shared/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
@@ -207,6 +207,7 @@ export class TabFieldsComponent implements OnInit, OnChanges {
         componentRef.instance.setForm(this.fieldForm);
         componentRef.instance.canExpand = this.fieldForm.value.kind === 'LIST';
         componentRef.instance.showLimit = this.showLimit;
+        componentRef.instance.showColumnWidth = this.showColumnWidth;
         componentRef.instance.closeField.subscribe(() => {
           this.onCloseField();
           componentRef.destroy();

--- a/libs/shared/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
+++ b/libs/shared/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
@@ -27,28 +27,32 @@ import { INLINE_EDITOR_CONFIG } from '../../../const/tinymce.const';
   styleUrls: ['./tab-fields.component.scss'],
 })
 export class TabFieldsComponent implements OnInit, OnChanges {
+  /** Current form array */
   @Input() form: UntypedFormArray = new UntypedFormArray([]);
+  /** All fields */
   @Input() fields: any[] = [];
-  @ViewChild('childTemplate', { read: ViewContainerRef })
-  childTemplate?: ViewContainerRef;
-
-  public availableFields: any[] = [];
-  public selectedFields: any[] = [];
-  public fieldForm: UntypedFormGroup | null = null;
-
-  public searchAvailable = '';
-  public searchSelected = '';
-
-  /** tinymce editor */
-  public editor: any = INLINE_EDITOR_CONFIG;
-
+  /** Should show limit input */
   @Input() showLimit = false;
-
   /** Is the column width field displayed */
   @Input() showColumnWidth = false;
+  /** Reference to child template, in order to inject query builder component */
+  @ViewChild('childTemplate', { read: ViewContainerRef })
+  childTemplate?: ViewContainerRef;
+  /** Available fields */
+  public availableFields: any[] = [];
+  /** Selected fields */
+  public selectedFields: any[] = [];
+  /** Current field form group */
+  public fieldForm: UntypedFormGroup | null = null;
+  /** Search on available fields */
+  public searchAvailable = '';
+  /** Search on selected fields */
+  public searchSelected = '';
+  /** Tinymce editor configuration */
+  public editor: any = INLINE_EDITOR_CONFIG;
 
   /**
-   * The constructor function is a special function that is called when a new instance of the class is created.
+   * Component used for the selection of fields to display the fields in tabs.
    *
    * @param editorService Editor service used to get main URL and current language
    */

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -887,17 +887,6 @@ export class GridComponent
     const stickyColumns = this.columns.filter(
       (column) => !column.hidden && !!column.sticky
     );
-    // get the width of fixed width columns
-    const fixedWidthColumns = this.columns.filter(
-      (column) =>
-        this.fields.find((field) => field.name === column.field)?.fixedWidth
-    );
-    fixedWidthColumns.forEach(
-      (column) =>
-        (column.width = this.fields.find(
-          (field) => field.name === column.field
-        ).fixedWidth)
-    );
     let totalWidthSticky = 0;
     stickyColumns.forEach((column: any) => {
       if (column.width) {
@@ -908,6 +897,19 @@ export class GridComponent
     if (this.selectable) {
       totalWidthSticky += 41;
     }
+
+    // Set the width of fixed width columns
+    const fixedWidthColumns = this.columns.filter(
+      (column) =>
+        this.fields.find((field) => field.name === column.field)?.fixedWidth
+    );
+    fixedWidthColumns.forEach(
+      (column) =>
+        (column.width = this.fields.find(
+          (field) => field.name === column.field
+        ).fixedWidth)
+    );
+
     /** Subtract the width of non-fields columns (details, actions etc.), columns with fixed width and small calculation errors ( border + scrollbar ) */
     const gridTotalWidth =
       gridElement.offsetWidth -

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -887,6 +887,7 @@ export class GridComponent
     const stickyColumns = this.columns.filter(
       (column) => !column.hidden && !!column.sticky
     );
+    // get the width of fixed width columns
     const fixedWidthColumns = this.columns.filter(
       (column) =>
         this.fields.find((field) => field.name === column.field)?.fixedWidth
@@ -907,7 +908,7 @@ export class GridComponent
     if (this.selectable) {
       totalWidthSticky += 41;
     }
-    // Subtract the width of non-fields columns (details, actions etc.) and small calculation errors ( border + scrollbar )
+    /** Subtract the width of non-fields columns (details, actions etc.), columns with fixed width and small calculation errors ( border + scrollbar ) */
     const gridTotalWidth =
       gridElement.offsetWidth -
       totalWidthSticky -

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -887,6 +887,16 @@ export class GridComponent
     const stickyColumns = this.columns.filter(
       (column) => !column.hidden && !!column.sticky
     );
+    const fixedWidthColumns = this.columns.filter(
+      (column) =>
+        this.fields.find((field) => field.name === column.field)?.fixedWidth
+    );
+    fixedWidthColumns.forEach(
+      (column) =>
+        (column.width = this.fields.find(
+          (field) => field.name === column.field
+        ).fixedWidth)
+    );
     let totalWidthSticky = 0;
     stickyColumns.forEach((column: any) => {
       if (column.width) {
@@ -898,13 +908,25 @@ export class GridComponent
       totalWidthSticky += 41;
     }
     // Subtract the width of non-fields columns (details, actions etc.) and small calculation errors ( border + scrollbar )
-    const gridTotalWidth = gridElement.offsetWidth - totalWidthSticky - 12;
+    const gridTotalWidth =
+      gridElement.offsetWidth -
+      totalWidthSticky -
+      fixedWidthColumns.reduce((sum, column) => sum + column.width, 0) -
+      12;
     // Get all the columns with a title or that are not hidden from the grid
     const availableColumns = this.columns.filter(
-      (column) => !column.hidden && !!column.title && !column.sticky
+      (column) =>
+        !column.hidden &&
+        !!column.title &&
+        !column.sticky &&
+        !fixedWidthColumns.includes(column)
     );
     // Verify what kind of field is and deal with this logic
-    const typesFields: { field: string; type: string; title: string }[] = [];
+    const typesFields: {
+      field: string;
+      type: string;
+      title: string;
+    }[] = [];
     this.fields.forEach((field: any) => {
       const availableFields = availableColumns.filter(
         (column: any) => column.field === field.name

--- a/libs/shared/src/lib/services/grid/grid.service.ts
+++ b/libs/shared/src/lib/services/grid/grid.service.ts
@@ -117,6 +117,7 @@ export class GridService {
                 disabled: f.type.endsWith(REFERENCE_DATA_END) ? false : true,
                 hidden: hidden || cachedField?.hidden || false,
                 width: cachedField?.width || title.length * 7 + 50,
+                fixedWidth: f.width, // width used to overwrite autocalculation
                 order: cachedField?.order,
                 query: {
                   sort: f.sort,
@@ -171,6 +172,7 @@ export class GridService {
               disabled: f.type.endsWith(REFERENCE_DATA_END) ? false : true,
               hidden: hidden || cachedField?.hidden || false,
               width: cachedField?.width || title.length * 7 + 50,
+              fixedWidth: f.width, // width used to overwrite autocalculation
               order: cachedField?.order,
               query: {
                 sort: f.sort,
@@ -202,6 +204,7 @@ export class GridService {
                 get(metaData, 'isCalculated', false),
               hidden: hidden || cachedField?.hidden || false,
               width: cachedField?.width || title.length * 7 + 50,
+              fixedWidth: f.width, // width used to overwrite autocalculation
               order: cachedField?.order,
               canSee,
             };


### PR DESCRIPTION
# Description

Activated width option in query builder for layout edition.
Took width into account for columns auto-calculation.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/80081/)

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Tested to change width, both big and small. 

## Screenshots

<img width="827" alt="Screenshot 2023-11-28 at 09 16 56" src="https://github.com/ReliefApplications/ems-frontend/assets/59645813/51ead6f7-5ea5-4925-8093-7b14a5683a31">
<img width="1184" alt="Screenshot 2023-11-28 at 09 03 31" src="https://github.com/ReliefApplications/ems-frontend/assets/59645813/6d484091-490a-4ee3-b5a1-607745eef39a">
<img width="1179" alt="Screenshot 2023-11-28 at 09 18 59" src="https://github.com/ReliefApplications/ems-frontend/assets/59645813/5d6a05ce-dd3c-4b38-bbc5-41c94e2e2536">



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
