### PR TITLE
fix/AB#81561_text_widget_editor_autocomplete_not_working_correctly

### DIFF
--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.ts
@@ -54,6 +54,8 @@ export class EditorSettingsComponent
   public referenceData: ReferenceData | null = null;
   /** Current layout */
   public layout: Layout | null = null;
+  /** boolean for check if added calc and keys auto completer */
+  public addedCalcKeys = false;
 
   /**
    * Modal content for the settings of the editor widgets.
@@ -231,9 +233,19 @@ export class EditorSettingsComponent
         });
     }
     // Setup editor auto complete
-    this.editorService.addCalcAndKeysAutoCompleter(this.editor, [
-      ...this.dataTemplateService.getAutoCompleterKeys(fields),
-      ...this.dataTemplateService.getAutoCompleterPageKeys(),
-    ]);
+    // if not added calc and keys yet add
+    if (!this.addedCalcKeys) {
+      this.editorService.addCalcAndKeysAutoCompleter(this.editor, [
+        ...this.dataTemplateService.getAutoCompleterKeys(fields),
+        ...this.dataTemplateService.getAutoCompleterPageKeys(),
+      ]);
+      this.addedCalcKeys = true;
+      // otherwise update it
+    } else {
+      this.editorService.updateCalcAndKeysAutoCompleter(this.editor, [
+        ...this.dataTemplateService.getAutoCompleterKeys(fields),
+        ...this.dataTemplateService.getAutoCompleterPageKeys(),
+      ]);
+    }
   }
 }

--- a/libs/shared/src/lib/services/editor/editor.service.ts
+++ b/libs/shared/src/lib/services/editor/editor.service.ts
@@ -14,10 +14,14 @@ import { DOCUMENT } from '@angular/common';
 export class EditorService {
   /** environment variable */
   private environment: any;
-
+  /** edit scroll listener */
   private editorScrollListener!: any;
+  /** active item scroll listener */
   public activeItemScrollListener!: any;
+  /** renderer */
   private renderer!: Renderer2;
+  /** current calc keys for auto completer */
+  private currentKeys: { value: string; text: string }[] = [];
 
   /**
    * Compute the base url based on the environment file
@@ -77,6 +81,7 @@ export class EditorService {
     editor: RawEditorSettings,
     keys: { value: string; text: string }[]
   ) {
+    this.currentKeys = keys;
     const defaultSetup = editor.setup;
     editor.setup = (e: Editor) => {
       if (defaultSetup && typeof defaultSetup === 'function') defaultSetup(e);
@@ -102,12 +107,26 @@ export class EditorService {
             this.activeItemScrollListener = null;
           }
           this.allowScrolling();
-          return keys.filter((key) =>
+          return this.currentKeys.filter((key) =>
             (key.value || key.text).includes(pattern)
           );
         },
       });
     };
+  }
+
+  /**
+   * Update auto completer with {{ }} for data and calc keys
+   *
+   * @param editor current editor
+   * @param keys list of keys
+   */
+  updateCalcAndKeysAutoCompleter(
+    editor: RawEditorSettings,
+    keys: { value: string; text: string }[]
+  ) {
+    this.currentKeys = keys;
+    editor.instance.execCommand('autocomplete');
   }
 
   /**


### PR DESCRIPTION
# Description

Fixed: User has to go to record selection tab to see autocomplete list in text widget editor, for that was created a method to update calc and keys for autocomplete

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81561)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested opening a text editor widget settings and testing of now the autocomplete is working correctly without the need to go to record selection tab.

## Screenshots

![Peek 12-12-2023 19-46](https://github.com/ReliefApplications/ems-frontend/assets/56398308/825c409e-c6dd-4ab8-9c3c-0d6e1d78ec8a)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
