### PR TITLE
bugfix/AB#82362_summary-cards-view-not-updated-on-editing-records-from-grid-view 

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -664,6 +664,7 @@ export class CoreGridComponent
             item.saved = true;
           }
         }
+        this.inlineEdition.emit();
         // the items still in the updatedItems list are the ones with errors
         if (this.updatedItems.length) {
           // show an error message
@@ -683,7 +684,6 @@ export class CoreGridComponent
           );
           return true;
         }
-        this.inlineEdition.emit();
         return false;
       });
     } else {

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -136,6 +136,8 @@ export class CoreGridComponent
   @Output() defaultLayoutReset: EventEmitter<any> = new EventEmitter();
   /** Event emitter for edit */
   @Output() edit: EventEmitter<any> = new EventEmitter();
+  /** Event emitter for inline edition of records */
+  @Output() inlineEdition: EventEmitter<any> = new EventEmitter();
 
   // === SELECTION OUTPUTS ===
   /** Event emitter for row selection */
@@ -680,9 +682,9 @@ export class CoreGridComponent
             }
           );
           return true;
-        } else {
-          return false;
         }
+        this.inlineEdition.emit();
+        return false;
       });
     } else {
       return Promise.resolve(false);

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.html
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.html
@@ -46,6 +46,7 @@
     [settings]="gridSettings"
     (defaultLayoutReset)="onResetLayout()"
     (edit)="edit.emit($event)"
+    (inlineEdition)="inlineEdition.emit()"
     [widget]="widget"
     [canUpdate]="canUpdate"
     [status]="status"

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -119,6 +119,9 @@ export class GridWidgetComponent
   /** Emit event */
   @Output() edit: EventEmitter<any> = new EventEmitter();
 
+  /** Event emitter for inline edition of records */
+  @Output() inlineEdition: EventEmitter<any> = new EventEmitter();
+
   /**
    * Test if the grid uses a layout, and if a layout is used, if any item is currently updated.
    *

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -57,6 +57,7 @@
         class="flex-1 h-full w-full"
         [settings]="gridSettings"
         [widget]="widget"
+        (inlineEdition)="refreshCardList()"
       ></shared-grid-widget>
     </div>
   </ng-container>


### PR DESCRIPTION
# Description

feat: add inlineEdition event to refetch card list data after any record is edited from the grid view 

fix: scroll event listener lost on switching views

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82362)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to video below

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/123092672/5ffbc23e-eb20-40dd-8482-ad4b048c470c


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
