### PR TITLE
feat: added spinner in text widget while it is not ready to be loaded

### DIFF
--- a/libs/shared/src/lib/components/widgets/editor/editor.component.html
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.html
@@ -8,9 +8,11 @@
   >
     <div class="w-full h-fit" (click)="onClick($event)">
       <shared-html-widget-content
+        *ngIf="!loading"
         [html]="formattedHtml"
         [style]="formattedStyle"
       ></shared-html-widget-content>
+      <ui-spinner *ngIf="loading"></ui-spinner>
     </div>
   </div>
 </div>

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -65,6 +65,8 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
   public formattedHtml: SafeHtml = '';
   /** Formatted style */
   public formattedStyle?: string;
+  /** Loading indicator */
+  public loading = true;
 
   /** Reference to header template */
   @ViewChild('headerTemplate') headerTemplate!: TemplateRef<any>;
@@ -131,6 +133,7 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
       );
     } else if (this.settings.element && this.settings.referenceData) {
       await this.getReferenceData();
+      this.loading = true;
       await this.referenceDataService
         .cacheItems(this.settings.referenceData)
         .then((value) => {
@@ -154,6 +157,7 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
         this.settings.text
       );
     }
+    this.loading = false;
   }
 
   /**
@@ -246,6 +250,7 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
    * Get reference data.
    */
   private async getReferenceData() {
+    this.loading = true;
     this.apollo
       .query<ReferenceDataQueryResponse>({
         query: GET_REFERENCE_DATA,
@@ -266,11 +271,13 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
               };
             });
         }
+        this.loading = false;
       });
   }
 
   /** Sets layout */
   private async getLayout(): Promise<void> {
+    this.loading = true;
     const apolloRes = await firstValueFrom(
       this.apollo.query<ResourceQueryResponse>({
         query: GET_LAYOUT,
@@ -287,12 +294,14 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
         this.styles = this.layout?.query.style;
       }
     }
+    this.loading = false;
   }
 
   /**
    * Queries the data.
    */
   private async getRecord() {
+    this.loading = true;
     const metaRes = await firstValueFrom(
       this.apollo.query<ResourceQueryResponse>({
         query: GET_RESOURCE_METADATA,
@@ -364,6 +373,7 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
         }
       }
     }
+    this.loading = false;
   }
 
   /**

--- a/libs/shared/src/lib/components/widgets/editor/editor.module.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { EditorComponent } from './editor.component';
-import { ButtonModule } from '@oort-front/ui';
+import { ButtonModule, SpinnerModule } from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { HtmlWidgetContentModule } from '../common/html-widget-content/html-widget-content.module';
 
@@ -15,6 +15,7 @@ import { HtmlWidgetContentModule } from '../common/html-widget-content/html-widg
     ButtonModule,
     TranslateModule,
     HtmlWidgetContentModule,
+    SpinnerModule,
   ],
   exports: [EditorComponent],
 })


### PR DESCRIPTION
# Description

Feat: Added spinner in text widget while template is not ready to be loaded.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81667)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested verifying if the spinner is being displayed when the text editor template is not ready to be loaded.

## Screenshots

![Peek 13-12-2023 17-24](https://github.com/ReliefApplications/ems-frontend/assets/56398308/11242e05-951b-48a1-b67e-cb0a2ed57189)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
