### PR TITLE
Fix/ab#55095 choices by url should be erased automatically if set choices from ref data

### DIFF
--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -1,5 +1,6 @@
 import { QuestionSelectBase, Question } from '../types';
 import {
+  ChoicesRestfull,
   ItemValue,
   JsonMetadata,
   Serializer,
@@ -36,6 +37,7 @@ export const init = (referenceDataService: ReferenceDataService): void => {
       type: CustomPropertyGridComponentTypes.referenceDataDropdown,
       visibleIndex: 1,
       onSetValue: (obj: QuestionSelectBase, value: string) => {
+        obj.setPropertyValue('choicesByUrl', new ChoicesRestfull());
         obj.choicesByUrl.setData([]);
         obj.setPropertyValue('referenceData', value);
       },

--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -36,9 +36,9 @@ export const init = (referenceDataService: ReferenceDataService): void => {
       type: CustomPropertyGridComponentTypes.referenceDataDropdown,
       visibleIndex: 1,
       onSetValue: (obj: QuestionSelectBase, value: string) => {
-        obj.choicesByUrl.setData([]); 
+        obj.choicesByUrl.setData([]);
         obj.setPropertyValue('referenceData', value);
-      }
+      },
     });
 
     registerCustomPropertyEditor(

--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -35,6 +35,10 @@ export const init = (referenceDataService: ReferenceDataService): void => {
       category: 'Choices from Reference data',
       type: CustomPropertyGridComponentTypes.referenceDataDropdown,
       visibleIndex: 1,
+      onSetValue: (obj: QuestionSelectBase, value: string) => {
+        obj.choicesByUrl.setData([]); 
+        obj.setPropertyValue('referenceData', value);
+      }
     });
 
     registerCustomPropertyEditor(


### PR DESCRIPTION
# Description

Choices by url properties should be erased automatically if we set choices from reference data.

Priority order for choices:

First choices from ref data,
If not available choices from url,
If not available choices from static choices

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/55095

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Adding choices by url, after that setting choices from ref data and seeing if it erase the choices by url automatically.

## Screenshots


https://github.com/ReliefApplications/ems-frontend/assets/24783896/e7be52b8-06c6-484d-badf-79fe44da3158



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
