### PR TITLE
fix/AB#80508_reset_default_button_do_not_put_back_sticky_hidden_columns

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -103,7 +103,7 @@
         <button
           kendoButton
           title="This will erase current layout with default layout"
-          (click)="action.emit({ action: 'resetLayout' })"
+          (click)="action.emit({ action: 'resetLayout' }); restoreColumns()"
         >
           {{ 'components.widget.grid.layout.reset' | translate }}
         </button>

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -1118,4 +1118,11 @@ export class GridComponent
       }
     });
   }
+
+  /** Restore all columns visibility when reset the layout of the grid */
+  restoreColumns() {
+    this.columns.forEach((column: any) => {
+      column.hidden = false;
+    });
+  }
 }


### PR DESCRIPTION
# Description

 Fixed reset default layout button do not put back sticky columns if hidden.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/80508)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested unselecting a sticky column and then clicking in the reset default layout button and verifying if the column is now not hidden anymore.

## Screenshots

![Peek 01-12-2023 14-00](https://github.com/ReliefApplications/ems-frontend/assets/56398308/1594f9c6-3439-4324-a138-fd148c8bb39a)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

