### PR TITLE
bugfix/AB#82593_fix-icons-positioning-when-row-is-not-full-for-icon-picker

### DIFF
--- a/libs/shared/src/lib/components/controls/icon-picker/icon-picker-popup/icon-picker-popup.component.html
+++ b/libs/shared/src/lib/components/controls/icon-picker/icon-picker-popup/icon-picker-popup.component.html
@@ -17,7 +17,7 @@
       ></ui-button>
     </div>
     <div class="h-60 overflow-y-auto">
-      <div class="flex flex-row flex-wrap gap-2 justify-evenly p-2">
+      <div class="grid grid-cols-6 p-2">
         <button
           class="w-10 h-10"
           *ngFor="let icon of filteredIcons$ | async"


### PR DESCRIPTION
# Description

fix: use grid styling instead of flex in order to avoid items to take all available space when the row is not full loaded of icons

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82593)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to screenshot below

## Screenshots

Current behavior:
![image](https://github.com/ReliefApplications/ems-frontend/assets/123092672/20dbc0ba-1f7a-45ac-8856-6a6292247dd2)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
