### PR TITLE
AB#82246_fix_drag_drop_and_open_close_for_unique_values_in_layers

### DIFF
--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-styling/unique-value-renderer/unique-value-renderer.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-styling/unique-value-renderer/unique-value-renderer.component.html
@@ -34,22 +34,60 @@
         class="hover:bg-gray-50 p-4 flex flex-col divide-y divide-gray-100"
         cdkDrag
       >
-        <ng-container *ngIf="index === openedIndex">
-          <ng-container
-            *ngTemplateOutlet="
-              openedTemplate;
-              context: { form: uniqueValueInfos.at(index), index: index }
-            "
-          ></ng-container>
-        </ng-container>
-        <ng-container *ngIf="index !== openedIndex">
-          <ng-container
-            *ngTemplateOutlet="
-              defaultTemplate;
-              context: { value: uniqueValueInfos.at(index).value, index: index }
-            "
-          ></ng-container>
-        </ng-container>
+        <!-- header -->
+        <div
+          class="flex justify-between items-center"
+          [ngClass]="{ 'pb-2': index === openedIndex }"
+        >
+          <div class="flex flex-1 gap-4 items-center cursor-pointer">
+            <ui-icon
+              cdkDragHandle
+              icon="drag_indicator"
+              variant="grey"
+              class="cursor-move"
+            ></ui-icon>
+            <div
+              class="flex flex-1 gap-2 items-center"
+              (click)="openedIndex = openedIndex === index ? -1 : index"
+            >
+              <span [innerHTML]="svgIcons[index] | sharedSanitizeHtml"></span>
+              <span
+                >{{ index }} -
+                {{ uniqueValueInfos.at(index).value.label }}</span
+              >
+            </div>
+          </div>
+          <ui-button
+            (click)="onRemoveInfo(index)"
+            [isIcon]="true"
+            icon="delete"
+            variant="danger"
+            [uiTooltip]="'common.delete' | translate"
+          ></ui-button>
+        </div>
+        <!-- body -->
+        <div
+          [formGroup]="$any(uniqueValueInfos.at(index))"
+          class="flex flex-col pt-2"
+          *ngIf="index === openedIndex"
+        >
+          <div uiFormFieldDirective>
+            <label>{{
+              'components.widget.settings.map.renderer.label' | translate
+            }}</label>
+            <input formControlName="label" type="text" />
+          </div>
+          <div uiFormFieldDirective>
+            <label>{{
+              'components.widget.settings.map.renderer.value' | translate
+            }}</label>
+            <input formControlName="value" type="text" />
+          </div>
+          <shared-simple-renderer
+            [geometryType]="geometryType"
+            [formGroup]="$any(uniqueValueInfos.at(index).get('symbol'))"
+          ></shared-simple-renderer>
+        </div>
       </li>
     </ul>
   </div>
@@ -70,65 +108,3 @@
     ></shared-simple-renderer>
   </div>
 </div>
-
-<!-- Opened unique value template -->
-<ng-template #openedTemplate let-form="form" let-index="index">
-  <div class="pb-2">
-    <ng-container
-      *ngTemplateOutlet="
-        headerTemplate;
-        context: { value: form.value, index: index }
-      "
-    ></ng-container>
-  </div>
-  <div [formGroup]="form" class="flex flex-col pt-2">
-    <div uiFormFieldDirective>
-      <label>{{
-        'components.widget.settings.map.renderer.label' | translate
-      }}</label>
-      <input formControlName="label" type="text" />
-    </div>
-    <div uiFormFieldDirective>
-      <label>{{
-        'components.widget.settings.map.renderer.value' | translate
-      }}</label>
-      <input formControlName="value" type="text" />
-    </div>
-    <shared-simple-renderer
-      [geometryType]="geometryType"
-      [formGroup]="form.get('symbol')"
-    ></shared-simple-renderer>
-  </div>
-</ng-template>
-
-<!-- Default unique value template -->
-<ng-template #defaultTemplate let-value="value" let-index="index">
-  <ng-container
-    *ngTemplateOutlet="headerTemplate; context: { value: value, index: index }"
-  ></ng-container>
-</ng-template>
-
-<!-- Unique value header template -->
-<ng-template #headerTemplate let-value="value" let-index="index">
-  <div class="flex justify-between items-center">
-    <div class="flex flex-1 gap-4 items-center cursor-pointer">
-      <ui-icon
-        cdkDraghandle
-        icon="drag_indicator"
-        variant="grey"
-        class="cursor-move"
-      ></ui-icon>
-      <div class="flex flex-1 gap-2 items-center" (click)="openedIndex = index">
-        <span [innerHTML]="svgIcons[index] | sharedSanitizeHtml"></span>
-        <span>{{ index }} - {{ value.label }}</span>
-      </div>
-    </div>
-    <ui-button
-      (click)="onRemoveInfo(index)"
-      [isIcon]="true"
-      icon="delete"
-      variant="danger"
-      [uiTooltip]="'common.delete' | translate"
-    ></ui-button>
-  </div>
-</ng-template>


### PR DESCRIPTION
# Description

- Add close functionality when clicking on opened tab
- cdkDragHandle not supported inside of ng-template: removed the templates (that were only to prettify since used only once).

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82246)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

see video.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/59645813/dc3778d8-c3de-4a8c-b2bb-252422cc4f52

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

