### PR TITLE
feat/AB#81471_allow_to_remove_on_click_refData_resource_in_widgets_settings

### DIFF
--- a/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.html
+++ b/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.html
@@ -34,6 +34,16 @@
       formControlName="resource"
       [selectedElements]="[resource]"
     ></shared-resource-select>
+    <ui-button
+      *ngIf="formGroup.value.resource"
+      uiSuffix
+      size="small"
+      [isIcon]="true"
+      (click)="clearFormField('resource', $event)"
+      icon="close"
+      variant="danger"
+      [uiTooltip]="'common.remove' | translate"
+    ></ui-button>
   </div>
   <ng-container *ngIf="resource">
     <!-- Aggregation -->

--- a/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.ts
+++ b/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.ts
@@ -197,4 +197,18 @@ export class TabMainComponent extends UnsubscribeComponent implements OnInit {
       }
     });
   }
+
+  /**
+   * Reset given form field value if there is a value previously to avoid triggering
+   * not necessary actions
+   *
+   * @param formField Current form field
+   * @param event click event
+   */
+  clearFormField(formField: string, event: Event) {
+    if (this.formGroup.get(formField)?.value) {
+      this.formGroup.get(formField)?.setValue(null);
+    }
+    event.stopPropagation();
+  }
 }

--- a/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.html
+++ b/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.html
@@ -8,6 +8,16 @@
           formControlName="referenceData"
           [selectedElements]="[referenceData]"
         ></shared-reference-data-select>
+        <ui-button
+          *ngIf="form.value.referenceData"
+          uiSuffix
+          size="small"
+          [isIcon]="true"
+          (click)="clearFormField('referenceData', $event)"
+          icon="close"
+          variant="danger"
+          [uiTooltip]="'common.remove' | translate"
+        ></ui-button>
       </div>
       <ui-divider
         class="max-w-xs m-auto"
@@ -25,6 +35,16 @@
           formControlName="resource"
           [selectedElements]="[resource]"
         ></shared-resource-select>
+        <ui-button
+          *ngIf="form.value.resource"
+          uiSuffix
+          size="small"
+          [isIcon]="true"
+          (click)="clearFormField('resource', $event)"
+          icon="close"
+          variant="danger"
+          [uiTooltip]="'common.remove' | translate"
+        ></ui-button>
       </div>
     </div>
 

--- a/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.ts
@@ -150,4 +150,18 @@ export class RecordSelectionTabComponent
       this.selectedRecordID = null;
     }
   }
+
+  /**
+   * Reset given form field value if there is a value previously to avoid triggering
+   * not necessary actions
+   *
+   * @param formField Current form field
+   * @param event click event
+   */
+  clearFormField(formField: string, event: Event) {
+    if (this.form.get(formField)?.value) {
+      this.form.get(formField)?.setValue(null);
+    }
+    event.stopPropagation();
+  }
 }

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -144,7 +144,11 @@ export class GridSettingsComponent
           }
           this.getQueryMetaData();
         } else {
+          this.formGroup?.get('layouts')?.setValue([]);
+          this.formGroup?.get('aggregations')?.setValue([]);
+          this.formGroup?.get('template')?.setValue(null);
           this.fields = [];
+          this.resource = null;
         }
 
         // clear sort fields array

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
@@ -25,7 +25,7 @@
       ></ui-button>
     </div>
     <!-- Template selection -->
-    <div uiFormFieldDirective class="flex-1">
+    <div *ngIf="resource" uiFormFieldDirective class="flex-1">
       <label>{{ 'models.form.template' | translate }}</label>
       <ui-select-menu formControlName="template">
         <ui-select-option>-</ui-select-option>

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
@@ -13,6 +13,16 @@
         formControlName="resource"
         [selectedElements]="[resource]"
       ></shared-resource-select>
+      <ui-button
+        *ngIf="formGroup.value.resource"
+        uiSuffix
+        size="small"
+        [isIcon]="true"
+        (click)="clearFormField('resource', $event)"
+        icon="close"
+        variant="danger"
+        [uiTooltip]="'common.remove' | translate"
+      ></ui-button>
     </div>
     <!-- Template selection -->
     <div uiFormFieldDirective class="flex-1">

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.ts
@@ -18,4 +18,18 @@ export class TabMainComponent {
   @Input() resource: Resource | null = null;
   /** Available resource templates */
   @Input() templates: Form[] = [];
+
+  /**
+   * Reset given form field value if there is a value previously to avoid triggering
+   * not necessary actions
+   *
+   * @param formField Current form field
+   * @param event click event
+   */
+  clearFormField(formField: string, event: Event) {
+    if (this.formGroup.get(formField)?.value) {
+      this.formGroup.get(formField)?.setValue(null);
+    }
+    event.stopPropagation();
+  }
 }

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.module.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.module.ts
@@ -10,6 +10,7 @@ import {
   FormWrapperModule,
   SelectMenuModule,
   IconModule,
+  ButtonModule
 } from '@oort-front/ui';
 import { AggregationTableModule } from '../../../aggregation/aggregation-table/aggregation-table.module';
 import { ResourceSelectComponent } from '../../../controls/public-api';
@@ -32,6 +33,7 @@ import { ResourceSelectComponent } from '../../../controls/public-api';
     AggregationTableModule,
     SelectMenuModule,
     ResourceSelectComponent,
+    ButtonModule,
   ],
   exports: [TabMainComponent],
 })

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.module.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.module.ts
@@ -10,7 +10,7 @@ import {
   FormWrapperModule,
   SelectMenuModule,
   IconModule,
-  ButtonModule
+  ButtonModule,
 } from '@oort-front/ui';
 import { AggregationTableModule } from '../../../aggregation/aggregation-table/aggregation-table.module';
 import { ResourceSelectComponent } from '../../../controls/public-api';

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
@@ -18,6 +18,16 @@
             formControlName="referenceData"
             [selectedElements]="[referenceData]"
           ></shared-reference-data-select>
+          <ui-button
+            *ngIf="formGroup.value.card?.referenceData"
+            uiSuffix
+            size="small"
+            [isIcon]="true"
+            (click)="clearFormField('card.referenceData', $event)"
+            icon="close"
+            variant="danger"
+            [uiTooltip]="'common.remove' | translate"
+          ></ui-button>
         </div>
         <ui-divider
           class="max-w-xs m-auto"
@@ -38,6 +48,16 @@
             formControlName="resource"
             [selectedElements]="[resource]"
           ></shared-resource-select>
+          <ui-button
+            *ngIf="formGroup.value.card?.resource"
+            uiSuffix
+            size="small"
+            [isIcon]="true"
+            (click)="clearFormField('card.resource', $event)"
+            icon="close"
+            variant="danger"
+            [uiTooltip]="'common.remove' | translate"
+          ></ui-button>
         </div>
       </div>
 

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.ts
@@ -193,4 +193,18 @@ export class SummaryCardGeneralComponent extends UnsubscribeComponent {
       }
     });
   }
+
+  /**
+   * Reset given form field value if there is a value previously to avoid triggering
+   * not necessary actions
+   *
+   * @param formField Current form field
+   * @param event click event
+   */
+  clearFormField(formField: string, event: Event) {
+    if (this.formGroup.get(formField)?.value) {
+      this.formGroup.get(formField)?.setValue(null);
+    }
+    event.stopPropagation();
+  }
 }


### PR DESCRIPTION
# Description

Feat: widget settings where both ref data & resource are selectable should allow the admin to quickly undo the configuration, for that was added a remove button icon.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81471)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested accessing all the widgets and verifying if when the widget has option to select reference data or resource is possible to remove it with one click in the remove button.

## Screenshots

![Peek 11-12-2023 18-12](https://github.com/ReliefApplications/ems-frontend/assets/56398308/a33903c6-11b5-420b-b333-8779a29f0ac4)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
