### PR TITLE
fix/AB#82405_incorrect_text_in_unique_value_renderer

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1755,6 +1755,7 @@
 						"defaultLabel": "Default label",
 						"label": "Label",
 						"symbol": "Symbol",
+						"uniqueValue": "Unique values",
 						"value": "Value"
 					},
 					"tooltip": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1768,6 +1768,7 @@
 						"defaultLabel": "Libellé par défaut",
 						"label": "Libellé",
 						"symbol": "Symbole",
+						"uniqueValue": "Valeurs uniques",
 						"value": "Valeur"
 					},
 					"tooltip": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1755,6 +1755,7 @@
 						"defaultLabel": "******",
 						"label": "******",
 						"symbol": "******",
+						"uniqueValue": "******",
 						"value": "******"
 					},
 					"tooltip": {

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-styling/unique-value-renderer/unique-value-renderer.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-styling/unique-value-renderer/unique-value-renderer.component.html
@@ -13,7 +13,9 @@
   <!-- Unique values -->
   <div>
     <div class="flex gap-1 items-center mb-2">
-      <h2 class="m-0">{{ 'common.value.none' | translate }}</h2>
+      <h2 class="m-0">{{
+        'components.widget.settings.map.renderer.uniqueValue' | translate
+      }}</h2>
       <ui-button
         (click)="onAddInfo()"
         [isIcon]="true"


### PR DESCRIPTION
# Description

Fix: Incorrect text in unique value renderer.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82405)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested accessing Layer styling settings in map widget settings and verifying if the text in the unique value renderer is correct.

## Screenshots

![Captura de tela de 2023-12-22 08-51-12](https://github.com/ReliefApplications/ems-frontend/assets/56398308/ab8791d3-fd05-4142-870f-7807ce2451c2)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
