### PR TITLE
add isdoneloading observable to fetch fields only after they are load…

### DIFF
--- a/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
+++ b/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
@@ -102,7 +102,11 @@ export class AggregationGridComponent
       .subscribe(() => {
         this.getAggregationData();
       });
-    this.getAggregationFields();
+    this.queryBuilder.isDoneLoading$.subscribe((doneLoading) => {
+      if (doneLoading) {
+        this.getAggregationFields();
+      }
+    });
   }
 
   ngOnChanges(): void {

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -1157,6 +1157,12 @@ export class GridComponent
     });
     // If aggregation, set the width of the columns here (cannot use layout parameters)
     if (this.useAggregation) {
+      this.columns.forEach((column) =>
+        this.grid?.reorderColumn(
+          column,
+          this.fields.findIndex((field: any) => field.name === column.field)
+        )
+      );
       this.setColumnsWidth();
     }
   }

--- a/libs/shared/src/lib/services/query-builder/query-builder.service.ts
+++ b/libs/shared/src/lib/services/query-builder/query-builder.service.ts
@@ -108,6 +108,7 @@ export class QueryBuilderService {
 
   /** Loading indicator that asserts whether available queries are done loading */
   private isDoneLoading = new ReplaySubject<boolean>();
+  /** Loading indicator as observable */
   public isDoneLoading$ = this.isDoneLoading.asObservable();
 
   /** User fields */


### PR DESCRIPTION
# Description

- Adds _isDoneLoading_ observable to wait before fetching aggregations fields.
-  Now columns are set back to their original orders when resetting to default layout.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81148)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Acquirement of fields was not tested.
Tried to change order of columns and reset layout.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/59645813/7277ba52-8a35-40b8-9646-ce4a04c3c032

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

