### PR TITLE
fix/AB#82869-value-not-appearing-in-layer-popup-when-zero 

### DIFF
--- a/libs/shared/src/lib/components/ui/map/map-popup/map-popup.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map-popup/map-popup.component.ts
@@ -14,6 +14,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ButtonModule, DividerModule, TooltipModule } from '@oort-front/ui';
 import { LatLng } from 'leaflet';
 import get from 'lodash/get';
+import { isNil } from 'lodash';
 
 /** Component for a popup that has information on multiple points */
 @Component({
@@ -93,7 +94,7 @@ export class MapPopupComponent
             value = this.coordinates;
           }
 
-          return value ? value : '';
+          return isNil(value) ? '' : value;
         })
       : this.template.replace(regex, '');
     const scriptRegex = /<script>(.*?)<\/script>/g;


### PR DESCRIPTION
# Description
When replacing the properties values for the map popup HTML, zero values were ignored. Lodash isNil for the rescue.

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82869


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Create a map widget with a layer where the proprieties have a numeric value that can be zero, set popups for it and check if the zero appears as expected.

## Screenshots
[video.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/d46a4087-2a06-4fcd-83af-65f06d05d1c1)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
