### PR TITLE
bugfix/AB#82795_ABC-summary-cards-using-reference-data-seems-to-send-twice-a-reference-data-query

### DIFF
--- a/libs/shared/src/lib/components/controls/reference-data-select/reference-data-select.component.ts
+++ b/libs/shared/src/lib/components/controls/reference-data-select/reference-data-select.component.ts
@@ -21,6 +21,7 @@ import { Apollo } from 'apollo-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { GET_REFERENCE_DATAS } from './graphql/queries';
 import { ReferenceDatasQueryResponse } from '../../../models/reference-data.model';
+import { takeUntil } from 'rxjs';
 
 /** Default items per query, for pagination */
 const ITEMS_PER_PAGE = 10;
@@ -85,7 +86,7 @@ export class ReferenceDataSelectComponent extends GraphQLSelectComponent {
     this.valueField = 'id';
     this.textField = 'name';
     this.filterable = true;
-    this.searchChange.subscribe((value) => {
+    this.searchChange.pipe(takeUntil(this.destroy$)).subscribe((value) => {
       this.onSearchChange(value);
     });
   }

--- a/libs/shared/src/lib/components/widgets/editor/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/editor/graphql/queries.ts
@@ -9,16 +9,3 @@ export const GET_RECORD_BY_ID = gql`
     }
   }
 `;
-
-/** Get reference data gql query definition */
-export const GET_REFERENCE_DATA = gql`
-  query GetReferenceData($id: ID!) {
-    referenceData(id: $id) {
-      id
-      name
-      type
-      fields
-      valueField
-    }
-  }
-`;

--- a/libs/shared/src/lib/components/widgets/summary-card/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/graphql/queries.ts
@@ -60,15 +60,3 @@ export const GET_LAYOUT = gql`
     }
   }
 `;
-
-/** Get reference data gql query definition */
-export const GET_REFERENCE_DATA = gql`
-  query GetReferenceData($id: ID!) {
-    referenceData(id: $id) {
-      id
-      name
-      type
-      fields
-    }
-  }
-`;

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -21,7 +21,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { AggregationService } from '../../../services/aggregation/aggregation.service';
 import { GridLayoutService } from '../../../services/grid-layout/grid-layout.service';
 import { QueryBuilderService } from '../../../services/query-builder/query-builder.service';
-import { GET_REFERENCE_DATA, GET_RESOURCE_METADATA } from './graphql/queries';
+import { GET_RESOURCE_METADATA } from './graphql/queries';
 import { UnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.component';
 import { SummaryCardFormT } from '../summary-card-settings/summary-card-settings.component';
 import { Record } from '../../../models/record.model';
@@ -45,7 +45,6 @@ import { CompositeFilterDescriptor } from '@progress/kendo-data-query';
 import { GridWidgetComponent } from '../grid/grid.component';
 import { GridService } from '../../../services/grid/grid.service';
 import { ReferenceDataService } from '../../../services/reference-data/reference-data.service';
-import { ReferenceDataQueryResponse } from '../../../models/reference-data.model';
 import searchFilters from '../../../utils/filter/search-filters';
 import filterReferenceData from '../../../utils/filter/reference-data-filter.util';
 
@@ -723,33 +722,26 @@ export class SummaryCardComponent
     card: NonNullable<SummaryCardFormT['value']['card']>
   ) {
     this.loading = true;
-    const metaData = await firstValueFrom(
-      this.apollo.query<ReferenceDataQueryResponse>({
-        query: GET_REFERENCE_DATA,
-        variables: {
-          id: card.referenceData,
-        },
-      })
-    );
-    if (metaData.data.referenceData) {
-      const fields = (metaData.data.referenceData.fields || [])
-        .filter((field) => field && typeof field !== 'string')
-        .map((field) => {
+    if (card.referenceData) {
+      const { items, referenceData } =
+        await this.referenceDataService.cacheItems(
+          card.referenceData as string,
+          true
+        );
+      const metadata = (referenceData?.fields || [])
+        .filter((field: any) => field && typeof field !== 'string')
+        .map((field: any) => {
           return {
             label: field.name,
             name: field.name,
             type: field.type,
           };
         });
-      this.cachedCards = (
-        (await this.referenceDataService.cacheItems(
-          card.referenceData as string
-        )) || []
-      ).map((x: any, index: number) => ({
+      this.cachedCards = (items || []).map((x: any, index: number) => ({
         ...this.settings.card,
         rawValue: x,
         index,
-        metadata: fields,
+        metadata,
       }));
       this.pageInfo.length = this.cachedCards.length;
       const contextFilters = this.contextService.injectContext(

--- a/libs/shared/src/lib/services/reference-data/reference-data.service.ts
+++ b/libs/shared/src/lib/services/reference-data/reference-data.service.ts
@@ -152,9 +152,13 @@ export class ReferenceDataService {
    * Get the items and the value field of a reference data
    *
    * @param referenceDataID The reference data id
+   * @param includeReferenceDataObj Boolean flag to return or not reference data obj with items
    * @returns The item list and the value field
    */
-  public async cacheItems(referenceDataID: string): Promise<any> {
+  public async cacheItems(
+    referenceDataID: string,
+    includeReferenceDataObj = false
+  ): Promise<any> {
     // Initialization
     let items: any;
     const referenceData = await this.loadReferenceData(referenceDataID);
@@ -213,7 +217,7 @@ export class ReferenceDataService {
         }
       }
     }
-    return items;
+    return includeReferenceDataObj ? { items, referenceData } : items;
   }
 
   /**


### PR DESCRIPTION
# Description

fix: add missing teardown trigger for search change in reference data select component 

refactor: improve cacheItems method from reference data service in order to be able to return referenceData object on demand with the items 

refactor: summary-card component reference data items and fields loading using the new improved cacheItems method from the reference data service in order to avoid multiple requests for the same information 

refactor: editor component reference data items and fields loading using the new improved cacheItems method from the reference data service in order to avoid multiple requests for the same information 

refactor: remove not more needed reference data queries

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82795)

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please refer to steps in the linked ticket

## Screenshots

Single request on dashboard loading
Before:
![image](https://github.com/ReliefApplications/ems-frontend/assets/123092672/a09fcca2-6adb-4329-9936-ff38af740fce)
Now:
![image](https://github.com/ReliefApplications/ems-frontend/assets/123092672/365d91ed-60d9-4201-8b94-f3aa5e720203)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
