### PR TITLE
Fix/ab#82564 widgets unnecessarily reloading

### DIFF
--- a/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
+++ b/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
@@ -110,11 +110,13 @@ export class AggregationGridComponent
   }
 
   ngOnInit(): void {
-    this.contextService.filter$
-      .pipe(debounceTime(500), takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.getAggregationData();
-      });
+    if (this.contextService.filterRegex.test(this.contextFilters as string)) {
+      this.contextService.filter$
+        .pipe(debounceTime(500), takeUntil(this.destroy$))
+        .subscribe(() => {
+          this.getAggregationData();
+        });
+    }
     this.queryBuilder.isDoneLoading$.subscribe((doneLoading) => {
       if (doneLoading) {
         this.getAggregationFields();

--- a/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
+++ b/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
@@ -110,6 +110,7 @@ export class AggregationGridComponent
   }
 
   ngOnInit(): void {
+    // Listen to dashboard filters changes if it is necessary
     if (this.contextService.filterRegex.test(this.contextFilters as string)) {
       this.contextService.filter$
         .pipe(debounceTime(500), takeUntil(this.destroy$))

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -361,6 +361,7 @@ export class CoreGridComponent
   ) {
     super();
     this.environment = environment;
+    // Listen to dashboard filters changes if it is necessary
     if (contextService.filterRegex.test(this.settings.contextFilters)) {
       contextService.filter$
         .pipe(debounceTime(500), takeUntil(this.destroy$))

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -361,12 +361,13 @@ export class CoreGridComponent
   ) {
     super();
     this.environment = environment;
-
-    contextService.filter$
-      .pipe(debounceTime(500), takeUntil(this.destroy$))
-      .subscribe(() => {
-        if (this.dataQuery) this.reloadData();
-      });
+    if (contextService.filterRegex.test(this.settings.contextFilters)) {
+      contextService.filter$
+        .pipe(debounceTime(500), takeUntil(this.destroy$))
+        .subscribe(() => {
+          if (this.dataQuery) this.reloadData();
+        });
+    }
   }
 
   /**

--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -193,6 +193,8 @@ export class Layer implements LayerModel {
   // private properties: any | null = null;
   /** Layer filter */
   private filter: LayerFilter | null = null;
+  /** Layer context filters  */
+  public contextFilters: string;
   // private styling: any | null = null;
   // private label: LayerLabel | null = null;
 
@@ -289,6 +291,7 @@ export class Layer implements LayerModel {
       this.datasource = get(options, 'datasource', null);
       this.geojson = get(options, 'geojson', EMPTY_FEATURE_COLLECTION);
       // this.properties = options.properties || DEFAULT_LAYER_PROPERTIES;
+      this.contextFilters = get(options, 'contextFilters', null);
       this.filter = get(options, 'filter', DEFAULT_LAYER_FILTER);
       // this.styling = options.styling || [];
       // this.label = options.labels || null;

--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -194,7 +194,7 @@ export class Layer implements LayerModel {
   /** Layer filter */
   private filter: LayerFilter | null = null;
   /** Layer context filters  */
-  public contextFilters: string;
+  public contextFilters!: string;
   // private styling: any | null = null;
   // private label: LayerLabel | null = null;
 

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -227,12 +227,14 @@ export class MapComponent
     }, 1000);
   }
 
+  /** Initialize filters */
   private initFilters() {
+    // Gather all context filters in a single text value
     const allContextFilters = this.layers
-      .map((layer: any) => JSON.stringify(layer.filter))
+      .map((layer: any) => JSON.stringify(layer.contextFilters))
       .join('');
 
-    // Listen to dashboard filters changes
+    // Listen to dashboard filters changes if it is necessary
     if (this.contextService.filterRegex.test(allContextFilters)) {
       this.contextService.filter$
         .pipe(
@@ -561,6 +563,7 @@ export class MapComponent
             this.layerControlButtons.remove();
           }
         }
+        // When layers are created, filters are then initialized
         this.initFilters();
       });
     } else {

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -225,6 +225,29 @@ export class MapComponent
       });
       //}
     }, 1000);
+  }
+
+  private initFilters() {
+    const allContextFilters = this.layers
+      .map((layer: any) => JSON.stringify(layer.filter))
+      .join('');
+
+    // Listen to dashboard filters changes
+    if (this.contextService.filterRegex.test(allContextFilters)) {
+      this.contextService.filter$
+        .pipe(
+          debounceTime(500),
+          filter(() => {
+            const filters = this.contextService.filter.getValue();
+            return !isEqual(filters, this.appliedDashboardFilters);
+          }),
+          concatMap(() => loadNextFilters()),
+          takeUntil(this.destroy$)
+        )
+        .subscribe(() => {
+          this.filterLayers();
+        });
+    }
 
     /**
      * Keep checking until filters are applied in order to apply next one
@@ -249,21 +272,6 @@ export class MapComponent
       };
       return new Promise(checkAgain);
     };
-
-    // Listen to dashboard filters changes
-    this.contextService.filter$
-      .pipe(
-        debounceTime(500),
-        filter(() => {
-          const filters = this.contextService.filter.getValue();
-          return !isEqual(filters, this.appliedDashboardFilters);
-        }),
-        concatMap(() => loadNextFilters()),
-        takeUntil(this.destroy$)
-      )
-      .subscribe(() => {
-        this.filterLayers();
-      });
   }
 
   override ngOnDestroy(): void {
@@ -553,6 +561,7 @@ export class MapComponent
             this.layerControlButtons.remove();
           }
         }
+        this.initFilters();
       });
     } else {
       // No update on the layers, we only update the controls

--- a/libs/shared/src/lib/components/widgets/chart/chart.component.ts
+++ b/libs/shared/src/lib/components/widgets/chart/chart.component.ts
@@ -152,11 +152,15 @@ export class ChartComponent
   }
 
   ngOnInit(): void {
-    this.contextService.filter$.pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.series.next([]);
-      this.loadChart();
-      this.getOptions();
-    });
+    if (this.contextService.filterRegex.test(this.settings.contextFilters)) {
+      this.contextService.filter$
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(() => {
+          this.series.next([]);
+          this.loadChart();
+          this.getOptions();
+        });
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/libs/shared/src/lib/components/widgets/chart/chart.component.ts
+++ b/libs/shared/src/lib/components/widgets/chart/chart.component.ts
@@ -152,6 +152,7 @@ export class ChartComponent
   }
 
   ngOnInit(): void {
+    // Listen to dashboard filters changes if it is necessary
     if (this.contextService.filterRegex.test(this.settings.contextFilters)) {
       this.contextService.filter$
         .pipe(takeUntil(this.destroy$))

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -124,9 +124,11 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     this.setHtml();
 
+    // Gather all context filters in a single text value
     const allContextFilters = this.aggregations
       .map((aggregation: any) => aggregation.contextFilters)
       .join('');
+    // Listen to dashboard filters changes if it is necessary
     if (this.contextService.filterRegex.test(allContextFilters)) {
       this.contextService.filter$
         .pipe(debounceTime(500), takeUntil(this.destroy$))

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -124,13 +124,18 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     this.setHtml();
 
-    this.contextService.filter$
-      .pipe(debounceTime(500), takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.refresh$.next(true);
-        this.loading = true;
-        this.setHtml();
-      });
+    const allContextFilters = this.aggregations
+      .map((aggregation: any) => aggregation.contextFilters)
+      .join('');
+    if (this.contextService.filterRegex.test(allContextFilters)) {
+      this.contextService.filter$
+        .pipe(debounceTime(500), takeUntil(this.destroy$))
+        .subscribe(() => {
+          this.refresh$.next(true);
+          this.loading = true;
+          this.setHtml();
+        });
+    }
   }
 
   /**

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -272,6 +272,7 @@ export class SummaryCardComponent
         this.handleSearch(value || '');
       });
 
+    // Listen to dashboard filters changes if it is necessary
     if (
       this.contextService.filterRegex.test(this.widget.settings.contextFilters)
     ) {

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -272,11 +272,15 @@ export class SummaryCardComponent
         this.handleSearch(value || '');
       });
 
-    this.contextService.filter$
-      .pipe(debounceTime(500), takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.refresh();
-      });
+    if (
+      this.contextService.filterRegex.test(this.widget.settings.contextFilters)
+    ) {
+      this.contextService.filter$
+        .pipe(debounceTime(500), takeUntil(this.destroy$))
+        .subscribe(() => {
+          this.refresh();
+        });
+    }
   }
 
   ngAfterViewInit(): void {

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -44,6 +44,8 @@ export class ContextService {
   public filterPosition = new BehaviorSubject<any>(null);
   /** Is filter opened */
   public filterOpened = new BehaviorSubject<boolean>(false);
+  /** Regex used to allow widget refresh */
+  public filterRegex = /{{filter\.[^}]+}}/;
   /** Dashboard object */
   public dashboard?: Dashboard;
   /** Available filter positions */


### PR DESCRIPTION
# Description

Widgets are unnecessarily reloaded when dashboard filters are used. Adding a regex expression to prevent unwanted reloading. 

For the maps, I added the contextFilters variable to the layer to be able to read them from the map component. I didn't find a better way of doing it. 

I was looking at `featureSatisfiesFilter()` into `layer.ts` during my investigation and it may be unused. It is called if `this.filter` isn't empty or when it is initialized: `this.filter = get(options, 'filter', DEFAULT_LAYER_FILTER);` it seems that `options.filter` doesn't exist, then `DEFAULT_LAYER_FILTER` is used. I don't know all the features of the project that's why I didn't remove this part.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82564/)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Setup: I created a dashboard and added each widget in it. I created a context filter.
Test: I tried to modify the dashboard filter to see if widgets were reloaded or not. I did the same test with filter configuration for each of them.

## Screenshots

![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/184c20b5-0ff8-4b13-b87e-ef14ca5be88e)
In this example, the pie chart widget is the only one configured with context filters.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
