### PR TITLE
fix/AB#82604_summary_cards_scrolling_and_filters_conflict

### DIFF
--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -422,18 +422,16 @@ export class SummaryCardComponent
       this.pageInfo.length = this.sortedCachedCards.length;
     } else if (this.useLayout) {
       this.loading = true;
-      this.dataQuery
-        ?.refetch({
-          skip: 0,
-          first: this.pageInfo.pageSize,
-          filter: this.queryFilter,
-          sortField: this.sortOptions.field,
-          sortOrder: this.sortOptions.order,
-          ...(this.settings.at && {
-            at: this.contextService.atArgumentValue(this.settings.at),
-          }),
-        })
-        .then(this.updateCards.bind(this));
+      this.dataQuery?.refetch({
+        skip: 0,
+        first: this.pageInfo.pageSize,
+        filter: this.queryFilter,
+        sortField: this.sortOptions.field,
+        sortOrder: this.sortOptions.order,
+        ...(this.settings.at && {
+          at: this.contextService.atArgumentValue(this.settings.at),
+        }),
+      });
     } else if (this.useReferenceData) {
       const contextFilters = this.contextService.injectContext(
         this.contextFilters
@@ -494,7 +492,8 @@ export class SummaryCardComponent
 
     if (
       !this.settings.widgetDisplay?.usePagination &&
-      !this.triggerRefreshCardList
+      !this.triggerRefreshCardList &&
+      !this.loading // avoid conflict with searchbar (data duplication)
     ) {
       this.cards = [...this.cards, ...newCards];
     } else {
@@ -815,19 +814,17 @@ export class SummaryCardComponent
     if (this.dataQuery) {
       this.loading = true;
       const layoutQuery = this.layout?.query;
-      this.dataQuery
-        .refetch({
-          first: this.pageInfo.pageSize,
-          skip: event.skip,
-          filter: this.queryFilter,
-          sortField: this.sortOptions.field,
-          sortOrder: this.sortOptions.order,
-          styles: layoutQuery?.style || null,
-          ...(this.settings.at && {
-            at: this.contextService.atArgumentValue(this.settings.at),
-          }),
-        })
-        .then(this.updateCards.bind(this));
+      this.dataQuery.refetch({
+        first: this.pageInfo.pageSize,
+        skip: event.skip,
+        filter: this.queryFilter,
+        sortField: this.sortOptions.field,
+        sortOrder: this.sortOptions.order,
+        styles: layoutQuery?.style || null,
+        ...(this.settings.at && {
+          at: this.contextService.atArgumentValue(this.settings.at),
+        }),
+      });
     } else if (this.useReferenceData) {
       this.cards = this.sortedCachedCards.slice(
         this.pageInfo.skip,
@@ -862,6 +859,7 @@ export class SummaryCardComponent
         });
       }
     }
+    this.triggerRefreshCardList = true;
     this.onPage({
       pageSize: DEFAULT_PAGE_SIZE,
       skip: 0,

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -269,7 +269,7 @@ export class SummaryCardComponent
         distinctUntilChanged(),
         takeUntil(this.destroy$)
       )
-      .subscribe((value) => {
+      .subscribe((value: any) => {
         this.handleSearch(value || '');
       });
 
@@ -733,8 +733,8 @@ export class SummaryCardComponent
     );
     if (metaData.data.referenceData) {
       const fields = (metaData.data.referenceData.fields || [])
-        .filter((field) => field && typeof field !== 'string')
-        .map((field) => {
+        .filter((field: any) => field && typeof field !== 'string')
+        .map((field: any) => {
           return {
             label: field.name,
             name: field.name,
@@ -755,7 +755,7 @@ export class SummaryCardComponent
       const contextFilters = this.contextService.injectContext(
         this.contextFilters
       );
-      this.sortedCachedCards = cloneDeep(this.cachedCards).filter((x) =>
+      this.sortedCachedCards = cloneDeep(this.cachedCards).filter((x: any) =>
         filterReferenceData(x.rawValue, contextFilters)
       );
       this.cards = this.sortedCachedCards.slice(0, this.pageInfo.pageSize);


### PR DESCRIPTION
# Description

Data was duplicated when using scrolling and filters refresh. I used the triggerRefreshCardList which was already implemented to avoid the conflict. The same behavior happened with the searchbar. This time is used the loading boolean to fix it. 

I removed bind functions after refetch at two different places because the updateCards function was called twice. An event listener was already defined on valueChanges, then calling the function again was unnecessary.

## Useful links

[Ticket 82604](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82604)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created a summary cards widget with a filter configuration and a text widget that allows you to filter (see screenshots). I checked if the behavior was correct for scrolling and pagination.

## Screenshots

Summary cards filter configuration
![image](https://github.com/ReliefApplications/ems-frontend/assets/65243509/ff7cb8f1-f9ae-4d0b-821f-45a42b0a3c53)

Example of text widget filter
![image](https://github.com/ReliefApplications/ems-frontend/assets/65243509/0c97a55f-595a-405a-90b7-893aaa640b71)

Demonstration
![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/f7b55954-7463-49cf-99c3-c655246a288c)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
