### PR TITLE
feat/AB#82962_ABC-the-data-for-map-popouts-should-be-loaded-on-demand

### DIFF
--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -293,7 +293,7 @@ export class Layer implements LayerModel {
       // this.styling = options.styling || [];
       // this.label = options.labels || null;
       this.layerDefinition = get(options, 'layerDefinition');
-      this.popupInfo = get(options, 'popupInfo');
+      // this.popupInfo = get(options, 'popupInfo');
       this.setFields();
     } else if (options.sublayers) {
       // Group layer, add sublayers
@@ -521,8 +521,8 @@ export class Layer implements LayerModel {
               lat: center.geometry.coordinates[1],
               lng: center.geometry.coordinates[0],
             }),
-            this.popupInfo,
-            layer
+            // this.popupInfo,
+            this.id
           );
         };
         const listener = this.renderer.listen(layer, 'click', setPopupListener);
@@ -673,7 +673,8 @@ export class Layer implements LayerModel {
                 this.popupService.setPopUp(
                   matchedPoints,
                   event,
-                  this.popupInfo
+                  this.id
+                  // this.popupInfo
                 );
               }
             };
@@ -774,7 +775,8 @@ export class Layer implements LayerModel {
                   this.popupService.setPopUp(
                     children,
                     event.latlng,
-                    this.popupInfo,
+                    this.id,
+                    // this.popupInfo,
                     event.layer
                   );
                 });

--- a/libs/shared/src/lib/models/layer.model.ts
+++ b/libs/shared/src/lib/models/layer.model.ts
@@ -150,12 +150,18 @@ export interface LayerModel {
   visibility: boolean;
   opacity: number;
   layerDefinition?: LayerDefinition;
-  popupInfo?: PopupInfo;
   datasource?: LayerDatasource;
   createdAt: Date;
   updatedAt: Date;
   contextFilters?: string;
   at?: string;
+}
+
+/**
+ * Backend layer popup info model
+ */
+export interface LayerPopupInfoQueryResponse {
+  layer: { popupInfo: PopupInfo };
 }
 
 /** Model for AddLayerMutationResponse object */

--- a/libs/shared/src/lib/services/map/graphql/queries.ts
+++ b/libs/shared/src/lib/services/map/graphql/queries.ts
@@ -84,6 +84,18 @@ export const GET_LAYER_BY_ID = gql`
           }
         }
       }
+      sublayers
+      contextFilters
+      at
+    }
+  }
+`;
+
+// === GET LAYER POPUP INFO BY ID ===
+/** Graphql request for getting layer popup data by its id */
+export const GET_LAYER_POPUP_INFO = gql`
+  query GetLayerPopupInfo($id: ID!) {
+    layer(id: $id) {
       popupInfo {
         title
         description
@@ -100,9 +112,6 @@ export const GET_LAYER_BY_ID = gql`
           fields
         }
       }
-      sublayers
-      contextFilters
-      at
     }
   }
 `;


### PR DESCRIPTION
# Description

refactor: popupinfo retrieve from layer on layer click instead of adding it on layer info query to split query complexity in two

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82962)

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
