### PR TITLE
 fix/AB#69129_Filters-not-working-with-date-2

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -425,9 +425,39 @@ export class GridComponent
    */
   public onFilterChange(filter: CompositeFilterDescriptor): void {
     if (!this.loadingRecords) {
+      // format filter timezones before sending
+      this.formatFiltersTimezones(filter);
       this.filter = filter;
       this.filterChange.emit(filter);
     }
+  }
+
+  /**
+   * Format filter before sending.
+   * Adjust date filters to remove timezone.
+   *
+   * @param filter Filter value.
+   */
+  private formatFiltersTimezones(filter: any) {
+    filter.filters.forEach((subFilter: any) => {
+      // if there are sub filters
+      if (subFilter.filters) {
+        this.formatFiltersTimezones(subFilter);
+      } else if (subFilter.value instanceof Date) {
+        const currentDate = subFilter.value;
+        const hoursToAdjustTimezone = Math.floor(
+          (currentDate as Date).getTimezoneOffset() / 60
+        );
+        const minutesToAdjustTimezone =
+          (currentDate as Date).getTimezoneOffset() % 60;
+
+        const dateObj = new Date(currentDate);
+        dateObj.setHours(dateObj.getHours() - hoursToAdjustTimezone);
+        dateObj.setMinutes(dateObj.getMinutes() - minutesToAdjustTimezone);
+
+        subFilter.value = dateObj;
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
# Description

See PR #1962. It is the exact same but with some code removed that appeared to be useless.

## Useful links

- Link to ticket : https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/69129

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested on local with own database, with different timezone set to the browser
- [x] Tested with different resources including the exact one used in the WHO video

## Screenshots

Before:
![image](https://github.com/ReliefApplications/ems-frontend/assets/80319175/11c1ac7f-1fdf-45ea-af4b-614a5db20251)
![image](https://github.com/ReliefApplications/ems-frontend/assets/80319175/d166af39-ced1-4b47-b834-4e87e2993ac3)
![image](https://github.com/ReliefApplications/ems-frontend/assets/80319175/f9a01108-6182-4a7d-8e9a-b7a1c93b2b43)


After:
![image](https://github.com/ReliefApplications/ems-frontend/assets/80319175/84acef77-40f9-4dc5-817f-2c2a0cb44a87)
![image](https://github.com/ReliefApplications/ems-frontend/assets/80319175/18a5ddf3-2d2b-4e57-b77b-59bd8eae9d62)

I reckon the one-hour difference is caused by the difference between server and DB timezones.

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
