### PR TITLE
Bugfix/ab#82256 summary card and text widgets checkbox inconclusive

### DIFF
--- a/libs/shared/src/lib/utils/parser/utils.ts
+++ b/libs/shared/src/lib/utils/parser/utils.ts
@@ -174,15 +174,28 @@ const replaceRecordFields = (
     });
 
     for (const field of fields) {
-      const toReadableObject = (obj: any): any =>
-        typeof obj === 'object' && obj !== null
-          ? Array.isArray(obj)
-            ? obj.map((o) => toReadableObject(o)).join('<br>') // If array, return mapped elements
-            : Object.keys(obj) // If object, return object keys and values as strings
+      const toReadableObject = (obj: any): any => {
+        // If value exists keep checking
+        if (!!obj) {
+          if (typeof obj === 'object') {
+            // If array, return mapped elements
+            if (Array.isArray(obj)) {
+              return obj.map((o) => toReadableObject(o)).join('<br>');
+            } else {
+              // If object, return object keys and values as strings
+              return Object.keys(obj)
                 .filter((key) => key !== '__typename')
                 .map((key) => `${key}: ${obj[key]}`)
-                .join(', ')
-          : `${obj}`; // If not an object, return string representation
+                .join(', ');
+            }
+          } else {
+            // If not an object, return string representation
+            return `${obj}`;
+          }
+        }
+        // Return default undefined/null value if no obj
+        return obj;
+      };
 
       const value = toReadableObject(get(fieldsValue, field.name));
 

--- a/libs/shared/src/lib/utils/parser/utils.ts
+++ b/libs/shared/src/lib/utils/parser/utils.ts
@@ -176,7 +176,7 @@ const replaceRecordFields = (
     for (const field of fields) {
       const toReadableObject = (obj: any): any => {
         // If value exists keep checking
-        if (!!obj) {
+        if (obj) {
           if (typeof obj === 'object') {
             // If array, return mapped elements
             if (Array.isArray(obj)) {


### PR DESCRIPTION
# Description

fix: undefined values where returned as strings, which triggers the isNil function and renders html data when no data is available
![image](https://github.com/ReliefApplications/ems-frontend/assets/123092672/e84df0bb-7549-490f-9610-ad2d0456d746)

refactor: toReadableObject method in order to be more readable for the developers

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82256)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to video below

## Screenshots

Undefined values where stringified which triggers the isNil function, rendering falsy values

After fix:

https://github.com/ReliefApplications/ems-frontend/assets/123092672/818dfaab-2edf-411f-ae55-344c42b27c46



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
