### PR TITLE
feat/AB#81521_ABC-trigger-filter-from-text-and-summary-card

### DIFF
--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -171,7 +171,19 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
       // Cleanup filter value from the span set by default in the tinymce calculated field if exists
       const cleanContent = filterValue.match(/(?<=>)(.*?)(?=<)/gi);
       const cleanFilterValue = cleanContent ? cleanContent[0] : filterValue;
-      this.contextService.filter.next({ [filterField]: cleanFilterValue });
+      const currentFilters = { ...this.contextService.filter.getValue() };
+      // If current filters contains the field but there is no value set, delete it
+      if (filterField in currentFilters && !cleanFilterValue) {
+        delete currentFilters[filterField];
+      }
+      // Update filter object with existing fields and values
+      const updatedFilters = {
+        ...(currentFilters && { ...currentFilters }),
+        ...(cleanFilterValue && {
+          [filterField]: cleanFilterValue,
+        }),
+      };
+      this.contextService.filter.next(updatedFilters);
     } else {
       const content = this.htmlContentComponent.el.nativeElement;
       const editorTriggers = content.querySelectorAll('.record-editor');

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -29,6 +29,7 @@ import {
 import { GET_REFERENCE_DATA } from './graphql/queries';
 import { HtmlWidgetContentComponent } from '../common/html-widget-content/html-widget-content.component';
 import { UnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.component';
+import { ContextService } from '../../../services/context/context.service';
 
 /**
  * Text widget component using KendoUI
@@ -84,6 +85,7 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
    * @param translate Angular translate service
    * @param gridService Shared grid service
    * @param referenceDataService Shared reference data service
+   * @param contextService Context service
    */
   constructor(
     private apollo: Apollo,
@@ -93,7 +95,8 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
     private snackBar: SnackbarService,
     private translate: TranslateService,
     private gridService: GridService,
-    private referenceDataService: ReferenceDataService
+    private referenceDataService: ReferenceDataService,
+    private contextService: ContextService
   ) {
     super();
   }
@@ -148,13 +151,21 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
    */
   @HostListener('click', ['$event'])
   onContentClick(event: any) {
-    const content = this.htmlContentComponent.el.nativeElement;
-    const editorTriggers = content.querySelectorAll('.record-editor');
-    editorTriggers.forEach((recordEditor: HTMLElement) => {
-      if (recordEditor.contains(event.target)) {
-        this.openEditRecordModal();
-      }
-    });
+    if (event.target.dataset.filterField) {
+      const { filterField, filterValue } = event.target.dataset;
+      // Cleanup filter value from the span set by default in the tinymce calculated field if exists
+      const cleanContent = filterValue.match(/(?<=>)(.*?)(?=<)/gi);
+      const cleanFilterValue = cleanContent ? cleanContent[0] : filterValue;
+      this.contextService.filter.next({ [filterField]: cleanFilterValue });
+    } else {
+      const content = this.htmlContentComponent.el.nativeElement;
+      const editorTriggers = content.querySelectorAll('.record-editor');
+      editorTriggers.forEach((recordEditor: HTMLElement) => {
+        if (recordEditor.contains(event.target)) {
+          this.openEditRecordModal();
+        }
+      });
+    }
   }
 
   /**

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -124,7 +124,19 @@ export class SummaryCardItemContentComponent
       // Cleanup filter value from the span set by default in the tinymce calculated field if exists
       const cleanContent = filterValue.match(/(?<=>)(.*?)(?=<)/gi);
       const cleanFilterValue = cleanContent ? cleanContent[0] : filterValue;
-      this.contextService.filter.next({ [filterField]: cleanFilterValue });
+      const currentFilters = { ...this.contextService.filter.getValue() };
+      // If current filters contains the field but there is no value set, delete it
+      if (filterField in currentFilters && !cleanFilterValue) {
+        delete currentFilters[filterField];
+      }
+      // Update filter object with existing fields and values
+      const updatedFilters = {
+        ...(currentFilters && { ...currentFilters }),
+        ...(cleanFilterValue && {
+          [filterField]: cleanFilterValue,
+        }),
+      };
+      this.contextService.filter.next(updatedFilters);
     } else {
       const content = this.htmlContentComponent.el.nativeElement;
       const editorTriggers = content.querySelectorAll('.record-editor');

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -5,6 +5,7 @@ import {
   OnChanges,
   OnInit,
   Optional,
+  Renderer2,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -56,12 +57,14 @@ export class SummaryCardItemContentComponent
    * @param dialog CDK Dialog service
    * @param parent Reference to parent summary card item component
    * @param contextService Context service
+   * @param renderer Angular renderer2 service
    */
   constructor(
     private dataTemplateService: DataTemplateService,
     private dialog: Dialog,
     @Optional() public parent: SummaryCardItemComponent,
-    private contextService: ContextService
+    private contextService: ContextService,
+    private renderer: Renderer2
   ) {
     super();
   }
@@ -104,8 +107,20 @@ export class SummaryCardItemContentComponent
    */
   @HostListener('click', ['$event'])
   onContentClick(event: any) {
-    if (event.target.dataset.filterField) {
-      const { filterField, filterValue } = event.target.dataset;
+    let filterButtonIsClicked = !!event.target.dataset.filterField;
+    let currentNode = event.target;
+    if (!filterButtonIsClicked) {
+      // Check parent node if contains the dataset for filtering until we hit the host node or find the node with the filter dataset
+      while (
+        currentNode.localName !== 'shared-summary-card-item-content' &&
+        !filterButtonIsClicked
+      ) {
+        currentNode = this.renderer.parentNode(currentNode);
+        filterButtonIsClicked = !!currentNode.dataset.filterField;
+      }
+    }
+    if (filterButtonIsClicked) {
+      const { filterField, filterValue } = currentNode.dataset;
       // Cleanup filter value from the span set by default in the tinymce calculated field if exists
       const cleanContent = filterValue.match(/(?<=>)(.*?)(?=<)/gi);
       const cleanFilterValue = cleanContent ? cleanContent[0] : filterValue;

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -15,6 +15,7 @@ import { Dialog } from '@angular/cdk/dialog';
 import { HtmlWidgetContentComponent } from '../../common/html-widget-content/html-widget-content.component';
 import { takeUntil } from 'rxjs';
 import { SummaryCardItemComponent } from '../summary-card-item/summary-card-item.component';
+import { ContextService } from '../../../../services/context/context.service';
 
 /**
  * Content component of Single Item of Summary Card.
@@ -54,11 +55,13 @@ export class SummaryCardItemContentComponent
    * @param dataTemplateService Shared data template service, used to render content from template
    * @param dialog CDK Dialog service
    * @param parent Reference to parent summary card item component
+   * @param contextService Context service
    */
   constructor(
     private dataTemplateService: DataTemplateService,
     private dialog: Dialog,
-    @Optional() public parent: SummaryCardItemComponent
+    @Optional() public parent: SummaryCardItemComponent,
+    private contextService: ContextService
   ) {
     super();
   }
@@ -101,13 +104,21 @@ export class SummaryCardItemContentComponent
    */
   @HostListener('click', ['$event'])
   onContentClick(event: any) {
-    const content = this.htmlContentComponent.el.nativeElement;
-    const editorTriggers = content.querySelectorAll('.record-editor');
-    editorTriggers.forEach((recordEditor: HTMLElement) => {
-      if (recordEditor.contains(event.target)) {
-        this.openEditRecordModal();
-      }
-    });
+    if (event.target.dataset.filterField) {
+      const { filterField, filterValue } = event.target.dataset;
+      // Cleanup filter value from the span set by default in the tinymce calculated field if exists
+      const cleanContent = filterValue.match(/(?<=>)(.*?)(?=<)/gi);
+      const cleanFilterValue = cleanContent ? cleanContent[0] : filterValue;
+      this.contextService.filter.next({ [filterField]: cleanFilterValue });
+    } else {
+      const content = this.htmlContentComponent.el.nativeElement;
+      const editorTriggers = content.querySelectorAll('.record-editor');
+      editorTriggers.forEach((recordEditor: HTMLElement) => {
+        if (recordEditor.contains(event.target)) {
+          this.openEditRecordModal();
+        }
+      });
+    }
   }
 
   /**

--- a/libs/shared/src/lib/const/tinymce.const.ts
+++ b/libs/shared/src/lib/const/tinymce.const.ts
@@ -17,7 +17,7 @@ export const WIDGET_EDITOR_CONFIG: RawEditorSettings = {
   imagetools_cors_hosts: ['picsum.photos'],
   menubar: 'edit view insert format tools table help',
   toolbar:
-    'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist | forecolor backcolor removeformat | charmap emoticons | fullscreen  preview save | insertfile image media link avatar recordeditor card',
+    'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist | forecolor backcolor removeformat | charmap emoticons | fullscreen  preview save | insertfile image media link avatar recordeditor',
   toolbar_sticky: true,
   image_advtab: true,
   importcss_append: true,
@@ -163,32 +163,6 @@ export const WIDGET_EDITOR_CONFIG: RawEditorSettings = {
             },
           ],
         });
-      },
-    });
-    // Card
-    const cardIcon = createFontAwesomeIcon(
-      {
-        icon: 'book-open',
-        color: 'none',
-        opacity: 1,
-        size: 21,
-      },
-      (editor.editorManager as any).DOM.doc
-    );
-    editor.ui.registry.addIcon('card-icon', cardIcon.innerHTML);
-    editor.ui.registry.addButton('card', {
-      icon: 'card-icon',
-      tooltip: 'Card',
-      onAction: () => {
-        const cardElement = (editor.editorManager as any).DOM.doc.createElement(
-          'article'
-        );
-        cardElement.style.backgroundColor = '#90C5F3';
-        cardElement.style.padding = '.5rem 1rem';
-        cardElement.style.cursor = 'pointer';
-        cardElement.style.borderRadius = '6px';
-        cardElement.textContent = 'Add your card content and data here';
-        editor.insertContent(cardElement.outerHTML);
       },
     });
   },

--- a/libs/shared/src/lib/const/tinymce.const.ts
+++ b/libs/shared/src/lib/const/tinymce.const.ts
@@ -17,7 +17,7 @@ export const WIDGET_EDITOR_CONFIG: RawEditorSettings = {
   imagetools_cors_hosts: ['picsum.photos'],
   menubar: 'edit view insert format tools table help',
   toolbar:
-    'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist | forecolor backcolor removeformat | charmap emoticons | fullscreen  preview save | insertfile image media link avatar recordeditor',
+    'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist | forecolor backcolor removeformat | charmap emoticons | fullscreen  preview save | insertfile image media link avatar recordeditor card',
   toolbar_sticky: true,
   image_advtab: true,
   importcss_append: true,
@@ -163,6 +163,32 @@ export const WIDGET_EDITOR_CONFIG: RawEditorSettings = {
             },
           ],
         });
+      },
+    });
+    // Card
+    const cardIcon = createFontAwesomeIcon(
+      {
+        icon: 'book-open',
+        color: 'none',
+        opacity: 1,
+        size: 21,
+      },
+      (editor.editorManager as any).DOM.doc
+    );
+    editor.ui.registry.addIcon('card-icon', cardIcon.innerHTML);
+    editor.ui.registry.addButton('card', {
+      icon: 'card-icon',
+      tooltip: 'Card',
+      onAction: () => {
+        const cardElement = (editor.editorManager as any).DOM.doc.createElement(
+          'article'
+        );
+        cardElement.style.backgroundColor = '#90C5F3';
+        cardElement.style.padding = '.5rem 1rem';
+        cardElement.style.cursor = 'pointer';
+        cardElement.style.borderRadius = '6px';
+        cardElement.textContent = 'Add your card content and data here';
+        editor.insertContent(cardElement.outerHTML);
       },
     });
   },


### PR DESCRIPTION
# Description

feat: listen to filter events from summary card and text widget using custom attributes in the content set from the tinymce
feat: trigger event on click in child elements of the element containing the filter dataset by bubling up through parent nodes
feat: add renderer2 service in order safely handle the loop aforementioned

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81521)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please refer to video below

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/123092672/63168187-e3ca-49dd-82fe-2046f24a46a8

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
