### PR TITLE
AB#80271 ABC filter values shared between dashboard pages

### DIFF
--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -190,12 +190,11 @@ export class DashboardFilterComponent
 
   /** Render the survey using the saved structure */
   private initSurvey(): void {
-
     const keptValues = this.getKeptValues();
 
     this.survey = this.contextService.initSurvey();
 
-    this.survey.data = {...keptValues, ...this.survey.data};
+    this.survey.data = { ...keptValues, ...this.survey.data };
 
     this.setAvailableFiltersForContext();
 
@@ -404,19 +403,21 @@ export class DashboardFilterComponent
 
   /**
    * Compares previous filter values with the new filter structure to return the value for matching fields
-   * 
+   *
    * @returns Object with all matching fields
    */
   private getKeptValues(): any {
     const keptValues: any = {};
 
     // Gets all valueName's in the structure
-    const availableFields = [...this.surveyStructure.matchAll(/"valueName":\s?"(.*?)"/g)].map(match => match[1]);
-    availableFields.map(field => {
+    const availableFields = [
+      ...this.surveyStructure.matchAll(/"valueName":\s?"(.*?)"/g),
+    ].map((match) => match[1]);
+    availableFields.map((field) => {
       if (this.survey.data[field]) {
         keptValues[field] = this.survey.data[field];
       }
-    })
+    });
 
     return keptValues;
   }

--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -190,7 +190,12 @@ export class DashboardFilterComponent
 
   /** Render the survey using the saved structure */
   private initSurvey(): void {
+
+    const keptValues = this.getKeptValues();
+
     this.survey = this.contextService.initSurvey();
+
+    this.survey.data = {...keptValues, ...this.survey.data};
 
     this.setAvailableFiltersForContext();
 
@@ -395,5 +400,24 @@ export class DashboardFilterComponent
     }
     // force change detection
     this.changeDetectorRef.detectChanges();
+  }
+
+  /**
+   * Compares previous filter values with the new filter structure to return the value for matching fields
+   * 
+   * @returns Object with all matching fields
+   */
+  private getKeptValues(): any {
+    const keptValues: any = {};
+
+    // Gets all valueName's in the structure
+    const availableFields = [...this.surveyStructure.matchAll(/"valueName":\s?"(.*?)"/g)].map(match => match[1]);
+    availableFields.map(field => {
+      if (this.survey.data[field]) {
+        keptValues[field] = this.survey.data[field];
+      }
+    })
+
+    return keptValues;
   }
 }


### PR DESCRIPTION
# Description

When changing from one dashboard to another the values on the filter are kept if the fields use the same value name.

## Useful links

- [AB#80271](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/80271)

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Changed between dashboards with a similar filter and confirmed that the values are maintained.
- [x] Confirmed that the values for non-existing fields are deleted
- [x] Confirmed that keeping the values for different types of fields works

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/94831019/79bd653d-e625-46d9-bfa1-ca3a750a418f

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
