### PR TITLE
feat/AB#80396-better-indication-group-stage-is-not-only-about-grouping

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -485,7 +485,7 @@
 				"addFields": "Add fields",
 				"custom": "Custom",
 				"filter": "Filter",
-				"group": "Group",
+				"group": "Group & Accumulator",
 				"sort": "Sort",
 				"unwind": "Unwind"
 			},
@@ -493,7 +493,8 @@
 				"addFields": "Adds new fields to documents.",
 				"custom": "Defines a custom aggregation function or expression in JavaScript.",
 				"filter": "Returns an array with only those elements that match the condition.",
-				"group": "Groups input documents by the specified 'id' expression and for each distinct grouping, outputs a document.",
+				"group": "Groups input documents by the specified 'id' expression and for each distinct grouping, outputs a document. It's also about accumulators.",
+				"groupingRules": "Grouping rules are optional.",
 				"selectedFields": "Only unused fields can removed.",
 				"sort": "Sorts all input documents and returns them to the pipeline in sorted order.\nEstablishing consecutive sorting stages will simultaneously sort all fields.",
 				"unwind": "Deconstructs an array field from the input documents to output a document for each element."

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -493,7 +493,7 @@
 				"addFields": "Adds new fields to documents.",
 				"custom": "Defines a custom aggregation function or expression in JavaScript.",
 				"filter": "Returns an array with only those elements that match the condition.",
-				"group": "Groups input documents by the specified 'id' expression and for each distinct grouping, outputs a document. It's also about accumulators.",
+				"group": "Group records based on field values and construct personalized accumulators",
 				"groupingRules": "Grouping rules are optional.",
 				"selectedFields": "Only unused fields can removed.",
 				"sort": "Sorts all input documents and returns them to the pipeline in sorted order.\nEstablishing consecutive sorting stages will simultaneously sort all fields.",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -485,7 +485,7 @@
 				"addFields": "Ajouter des champs",
 				"custom": "Personnaliser",
 				"filter": "Filtrer",
-				"group": "Grouper",
+				"group": "Grouper & Accumulateur",
 				"sort": "Trier",
 				"unwind": "Dissocier"
 			},
@@ -493,7 +493,8 @@
 				"addFields": "Ajouter de nouveaux champs au document.",
 				"custom": "Définit une fonction ou une expression d'agrégation personnalisée en JavaScript.",
 				"filter": "Retourne un tableau contenant uniquement les éléments qui vérifient la condition.",
-				"group": "Regroupe les documents mis en entrée par l'expression 'id' qui a été spécifiée et qui sort un document pour chaque regroupement.",
+				"group": "Regroupe les documents mis en entrée par l'expression 'id' qui a été spécifiée et qui sort un document pour chaque regroupement. Il s'agit également d'accumulateurs.",
+				"groupingRules": "Les règles de regroupement sont facultatives.",
 				"selectedFields": "Seuls les champs non utilisés peuvent être supprimés.",
 				"sort": "Trie tous les documents mis en entrée et les retourne vers la pipeline dans l'ordre.\nLa mise en place de des étapes de tri successives triera simultanément tous les champs.",
 				"unwind": "Déconstruit un tableau depuis les documents d'entrée et ressort un document pour chaque élément."

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -493,7 +493,7 @@
 				"addFields": "Ajouter de nouveaux champs au document.",
 				"custom": "Définit une fonction ou une expression d'agrégation personnalisée en JavaScript.",
 				"filter": "Retourne un tableau contenant uniquement les éléments qui vérifient la condition.",
-				"group": "Regroupe les documents mis en entrée par l'expression 'id' qui a été spécifiée et qui sort un document pour chaque regroupement. Il s'agit également d'accumulateurs.",
+				"group": "Regroupe les enregistrements en fonction des valeurs de champ et construit des accumulateurs personnalisés.",
 				"groupingRules": "Les règles de regroupement sont facultatives.",
 				"selectedFields": "Seuls les champs non utilisés peuvent être supprimés.",
 				"sort": "Trie tous les documents mis en entrée et les retourne vers la pipeline dans l'ordre.\nLa mise en place de des étapes de tri successives triera simultanément tous les champs.",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -494,6 +494,7 @@
 				"custom": "******",
 				"filter": "******",
 				"group": "******",
+				"groupingRules": "******",
 				"selectedFields": "******",
 				"sort": "******",
 				"unwind": "******"

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/group-stage/group-stage.component.html
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/group-stage/group-stage.component.html
@@ -1,5 +1,14 @@
 <div>
-  <h3>{{ 'components.aggregationBuilder.groupingRules' | translate }}</h3>
+  <div class="flex items-center mb-4">
+    <h3 class="m-0">{{ 'components.aggregationBuilder.groupingRules' | translate }}</h3>
+    <ui-icon
+      class="cursor-help ml-1 self-center"
+      icon="info_outline"
+      variant="grey"
+      [size]="18"
+      [uiTooltip]="'components.aggregationBuilder.tooltip.groupingRules' | translate"
+    ></ui-icon>
+  </div>
   <div class="flex flex-col gap-2">
     <div
       class="flex items-end gap-2"

--- a/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/group-stage/group-stage.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/pipeline/group-stage/group-stage.component.ts
@@ -12,7 +12,7 @@ import { UnsubscribeComponent } from '../../../../utils/unsubscribe/unsubscribe.
 import { takeUntil } from 'rxjs/operators';
 
 /**
- * Group Stage pipeline component.
+ * Group Stage (it's also about accumulators) pipeline component.
  */
 @Component({
   selector: 'shared-group-stage',


### PR DESCRIPTION
# Description
Update name and tooltips in group pipeline stage to indicates that's also about accumulators

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/80396

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
In the aggregation editor, add a "Group & Accumulator" stage and to see the new texts.

## Screenshots
[ganda.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/76659162-9a4c-4a2a-909e-3505f5e4cf16)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
