### PR TITLE
AB#81834_resources_questions_grid_take_too_much_width'

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -951,27 +951,21 @@ export class GridComponent
       type: string;
       title: string;
     }[] = [];
-    this.fields.forEach((field: any) => {
-      const availableFields = availableColumns.filter((column: any) => {
-        // To correctly size referenceData columns when hiding / show them
-        if (
-          field.meta.type === 'referenceData' &&
-          field.meta[column.field.split(field.name + '.')[1]]
-        ) {
-          return true;
-        } else {
+    this.fields
+      .reduce((acc, field) => acc.concat(field, field.subFields || []), []) // Unnesting reference data to correctly get them
+      .forEach((field: any) => {
+        const availableFields = availableColumns.filter((column: any) => {
           return column.field === field.name;
+        });
+        // should only add items to typesFields if they are available in availableColumns
+        if (availableFields.length > 0) {
+          typesFields.push({
+            field: field.name,
+            type: field.meta.type,
+            title: field.title,
+          });
         }
       });
-      // should only add items to typesFields if they are available in availableColumns
-      if (availableFields.length > 0) {
-        typesFields.push({
-          field: field.name,
-          type: field.meta.type,
-          title: field.title,
-        });
-      }
-    });
     // Get average column width given the active columns and the grid's actual width
     const averagePixelsPerColumn = gridTotalWidth / availableColumns.length;
     // Max size of the column is the average * 2
@@ -1086,7 +1080,7 @@ export class GridComponent
     }
 
     entries = Object.entries(activeColumns);
-    const min_percentage = Math.floor(
+    const minPercentage = Math.floor(
       (minCharacterToDisplay / totalCharacterCountColumns) * 100
     );
     let total_percentage = 0;
@@ -1138,9 +1132,9 @@ export class GridComponent
           (activeColumns[columnFieldType.field] * gridTotalWidth) / 100
         );
       } else {
-        // If contains a title, we set the min_percentage
+        // If contains a title, we set the minPercentage
         if (column.title) {
-          column.width = Math.floor((min_percentage * gridTotalWidth) / 100);
+          column.width = Math.floor((minPercentage * gridTotalWidth) / 100);
         }
       }
       // Make sure that every column has a width set

--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -723,6 +723,7 @@ export const init = (
         CoreGridComponent,
         el.parentElement
       );
+      grid.location.nativeElement.style.maxWidth = `${grid.location.nativeElement.clientWidth}px`; //avoids the grid from getting huge after searching records
       instance = grid.instance;
       setGridInputs(instance, question);
       question.survey?.onValueChanged.add((_: any, options: any) => {


### PR DESCRIPTION
# Description

Adds a maxwidth property to the grid on creation. Not ideal because resizing the window will cause the grid to be too small/too large, but at least fixes the major use case.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81834/)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Reproduce bug like in ticket, grid should now have a reasonable size.

## Screenshots
Bug:
![image](https://github.com/ReliefApplications/ems-frontend/assets/59645813/a7f3b404-6a7c-45d8-9723-2c7ea5909903)
Limitations after fix:
![fix_limitations](https://github.com/ReliefApplications/ems-frontend/assets/59645813/6245ad38-351d-4cb6-9ca8-24686d3f01a4)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
