### PR TITLE
feat/AB#82647-time-format-in-filter

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/date-filter-menu/date-filter-menu.component.html
+++ b/libs/shared/src/lib/components/ui/core-grid/date-filter-menu/date-filter-menu.component.html
@@ -66,6 +66,7 @@
         *ngIf="dateModeProperty === 'date'"
         formControlName="value"
         [popupSettings]="popupSettings"
+        [format]="format"
       ></kendo-datepicker>
 
       <button

--- a/libs/shared/src/lib/components/ui/core-grid/date-filter-menu/date-filter-menu.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/date-filter-menu/date-filter-menu.component.ts
@@ -44,6 +44,8 @@ export class DateFilterMenuComponent
 {
   /** Field */
   @Input() public field = '';
+  /** Field format */
+  @Input() public format = 'dd/MM/yy HH:mm';
   /** Filter */
   @Input() public filter: any;
   /** Field value */

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -154,6 +154,7 @@
               <shared-date-filter-menu
                 [filter]="filter"
                 [field]="field.name"
+                [format]="field.format"
                 [filterService]="filterService"
                 valueField="value"
               >


### PR DESCRIPTION
# Description
The shared-date-filter-menu component didn't use the correct format in the kendo-datepicker

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82647

## Type of change

Please delete options that are not relevant.
- [X] Improvement (refactor or addition to existing functionality)


# How Has This Been Tested?
In a grid widget with date / datetime fields, open the filter from the 3 dots in the column header to see in the datepicker placeholder the correct field format

## Screenshots
[date-filter.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/f25b70b6-b882-4d26-8644-2dec362bada8)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
