### PR TITLE
use kendo popup service to open popup at root of app

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -52,20 +52,15 @@
     <kendo-button
       #anchor
       fillMode="flat"
-      (click)="toggleColumnChooser()"
+      (click)="toggleColumnChooser(anchor.element, columnChooser)"
       icon="columns"
     ></kendo-button>
-    <kendo-popup
-      [anchor]="anchor.element"
-      (anchorViewportLeave)="showColumnChooser = false"
-      [collision]="{ horizontal: 'fit', vertical: 'fit' }"
-      *ngIf="showColumnChooser"
-    >
+    <ng-template #columnChooser>
       <shared-grid-column-chooser
         [originalColumns]="grid?.columns"
-        (hideColumnChooser)="toggleColumnChooser($event)"
+        (hideColumnChooser)="toggleColumnChooser(anchor.element, columnChooser, $event)"
       ></shared-grid-column-chooser>
-    </kendo-popup>
+    </ng-template>
 
     <button
       *ngIf="actions.add && canAdd"
@@ -789,7 +784,7 @@
               : field.meta.items
           "
         >
-        <kendo-grid-column
+          <kendo-grid-column
             [field]="field.name"
             [title]="column.label"
             [columnMenu]="false"

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -13,6 +13,7 @@ import {
   QueryList,
   Renderer2,
   SimpleChanges,
+  TemplateRef,
   ViewChild,
   ViewChildren,
 } from '@angular/core';
@@ -37,7 +38,7 @@ import {
   SortDescriptor,
 } from '@progress/kendo-data-query';
 import { ResizeBatchService } from '@progress/kendo-angular-common';
-import { PopupService } from '@progress/kendo-angular-popup';
+import { PopupRef, PopupService } from '@progress/kendo-angular-popup';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { GridService } from '../../../../services/grid/grid.service';
 import { DownloadService } from '../../../../services/download/download.service';
@@ -223,6 +224,8 @@ export class GridComponent
   private closeEditorListener!: any;
   /** A boolean indicating if actions are enabled */
   public hasEnabledActions = false;
+  /** Reference to the column chooser element */
+  private columnChooserRef: PopupRef | null = null;
 
   /** @returns show border of grid */
   get showBorder(): boolean {
@@ -296,6 +299,7 @@ export class GridComponent
    * @param snackBar The snackbar service
    * @param el Ref to html element
    * @param document document
+   * @param popupService Kendo popup service
    */
   constructor(
     @Optional() public widgetComponent: WidgetComponent,
@@ -309,7 +313,8 @@ export class GridComponent
     private translate: TranslateService,
     private snackBar: SnackbarService,
     private el: ElementRef,
-    @Inject(DOCUMENT) private document: Document
+    @Inject(DOCUMENT) private document: Document,
+    private popupService: PopupService
   ) {
     super();
     this.environment = environment.module || 'frontoffice';
@@ -518,9 +523,15 @@ export class GridComponent
   /**
    * Toggles the menu for choosing columns
    *
+   * @param anchor button reference to attach the popup to
+   * @param template Template to use for the popup
    * @param showColumnChooser optional parameter to decide of the state of the popup
    */
-  public toggleColumnChooser(showColumnChooser?: boolean) {
+  public toggleColumnChooser(
+    anchor: ElementRef | HTMLElement,
+    template: TemplateRef<{ [Key: string]: unknown }>,
+    showColumnChooser?: boolean
+  ) {
     // Emit column change event
     if (this.showColumnChooser) {
       this.onColumnVisibilityChange();
@@ -529,6 +540,19 @@ export class GridComponent
       this.showColumnChooser = showColumnChooser;
     } else {
       this.showColumnChooser = !this.showColumnChooser;
+    }
+    switch (this.showColumnChooser) {
+      case false:
+        this.columnChooserRef?.close();
+        this.columnChooserRef = null;
+        break;
+      case true:
+        this.columnChooserRef = this.popupService.open({
+          anchor: anchor,
+          content: template,
+          collision: { horizontal: 'fit', vertical: 'fit' },
+        });
+        break;
     }
   }
 

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.module.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.module.ts
@@ -13,7 +13,6 @@ import { DateInputsModule } from '@progress/kendo-angular-dateinputs';
 import { DropDownsModule } from '@progress/kendo-angular-dropdowns';
 import { GridModule as KendoGridModule } from '@progress/kendo-angular-grid';
 import { InputsModule } from '@progress/kendo-angular-inputs';
-import { PopupModule } from '@progress/kendo-angular-popup';
 import { DateModule } from '../../../../pipes/date/date.module';
 import { DateFilterMenuModule } from '../date-filter-menu/date-filter-menu.module';
 import { ExpandedCommentModule } from '../expanded-comment/expanded-comment.module';
@@ -41,7 +40,6 @@ import { GridFilterMenuModule } from '../filter-menu/filter-menu.module';
     DateInputsModule,
     DropDownsModule,
     ButtonsModule,
-    PopupModule,
     // === UTILS ===
     ExpandedCommentModule,
     // === FILTER ===


### PR DESCRIPTION
# Description

Change kendo popup to use the popup service form kendo that by default opens the popup at the root level of the application. Popup can now go outside the widget.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/80891)
- [Please insert any useful link ( documentation you used for example )](https://www.telerik.com/kendo-angular-ui/components/popup/api/PopupService/#toc-open/)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create grid, make it small, open column chooser.

## Screenshots

<img width="1187" alt="Screenshot 2023-12-06 at 15 55 40" src="https://github.com/ReliefApplications/ems-frontend/assets/59645813/db118dc8-5396-453e-8803-9ca006c8f0bc">

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
