### PR TITLE
feat/create-abstract-class-for-all-widget-settings-form

### DIFF
--- a/libs/shared/src/lib/components/controls/resource-select/resource-select.component.ts
+++ b/libs/shared/src/lib/components/controls/resource-select/resource-select.component.ts
@@ -21,6 +21,7 @@ import { Apollo } from 'apollo-angular';
 import { ResourcesQueryResponse } from '../../../models/resource.model';
 import { GET_RESOURCES } from './graphql/queries';
 import { TranslateModule } from '@ngx-translate/core';
+import { takeUntil } from 'rxjs';
 
 /** Default items per query, for pagination */
 const ITEMS_PER_PAGE = 10;
@@ -85,7 +86,7 @@ export class ResourceSelectComponent extends GraphQLSelectComponent {
     this.valueField = 'id';
     this.textField = 'name';
     this.filterable = true;
-    this.searchChange.subscribe((value) => {
+    this.searchChange.pipe(takeUntil(this.destroy$)).subscribe((value) => {
       this.onSearchChange(value);
     });
   }

--- a/libs/shared/src/lib/components/widget-grid/edit-widget-modal/edit-widget-modal.component.html
+++ b/libs/shared/src/lib/components/widget-grid/edit-widget-modal/edit-widget-modal.component.html
@@ -14,7 +14,7 @@
       variant="primary"
       (click)="onSubmit()"
       cdkFocusInitial
-      [disabled]="!widgetForm || !widgetForm.valid"
+      [disabled]="!widgetForm?.valid"
     >
       {{ 'common.save' | translate }}
     </ui-button>

--- a/libs/shared/src/lib/components/widget-grid/edit-widget-modal/edit-widget-modal.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/edit-widget-modal/edit-widget-modal.component.ts
@@ -86,7 +86,10 @@ export class EditWidgetModalComponent
 
   /** Once the template is ready, inject the settings component linked to the widget type passed as a parameter. */
   ngAfterViewInit(): void {
-    this.settingsContainer.insert(this.componentRef.hostView);
+    // Allows to set the change detector check in the next cycle so it waits until host view is complete loaded
+    Promise.resolve().then(() =>
+      this.settingsContainer.insert(this.componentRef.hostView)
+    );
   }
 
   /**

--- a/libs/shared/src/lib/components/widget-grid/edit-widget-modal/edit-widget-modal.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/edit-widget-modal/edit-widget-modal.component.ts
@@ -4,6 +4,9 @@ import {
   ViewChild,
   ViewContainerRef,
   AfterViewInit,
+  createComponent,
+  EnvironmentInjector,
+  ComponentRef,
 } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
@@ -12,6 +15,7 @@ import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { takeUntil } from 'rxjs';
 import { UnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.component';
 import { ButtonModule, DialogModule } from '@oort-front/ui';
+import { WidgetSettingsType } from '../../../models/dashboard.model';
 
 /** Model for dialog data */
 interface DialogData {
@@ -39,7 +43,9 @@ export class EditWidgetModalComponent
   public widgetForm?: UntypedFormGroup;
   /** Reference to widget settings container */
   @ViewChild('settingsContainer', { read: ViewContainerRef })
-  public settingsContainer: any;
+  public settingsContainer!: ViewContainerRef;
+  /** Settings component ref used to display content */
+  private componentRef!: ComponentRef<WidgetSettingsType>;
 
   /**
    * Edition of widget configuration in modal.
@@ -49,25 +55,38 @@ export class EditWidgetModalComponent
    * @param data The dialog data
    * @param confirmService Shared confirm service
    * @param translate Angular translate service
+   * @param environmentInjector Angular environment injector containing all registered DI for the settings component
    */
   constructor(
     public dialogRef: DialogRef<EditWidgetModalComponent>,
     @Inject(DIALOG_DATA) public data: DialogData,
     private confirmService: ConfirmService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private environmentInjector: EnvironmentInjector
   ) {
     super();
+    // Create the settings component in the modal constructor to keep all hooks ready for the view insertion
+    this.componentRef = createComponent<WidgetSettingsType>(
+      this.data.template,
+      {
+        environmentInjector: this.environmentInjector,
+      }
+    );
+    /** Set current widget data and build up settings form in order to be ready once view is added to the DOM */
+    this.componentRef.instance.widget = this.data.widget;
+    this.componentRef.instance.buildSettingsForm();
+    this.widgetForm = this.componentRef.instance.widgetFormGroup;
+    /** Subscribe to current widget form changes */
+    this.componentRef.instance.formChange
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((e: any) => {
+        this.widgetForm = e;
+      });
   }
 
   /** Once the template is ready, inject the settings component linked to the widget type passed as a parameter. */
   ngAfterViewInit(): void {
-    const componentRef = this.settingsContainer.createComponent(
-      this.data.template
-    );
-    componentRef.instance.widget = this.data.widget;
-    componentRef.instance.change.subscribe((e: any) => {
-      this.widgetForm = e;
-    });
+    this.settingsContainer.insert(this.componentRef.hostView);
   }
 
   /**
@@ -84,6 +103,7 @@ export class EditWidgetModalComponent
   onClose(): void {
     if (this.widgetForm?.pristine) {
       this.dialogRef.close();
+      this.settingsContainer.clear();
     } else {
       const confirmDialogRef = this.confirmService.openConfirmModal({
         title: this.translate.instant('common.close'),
@@ -98,6 +118,7 @@ export class EditWidgetModalComponent
         .subscribe((value: any) => {
           if (value) {
             this.dialogRef.close();
+            this.settingsContainer.clear();
           }
         });
     }

--- a/libs/shared/src/lib/components/widgets/chart-settings/chart-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/chart-settings/chart-settings.component.html
@@ -10,7 +10,10 @@
       <span>{{ 'common.general' | translate }}</span>
     </ng-container>
     <ng-template uiTabContent>
-      <shared-tab-main [formGroup]="formGroup" [type]="type"></shared-tab-main>
+      <shared-tab-main
+        [formGroup]="widgetFormGroup"
+        [type]="type"
+      ></shared-tab-main>
     </ng-template>
   </ui-tab>
   <!-- Display options -->
@@ -25,7 +28,7 @@
     </ng-container>
     <ng-template uiTabContent>
       <shared-tab-display
-        [formGroup]="formGroup"
+        [formGroup]="widgetFormGroup"
         [type]="type"
       ></shared-tab-display>
     </ng-template>
@@ -38,7 +41,7 @@
     </ng-container>
     <ng-template uiTabContent>
       <shared-contextual-filters-settings
-        [form]="formGroup"
+        [form]="widgetFormGroup"
       ></shared-contextual-filters-settings>
     </ng-template>
   </ui-tab>
@@ -51,7 +54,7 @@
       }}</span>
     </ng-container>
     <ng-template uiTabContent>
-      <shared-tab-filters [formGroup]="formGroup"></shared-tab-filters>
+      <shared-tab-filters [formGroup]="widgetFormGroup"></shared-tab-filters>
     </ng-template>
   </ui-tab>
   <!-- Widget display options -->
@@ -66,7 +69,7 @@
     </ng-container>
     <ng-template uiTabContent>
       <shared-display-settings
-        [formGroup]="formGroup"
+        [formGroup]="widgetFormGroup"
       ></shared-display-settings>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/chart-settings/chart-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/chart-settings/chart-settings.component.ts
@@ -4,6 +4,7 @@ import { createChartWidgetForm } from './chart-forms';
 import { CHART_TYPES } from './constants';
 import { UnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.component';
 import { takeUntil } from 'rxjs';
+import { WidgetSettings } from '../../../models/dashboard.model';
 
 /**
  * Chart settings component
@@ -16,15 +17,15 @@ import { takeUntil } from 'rxjs';
 /** Modal content for the settings of the chart widgets. */
 export class ChartSettingsComponent
   extends UnsubscribeComponent
-  implements OnInit
+  implements OnInit, WidgetSettings<typeof createChartWidgetForm>
 {
   /** Widget definition */
   @Input() widget: any;
   /** Emit the applied change */
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() change: EventEmitter<any> = new EventEmitter();
+  @Output() formChange: EventEmitter<ReturnType<typeof createChartWidgetForm>> =
+    new EventEmitter();
   /** Widget form group */
-  public formGroup!: ReturnType<typeof createChartWidgetForm>;
+  public widgetFormGroup!: ReturnType<typeof createChartWidgetForm>;
   /** Available chart types */
   public types = CHART_TYPES;
   /** Current chart type */
@@ -32,28 +33,36 @@ export class ChartSettingsComponent
 
   /** @returns the form for the chart */
   public get chartForm(): UntypedFormGroup {
-    return (this.formGroup?.controls.chart as UntypedFormGroup) || null;
+    return (this.widgetFormGroup?.controls.chart as UntypedFormGroup) || null;
   }
 
-  /** Build the settings form, using the widget saved parameters. */
   ngOnInit(): void {
-    this.formGroup = createChartWidgetForm(
-      this.widget.id,
-      this.widget.settings
-    );
-
+    if (!this.widgetFormGroup) {
+      this.buildSettingsForm();
+    }
     this.type = this.types.find((x) => x.name === this.chartForm.value.type);
-    this.change.emit(this.formGroup);
 
-    this.formGroup.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.formGroup.markAsDirty({ onlySelf: true });
-      this.change.emit(this.formGroup);
-    });
+    this.widgetFormGroup.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.widgetFormGroup.markAsDirty({ onlySelf: true });
+        this.formChange.emit(this.widgetFormGroup);
+      });
 
     this.chartForm.controls.type.valueChanges
       .pipe(takeUntil(this.destroy$))
       .subscribe((value) => {
         this.type = this.types.find((x) => x.name === value);
       });
+  }
+
+  /**
+   * Build the settings form, using the widget saved parameters
+   */
+  public buildSettingsForm() {
+    this.widgetFormGroup = createChartWidgetForm(
+      this.widget.id,
+      this.widget.settings
+    );
   }
 }

--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.html
@@ -28,7 +28,7 @@
       </ng-template>
     </ui-tab>
     <!-- Preview -->
-    <ui-tab *ngIf="widgetFormGroup.value">
+    <ui-tab>
       <ng-container ngProjectAs="label">
         <ui-icon icon="preview" [size]="24"></ui-icon>
         <span>{{

--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.ts
@@ -24,6 +24,7 @@ import {
   ReferenceDataQueryResponse,
 } from '../../../models/reference-data.model';
 import { createEditorForm } from './editor-settings.forms';
+import { WidgetSettings } from '../../../models/dashboard.model';
 
 // export type EditorFormType = ReturnType<typeof createEditorForm>;
 
@@ -37,15 +38,15 @@ import { createEditorForm } from './editor-settings.forms';
 })
 export class EditorSettingsComponent
   extends UnsubscribeComponent
-  implements OnInit, AfterViewInit
+  implements OnInit, AfterViewInit, WidgetSettings<typeof createEditorForm>
 {
   /** Widget configuration */
   @Input() widget: any;
   /** Widget form group */
   widgetFormGroup!: ReturnType<typeof createEditorForm>;
   /** Change event emitter */
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() change: EventEmitter<any> = new EventEmitter();
+  @Output() formChange: EventEmitter<ReturnType<typeof createEditorForm>> =
+    new EventEmitter();
   /** tinymce editor configuration */
   public editor: any = WIDGET_EDITOR_CONFIG;
   /** Current resource */
@@ -77,15 +78,10 @@ export class EditorSettingsComponent
     this.dataTemplateService.setEditorLinkList(this.editor);
   }
 
-  /**
-   * Build the settings form, using the widget saved parameters.
-   */
   ngOnInit(): void {
-    this.widgetFormGroup = createEditorForm(
-      this.widget.id,
-      this.widget.settings
-    );
-    this.change.emit(this.widgetFormGroup);
+    if (!this.widgetFormGroup) {
+      this.buildSettingsForm();
+    }
 
     // Initialize the selected resource, layout and record from the form
     const resourceID = this.widgetFormGroup?.get('resource')?.value;
@@ -161,7 +157,7 @@ export class EditorSettingsComponent
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.widgetFormGroup.markAsDirty({ onlySelf: true });
-        this.change.emit(this.widgetFormGroup);
+        this.formChange.emit(this.widgetFormGroup);
         // todo: check if relevant
         this.widget.settings.text = this.widgetFormGroup.value.text;
         this.widget.settings.record = this.widgetFormGroup.value.record;
@@ -256,5 +252,15 @@ export class EditorSettingsComponent
       ),
       ...this.dataTemplateService.getAutoCompleterPageKeys(),
     ]);
+  }
+
+  /**
+   * Build the settings form, using the widget saved parameters.
+   */
+  public buildSettingsForm() {
+    this.widgetFormGroup = createEditorForm(
+      this.widget.id,
+      this.widget.settings
+    );
   }
 }

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -125,7 +125,7 @@
     <ng-template uiTabContent>
       <shared-sorting-settings
         [fields]="fields"
-        [formArray]="$any(widgetFormGroup.get('sortFields'))"
+        [formArray]="widgetFormGroup.controls.sortFields"
         [formGroup]="widgetFormGroup"
       ></shared-sorting-settings>
     </ng-template>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -15,14 +15,16 @@
     </ng-container>
     <ng-template uiTabContent>
       <shared-tab-main
-        [formGroup]="formGroup"
+        [formGroup]="widgetFormGroup"
         [resource]="resource"
         [templates]="templates"
       ></shared-tab-main>
     </ng-template>
   </ui-tab>
   <!-- AVAILABLE ACTIONS -->
-  <ui-tab *ngIf="formGroup && !(formGroup.value.aggregations.length > 0)">
+  <ui-tab
+    *ngIf="widgetFormGroup && !(widgetFormGroup.value.aggregations.length > 0)"
+  >
     <ng-container ngProjectAs="label">
       <ui-icon
         icon="toggle_on"
@@ -36,7 +38,7 @@
       }}</span>
       <!-- Icon with warning if any -->
       <ui-icon
-        *ngIf="formGroup.get('actions')?.invalid"
+        *ngIf="widgetFormGroup.get('actions')?.invalid"
         class="ml-1 cursor-help self-center"
         variant="danger"
         icon="warning"
@@ -49,13 +51,15 @@
     </ng-container>
     <ng-template uiTabContent>
       <shared-tab-actions
-        [formGroup]="formGroup"
+        [formGroup]="widgetFormGroup"
         [fields]="fields"
       ></shared-tab-actions>
     </ng-template>
   </ui-tab>
   <!-- BUTTONS -->
-  <ui-tab *ngIf="formGroup && !(formGroup.value.aggregations.length > 0)">
+  <ui-tab
+    *ngIf="widgetFormGroup && !(widgetFormGroup.value.aggregations.length > 0)"
+  >
     <ng-container ngProjectAs="label">
       <ui-icon
         icon="bolt"
@@ -71,7 +75,7 @@
     <ng-template uiTabContent>
       <shared-tab-buttons
         class="flex flex-col h-full"
-        [formGroup]="formGroup"
+        [formGroup]="widgetFormGroup"
         [fields]="fields"
         [templates]="appTemplates"
         [distributionLists]="distributionLists"
@@ -88,7 +92,7 @@
     </ng-container>
     <ng-template uiTabContent>
       <shared-contextual-filters-settings
-        [form]="formGroup"
+        [form]="widgetFormGroup"
       ></shared-contextual-filters-settings>
     </ng-template>
   </ui-tab>
@@ -103,7 +107,7 @@
       <span>{{ 'models.widget.display.title' | translate }}</span>
     </ng-container>
     <ng-template uiTabContent>
-      <shared-display-settings [formGroup]="formGroup">
+      <shared-display-settings [formGroup]="widgetFormGroup">
       </shared-display-settings>
     </ng-template>
   </ui-tab>
@@ -121,8 +125,8 @@
     <ng-template uiTabContent>
       <shared-sorting-settings
         [fields]="fields"
-        [formArray]="$any(formGroup.get('sortFields'))"
-        [formGroup]="formGroup"
+        [formArray]="$any(widgetFormGroup.get('sortFields'))"
+        [formGroup]="widgetFormGroup"
       ></shared-sorting-settings>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -8,7 +8,6 @@ import {
   AfterViewInit,
 } from '@angular/core';
 import {
-  UntypedFormGroup,
   UntypedFormArray,
   Validators,
   FormBuilder,
@@ -29,6 +28,7 @@ import { DistributionList } from '../../../models/distribution-list.model';
 import { UnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.component';
 import { takeUntil } from 'rxjs/operators';
 import { AggregationService } from '../../../services/aggregation/aggregation.service';
+import { WidgetSettings } from '../../../models/dashboard.model';
 
 /**
  * Modal content for the settings of the grid widgets.
@@ -40,22 +40,25 @@ import { AggregationService } from '../../../services/aggregation/aggregation.se
 })
 export class GridSettingsComponent
   extends UnsubscribeComponent
-  implements OnInit, AfterViewInit
+  implements
+    OnInit,
+    AfterViewInit,
+    WidgetSettings<typeof createGridWidgetFormGroup>
 {
-  // === REACTIVE FORM ===
-  /** Form group */
-  public formGroup!: UntypedFormGroup;
-  /** Form array for filters */
-  public filtersFormArray: any = null;
-
   // === WIDGET ===
   /** Widget */
   @Input() widget: any;
-
   // === EMIT THE CHANGES APPLIED ===
   /** Event emitter for change */
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() change: EventEmitter<any> = new EventEmitter();
+  @Output() formChange: EventEmitter<
+    ReturnType<typeof createGridWidgetFormGroup>
+  > = new EventEmitter();
+
+  // === REACTIVE FORM ===
+  /** Form group */
+  public widgetFormGroup!: ReturnType<typeof createGridWidgetFormGroup>;
+  /** Form array for filters */
+  public filtersFormArray: any = null;
 
   // === NOTIFICATIONS ===
   /** List of channels */
@@ -105,15 +108,10 @@ export class GridSettingsComponent
     super();
   }
 
-  /** Build the settings form, using the widget saved parameters. */
   ngOnInit(): void {
-    this.formGroup = createGridWidgetFormGroup(
-      this.widget.id,
-      this.widget.settings
-    );
-
-    this.change.emit(this.formGroup);
-
+    if (!this.widgetFormGroup) {
+      this.buildSettingsForm();
+    }
     // this.formGroup?.get('query.name')?.valueChanges.subscribe((res) => {
     //   this.filteredQueries = this.filterQueries(res);
     // });
@@ -122,7 +120,7 @@ export class GridSettingsComponent
     this.getQueryMetaData();
 
     // Subscribe to form resource changes
-    this.formGroup
+    this.widgetFormGroup
       .get('resource')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((value) => {
@@ -130,43 +128,48 @@ export class GridSettingsComponent
           // Check if the query changed to clean modifications and fields for email in floating button
           if (value !== this.resource?.id) {
             // this.queryName = name;
-            this.formGroup?.get('layouts')?.setValue([]);
-            this.formGroup?.get('aggregations')?.setValue([]);
-            this.formGroup?.get('template')?.setValue(null);
-            this.formGroup?.get('template')?.enable();
-            const floatingButtons = this.formGroup?.get(
+            this.widgetFormGroup?.get('layouts')?.setValue([]);
+            this.widgetFormGroup?.get('aggregations')?.setValue([]);
+            this.widgetFormGroup?.get('template')?.setValue(null);
+            this.widgetFormGroup?.get('template')?.enable();
+            const floatingButtons = this.widgetFormGroup?.get(
               'floatingButtons'
             ) as UntypedFormArray;
+            let floatingButtonIndex = 0;
             for (const floatingButton of floatingButtons.controls) {
               const modifications = floatingButton.get(
                 'modifications'
               ) as UntypedFormArray;
               modifications.clear();
-              this.formGroup
-                ?.get('floatingButton.modifySelectedRows')
+              (
+                this.widgetFormGroup?.get('floatingButtons') as UntypedFormArray
+              ).controls
+                .at(floatingButtonIndex)
+                ?.get('modifySelectedRows')
                 ?.setValue(false);
               const bodyFields = floatingButton.get(
                 'bodyFields'
               ) as UntypedFormArray;
               bodyFields.clear();
+              floatingButtonIndex++;
             }
           }
           this.getQueryMetaData();
         } else {
-          this.formGroup?.get('layouts')?.setValue([]);
-          this.formGroup?.get('aggregations')?.setValue([]);
-          this.formGroup?.get('template')?.setValue(null);
+          this.widgetFormGroup?.get('layouts')?.setValue([]);
+          this.widgetFormGroup?.get('aggregations')?.setValue([]);
+          this.widgetFormGroup?.get('template')?.setValue(null);
           this.fields = [];
           this.resource = null;
         }
 
         // clear sort fields array
-        const sortFields = this.formGroup?.get('sortFields') as FormArray;
+        const sortFields = this.widgetFormGroup?.get('sortFields') as FormArray;
         sortFields.clear();
       });
 
     // Subscribe to form aggregations changes
-    this.formGroup
+    this.widgetFormGroup
       .get('aggregations')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((value) => {
@@ -176,20 +179,20 @@ export class GridSettingsComponent
         }
       });
     // If some aggregations are selected, remove validators on layouts field
-    if (this.formGroup.get('aggregations')?.value.length > 0) {
-      this.formGroup.controls.layouts.clearValidators();
+    if (this.widgetFormGroup.get('aggregations')?.value.length > 0) {
+      this.widgetFormGroup.controls.layouts.clearValidators();
     }
 
     // Subscribe to form layouts changes
-    this.formGroup
+    this.widgetFormGroup
       .get('layouts')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((value) => {
         this.updateValueAndValidityByType(value, 'layouts');
       });
     // If some layouts are selected, remove validators on aggregations field
-    if (this.formGroup.get('layouts')?.value.length > 0) {
-      this.formGroup.controls.aggregations.clearValidators();
+    if (this.widgetFormGroup.get('layouts')?.value.length > 0) {
+      this.widgetFormGroup.controls.aggregations.clearValidators();
     }
 
     this.initSortFields();
@@ -205,7 +208,7 @@ export class GridSettingsComponent
         order: [item.order, Validators.required],
         label: [item.label, Validators.required],
       });
-      (this.formGroup?.get('sortFields') as any).push(row);
+      (this.widgetFormGroup?.get('sortFields') as any).push(row);
     });
   }
 
@@ -224,36 +227,38 @@ export class GridSettingsComponent
       // Some type are selected
       if (value.length > 0) {
         // Remove validators on other type fields fields
-        this.formGroup.controls[otherType].clearValidators();
+        this.widgetFormGroup.controls[otherType].clearValidators();
       } else {
         // No type selected
-        if (this.formGroup.controls[otherType].value.length > 0) {
+        if (this.widgetFormGroup.controls[otherType].value.length > 0) {
           // Remove validators on type field if other type are selected
-          this.formGroup.controls[type].clearValidators();
+          this.widgetFormGroup.controls[type].clearValidators();
         } else {
           // Else, reset all validators
-          this.formGroup.controls[type].setValidators([Validators.required]);
-          this.formGroup.controls[otherType].setValidators([
+          this.widgetFormGroup.controls[type].setValidators([
+            Validators.required,
+          ]);
+          this.widgetFormGroup.controls[otherType].setValidators([
             Validators.required,
           ]);
         }
       }
     }
     // Update fields without sending update events to prevent infinite loops
-    this.formGroup.controls[type].updateValueAndValidity({
+    this.widgetFormGroup.controls[type].updateValueAndValidity({
       emitEvent: false,
     });
-    this.formGroup.controls[otherType].updateValueAndValidity({
+    this.widgetFormGroup.controls[otherType].updateValueAndValidity({
       emitEvent: false,
     });
   }
 
   ngAfterViewInit(): void {
-    if (this.formGroup) {
-      this.formGroup.valueChanges
+    if (this.widgetFormGroup) {
+      this.widgetFormGroup.valueChanges
         .pipe(takeUntil(this.destroy$))
         .subscribe(() => {
-          this.change.emit(this.formGroup);
+          this.formChange.emit(this.widgetFormGroup);
         });
 
       this.applicationService.application$
@@ -289,16 +294,16 @@ export class GridSettingsComponent
    * Gets query metadata for grid settings, from the query name
    */
   private getQueryMetaData(): void {
-    if (this.formGroup.get('resource')?.value) {
+    if (this.widgetFormGroup.get('resource')?.value) {
       const layoutIds: string[] | undefined =
-        this.formGroup?.get('layouts')?.value;
+        this.widgetFormGroup?.get('layouts')?.value;
       const aggregationIds: string[] | undefined =
-        this.formGroup?.get('aggregations')?.value;
+        this.widgetFormGroup?.get('aggregations')?.value;
       this.apollo
         .query<ResourceQueryResponse>({
           query: GET_GRID_RESOURCE_META,
           variables: {
-            resource: this.formGroup.get('resource')?.value,
+            resource: this.widgetFormGroup.get('resource')?.value,
             layoutIds,
             firstLayouts: layoutIds?.length || 10,
             aggregationIds,
@@ -310,9 +315,9 @@ export class GridSettingsComponent
             this.resource = data.resource;
             this.relatedForms = data.resource.relatedForms || [];
             this.templates = data.resource.forms || [];
-            if (this.formGroup.get('aggregations')?.value.length > 0) {
+            if (this.widgetFormGroup.get('aggregations')?.value.length > 0) {
               this.onAggregationChange(
-                this.formGroup.get('aggregations')?.value[0]
+                this.widgetFormGroup.get('aggregations')?.value[0]
               );
             } else {
               this.fields = this.queryBuilder.getFields(
@@ -367,5 +372,15 @@ export class GridSettingsComponent
           }
         });
     }
+  }
+
+  /**
+   * Build the settings form, using the widget saved parameters
+   */
+  public buildSettingsForm() {
+    this.widgetFormGroup = createGridWidgetFormGroup(
+      this.widget.id,
+      this.widget.settings
+    );
   }
 }

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -150,7 +150,7 @@ export const createGridWidgetFormGroup = (id: string, configuration: any) => {
             )
           : [createButtonFormGroup(null)]
       ) as FormArray<FormControl<typeof createButtonFormGroup>>,
-      sortFields: new FormArray([]),
+      sortFields: new FormArray<any>([]),
       contextFilters: [
         get(configuration, 'contextFilters', DEFAULT_CONTEXT_FILTER),
       ],

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -2,6 +2,7 @@ import {
   AbstractControl,
   FormArray,
   FormBuilder,
+  FormControl,
   ValidationErrors,
   Validators,
 } from '@angular/forms';
@@ -148,7 +149,7 @@ export const createGridWidgetFormGroup = (id: string, configuration: any) => {
               createButtonFormGroup(x)
             )
           : [createButtonFormGroup(null)]
-      ),
+      ) as FormArray<FormControl<typeof createButtonFormGroup>>,
       sortFields: new FormArray([]),
       contextFilters: [
         get(configuration, 'contextFilters', DEFAULT_CONTEXT_FILTER),

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -211,7 +211,7 @@
       <ng-template uiTabContent>
         <shared-sorting-settings
           [fields]="fields"
-          [formArray]="$any(widgetFormGroup.get('sortFields'))"
+          [formArray]="widgetFormGroup.controls.sortFields"
           [formGroup]="widgetFormGroup"
         ></shared-sorting-settings>
       </ng-template>

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -59,11 +59,13 @@
     </ui-tab>
     <!-- Available actions -->
     <ui-tab
-      *ngIf="
-        resource &&
-        layout &&
-        $any(widgetFormGroup.get('widgetDisplay.gridMode'))?.value
-      "
+      [ngClass]="{
+        hidden: !(
+          resource &&
+          layout &&
+          $any(widgetFormGroup.get('widgetDisplay.gridMode'))?.value
+        )
+      }"
     >
       <ng-container ngProjectAs="label">
         <ui-icon

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -33,6 +33,7 @@ import {
   ReferenceDataQueryResponse,
 } from '../../../models/reference-data.model';
 import { TabComponent, TabsComponent } from '@oort-front/ui';
+import { WidgetSettings } from '../../../models/dashboard.model';
 
 export type SummaryCardFormT = ReturnType<typeof createSummaryCardForm>;
 
@@ -46,13 +47,15 @@ export type SummaryCardFormT = ReturnType<typeof createSummaryCardForm>;
 })
 export class SummaryCardSettingsComponent
   extends UnsubscribeComponent
-  implements OnInit, AfterViewInit
+  implements
+    OnInit,
+    AfterViewInit,
+    WidgetSettings<typeof createSummaryCardForm>
 {
   /** Widget configuration */
   @Input() widget: any;
   /** Emit changes applied to the settings */
-  // eslint-disable-next-line @angular-eslint/no-output-native
-  @Output() change: EventEmitter<any> = new EventEmitter();
+  @Output() formChange: EventEmitter<SummaryCardFormT> = new EventEmitter();
   /** Widget form group */
   public widgetFormGroup!: SummaryCardFormT;
   /** Current reference data */
@@ -102,16 +105,10 @@ export class SummaryCardSettingsComponent
     super();
   }
 
-  /**
-   * Build the settings form, using the widget saved parameters.
-   */
   ngOnInit(): void {
-    this.widgetFormGroup = createSummaryCardForm(
-      this.widget.id,
-      this.widget.settings
-    );
-    this.change.emit(this.widgetFormGroup);
-
+    if (!this.widgetFormGroup) {
+      this.buildSettingsForm();
+    }
     // Initialize resource
     const resourceID = this.widgetFormGroup?.get('card.resource')?.value;
     if (resourceID) {
@@ -219,7 +216,7 @@ export class SummaryCardSettingsComponent
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.widgetFormGroup.markAsDirty({ onlySelf: true });
-        this.change.emit(this.widgetFormGroup);
+        this.formChange.emit(this.widgetFormGroup);
       });
 
     this.tabsComponent.tabs.changes
@@ -370,5 +367,15 @@ export class SummaryCardSettingsComponent
             : [];
         }
       });
+  }
+
+  /**
+   * Build the settings form, using the widget saved parameters.
+   */
+  public buildSettingsForm() {
+    this.widgetFormGroup = createSummaryCardForm(
+      this.widget.id,
+      this.widget.settings
+    );
   }
 }

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.forms.ts
@@ -27,7 +27,7 @@ export const createSummaryCardForm = (id: string, configuration: any) => {
       id,
       title: get<string>(configuration, 'title', ''),
       card: createCardForm(get(configuration, 'card', null)),
-      sortFields: new FormArray([]),
+      sortFields: new FormArray<any>([]),
       contextFilters: get<string>(
         configuration,
         'contextFilters',

--- a/libs/shared/src/lib/components/widgets/tabs-settings/tabs-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tabs-settings.component.html
@@ -7,7 +7,7 @@
     <ng-template uiTabContent>
       <shared-tab-main
         class="flex flex-col h-full"
-        [formGroup]="widgetForm"
+        [formGroup]="widgetFormGroup"
       ></shared-tab-main>
     </ng-template>
   </ui-tab>
@@ -21,7 +21,7 @@
       <span>{{ 'models.widget.display.title' | translate }}</span>
     </ng-container>
     <ng-template uiTabContent>
-      <shared-display-settings [formGroup]="widgetForm">
+      <shared-display-settings [formGroup]="widgetFormGroup">
       </shared-display-settings>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/models/dashboard.model.ts
+++ b/libs/shared/src/lib/models/dashboard.model.ts
@@ -31,6 +31,8 @@ export type WidgetSettingsType = WidgetSettings<any>;
 
 /**
  * Extended class of all widget settings components
+ *
+ * Implement this class for any widget settings class component that is created
  */
 export abstract class WidgetSettings<T extends (...args: any[]) => any> {
   /** Change event emitted on widget settings form group value change */

--- a/libs/shared/src/lib/models/dashboard.model.ts
+++ b/libs/shared/src/lib/models/dashboard.model.ts
@@ -7,6 +7,7 @@ import { EditorSettingsComponent } from '../components/widgets/editor-settings/e
 import { SummaryCardSettingsComponent } from '../components/widgets/summary-card-settings/summary-card-settings.component';
 import { Category, Variant } from '@oort-front/ui';
 import { TabsSettingsComponent } from '../components/widgets/tabs-settings/tabs-settings.component';
+import { EventEmitter } from '@angular/core';
 
 /** Model for IWidgetType object */
 export interface IWidgetType {
@@ -23,6 +24,23 @@ export interface DashboardFilter {
   closable?: boolean;
   structure?: any;
   position?: string;
+}
+
+/** Widget settings types */
+export type WidgetSettingsType = WidgetSettings<any>;
+
+/**
+ * Extended class of all widget settings components
+ */
+export abstract class WidgetSettings<T extends (...args: any[]) => any> {
+  /** Change event emitted on widget settings form group value change */
+  public formChange!: EventEmitter<ReturnType<T>>;
+  /** Related widget property */
+  public widget: any;
+  /** Widget settings form group */
+  public widgetFormGroup!: ReturnType<T>;
+  /** Build settings form for the given widget type */
+  public buildSettingsForm!: () => void;
 }
 
 /** List of Widget types with their properties */

--- a/libs/ui/src/lib/graphql-select/graphql-select.component.ts
+++ b/libs/ui/src/lib/graphql-select/graphql-select.component.ts
@@ -146,7 +146,7 @@ export class GraphQLSelectComponent
   public touched = false;
 
   /** Destroy subject */
-  private destroy$ = new Subject<void>();
+  public destroy$ = new Subject<void>();
   /** Query name */
   private queryName!: string;
   /** Query change subject */

--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -180,26 +180,7 @@ export class SelectMenuComponent
       .pipe(startWith(this.optionList), takeUntil(this.destroy$))
       .subscribe({
         next: (options: QueryList<SelectOptionComponent>) => {
-          if (this.value) {
-            this.selectedValues.push(
-              this.value instanceof Array ? [...this.value] : this.value
-            );
-          }
-          options.forEach((option) => {
-            option.optionClick.pipe(takeUntil(this.destroy$)).subscribe({
-              next: (isSelected: boolean) => {
-                this.updateSelectedValues(option, isSelected);
-                this.onChangeFunction();
-              },
-            });
-            // Initialize any selected values
-            if (this.selectedValues.includes(option.value)) {
-              option.selected = true;
-            } else {
-              option.selected = false;
-            }
-            this.setDisplayTriggerText();
-          });
+          this.handleOptionsQueryChange(options);
         },
       });
     if (this.control) {
@@ -227,28 +208,37 @@ export class SelectMenuComponent
       .pipe(startWith(this.optionList), takeUntil(this.destroy$))
       .subscribe({
         next: (options: QueryList<SelectOptionComponent>) => {
-          if (this.value) {
-            this.selectedValues.push(
-              this.value instanceof Array ? [...this.value] : this.value
-            );
-          }
-          options.forEach((option) => {
-            option.optionClick.pipe(takeUntil(this.destroy$)).subscribe({
-              next: (isSelected: boolean) => {
-                this.updateSelectedValues(option, isSelected);
-                this.onChangeFunction();
-              },
-            });
-            // Initialize any selected values
-            if (this.selectedValues.includes(option.value)) {
-              option.selected = true;
-            } else {
-              option.selected = false;
-            }
-            this.setDisplayTriggerText();
-          });
+          this.handleOptionsQueryChange(options);
         },
       });
+  }
+
+  /**
+   * Update selected values and all handlers for the given options query list
+   *
+   * @param options Select menu options query list items
+   */
+  private handleOptionsQueryChange(options: QueryList<SelectOptionComponent>) {
+    if (this.value) {
+      this.selectedValues.push(
+        this.value instanceof Array ? [...this.value] : this.value
+      );
+    }
+    options.forEach((option) => {
+      option.optionClick.pipe(takeUntil(this.destroy$)).subscribe({
+        next: (isSelected: boolean) => {
+          this.updateSelectedValues(option, isSelected);
+          this.onChangeFunction();
+        },
+      });
+      // Initialize any selected values
+      if (this.selectedValues.includes(option.value)) {
+        option.selected = true;
+      } else {
+        option.selected = false;
+      }
+      this.setDisplayTriggerText();
+    });
   }
 
   /**

--- a/libs/ui/src/lib/tabs/components/tab/tab.component.html
+++ b/libs/ui/src/lib/tabs/components/tab/tab.component.html
@@ -1,7 +1,6 @@
 <div>
   <button
     [disabled]="disabled"
-    [attr.selected]="selected"
     [ngClass]="resolveTabClasses"
     class="w-full whitespace-nowrap py-2 text-sm font-medium button-min-width"
     (click)="openTab.emit()"

--- a/libs/ui/src/lib/tabs/components/tab/tab.component.scss
+++ b/libs/ui/src/lib/tabs/components/tab/tab.component.scss
@@ -10,12 +10,18 @@
   &[selected='false']:not([disabled]) {
     @apply text-gray-500 hover:bg-gray-100 hover:border-gray-500 hover:text-gray-700;
   }
+  &[disabled] {
+    @apply text-gray-400;
+  }
 }
 
 .ui-tab__vertical {
   @apply rounded-md text-left p-2 text-gray-700 gap-1.5 inline-flex items-center;
   &[selected='false']:not([disabled]) {
     @apply hover:text-gray-700 text-gray-500;
+  }
+  &[disabled] {
+    @apply text-gray-400;
   }
 }
 

--- a/libs/ui/src/lib/tabs/components/tab/tab.component.ts
+++ b/libs/ui/src/lib/tabs/components/tab/tab.component.ts
@@ -95,9 +95,6 @@ export class TabComponent implements AfterContentChecked, AfterContentInit {
         );
       }
     }
-    if (this.disabled) {
-      classes.push('text-gray-400');
-    }
     this.resolveTabClasses = classes;
   }
 }

--- a/libs/ui/src/lib/tabs/tabs.component.ts
+++ b/libs/ui/src/lib/tabs/tabs.component.ts
@@ -76,7 +76,7 @@ export class TabsComponent implements AfterViewInit, OnDestroy, OnChanges {
   /** Reference to the TabBodyHostDirective. */
   @ViewChild(TabBodyHostDirective)
   tabBodyHost!: TabBodyHostDirective;
-  /** Refenrece to tab list element */
+  /** Reference to tab list element */
   @ViewChild('tabList')
   tabList!: ElementRef<any>;
 


### PR DESCRIPTION
# Description

feat: add WidgetSettings abstract class in order to keep track of common methods for all settings classes for each widget. Each one contains widget data, widget settings form group, form changes output event and a void method to load settings form with the given widget data that all settings implement 

refactor: implement the new abstract class in all widget settings class, adding missing types for each forms and classes 

fix: change detector ref error for edit widget settings modal component by creating the given settings component in the modal constructor itself, keeping track of the lifecycle hooks in order for each component plus having the settings component full loaded once it reaches after view init of the modal component

## Useful links

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Open any settings modal for the given widget. Check that modal opens correctly and no more change detector ref error for **edit-widget modal** are shown and settings view set is less error prone

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
