### PR TITLE
feat/AB#83059-useless-queries-graphql-fields-in-widget-queries

### DIFF
--- a/libs/shared/src/lib/components/widgets/chart/chart.component.ts
+++ b/libs/shared/src/lib/components/widgets/chart/chart.component.ts
@@ -94,6 +94,8 @@ export class ChartComponent
   public hasError = false;
   /** Selected predefined filter */
   public selectedFilter: CompositeFilterDescriptor | null = null;
+  /** Aggregation id */
+  private aggregationId?: string;
 
   /** @returns Context filters array */
   get contextFilters(): CompositeFilterDescriptor {
@@ -187,6 +189,13 @@ export class ChartComponent
     };
 
     if (!isEqual(previousDatasource, currentDatasource)) {
+      const currentAggregationId = get(
+        changes,
+        'settings.currentValue.chart.aggregationId'
+      );
+      this.aggregationId = String(currentAggregationId)
+        ? String(currentAggregationId)
+        : this.aggregationId;
       this.loadChart();
     }
     this.getOptions();
@@ -196,39 +205,21 @@ export class ChartComponent
   private loadChart(): void {
     this.loading = true;
     if (this.settings.resource || this.settings.referenceData) {
-      this.aggregationService
-        .getAggregations({
-          resource: this.settings.resource,
-          referenceData: this.settings.referenceData,
-          ids: [get(this.settings, 'chart.aggregationId', null)],
-          first: 1,
-        })
-        .then((res) => {
-          const aggregation = res.edges[0]?.node || null;
-          if (aggregation) {
-            this.dataQuery = this.aggregationService.aggregationDataQuery({
-              referenceData: this.settings.referenceData,
-              resource: this.settings.resource,
-              aggregation: aggregation.id || '',
-              mapping: get(this.settings, 'chart.mapping', null),
-              contextFilters: joinFilters(
-                this.contextFilters,
-                this.selectedFilter
-              ),
-              at: this.settings.at
-                ? this.contextService.atArgumentValue(this.settings.at)
-                : undefined,
-            });
-            if (this.dataQuery) {
-              this.getData();
-            } else {
-              this.loading = false;
-            }
-          } else {
-            this.loading = false;
-          }
-        })
-        .catch(() => (this.loading = false));
+      this.dataQuery = this.aggregationService.aggregationDataQuery({
+        referenceData: this.settings.referenceData,
+        resource: this.settings.resource,
+        aggregation: this.aggregationId || '',
+        mapping: get(this.settings, 'chart.mapping', null),
+        contextFilters: joinFilters(this.contextFilters, this.selectedFilter),
+        at: this.settings.at
+          ? this.contextService.atArgumentValue(this.settings.at)
+          : undefined,
+      });
+      if (this.dataQuery) {
+        this.getData();
+      } else {
+        this.loading = false;
+      }
     } else {
       this.loading = false;
     }

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -250,7 +250,12 @@
       <div *ngIf="formGroup.value.notify" class="sub-parameters">
         <div uiFormFieldDirective>
           <label>{{ 'common.channel.one' | translate }}</label>
-          <ui-select-menu formControlName="notificationChannel">
+          <ui-select-menu
+            formControlName="notificationChannel"
+            (opened)="onOpenSelectChannel()"
+            [loading]="!channels"
+            [filterable]="true"
+          >
             <ui-select-option>--</ui-select-option>
             <ui-select-option
               *ngFor="let channel of channels"

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -40,7 +40,7 @@ export class ButtonConfigComponent
   /** List of fields */
   @Input() fields: any[] = [];
   /** List of channels */
-  @Input() channels: Channel[] = [];
+  @Input() channels?: Channel[];
   /** List of forms */
   @Input() relatedForms: Form[] = [];
 
@@ -58,6 +58,11 @@ export class ButtonConfigComponent
 
   /** Indicate if the next step is a Form and so we could potentially pass some data to it.*/
   public canPassData = false;
+
+  /** Emits when the select channel is opened for the first time */
+  @Output() loadChannels = new EventEmitter<void>();
+  /** Saves if the channels has been fetched */
+  public loadedChannel = false;
 
   /** @returns The list of fields which are of type scalar and not disabled */
   get scalarFields(): any[] {
@@ -465,5 +470,15 @@ export class ButtonConfigComponent
    */
   public scalarField(fieldName: string): any {
     return this.scalarFields.find((field: any) => field.name === fieldName);
+  }
+
+  /**
+   * On open select menu the first time, emits event to load channels query.
+   */
+  public onOpenSelectChannel(): void {
+    if (!this.loadedChannel) {
+      this.loadChannels.emit();
+      this.loadedChannel = true;
+    }
   }
 }

--- a/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
@@ -6,10 +6,6 @@ export const GET_CHANNELS = gql`
     channels(application: $application) {
       id
       title
-      application {
-        id
-        name
-      }
     }
   }
 `;

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -81,6 +81,7 @@
         [distributionLists]="distributionLists"
         [relatedForms]="relatedForms"
         [channels]="channels"
+        (loadChannels)="getChannels()"
       ></shared-tab-buttons>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -27,6 +27,7 @@ import { createGridWidgetFormGroup } from './grid-settings.forms';
 import { DistributionList } from '../../../models/distribution-list.model';
 import { UnsubscribeComponent } from '../../utils/unsubscribe/unsubscribe.component';
 import { takeUntil } from 'rxjs/operators';
+import { AggregationService } from '../../../services/aggregation/aggregation.service';
 import { WidgetSettings } from '../../../models/dashboard.model';
 
 /**
@@ -95,12 +96,14 @@ export class GridSettingsComponent
    * @param applicationService The application service
    * @param queryBuilder The query builder service
    * @param fb FormBuilder instance
+   * @param aggregationService Shared aggregation service
    */
   constructor(
     private apollo: Apollo,
     private applicationService: ApplicationService,
     private queryBuilder: QueryBuilderService,
-    private fb: FormBuilder
+    private fb: FormBuilder,
+    private aggregationService: AggregationService
   ) {
     super();
   }
@@ -359,17 +362,22 @@ export class GridSettingsComponent
    * @param aggregationId new aggregation id
    */
   private onAggregationChange(aggregationId: string): void {
-    if (this.resource?.aggregations && aggregationId) {
-      const customAggregation = this.resource?.aggregations.edges.find(
-        (aggregation: any) => aggregation.node.id === aggregationId
-      )?.node.sourceFields;
-      // @TODO: Figure out fields' types from aggregation
-      this.fields = customAggregation
-        ? customAggregation.map((field: string) => ({
-            name: field,
-            editor: 'text',
-          }))
-        : [];
+    if (this.resource?.id && aggregationId) {
+      this.aggregationService
+        .aggregationDataQuery({
+          resource: this.resource.id,
+          aggregation: aggregationId || '',
+        })
+        .subscribe(({ data }: any) => {
+          if (data.recordsAggregation) {
+            this.fields = data.recordsAggregation.items[0]
+              ? Object.keys(data.recordsAggregation.items[0]).map((f) => ({
+                  name: f,
+                  editor: 'text',
+                }))
+              : [];
+          }
+        });
     }
   }
 

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-buttons/tab-buttons.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-buttons/tab-buttons.component.html
@@ -62,6 +62,7 @@
       [distributionLists]="distributionLists"
       [relatedForms]="relatedForms"
       (deleteButton)="deleteButton(i)"
+      (loadChannels)="loadChannels.emit()"
     >
     </shared-button-config>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-buttons/tab-buttons.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-buttons/tab-buttons.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input, ViewChild } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { UntypedFormArray, UntypedFormGroup } from '@angular/forms';
 import { createButtonFormGroup } from '../grid-settings.forms';
 import { Form } from '../../../../models/form.model';
@@ -22,11 +28,13 @@ export class TabButtonsComponent {
   /** List of forms */
   @Input() relatedForms: Form[] = [];
   /** List of channels */
-  @Input() channels: Channel[] = [];
+  @Input() channels?: Channel[];
   /** List of templates */
   @Input() templates: any[] = [];
   /** List of distribution lists */
   @Input() distributionLists: any[] = [];
+  /** Emits when the select channel is opened for the first time */
+  @Output() loadChannels = new EventEmitter<void>();
 
   /** Tabs component */
   @ViewChild(TabsComponent, { static: false }) tabGroup!: TabsComponent;

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
@@ -49,7 +49,6 @@ export const GET_REFERENCE_DATA = gql`
     referenceData(id: $id) {
       id
       name
-      type
       fields
     }
   }

--- a/libs/ui/src/lib/graphql-select/graphql-select.component.ts
+++ b/libs/ui/src/lib/graphql-select/graphql-select.component.ts
@@ -148,9 +148,9 @@ export class GraphQLSelectComponent
   /** Destroy subject */
   public destroy$ = new Subject<void>();
   /** Query name */
-  private queryName!: string;
+  protected queryName!: string;
   /** Query change subject */
-  private queryChange$ = new Subject<void>();
+  protected queryChange$ = new Subject<void>();
   /** Query elements */
   private queryElements: any[] = [];
   /** Cached elements */
@@ -522,7 +522,7 @@ export class GraphQLSelectComponent
    * @param data query response data
    * @param loading loading status
    */
-  private updateValues(data: any, loading: boolean) {
+  protected updateValues(data: any, loading: boolean) {
     const path = this.path ? `${this.queryName}.${this.path}` : this.queryName;
     const elements: any[] = get(data, path).edges
       ? get(data, path).edges.map((x: any) => x.node)

--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -80,7 +80,7 @@ export class SelectMenuComponent
   /** Search control */
   public searchControl = new FormControl('', { nonNullable: true });
   /** Loading state */
-  public loading = false;
+  @Input() public loading = false;
   /** Subscription to the search control */
   private searchSubscriptionActive!: Subscription;
 


### PR DESCRIPTION
# Description
removed useless field from the queries: GET_CHANNELS, GET_REFERENCE_DATA 

refactor: GraphQLSelectComponent private proprieties to protected so the ResourceSelectComponent can access it

refactor: ResourceSelectComponent and ReferenceDataSelectComponent to only load resources/ref datas when clicking/opening the select menu

refactor: loadChart method. Charts widgets has the aggregation id in the settings input, so the  GET_RESOURCE_AGGREGATIONS query only to fetch this information is useless.

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83059

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Creating, using and editing all widgets and monitoring the queries fetched to get the necessary data.

## Screenshots
Grid aggregation:
[grid-a.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/d3f3e9d6-ad38-462b-9f04-2ad861398042)

Grid layout:
[grid-layout.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/3ace08e4-b60b-4eab-b4e9-f05bbf4fecec)

Summary card aggregation:
[sm-a.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/83187198-103b-4e88-8bed-043827ebe1a0)

Summary card layout:
[sm-layout.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/ca417781-a92e-4bdc-9d08-a58f9e387b9d)

Summary card ref data:
[sm-refdata.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/e8dd7a05-b1d1-4697-9230-c272857778df)

Charts:
[chart.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/f8997f5c-d3e2-48b5-88b4-f8f8c3b626b1)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
