### PR TITLE
AB#81468 ABC - Prevent edition of sorting fields to create UX issues

### DIFF
--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -37,7 +37,7 @@
       </ng-template>
     </ui-tab>
     <!-- Card text preview -->
-    <ui-tab *ngIf="widgetFormGroup && !widgetFormGroup.invalid">
+    <ui-tab>
       <ng-container ngProjectAs="label">
         <ui-icon icon="preview" [size]="24"></ui-icon>
         <span>{{


### PR DESCRIPTION
# Description

In summary cards, when adding a new sorting field and writing the label, the tabs were reloaded and the text field was unfocused, needing the user to click on it again.

The cause was a ngIf on the preview tab that was causing it to be unloaded when the form was invalid (A sorting field without a label is invalid). 

The solution has been to remove it altogether. For my testing, any invalid form we can configure in the settings doesn't conflict with the preview tab, as when it has any problem loading it will show the loading skeleton. Other settings as sorting fields are not displayed on the preview tab.

## Useful links

- [Azure ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81468)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Add a new sorting field in a summary card widget and write its label without interruptions.
- [x] Create a new summary card widget and go through the creation process making sure no new errors are generated and that the preview still works.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/94831019/41313e7d-0442-4d2d-8c70-0ed0a6e2948b


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as the assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented on my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes that the code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
