### PR TITLE
Ab#81454 add ref data support for layers

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -495,7 +495,7 @@
 				"filter": "Returns an array with only those elements that match the condition.",
 				"group": "Group records based on field values and construct personalized accumulators",
 				"groupingRules": "Grouping rules are optional.",
-				"selectedFields": "Only unused fields can removed.",
+				"selectedFields": "Only unused fields can be removed.",
 				"sort": "Sorts all input documents and returns them to the pipeline in sorted order.\nEstablishing consecutive sorting stages will simultaneously sort all fields.",
 				"unwind": "Deconstructs an array field from the input documents to output a document for each element."
 			}

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
@@ -380,6 +380,11 @@ export class EditLayerModalComponent
         .get('datasource.refData')
         ?.valueChanges.pipe(takeUntil(this.destroy$))
         .subscribe((value) => {
+          this.clearFields();
+          this.form
+            .get('datasource.aggregation')
+            ?.setValue(null, { emitEvent: false });
+          this.aggregation = null;
           if (value) {
             this.form.get('datasource.resource')?.setValue(null);
             this.getReferenceData();
@@ -394,20 +399,11 @@ export class EditLayerModalComponent
         .get('datasource.resource')
         ?.valueChanges.pipe(takeUntil(this.destroy$))
         .subscribe((value) => {
+          this.clearFields();
           const datasourceGroup = this.form.controls.datasource as FormGroup;
           datasourceGroup.get('layout')?.setValue(null, { emitEvent: false });
           datasourceGroup
             .get('aggregation')
-            ?.setValue(null, { emitEvent: false });
-          datasourceGroup.get('geoField')?.setValue(null, { emitEvent: false });
-          datasourceGroup
-            .get('adminField')
-            ?.setValue(null, { emitEvent: false });
-          datasourceGroup
-            .get('latitudeField')
-            ?.setValue(null, { emitEvent: false });
-          datasourceGroup
-            .get('longitudeField')
             ?.setValue(null, { emitEvent: false });
           this.layout = null;
           this.aggregation = null;
@@ -422,6 +418,7 @@ export class EditLayerModalComponent
         .get('datasource.layout')
         ?.valueChanges.pipe(takeUntil(this.destroy$))
         .subscribe((value) => {
+          this.clearFields;
           if (value) {
             this.getResource();
           } else {
@@ -432,15 +429,17 @@ export class EditLayerModalComponent
         .get('datasource.aggregation')
         ?.valueChanges.pipe(takeUntil(this.destroy$))
         .subscribe((value) => {
-          if (value) {
-            if (this.resource) {
-              this.getResource();
-            }
-            if (this.referenceData) {
-              this.getReferenceData();
-            }
-          } else {
+          this.clearFields();
+          const formValue = this.form.getRawValue();
+          if (!value) {
             this.aggregation = null;
+          }
+          if (get(formValue, 'datasource.refData')) {
+            //we refetch fields even when aggregation is deleted
+            this.getReferenceData();
+          }
+          if (value && get(formValue, 'datasource.resource')) {
+            this.getResource();
           }
         });
     }
@@ -448,6 +447,15 @@ export class EditLayerModalComponent
     this.data.mapComponent?.mapEvent.pipe(takeUntil(this.destroy$)).subscribe({
       next: (event: MapEvent) => this.handleMapEvent(event),
     });
+  }
+
+  /** Clears the geo, admin, latitude and longitude fields */
+  private clearFields() {
+    const datasourceGroup = this.form.controls.datasource as FormGroup;
+    datasourceGroup.get('geoField')?.setValue(null, { emitEvent: false });
+    datasourceGroup.get('adminField')?.setValue(null, { emitEvent: false });
+    datasourceGroup.get('latitudeField')?.setValue(null, { emitEvent: false });
+    datasourceGroup.get('longitudeField')?.setValue(null, { emitEvent: false });
   }
 
   /**

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.html
@@ -73,6 +73,8 @@
           *ngIf="!layout && !aggregation"
           [text]="'common.or' | translate"
         ></ui-divider>
+      </div>
+      <div class="flex flex-col gap-8" *ngIf="!layout && !aggregation">
         <h2>{{ 'common.aggregation.one' | translate }}</h2>
         <div class="flex justify-center mt-4">
           <ui-button

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.html
@@ -74,7 +74,10 @@
           [text]="'common.or' | translate"
         ></ui-divider>
       </div>
-      <div class="flex flex-col gap-8" *ngIf="!layout && !aggregation">
+      <div
+        class="flex flex-col gap-8"
+        *ngIf="(resource || referenceData) && !layout && !aggregation"
+      >
         <h2>{{ 'common.aggregation.one' | translate }}</h2>
         <div class="flex justify-center mt-4">
           <ui-button
@@ -84,6 +87,10 @@
             >{{ 'components.aggregation.add.select' | translate }}</ui-button
           >
         </div>
+        <ui-divider
+          *ngIf="referenceData"
+          [text]="'common.or' | translate"
+        ></ui-divider>
       </div>
 
       <!-- Selected layout -->

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.ts
@@ -100,15 +100,18 @@ export class LayerDatasourceComponent extends UnsubscribeComponent {
   selectAggregation(): void {
     const dialogRef = this.dialog.open(AddAggregationModalComponent, {
       data: {
-        hasAggregations: get(this.resource, 'aggregations.totalCount', 0) > 0,
+        hasAggregations:
+          get(this.resource, 'aggregations.totalCount', 0) > 0 ||
+          get(this.referenceData, 'aggregations.totalCount', 0) > 0,
         resource: this.resource,
+        referenceData: this.referenceData,
       },
     });
     dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value) => {
       if (typeof value === 'string') {
         this.formGroup.get('aggregation')?.setValue(value);
       } else {
-        this.formGroup.get('aggregation')?.setValue((value as any).id);
+        this.formGroup.get('aggregation')?.setValue((value as any)?.id);
       }
     });
   }
@@ -142,6 +145,7 @@ export class LayerDatasourceComponent extends UnsubscribeComponent {
       disableClose: true,
       data: {
         resource: this.resource,
+        referenceData: this.referenceData,
         aggregation: this.aggregation,
       },
     });
@@ -150,6 +154,7 @@ export class LayerDatasourceComponent extends UnsubscribeComponent {
         this.aggregationService
           .editAggregation(this.aggregation, value, {
             resource: this.resource?.id,
+            referenceData: this.referenceData?.id,
           })
           .subscribe(() => {
             this.formGroup

--- a/libs/shared/src/lib/components/widgets/map-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/graphql/queries.ts
@@ -38,12 +38,25 @@ export const GET_RESOURCE = gql`
 
 /** Get ref data gql query definition */
 export const GET_REFERENCE_DATA = gql`
-  query GetReferenceData($id: ID!) {
+  query GetReferenceData($id: ID!, $aggregation: [ID!]) {
     referenceData(id: $id) {
       id
       name
+      graphQLTypeName
       type
       fields
+      aggregations(ids: $aggregation) {
+        edges {
+          node {
+            id
+            name
+            sourceFields
+            pipeline
+            createdAt
+          }
+        }
+        totalCount
+      }
     }
   }
 `;

--- a/libs/shared/src/lib/services/map/map-layers.service.ts
+++ b/libs/shared/src/lib/services/map/map-layers.service.ts
@@ -21,7 +21,6 @@ import {
   LayerQueryResponse,
   LayersQueryResponse,
 } from '../../models/layer.model';
-import { Resource } from '../../models/resource.model';
 import { RestService } from '../rest/rest.service';
 import { QueryBuilderService } from '../query-builder/query-builder.service';
 import { AggregationBuilderService } from '../aggregation-builder/aggregation-builder.service';
@@ -196,17 +195,17 @@ export class MapLayersService {
   /**
    * Get fields from aggregation
    *
-   * @param resource A resource
+   * @param queryName query name to get the fields
    * @param aggregation A aggregation
    * @returns aggregation fields
    */
   public getAggregationFields(
-    resource: Resource | null,
+    queryName: string,
     aggregation: Aggregation | null
   ) {
     //@TODO this part should be refactored
     // Get fields
-    const fields = this.getAvailableSeriesFields(resource);
+    const fields = this.getAvailableSeriesFields(queryName);
     const selectedFields = aggregation?.sourceFields
       .map((x: string) => {
         const field = fields.find((y) => x === y.name);
@@ -240,11 +239,11 @@ export class MapLayersService {
   /**
    * Set available series fields, from resource fields and aggregation definition.
    *
-   * @param resource A resource
+   * @param queryName query name to get the fields
    */
-  private getAvailableSeriesFields(resource: Resource | null): any[] {
+  private getAvailableSeriesFields(queryName: string): any[] {
     return this.queryBuilder
-      .getFields(resource?.queryName as string)
+      .getFields(queryName as string)
       .filter(
         (field: any) =>
           !(


### PR DESCRIPTION
# Description

Now reference data aggregation can be used inside of layers.
Upon changing layout, aggregation, resource or reference data, geoField, admin, longitude and latitude fields are now cleared.
Upon choosing a reference data, you can either choose from its fields or choose an aggregation. If aggregation is chosen, only the aggregation fields are available.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81454/)
- [Please insert link to back-end branch if any](https://github.com/ReliefApplications/ems-backend/pull/875)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Created static reference data, and tested layers with that.

## Screenshots

![refdatainlayers](https://github.com/ReliefApplications/ems-frontend/assets/59645813/c9ef577e-a17d-4496-95b1-f0d6d4faff08)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
