### PR TITLE
AB#82564_prevent_unnecessary_reloading

### DIFF
--- a/apps/web-widgets/src/app/widgets/app-widget/app-widget.component.ts
+++ b/apps/web-widgets/src/app/widgets/app-widget/app-widget.component.ts
@@ -64,6 +64,7 @@ export class AppWidgetComponent
   /** Pass new value to the filter */
   @Input()
   set filter(value: any) {
+    this.contextService.lastComponentEmitter = null;
     this.contextService.filter.next(value);
   }
 

--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -311,6 +311,7 @@ export class DashboardFilterComponent
         };
         return acc;
       }, {});
+    this.contextService.lastComponentEmitter = null;
     this.contextService.filter.next(surveyData);
     this.ngZone.run(() => {
       this.quickFilters = displayValues

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -131,9 +131,11 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
     this.contextService.filter$
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(() => {
-        this.refresh$.next(true);
-        this.loading = true;
-        this.setHtml();
+        if (!(this.contextService.lastComponentEmitter === this)) {
+          this.refresh$.next(true);
+          this.loading = true;
+          this.setHtml();
+        }
       });
   }
 
@@ -304,6 +306,7 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
           [filterField]: cleanFilterValue,
         }),
       };
+      this.contextService.lastComponentEmitter = this;
       this.contextService.filter.next(updatedFilters);
     } else {
       const content = this.htmlContentComponent.el.nativeElement;

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -134,7 +134,7 @@ export class SummaryCardItemContentComponent
           [filterField]: cleanFilterValue,
         }),
       };
-      this.contextService.lastComponentEmitter = this.parent.parent;
+      this.contextService.lastComponentEmitter = this.parent?.parent;
       this.contextService.filter.next(updatedFilters);
     } else {
       const content = this.htmlContentComponent.el.nativeElement;

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -134,6 +134,7 @@ export class SummaryCardItemContentComponent
           [filterField]: cleanFilterValue,
         }),
       };
+      this.contextService.lastComponentEmitter = this.parent.parent;
       this.contextService.filter.next(updatedFilters);
     } else {
       const content = this.htmlContentComponent.el.nativeElement;

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -276,7 +276,9 @@ export class SummaryCardComponent
     this.contextService.filter$
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe(() => {
-        this.refresh();
+        if (!(this.contextService.lastComponentEmitter === this)) {
+          this.refresh();
+        }
       });
   }
 

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -44,6 +44,8 @@ export class ContextService {
   public filterPosition = new BehaviorSubject<any>(null);
   /** Is filter opened */
   public filterOpened = new BehaviorSubject<boolean>(false);
+  /** Stores the last component that emitted */
+  public lastComponentEmitter: any = null;
   /** Dashboard object */
   public dashboard?: Dashboard;
   /** Available filter positions */


### PR DESCRIPTION
# Description

- Add _lastComponentEmitter_ var to check what was the last emitter of the filter change. When emitting a new value, the component is changed.
- Only reload if the component is not at the origin of the change.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82564/)

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

http://localhost:4200/applications/63d7e5b7c7dee63f57e97dae/dashboard/6594253530c3c58403c02dae

## Screenshots

No visual change.

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
