### PR TITLE
Ab#82021 correct tooltip and text overflow for ref data on grid

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -600,7 +600,13 @@
                 class="textbox-container"
                 [style]="dataItem.style[field.name]"
               >
-                {{ dataItem.text[subField.name] }}
+                <div
+                  class="truncate"
+                  [uiTooltip]="dataItem.text[subField.name]"
+                  tooltipEnableBy="truncate"
+                >
+                  {{ dataItem.text[subField.name] }}
+                </div>
                 <!-- <button
                   kendoButton
                   icon="hyperlink-open-sm"


### PR DESCRIPTION
# Description

Add correct classes to get tooltip and overflow.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82021)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create grid with ref data, tooltips and dots should now appear when reducing grid column size.

## Screenshots

![Screenshot from 2023-12-18 16-31-18](https://github.com/ReliefApplications/ems-frontend/assets/59645813/4acef11a-1896-49c3-bd6f-1b1c2eaeaed9)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
