### PR TITLE
AB#82019 Make context filter work for text widget with aggregation

### DIFF
--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.forms.ts
@@ -28,7 +28,7 @@ export const createTemplateAggregationForm = (value: any) => {
       resource: get<string>(value, 'resource', ''),
       referenceData: get<string>(value, 'referenceData', ''),
       aggregation: [get<string>(value, 'aggregation', ''), Validators.required],
-      contextFilters: DEFAULT_CONTEXT_FILTER,
+      contextFilters: get<string>(value, 'contextFilters', ''),
       at: get<string>(value, 'at', ''),
     },
     {

--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.forms.ts
@@ -28,7 +28,9 @@ export const createTemplateAggregationForm = (value: any) => {
       resource: get<string>(value, 'resource', ''),
       referenceData: get<string>(value, 'referenceData', ''),
       aggregation: [get<string>(value, 'aggregation', ''), Validators.required],
-      contextFilters: get<string>(value, 'contextFilters', ''),
+      contextFilters: get<string>(value, 'contextFilters', '')
+        ? get<string>(value, 'contextFilters', '')
+        : DEFAULT_CONTEXT_FILTER,
       at: get<string>(value, 'at', ''),
     },
     {

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { SafeHtml } from '@angular/platform-browser';
 import { Apollo } from 'apollo-angular';
-import { firstValueFrom, takeUntil } from 'rxjs';
+import { debounceTime, firstValueFrom, takeUntil } from 'rxjs';
 import {
   GET_LAYOUT,
   GET_RESOURCE_METADATA,
@@ -124,6 +124,19 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
 
   /** Sanitizes the text. */
   async ngOnInit(): Promise<void> {
+    this.updateTextWidgetData();
+
+    this.contextService.filter$
+      .pipe(debounceTime(500), takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.updateTextWidgetData();
+      });
+  }
+
+  /**
+   * Refreshes the data.
+   */
+  private updateTextWidgetData() {
     if (this.settings.record && this.settings.resource) {
       Promise.all([
         new Promise<void>((resolve) => {
@@ -206,7 +219,6 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
   private getAggregationsData() {
     const promises: Promise<void>[] = [];
     this.aggregations.forEach((aggregation: any) => {
-      console.log('CONTEXT FILTERS HERE', aggregation.contextFilters);
       promises.push(
         new Promise<void>((resolve) => {
           firstValueFrom(

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { SafeHtml } from '@angular/platform-browser';
 import { Apollo } from 'apollo-angular';
-import { debounceTime, firstValueFrom, takeUntil } from 'rxjs';
+import { Subject, debounceTime, firstValueFrom, from, takeUntil } from 'rxjs';
 import {
   GET_LAYOUT,
   GET_RESOURCE_METADATA,
@@ -73,6 +73,8 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
   public aggregationsData: any = {};
   /** Loading indicator */
   public loading = true;
+  /** Refresh subject, emit a value when refresh needed */
+  refresh$: Subject<boolean> = new Subject<boolean>();
 
   /** @returns does the card use reference data */
   get useReferenceData() {
@@ -124,90 +126,102 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
 
   /** Sanitizes the text. */
   async ngOnInit(): Promise<void> {
-    this.updateTextWidgetData();
+    this.setHtml();
 
     this.contextService.filter$
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(() => {
-        this.updateTextWidgetData();
+        this.refresh$.next(true);
+        this.loading = true;
+        this.setHtml();
       });
   }
 
   /**
-   * Refreshes the data.
+   * Set widget html.
    */
-  private updateTextWidgetData() {
+  private setHtml() {
     if (this.settings.record && this.settings.resource) {
-      Promise.all([
-        new Promise<void>((resolve) => {
-          this.getLayout()
-            .then(() => this.getRecord().finally(() => resolve()))
-            .catch(() => resolve());
-        }),
-        this.getAggregationsData(),
-      ]).then(() => {
-        this.formattedStyle = this.dataTemplateService.renderStyle(
-          this.settings.wholeCardStyles || false,
-          this.fieldsValue,
-          this.styles
-        );
-        this.formattedHtml = this.dataTemplateService.renderHtml(
-          this.settings.text,
-          {
-            data: this.fieldsValue,
-            aggregation: this.aggregations,
-            fields: this.fields,
-            styles: this.styles,
-          }
-        );
-        this.loading = false;
-      });
+      from(
+        Promise.all([
+          new Promise<void>((resolve) => {
+            this.getLayout()
+              .then(() => this.getRecord().finally(() => resolve()))
+              .catch(() => resolve());
+          }),
+          this.getAggregationsData(),
+        ])
+      )
+        .pipe(takeUntil(this.refresh$))
+        .subscribe(() => {
+          this.formattedStyle = this.dataTemplateService.renderStyle(
+            this.settings.wholeCardStyles || false,
+            this.fieldsValue,
+            this.styles
+          );
+          this.formattedHtml = this.dataTemplateService.renderHtml(
+            this.settings.text,
+            {
+              data: this.fieldsValue,
+              aggregation: this.aggregations,
+              fields: this.fields,
+              styles: this.styles,
+            }
+          );
+          this.loading = false;
+        });
     } else if (this.settings.element && this.settings.referenceData) {
-      Promise.all([
-        new Promise<void>((resolve) => {
-          this.getReferenceData()
-            .then(() => {
-              this.referenceDataService
-                .cacheItems(this.settings.referenceData)
-                .then((value) => {
-                  if (value) {
-                    const field = this.referenceData?.valueField;
-                    const selectedItemKey = String(this.settings.element);
-                    if (field) {
-                      this.fieldsValue = value.find(
-                        (x: any) => String(get(x, field)) === selectedItemKey
-                      );
+      from(
+        Promise.all([
+          new Promise<void>((resolve) => {
+            this.getReferenceData()
+              .then(() => {
+                this.referenceDataService
+                  .cacheItems(this.settings.referenceData)
+                  .then((value) => {
+                    if (value) {
+                      const field = this.referenceData?.valueField;
+                      const selectedItemKey = String(this.settings.element);
+                      if (field) {
+                        this.fieldsValue = value.find(
+                          (x: any) => String(get(x, field)) === selectedItemKey
+                        );
+                      }
                     }
-                  }
-                })
-                .finally(() => resolve());
-            })
-            .catch(() => resolve());
-        }),
-        this.getAggregationsData(),
-      ]).then(() => {
-        this.formattedHtml = this.dataTemplateService.renderHtml(
-          this.settings.text,
-          {
-            data: this.fieldsValue,
-            aggregation: this.aggregations,
-            fields: this.fields,
-          }
-        );
-        this.loading = false;
-      });
+                  })
+                  .finally(() => resolve());
+              })
+              .catch(() => resolve());
+          }),
+          this.getAggregationsData(),
+        ])
+      )
+        .pipe(takeUntil(this.refresh$))
+        .subscribe(() => {
+          this.formattedHtml = this.dataTemplateService.renderHtml(
+            this.settings.text,
+            {
+              data: this.fieldsValue,
+              aggregation: this.aggregations,
+              fields: this.fields,
+            }
+          );
+          this.loading = false;
+        });
     } else {
-      Promise.all([this.getAggregationsData()]).then(() => {
-        this.formattedHtml = this.dataTemplateService.renderHtml(
-          this.settings.text,
-          {
-            data: this.fieldsValue,
-            aggregation: this.aggregations,
-            fields: this.fields,
-          }
-        );
-        this.loading = false;
-      });
+      from(Promise.all([this.getAggregationsData()]))
+        .pipe(takeUntil(this.refresh$))
+        .subscribe(() => {
+          this.formattedHtml = this.dataTemplateService.renderHtml(
+            this.settings.text,
+            {
+              data: this.fieldsValue,
+              aggregation: this.aggregations,
+              fields: this.fields,
+            }
+          );
+          this.loading = false;
+        });
     }
   }
 

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -206,6 +206,7 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
   private getAggregationsData() {
     const promises: Promise<void>[] = [];
     this.aggregations.forEach((aggregation: any) => {
+      console.log('CONTEXT FILTERS HERE', aggregation.contextFilters);
       promises.push(
         new Promise<void>((resolve) => {
           firstValueFrom(
@@ -213,7 +214,7 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
               resource: aggregation.resource,
               referenceData: aggregation.referenceData,
               aggregation: aggregation.aggregation,
-              contextFilters: aggregation.contextFilters,
+              contextFilters: JSON.parse(aggregation.contextFilters),
               at: this.contextService.atArgumentValue(aggregation.at),
             })
           )


### PR DESCRIPTION
# Description
Added logic so that when changing the contextFilter the entire text Widget screen is affected by the filter input.

## Useful links

- Please insert link to ticket : https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82017

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] An aggregation with filterContext was added, after listing on the grid the filter was applied and behavior was observed.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/55603259/7cfe0849-8691-4d0d-924e-820e22ce6d75

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
