### PR TITLE
AB#81435 : Add option to hide summary cards buttons

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1820,6 +1820,8 @@
 						}
 					},
 					"dynamic": "Dynamic",
+					"exportable": "Allow export of the cards",
+					"gridMode": "Allow to show as grid",
 					"hint": {
 						"dynamic": "Dynamic Summary cards adapt their display to the number of elements in the datasource. You must define a single card which will be repeated for each element."
 					},
@@ -2232,8 +2234,6 @@
 				"border": "Show widget border",
 				"expand": "Show button to expand widget",
 				"header": "Show widget header",
-				"hideExportButton": "Hide export button",
-				"hideGridCardButtons": "Hide view as card/grid buttons",
 				"padding": "Use widget inner padding",
 				"searchable": "Allow search",
 				"sortable": "Allow sorting",

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -2232,6 +2232,8 @@
 				"border": "Show widget border",
 				"expand": "Show button to expand widget",
 				"header": "Show widget header",
+				"hideExportButton": "Hide export button",
+				"hideGridCardButtons": "Hide view as card/grid buttons",
 				"padding": "Use widget inner padding",
 				"searchable": "Allow search",
 				"sortable": "Allow sorting",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1833,6 +1833,8 @@
 						}
 					},
 					"dynamic": "Dynamique",
+					"exportable": "Autoriser l'export des cartes",
+					"gridMode": "Peut être affiché en grille",
 					"hint": {
 						"dynamic": "Les cartes dynamiques adaptent leur affichage en fonction du nombre d'éléments dans la source de données. Vous devez définir une unique carte qui sera répétée pour chaque élément."
 					},
@@ -2246,8 +2248,6 @@
 				"border": "Afficher la bordure du widget",
 				"expand": "Afficher le bouton pour développer le widget",
 				"header": "Afficher l'en-tête du widget",
-				"hideExportButton": "Masquer le bouton d'export",
-				"hideGridCardButtons": "Masquer les boutons afficher en cartes/grilles",
 				"padding": "Utiliser la marge intérieure du widget",
 				"searchable": "Autoriser la recherche",
 				"sortable": "Autoriser le tri",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -2246,6 +2246,8 @@
 				"border": "Afficher la bordure du widget",
 				"expand": "Afficher le bouton pour développer le widget",
 				"header": "Afficher l'en-tête du widget",
+				"hideExportButton": "Masquer le bouton d'export",
+				"hideGridCardButtons": "Masquer les boutons afficher en cartes/grilles",
 				"padding": "Utiliser la marge intérieure du widget",
 				"searchable": "Autoriser la recherche",
 				"sortable": "Autoriser le tri",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -2232,6 +2232,8 @@
 				"border": "******",
 				"expand": "******",
 				"header": "******",
+				"hideExportButton": "******",
+				"hideGridCardButtons": "******",
 				"padding": "******",
 				"searchable": "******",
 				"sortable": "******",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1820,6 +1820,8 @@
 						}
 					},
 					"dynamic": "******",
+					"exportable": "******",
+					"gridMode": "******",
 					"hint": {
 						"dynamic": "******"
 					},
@@ -2232,8 +2234,6 @@
 				"border": "******",
 				"expand": "******",
 				"header": "******",
-				"hideExportButton": "******",
-				"hideGridCardButtons": "******",
 				"padding": "******",
 				"searchable": "******",
 				"sortable": "******",

--- a/libs/shared/src/lib/components/widget/widget.component.html
+++ b/libs/shared/src/lib/components/widget/widget.component.html
@@ -103,6 +103,7 @@
       *ngSwitchCase="'summaryCard'"
       #widgetContent
       [settings]="widget.settings"
+      [export]="!widget.settings.widgetDisplay?.hideExportButton"
       (edit)="edit.emit($event)"
       [widget]="widget"
       [usePadding]="usePadding"

--- a/libs/shared/src/lib/components/widget/widget.component.html
+++ b/libs/shared/src/lib/components/widget/widget.component.html
@@ -103,7 +103,6 @@
       *ngSwitchCase="'summaryCard'"
       #widgetContent
       [settings]="widget.settings"
-      [export]="!widget.settings.widgetDisplay?.hideExportButton"
       (edit)="edit.emit($event)"
       [widget]="widget"
       [usePadding]="usePadding"

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -136,6 +136,12 @@
               'models.widget.display.searchable' | translate
             }}</ng-container>
           </ui-toggle>
+          <ui-toggle>
+            <ng-container ngProjectAs="label">Hide export button</ng-container>
+          </ui-toggle>
+          <ui-toggle>
+            <ng-container ngProjectAs="label">Hide view as card/grid buttons</ng-container>
+          </ui-toggle>
           <div>
             <p class="font-medium mt-0 mb-0.5">
               {{

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -141,16 +141,18 @@
               $any(widgetFormGroup.get('widgetDisplay.hideExportButton'))
             "
           >
-            <ng-container ngProjectAs="label">Hide export button</ng-container>
+            <ng-container ngProjectAs="label">{{
+              'models.widget.display.hideExportButton' | translate
+            }}</ng-container>
           </ui-toggle>
           <ui-toggle
             [formControl]="
               $any(widgetFormGroup.get('widgetDisplay.hideGridCardButtons'))
             "
           >
-            <ng-container ngProjectAs="label"
-              >Hide view as card/grid buttons</ng-container
-            >
+            <ng-container ngProjectAs="label">{{
+              'models.widget.display.hideGridCardButtons' | translate
+            }}</ng-container>
           </ui-toggle>
           <div>
             <p class="font-medium mt-0 mb-0.5">

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -138,20 +138,20 @@
           </ui-toggle>
           <ui-toggle
             [formControl]="
-              $any(widgetFormGroup.get('widgetDisplay.hideExportButton'))
+              $any(widgetFormGroup.get('widgetDisplay.exportable'))
             "
           >
             <ng-container ngProjectAs="label">{{
-              'models.widget.display.hideExportButton' | translate
+              'components.widget.settings.summaryCard.exportable' | translate
             }}</ng-container>
           </ui-toggle>
           <ui-toggle
             [formControl]="
-              $any(widgetFormGroup.get('widgetDisplay.hideGridCardButtons'))
+              $any(widgetFormGroup.get('widgetDisplay.gridMode'))
             "
           >
             <ng-container ngProjectAs="label">{{
-              'models.widget.display.hideGridCardButtons' | translate
+              'components.widget.settings.summaryCard.gridMode' | translate
             }}</ng-container>
           </ui-toggle>
           <div>

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -136,11 +136,21 @@
               'models.widget.display.searchable' | translate
             }}</ng-container>
           </ui-toggle>
-          <ui-toggle>
+          <ui-toggle
+            [formControl]="
+              $any(widgetFormGroup.get('widgetDisplay.hideExportButton'))
+            "
+          >
             <ng-container ngProjectAs="label">Hide export button</ng-container>
           </ui-toggle>
-          <ui-toggle>
-            <ng-container ngProjectAs="label">Hide view as card/grid buttons</ng-container>
+          <ui-toggle
+            [formControl]="
+              $any(widgetFormGroup.get('widgetDisplay.hideGridCardButtons'))
+            "
+          >
+            <ng-container ngProjectAs="label"
+              >Hide view as card/grid buttons</ng-container
+            >
           </ui-toggle>
           <div>
             <p class="font-medium mt-0 mb-0.5">

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.forms.ts
@@ -56,6 +56,12 @@ export const createSummaryCardForm = (id: string, configuration: any) => {
       usePadding: new FormControl(
         get<boolean>(configuration, 'widgetDisplay.usePadding', true)
       ),
+      hideExportButton: new FormControl(
+        get<boolean>(configuration, 'widgetDisplay.hideExportButton', false)
+      ),
+      hideGridCardButtons: new FormControl(
+        get<boolean>(configuration, 'widgetDisplay.hideGridCardButtons', false)
+      ),
     }
   );
 

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.forms.ts
@@ -56,11 +56,11 @@ export const createSummaryCardForm = (id: string, configuration: any) => {
       usePadding: new FormControl(
         get<boolean>(configuration, 'widgetDisplay.usePadding', true)
       ),
-      hideExportButton: new FormControl(
-        get<boolean>(configuration, 'widgetDisplay.hideExportButton', false)
+      exportable: new FormControl(
+        get<boolean>(configuration, 'widgetDisplay.exportable', true)
       ),
-      hideGridCardButtons: new FormControl(
-        get<boolean>(configuration, 'widgetDisplay.hideGridCardButtons', false)
+      gridMode: new FormControl(
+        get<boolean>(configuration, 'widgetDisplay.gridMode', true)
       ),
     }
   );

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -114,24 +114,25 @@
     >
       {{ 'components.widget.summaryCard.dataSource' | translate }}
     </ui-button>
+    <ng-container *ngIf="canChangeDisplayMode">
+      <ui-button
+        [isIcon]="true"
+        icon="grid_view"
+        [disabled]="displayMode === 'cards'"
+        (click)="changeDisplayMode('cards')"
+        [uiTooltip]="'components.widget.summaryCard.viewAsCards' | translate"
+      ></ui-button>
+      <ui-button
+        [isIcon]="true"
+        icon="view_list"
+        [disabled]="displayMode === 'grid'"
+        (click)="changeDisplayMode('grid')"
+        [uiTooltip]="'components.widget.summaryCard.viewAsGrid' | translate"
+      ></ui-button>
+    </ng-container>
+
     <ui-button
-      *ngIf="!settings.widgetDisplay?.hideGridCardButtons"
-      [isIcon]="true"
-      icon="grid_view"
-      [disabled]="displayMode === 'cards'"
-      (click)="changeDisplayMode('cards')"
-      [uiTooltip]="'components.widget.summaryCard.viewAsCards' | translate"
-    ></ui-button>
-    <ui-button
-      *ngIf="!settings.widgetDisplay?.hideGridCardButtons"
-      [isIcon]="true"
-      icon="view_list"
-      [disabled]="displayMode === 'grid'"
-      (click)="changeDisplayMode('grid')"
-      [uiTooltip]="'components.widget.summaryCard.viewAsGrid' | translate"
-    ></ui-button>
-    <ui-button
-      *ngIf="export && displayMode === 'cards'"
+      *ngIf="exportable && displayMode === 'cards'"
       [isIcon]="true"
       icon="get_app"
       class="text-neutral-700"

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -131,7 +131,7 @@
       [uiTooltip]="'components.widget.summaryCard.viewAsGrid' | translate"
     ></ui-button>
     <ui-button
-      *ngIf="export && displayMode === 'cards' && !settings.widgetDisplay?.hideExportButton"
+      *ngIf="export && displayMode === 'cards'"
       [isIcon]="true"
       icon="get_app"
       class="text-neutral-700"

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -115,6 +115,7 @@
       {{ 'components.widget.summaryCard.dataSource' | translate }}
     </ui-button>
     <ui-button
+      *ngIf="!settings.widgetDisplay?.hideGridCardButtons"
       [isIcon]="true"
       icon="grid_view"
       [disabled]="displayMode === 'cards'"
@@ -122,6 +123,7 @@
       [uiTooltip]="'components.widget.summaryCard.viewAsCards' | translate"
     ></ui-button>
     <ui-button
+      *ngIf="!settings.widgetDisplay?.hideGridCardButtons"
       [isIcon]="true"
       icon="view_list"
       [disabled]="displayMode === 'grid'"
@@ -129,7 +131,7 @@
       [uiTooltip]="'components.widget.summaryCard.viewAsGrid' | translate"
     ></ui-button>
     <ui-button
-      *ngIf="export && displayMode === 'cards'"
+      *ngIf="export && displayMode === 'cards' && !settings.widgetDisplay?.hideExportButton"
       [isIcon]="true"
       icon="get_app"
       class="text-neutral-700"

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -67,8 +67,6 @@ export class SummaryCardComponent
 {
   /** Widget definition */
   @Input() widget: any;
-  /** Can export widget */
-  @Input() export = true;
   /** Widget settings */
   @Input() settings!: SummaryCardFormT['value'];
   /** Should show padding */
@@ -190,6 +188,16 @@ export class SummaryCardComponent
         false) &&
       !this.useReferenceData
     );
+  }
+
+  /** @returns user can change display mode */
+  get canChangeDisplayMode() {
+    return get(this.settings, 'widgetDisplay.gridMode', true);
+  }
+
+  /** @returns is widget exportable ( only cards mode ) */
+  get exportable() {
+    return get(this.settings, 'widgetDisplay.exportable', true);
   }
 
   /**


### PR DESCRIPTION
# Description

Adds an option in the widget settings to hide export and view as grid/card buttons in summary cards.

## Useful links

- Please insert link to ticket : https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81435

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Tested in back-office with summary card widget

## Screenshots

![ticket81435](https://github.com/ReliefApplications/ems-frontend/assets/103029022/ab6c7205-ec5a-455f-9f20-947e19f1c439)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
