### PR TITLE
bugfix/horizontal-tabs-label-color

### DIFF
--- a/libs/ui/src/lib/tabs/components/tab/tab.component.html
+++ b/libs/ui/src/lib/tabs/components/tab/tab.component.html
@@ -1,5 +1,6 @@
 <div>
   <button
+    [attr.selected]="selected"
     [disabled]="disabled"
     [ngClass]="resolveTabClasses"
     class="w-full whitespace-nowrap py-2 text-sm font-medium button-min-width"

--- a/libs/ui/src/lib/tabs/components/tab/tab.component.scss
+++ b/libs/ui/src/lib/tabs/components/tab/tab.component.scss
@@ -6,7 +6,7 @@
 }
 
 .ui-tab__horizontal {
-  @apply border-b-2 border-transparent px-3 flex justify-center gap-1.5;
+  @apply border-b-2 text-gray-700 border-transparent px-3 flex justify-center gap-1.5;
   &[selected='false']:not([disabled]) {
     @apply text-gray-500 hover:bg-gray-100 hover:border-gray-500 hover:text-gray-700;
   }


### PR DESCRIPTION
# Description

fix: restore selected attribute in order to apply tab css content

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/79543/)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to screenshots below

## Screenshots

Horizontal tabs:
![image](https://github.com/ReliefApplications/ems-frontend/assets/123092672/453fe4a8-399f-4510-8371-3449ef019c37)

Horizontal tabs on hover:
![image](https://github.com/ReliefApplications/ems-frontend/assets/123092672/dcc34b54-c576-4c2e-914a-129300af5970)

Vertical tabs:
![image](https://github.com/ReliefApplications/ems-frontend/assets/123092672/8efd5dbe-d2f5-4803-907e-1f02221f0d57)

Vertical tabs on hover:
![image](https://github.com/ReliefApplications/ems-frontend/assets/123092672/6d07b883-7754-415b-8c20-8e27af0cbf2f)

Disable state for tabs working fine:
![image](https://github.com/ReliefApplications/ems-frontend/assets/123092672/f2f27ba8-fd42-4ffc-98ab-f119ca768018)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
