### PR TITLE
fix/AB#81650-cannot-save-static-ref-data-valueField-required

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
@@ -258,6 +258,24 @@
         ></kendo-grid-column>
       </kendo-grid>
     </div>
+
+    <!-- Value field selection template -->
+    <ng-template #valueFieldTmpl>
+      <div
+        uiFormFieldDirective
+        class="flex-1"
+        *ngIf="!csvLoading && type && valueFields.length > 0"
+      >
+        <label>{{ 'pages.referenceData.valueField' | translate }}</label>
+        <ui-select-menu formControlName="valueField">
+          <ui-select-option
+            *ngFor="let value of valueFields"
+            [value]="value.name"
+            >{{ value.name }}</ui-select-option
+          >
+        </ui-select-menu>
+      </div>
+    </ng-template>
   </form>
   <!-- Floating div for actions buttons -->
   <ui-fixed-wrapper>
@@ -291,22 +309,4 @@
       {{ 'common.save' | translate }}
     </ui-button>
   </ui-fixed-wrapper>
-
-  <!-- Value field selection template -->
-  <ng-template #valueFieldTmpl>
-    <div
-      uiFormFieldDirective
-      class="flex-1"
-      *ngIf="!csvLoading && type && valueFields.length > 0"
-    >
-      <label>{{ 'pages.referenceData.valueField' | translate }}</label>
-      <ui-select-menu formControlName="valueField">
-        <ui-select-option
-          *ngFor="let value of valueFields"
-          [value]="value.name"
-          >{{ value.name }}</ui-select-option
-        >
-      </ui-select-menu>
-    </div>
-  </ng-template>
 </ng-container>

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
@@ -98,20 +98,7 @@
           ></ui-icon>
         </div>
         <!-- Value field to be displayed -->
-        <div
-          uiFormFieldDirective
-          class="flex-1"
-          *ngIf="!csvLoading && type && valueFields.length > 0"
-        >
-          <label>{{ 'pages.referenceData.valueField' | translate }}</label>
-          <ui-select-menu formControlName="valueField">
-            <ui-select-option
-              *ngFor="let value of valueFields"
-              [value]="value.name"
-              >{{ value.name }}</ui-select-option
-            >
-          </ui-select-menu>
-        </div>
+        <ng-container *ngTemplateOutlet="valueFieldTmpl"></ng-container>
       </div>
       <ui-alert class="mb-4">{{
         'pages.referenceData.fields.help' | translate
@@ -239,6 +226,8 @@
           {{ 'pages.referenceData.validateCsv' | translate }}
         </ui-button>
       </div>
+      <!-- Value field to be displayed -->
+      <ng-container *ngTemplateOutlet="valueFieldTmpl"></ng-container>
     </div>
     <ui-spinner *ngIf="csvLoading"></ui-spinner>
     <!-- For graphql -->
@@ -302,4 +291,22 @@
       {{ 'common.save' | translate }}
     </ui-button>
   </ui-fixed-wrapper>
+
+  <!-- Value field selection template -->
+  <ng-template #valueFieldTmpl>
+    <div
+      uiFormFieldDirective
+      class="flex-1"
+      *ngIf="!csvLoading && type && valueFields.length > 0"
+    >
+      <label>{{ 'pages.referenceData.valueField' | translate }}</label>
+      <ui-select-menu formControlName="valueField">
+        <ui-select-option
+          *ngFor="let value of valueFields"
+          [value]="value.name"
+          >{{ value.name }}</ui-select-option
+        >
+      </ui-select-menu>
+    </div>
+  </ng-template>
 </ng-container>


### PR DESCRIPTION
# Description
Value field selector was only available inside graphql and rest template.

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81650

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Create a new static reference data and after validating the csv, selected a value field.

## Screenshots
[video.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/b75233fb-103d-40af-9d0e-2edad351efb2)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
