### PR TITLE
AB#80331 ABC - Add edition warning to tab widgets

### DIFF
--- a/libs/shared/src/lib/components/widget-grid/edit-widget-modal/edit-widget-modal.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/edit-widget-modal/edit-widget-modal.component.ts
@@ -38,6 +38,9 @@ export class EditWidgetModalComponent
   /** Widget reactive form */
   widgetForm?: UntypedFormGroup;
 
+  /** Tabs widget strucure, used to check for changes */
+  tabsStructure: any;
+
   /** Reference to widget settings container */
   @ViewChild('settingsContainer', { read: ViewContainerRef })
   settingsContainer: any;
@@ -68,6 +71,12 @@ export class EditWidgetModalComponent
     componentRef.instance.widget = this.data.widget;
     componentRef.instance.change.subscribe((e: any) => {
       this.widgetForm = e;
+      if (this.widgetForm?.value.tabs && !this.tabsStructure) {
+        // We duplicate the object to save a clean copy of the tabs
+        this.tabsStructure = JSON.parse(
+          JSON.stringify(this.widgetForm.value.tabs)
+        );
+      }
     });
   }
 
@@ -83,7 +92,7 @@ export class EditWidgetModalComponent
    * Check if the form is updated or not, and display a confirmation modal if changes detected.
    */
   onClose(): void {
-    if (this.widgetForm?.pristine) {
+    if (this.widgetForm?.pristine && !this.tabsUpdated()) {
       this.dialogRef.close();
     } else {
       const confirmDialogRef = this.confirmService.openConfirmModal({
@@ -97,10 +106,28 @@ export class EditWidgetModalComponent
       confirmDialogRef.closed
         .pipe(takeUntil(this.destroy$))
         .subscribe((value: any) => {
+          if (this.tabsStructure) {
+            this.tabsStructure = undefined;
+          }
           if (value) {
             this.dialogRef.close();
           }
         });
     }
+  }
+
+  /**
+   * Checks if the tab dashboards have been updated
+   *
+   * @returns booelan indicating if tab dashboards have been updated
+   */
+  private tabsUpdated(): boolean {
+    if (this.tabsStructure) {
+      return (
+        JSON.stringify(this.widgetForm?.value.tabs) !==
+        JSON.stringify(this.tabsStructure)
+      );
+    }
+    return false;
   }
 }

--- a/libs/shared/src/lib/components/widget-grid/edit-widget-modal/edit-widget-modal.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/edit-widget-modal/edit-widget-modal.component.ts
@@ -106,10 +106,10 @@ export class EditWidgetModalComponent
       confirmDialogRef.closed
         .pipe(takeUntil(this.destroy$))
         .subscribe((value: any) => {
-          if (this.tabsStructure) {
-            this.tabsStructure = undefined;
-          }
           if (value) {
+            if (this.tabsStructure) {
+              this.tabsStructure = undefined;
+            }
             this.dialogRef.close();
           }
         });


### PR DESCRIPTION
# Description

Tab widgets edition for anything on one of the dashboards was not detected, this was caused because the obj we use for the dashboard structure is the same for the settings and the dashboard display. Since they reference the same thing any cooperation wasn't doing anything. For now, it has been fixed by doing a dup of the dashboard structure so it can be compared.

One issue persists, dashboards modified on the settings are also modified on the dashboard, since it still uses the same obj, reloading the page loads the correct structure (saved one).

## Useful links

- [AB#80331](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/80331)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Modified any dashboard widget on a tab widget and close the modal without saving, a warning message is displayed

## Screenshots

![Recording 2023-11-23 123744](https://github.com/ReliefApplications/ems-frontend/assets/94831019/e5ac9bd2-31de-4381-aafd-d732d3e4733f)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
