### PR TITLE
Ab#82858 incorrect grid width when resizing screen

### DIFF
--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
@@ -17,6 +17,7 @@
   <gridster [options]="gridOptions" class="!w-full">
     <gridster-item
       [item]="widget"
+      class="max-w-full"
       *ngFor="let widget of widgets; let i = index"
     >
       <shared-widget


### PR DESCRIPTION
# Description

Add max-width property so widgets can no longer go out of widget-grid (btw bug from ticket did not only happen on grids) => prevents widget too big but widget can still go too small but it happens rarely, if anybody has suggestion, would be glad.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82858/)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![StillBuggyButLittleLess](https://github.com/ReliefApplications/ems-frontend/assets/59645813/a539b573-73e4-41b1-99a4-c03d7aab4035)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
