### PR TITLE
feat/AB#83059-remove-useless-graphql-fields-in-widget-queries

### DIFF
--- a/libs/shared/src/lib/components/aggregation/add-aggregation-modal/add-aggregation-modal.component.html
+++ b/libs/shared/src/lib/components/aggregation/add-aggregation-modal/add-aggregation-modal.component.html
@@ -40,6 +40,19 @@
       </div>
       <div uiFormFieldDirective class="w-full">
         <label>{{ 'components.aggregation.add.select' | translate }}</label>
+
+        <ui-select-menu
+          *ngIf="data.useQueryRef === false"
+          [formControl]="selectedAggregationControl"
+        >
+          <ui-select-option
+            *ngFor="let aggregation of aggregations"
+            [value]="aggregation.id"
+          >
+            {{ aggregation.name }}
+          </ui-select-option>
+        </ui-select-menu>
+
         <ui-graphql-select
           *ngIf="queryRef"
           valueField="id"

--- a/libs/shared/src/lib/components/aggregation/add-aggregation-modal/add-aggregation-modal.component.ts
+++ b/libs/shared/src/lib/components/aggregation/add-aggregation-modal/add-aggregation-modal.component.ts
@@ -135,7 +135,7 @@ export class AddAggregationModalComponent
     // emits selected aggregation
     this.selectedAggregationControl.valueChanges.subscribe((value) => {
       if (value) {
-        if (this.data.useQueryRef) {
+        if (this.data.useQueryRef !== false) {
           this.dialogRef.close(
             this.aggregationSelect?.elements
               .getValue()

--- a/libs/shared/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.html
+++ b/libs/shared/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.html
@@ -50,6 +50,19 @@
         <label>{{
           'components.widget.settings.grid.layouts.select' | translate
         }}</label>
+
+        <ui-select-menu
+          *ngIf="data.useQueryRef === false"
+          [formControl]="selectedLayoutControl"
+        >
+          <ui-select-option
+            *ngFor="let layout of layouts"
+            [value]="layout.id"
+          >
+            {{ layout.name }}
+          </ui-select-option>
+        </ui-select-menu>
+
         <ui-graphql-select
           *ngIf="queryRef"
           valueField="id"

--- a/libs/shared/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.ts
+++ b/libs/shared/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.ts
@@ -123,20 +123,21 @@ export class AddLayoutModalComponent
 
   ngOnInit() {
     if (this.data.useQueryRef !== false) {
-      if (this.resource)
+      if (this.resource) {
         this.queryRef = this.apollo.watchQuery<ResourceQueryResponse>({
           query: GET_RESOURCE_LAYOUTS,
           variables: {
             resource: this.resource?.id,
           },
         });
-      else if (this.form)
+      } else if (this.form) {
         this.queryRef = this.apollo.watchQuery<FormQueryResponse>({
           query: GET_FORM_LAYOUTS,
           variables: {
             form: this.form?.id,
           },
         });
+      }
     } else {
       this.layouts = this.resource?.layouts?.edges.map(
         (edge: any) => edge.node

--- a/libs/shared/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.ts
+++ b/libs/shared/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.ts
@@ -146,7 +146,7 @@ export class AddLayoutModalComponent
 
     this.selectedLayoutControl.valueChanges.subscribe((value) => {
       if (value) {
-        if (this.data.useQueryRef) {
+        if (this.data.useQueryRef !== false) {
           this.dialogRef.close(
             this.layoutSelect?.elements.getValue().find((x) => x.id === value)
           );

--- a/libs/shared/src/lib/components/notifications/components/edit-notification-modal/edit-notification-modal.component.ts
+++ b/libs/shared/src/lib/components/notifications/components/edit-notification-modal/edit-notification-modal.component.ts
@@ -239,7 +239,6 @@ export class EditNotificationModalComponent
     const dialogRef = this.dialog.open(AddLayoutModalComponent, {
       data: {
         resource: this.resource,
-        hasLayouts: get(this.resource, 'layouts.totalCount', 0) > 0,
       },
     });
     dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value: any) => {

--- a/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.ts
+++ b/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.ts
@@ -14,7 +14,6 @@ import {
 } from '../../../../models/reference-data.model';
 import { AggregationBuilderService } from '../../../../services/aggregation-builder/aggregation-builder.service';
 import { AggregationService } from '../../../../services/aggregation/aggregation.service';
-import { get } from 'lodash';
 import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
 import { takeUntil } from 'rxjs/operators';
 import { Dialog } from '@angular/cdk/dialog';
@@ -173,12 +172,6 @@ export class TabMainComponent extends UnsubscribeComponent implements OnInit {
     );
     const dialogRef = this.dialog.open(AddAggregationModalComponent, {
       data: {
-        hasAggregations:
-          get(
-            this.resource ? this.resource : this.referenceData,
-            'aggregations.totalCount',
-            0
-          ) > 0, // check if at least one existing aggregation
         resource: this.resource,
         referenceData: this.referenceData,
       },

--- a/libs/shared/src/lib/components/widgets/common/template-aggregation-modal/template-aggregation-modal.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/template-aggregation-modal/template-aggregation-modal.component.ts
@@ -32,7 +32,6 @@ import { Aggregation } from '../../../../models/aggregation.model';
 import { GET_REFERENCE_DATA, GET_RESOURCE } from './graphql/queries';
 import { AggregationService } from '../../../../services/aggregation/aggregation.service';
 import { DIALOG_DATA, Dialog } from '@angular/cdk/dialog';
-import get from 'lodash/get';
 import { createTemplateAggregationForm } from '../../editor-settings/editor-settings.forms';
 
 /** Dialog data interface */
@@ -205,12 +204,6 @@ export class TemplateAggregationModalComponent
     );
     const dialogRef = this.dialog.open(AddAggregationModalComponent, {
       data: {
-        hasAggregations:
-          get(
-            this.resource ? this.resource : this.referenceData,
-            'aggregations.totalCount',
-            0
-          ) > 0, // check if at least one existing aggregation
         resource: this.resource,
         referenceData: this.referenceData,
       },

--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.html
@@ -67,6 +67,8 @@
           [referenceData]="referenceData"
           [resource]="resource"
           [layout]="layout"
+          [loadedLayouts]="loadedLayouts"
+          (loadLayouts)="getLayouts()"
         ></shared-record-selection-tab>
       </ng-template>
     </ui-tab>

--- a/libs/shared/src/lib/components/widgets/editor-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/graphql/queries.ts
@@ -58,3 +58,23 @@ export const GET_REFERENCE_DATA = gql`
     }
   }
 `;
+
+/** Graphql request for getting resource layouts by its id */
+export const GET_RESOURCE_LAYOUTS = gql`
+  query GetResource($resource: ID!) {
+    resource(id: $resource) {
+      layouts {
+        edges {
+          node {
+            id
+            name
+            query
+            createdAt
+            display
+          }
+        }
+        totalCount
+      }
+    }
+  }
+`;

--- a/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Resource } from '../../../../models/resource.model';
 import { Layout } from '../../../../models/layout.model';
-import { get } from 'lodash';
 import { GridLayoutService } from '../../../../services/grid-layout/grid-layout.service';
 import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
 import { takeUntil } from 'rxjs';
@@ -87,7 +86,6 @@ export class RecordSelectionTabComponent
     const dialogRef = this.dialog.open(AddLayoutModalComponent, {
       data: {
         resource: this.resource,
-        hasLayouts: get(this.resource, 'layouts.totalCount', 0) > 0,
       },
     });
     dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value) => {

--- a/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Resource } from '../../../../models/resource.model';
 import { Layout } from '../../../../models/layout.model';
 import { GridLayoutService } from '../../../../services/grid-layout/grid-layout.service';
@@ -24,7 +17,7 @@ import { createEditorForm } from '../editor-settings.forms';
 })
 export class RecordSelectionTabComponent
   extends UnsubscribeComponent
-  implements OnInit, OnDestroy
+  implements OnInit
 {
   /** Widget form group */
   @Input() form!: ReturnType<typeof createEditorForm>;
@@ -42,8 +35,6 @@ export class RecordSelectionTabComponent
   public selectedRecordID: string | null = null;
   /** Available reference data elements  */
   public refDataElements: any[] = [];
-  /** Timeout listener for add layout modal opening */
-  private timeoutListener!: NodeJS.Timeout;
 
   /**
    * Component for the record selection in the editor widget settings
@@ -92,34 +83,33 @@ export class RecordSelectionTabComponent
   public async addLayout() {
     if (!this.resource) {
       return;
+    } else {
+      this.openAddLayoutModal();
     }
-    if (!this.loadedLayouts) {
-      this.loadLayouts.emit();
-    }
+  }
+
+  /**
+   * Opens add layout modal
+   */
+  public async openAddLayoutModal(): Promise<void> {
     const { AddLayoutModalComponent } = await import(
       '../../../grid-layout/add-layout-modal/add-layout-modal.component'
     );
-    const awaitTime = this.loadedLayouts ? 0 : 500;
-    if (this.timeoutListener) {
-      clearTimeout(this.timeoutListener);
-    }
-    this.timeoutListener = setTimeout(() => {
-      const dialogRef = this.dialog.open(AddLayoutModalComponent, {
-        data: {
-          resource: this.resource,
-          useQueryRef: false,
-        },
-      });
-      dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value) => {
-        if (value) {
-          if (typeof value === 'string') {
-            this.form.get('layout')?.setValue(value);
-          } else {
-            this.form.get('layout')?.setValue((value as any).id);
-          }
+    const dialogRef = this.dialog.open(AddLayoutModalComponent, {
+      data: {
+        resource: this.resource,
+        useQueryRef: false,
+      },
+    });
+    dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value) => {
+      if (value) {
+        if (typeof value === 'string') {
+          this.form.get('layout')?.setValue(value);
+        } else {
+          this.form.get('layout')?.setValue((value as any).id);
         }
-      });
-    }, awaitTime);
+      }
+    });
   }
 
   /**
@@ -184,12 +174,5 @@ export class RecordSelectionTabComponent
       this.form.get(formField)?.setValue(null);
     }
     event.stopPropagation();
-  }
-
-  override ngOnDestroy(): void {
-    if (this.timeoutListener) {
-      clearTimeout(this.timeoutListener);
-    }
-    super.ngOnDestroy();
   }
 }

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.html
@@ -50,7 +50,7 @@
       </ui-checkbox>
 
       <!-- Attach record to another resource record -->
-      <ng-container *ngIf="relatedForms.length > 0">
+      <ng-container *ngIf="relatedForms && relatedForms.length > 0">
         <ui-checkbox formControlName="attachToRecord">
           <ng-container ngProjectAs="label">
             {{
@@ -81,7 +81,11 @@
         <!-- Selection of target resource -->
         <div uiFormFieldDirective>
           <label>{{ 'common.resource.one' | translate }}</label>
-          <ui-select-menu formControlName="targetResource">
+          <ui-select-menu
+            formControlName="targetResource"
+            [loading]="!relatedResources"
+            [filterable]="true"
+          >
             <ui-select-option>--</ui-select-option>
             <ui-select-option
               *ngFor="let resource of relatedResources"
@@ -133,7 +137,7 @@
       </div>
 
       <!-- Prefill form with selected records -->
-      <ng-container *ngIf="relatedForms.length > 0">
+      <ng-container *ngIf="relatedForms && relatedForms.length > 0">
         <ui-checkbox formControlName="prefillForm">
           <ng-container ngProjectAs="label">{{
             'components.widget.settings.grid.buttons.callback.prefill'
@@ -146,7 +150,11 @@
           </ui-alert>
           <div uiFormFieldDirective>
             <label>{{ 'models.form.template' | translate }}</label>
-            <ui-select-menu formControlName="prefillTargetForm">
+            <ui-select-menu
+              formControlName="prefillTargetForm"
+              [loading]="!relatedForms"
+              [filterable]="true"
+            >
               <ui-select-option>--</ui-select-option>
               <ui-select-option
                 *ngFor="let form of relatedForms"

--- a/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/button-config/button-config.component.ts
@@ -275,7 +275,6 @@ export class ButtonConfigComponent
       }
     });
 
-    console.log('on init');
     if (this.formGroup.value.targetResource) {
       this.targetResource = this.relatedResources.find(
         (x) => x.id === this.formGroup.value.targetResource

--- a/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
@@ -54,17 +54,6 @@ export const GET_GRID_RESOURCE_META = gql`
         id
         name
       }
-      relatedForms {
-        id
-        name
-        fields
-        resource {
-          id
-          queryName
-          name
-          fields
-        }
-      }
       layouts(ids: $layoutIds, first: $firstLayouts) {
         edges {
           node {
@@ -96,6 +85,25 @@ export const GET_GRID_RESOURCE_META = gql`
           endCursor
         }
         totalCount
+      }
+    }
+  }
+`;
+
+/** Graphql request for getting the related forms of a resource */
+export const GET_RELATED_FORMS = gql`
+  query GetGridResourceMeta($resource: ID!) {
+    resource(id: $resource) {
+      relatedForms {
+        id
+        name
+        fields
+        resource {
+          id
+          queryName
+          name
+          fields
+        }
       }
     }
   }

--- a/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
@@ -45,12 +45,13 @@ export const GET_GRID_RESOURCE_META = gql`
     $firstLayouts: Int
     $aggregationIds: [ID]
     $firstAggregations: Int
+    $formId: ID
   ) {
     resource(id: $resource) {
       id
       name
       queryName
-      forms {
+      form(id: $formId) {
         id
         name
       }
@@ -104,6 +105,18 @@ export const GET_RELATED_FORMS = gql`
           name
           fields
         }
+      }
+    }
+  }
+`;
+
+/** Graphql request for getting the related templates of a resource */
+export const GET_RESOURCE_TEMPLATES = gql`
+  query GetGridResourceMeta($resource: ID!) {
+    resource(id: $resource) {
+      forms {
+        id
+        name
       }
     }
   }

--- a/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
@@ -42,20 +42,23 @@ export const GET_GRID_RESOURCE_META = gql`
   query GetGridResourceMeta(
     $resource: ID!
     $layoutIds: [ID]
+    $ignoreLayouts: Boolean
     $firstLayouts: Int
     $aggregationIds: [ID]
+    $ignoreAggregations: Boolean
     $firstAggregations: Int
     $formId: ID
+    $ignoreForms: Boolean
   ) {
     resource(id: $resource) {
       id
       name
       queryName
-      form(id: $formId) {
+      forms(id: $formId, ignore: $ignoreForms) {
         id
         name
       }
-      layouts(ids: $layoutIds, first: $firstLayouts) {
+      layouts(ids: $layoutIds, first: $firstLayouts, ignore: $ignoreLayouts) {
         edges {
           node {
             id
@@ -71,7 +74,11 @@ export const GET_GRID_RESOURCE_META = gql`
         }
         totalCount
       }
-      aggregations(ids: $aggregationIds, first: $firstAggregations) {
+      aggregations(
+        ids: $aggregationIds
+        first: $firstAggregations
+        ignore: $ignoreAggregations
+      ) {
         edges {
           node {
             id
@@ -117,6 +124,30 @@ export const GET_RESOURCE_TEMPLATES = gql`
       forms {
         id
         name
+      }
+    }
+  }
+`;
+
+/** Graphql request for getting resource layouts by its id */
+export const GET_RESOURCE_LAYOUTS = gql`
+  query GetGridResourceMeta($resource: ID!) {
+    resource(id: $resource) {
+      layouts {
+        edges {
+          node {
+            id
+            name
+            query
+            createdAt
+            display
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        totalCount
       }
     }
   }

--- a/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
@@ -152,3 +152,23 @@ export const GET_RESOURCE_LAYOUTS = gql`
     }
   }
 `;
+
+/** Graphql request for getting resource aggregations by its id */
+export const GET_RESOURCE_AGGREGATIONS = gql`
+  query GetResource($resource: ID!) {
+    resource(id: $resource) {
+      aggregations {
+        edges {
+          node {
+            id
+            name
+            sourceFields
+            pipeline
+            createdAt
+          }
+        }
+        totalCount
+      }
+    }
+  }
+`;

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -18,7 +18,9 @@
         [formGroup]="widgetFormGroup"
         [resource]="resource"
         [templates]="templates"
+        [loadedLayouts]="loadedLayouts"
         (loadTemplates)="getTemplates()"
+        (loadLayouts)="getLayouts()"
       ></shared-tab-main>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -19,8 +19,10 @@
         [resource]="resource"
         [templates]="templates"
         [loadedLayouts]="loadedLayouts"
+        [loadedAggregations]="loadedAggregations"
         (loadTemplates)="getTemplates()"
         (loadLayouts)="getLayouts()"
+        (loadAggregations)="getAggregations()"
       ></shared-tab-main>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -18,6 +18,7 @@
         [formGroup]="widgetFormGroup"
         [resource]="resource"
         [templates]="templates"
+        (loadTemplates)="getTemplates()"
       ></shared-tab-main>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -1,7 +1,7 @@
 <ui-tabs
   class="grow"
   [vertical]="true"
-  (selectedIndexChange)="handleTabChange($event)"
+  (selectedIndexChange)="selectedTab = $event"
 >
   <!-- MAIN PARAMETERS / SELECTION OF LAYOUTS -->
   <ui-tab>
@@ -79,7 +79,7 @@
         [fields]="fields"
         [templates]="appTemplates"
         [distributionLists]="distributionLists"
-        [relatedForms]="relatedForms"
+        [relatedForms$]="relatedForms$"
         [channels]="channels"
         (loadChannels)="getChannels()"
       ></shared-tab-buttons>

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-buttons/tab-buttons.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-buttons/tab-buttons.component.html
@@ -60,7 +60,7 @@
       [channels]="channels"
       [templates]="templates"
       [distributionLists]="distributionLists"
-      [relatedForms]="relatedForms"
+      [relatedForms$]="relatedForms$"
       (deleteButton)="deleteButton(i)"
       (loadChannels)="loadChannels.emit()"
     >

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-buttons/tab-buttons.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-buttons/tab-buttons.component.ts
@@ -11,6 +11,7 @@ import { Form } from '../../../../models/form.model';
 import { Channel } from '../../../../models/channel.model';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { TabsComponent } from '@oort-front/ui';
+import { Observable } from 'rxjs';
 
 /**
  * Buttons tab of grid widget configuration modal.
@@ -26,7 +27,7 @@ export class TabButtonsComponent {
   /** List of fields */
   @Input() fields: any[] = [];
   /** List of forms */
-  @Input() relatedForms: Form[] = [];
+  @Input() relatedForms$?: Observable<Form[] | undefined>;
   /** List of channels */
   @Input() channels?: Channel[];
   /** List of templates */
@@ -76,7 +77,7 @@ export class TabButtonsComponent {
    *
    * @param event cdk drag and drop event.
    */
-  onReorder(event: CdkDragDrop<string[]>): void {
+  public onReorder(event: CdkDragDrop<string[]>): void {
     const reorderedButtons = this.buttons.value;
     moveItemInArray(reorderedButtons, event.previousIndex, event.currentIndex);
     this.buttons.setValue(reorderedButtons);

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
@@ -62,6 +62,8 @@
       [canAdd]="formGroup.get('aggregations')?.value.length === 0"
       [resource]="resource"
       [selectedAggregations]="$any(formGroup).get('aggregations')"
+      [loadedAggregations]="loadedAggregations"
+      (loadAggregations)="loadAggregations.emit()"
     ></shared-aggregation-table>
   </div>
   <ui-divider

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
@@ -27,7 +27,12 @@
     <!-- Template selection -->
     <div *ngIf="resource" uiFormFieldDirective class="flex-1">
       <label>{{ 'models.form.template' | translate }}</label>
-      <ui-select-menu formControlName="template">
+      <ui-select-menu
+        formControlName="template"
+        (opened)="onOpenSelectTemplates()"
+        [loading]="!templates"
+        [filterable]="true"
+      >
         <ui-select-option>-</ui-select-option>
         <ui-select-option
           *ngFor="let template of templates"

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
@@ -79,6 +79,8 @@
     <shared-layout-table
       [resource]="resource"
       [selectedLayouts]="$any(formGroup).get('layouts')"
+      [loadedLayouts]="loadedLayouts"
+      (loadLayouts)="loadLayouts.emit()"
     ></shared-layout-table>
   </div>
 </div>

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.ts
@@ -20,8 +20,12 @@ export class TabMainComponent {
   @Input() templates?: Form[];
   /** Saves if the layouts has been fetched */
   @Input() loadedLayouts = false;
-  /** Emits when complete layout list should be fetched */
+  /** Emits when complete layouts list should be fetched */
   @Output() loadLayouts = new EventEmitter<void>();
+  /** Saves if the aggregations has been fetched */
+  @Input() loadedAggregations = false;
+  /** Emits when complete aggregations list should be fetched */
+  @Output() loadAggregations = new EventEmitter<void>();
   /** Emits when the select template is opened for the first time */
   @Output() loadTemplates = new EventEmitter<void>();
   /** Saves if the templates has been fetched */

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.ts
@@ -18,6 +18,10 @@ export class TabMainComponent {
   @Input() resource: Resource | null = null;
   /** Available resource templates */
   @Input() templates?: Form[];
+  /** Saves if the layouts has been fetched */
+  @Input() loadedLayouts = false;
+  /** Emits when complete layout list should be fetched */
+  @Output() loadLayouts = new EventEmitter<void>();
   /** Emits when the select template is opened for the first time */
   @Output() loadTemplates = new EventEmitter<void>();
   /** Saves if the templates has been fetched */

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { Form } from '../../../../models/form.model';
 import { Resource } from '../../../../models/resource.model';
@@ -17,7 +17,11 @@ export class TabMainComponent {
   /** Selected resource */
   @Input() resource: Resource | null = null;
   /** Available resource templates */
-  @Input() templates: Form[] = [];
+  @Input() templates?: Form[];
+  /** Emits when the select template is opened for the first time */
+  @Output() loadTemplates = new EventEmitter<void>();
+  /** Saves if the templates has been fetched */
+  public loadedTemplates = false;
 
   /**
    * Reset given form field value if there is a value previously to avoid triggering
@@ -31,5 +35,15 @@ export class TabMainComponent {
       this.formGroup.get(formField)?.setValue(null);
     }
     event.stopPropagation();
+  }
+
+  /**
+   * On open select menu the first time, emits event to load resource templates query.
+   */
+  public onOpenSelectTemplates(): void {
+    if (!this.loadedTemplates) {
+      this.loadTemplates.emit();
+      this.loadedTemplates = true;
+    }
   }
 }

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.ts
@@ -6,7 +6,6 @@ import { Aggregation } from '../../../../../models/aggregation.model';
 import { Layout } from '../../../../../models/layout.model';
 import { UnsubscribeComponent } from '../../../../utils/unsubscribe/unsubscribe.component';
 import { AddLayoutModalComponent } from '../../../../grid-layout/add-layout-modal/add-layout-modal.component';
-import { get } from 'lodash';
 import { AddAggregationModalComponent } from '../../../../aggregation/add-aggregation-modal/add-aggregation-modal.component';
 import { EditLayoutModalComponent } from '../../../../grid-layout/edit-layout-modal/edit-layout-modal.component';
 import { GridLayoutService } from '../../../../../services/grid-layout/grid-layout.service';
@@ -101,9 +100,6 @@ export class LayerDatasourceComponent extends UnsubscribeComponent {
   selectAggregation(): void {
     const dialogRef = this.dialog.open(AddAggregationModalComponent, {
       data: {
-        hasAggregations:
-          get(this.resource, 'aggregations.totalCount', 0) > 0 ||
-          get(this.referenceData, 'aggregations.totalCount', 0) > 0,
         resource: this.resource,
         referenceData: this.referenceData,
       },

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.ts
@@ -84,7 +84,6 @@ export class LayerDatasourceComponent extends UnsubscribeComponent {
     const dialogRef = this.dialog.open(AddLayoutModalComponent, {
       data: {
         resource: this.resource,
-        hasLayouts: get(this.resource, 'layouts.totalCount', 0) > 0,
       },
     });
     dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value) => {

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
@@ -2,16 +2,24 @@ import { gql } from 'apollo-angular';
 
 /** Graphql request for getting resource by id */
 export const GET_RESOURCE = gql`
-  query GetResource($id: ID!, $layout: [ID], $aggregation: [ID]) {
+  query GetResource(
+    $id: ID!
+    $layout: [ID]
+    $ignoreLayouts: Boolean
+    $aggregation: [ID]
+    $ignoreAggregations: Boolean
+    $formId: ID
+    $ignoreForms: Boolean
+  ) {
     resource(id: $id) {
       id
       name
       queryName
-      forms {
+      forms(id: $formId, ignore: $ignoreForms) {
         id
         name
       }
-      layouts(ids: $layout) {
+      layouts(ids: $layout, ignore: $ignoreLayouts) {
         edges {
           node {
             id
@@ -23,7 +31,7 @@ export const GET_RESOURCE = gql`
         }
         totalCount
       }
-      aggregations(ids: $aggregation) {
+      aggregations(ids: $aggregation, ignore: $ignoreAggregations) {
         edges {
           node {
             id
@@ -50,6 +58,42 @@ export const GET_REFERENCE_DATA = gql`
       id
       name
       fields
+    }
+  }
+`;
+
+/** Graphql request for getting the related templates of a resource */
+export const GET_RESOURCE_TEMPLATES = gql`
+  query GetResource($resource: ID!) {
+    resource(id: $resource) {
+      forms {
+        id
+        name
+      }
+    }
+  }
+`;
+
+/** Graphql request for getting resource layouts by its id */
+export const GET_RESOURCE_LAYOUTS = gql`
+  query GetGridResourceMeta($resource: ID!) {
+    resource(id: $resource) {
+      layouts {
+        edges {
+          node {
+            id
+            name
+            query
+            createdAt
+            display
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        totalCount
+      }
     }
   }
 `;

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
@@ -10,6 +10,7 @@ export const GET_RESOURCE = gql`
     $ignoreAggregations: Boolean
     $formId: ID
     $ignoreForms: Boolean
+    $ignoreMetadata: Boolean
   ) {
     resource(id: $id) {
       id
@@ -43,7 +44,7 @@ export const GET_RESOURCE = gql`
         }
         totalCount
       }
-      metadata {
+      metadata(ignore: $ignoreMetadata) {
         name
         type
       }

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
@@ -97,3 +97,23 @@ export const GET_RESOURCE_LAYOUTS = gql`
     }
   }
 `;
+
+/** Graphql request for getting resource aggregations by its id */
+export const GET_RESOURCE_AGGREGATIONS = gql`
+  query GetResource($resource: ID!) {
+    resource(id: $resource) {
+      aggregations {
+        edges {
+          node {
+            id
+            name
+            sourceFields
+            pipeline
+            createdAt
+          }
+        }
+        totalCount
+      }
+    }
+  }
+`;

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
@@ -64,10 +64,15 @@
       <!-- TEMPLATE SELECTION -->
       <div uiFormFieldDirective class="flex-1" *ngIf="resource">
         <label>{{ 'models.form.template' | translate }}</label>
-        <ui-select-menu formControlName="template">
+        <ui-select-menu
+          formControlName="template"
+          (opened)="onOpenSelectTemplates()"
+          [loading]="!templates"
+          [filterable]="true"
+        >
           <ui-select-option>-</ui-select-option>
           <ui-select-option
-            *ngFor="let template of resource.forms || []"
+            *ngFor="let template of templates"
             [value]="template.id"
           >
             {{ template.name }}

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -23,7 +23,9 @@
           [aggregation]="aggregation"
           [templates]="templates"
           [loadedLayouts]="loadedLayouts"
+          [loadedAggregations]="loadedAggregations"
           (loadLayouts)="getLayouts()"
+          (loadAggregations)="getAggregations()"
           (loadTemplates)="getTemplates()"
         ></shared-summary-card-general>
       </ng-template>

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -21,6 +21,10 @@
           [resource]="resource"
           [layout]="layout"
           [aggregation]="aggregation"
+          [templates]="templates"
+          [loadedLayouts]="loadedLayouts"
+          (loadLayouts)="getLayouts()"
+          (loadTemplates)="getTemplates()"
         ></shared-summary-card-general>
       </ng-template>
     </ui-tab>

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -384,6 +384,7 @@ export class SummaryCardSettingsComponent
           ignoreAggregations: aggregationID ? false : true,
           formId,
           ignoreForms: formId ? false : true,
+          ignoreMetadata: layoutID ? false : true,
         },
       })
       .subscribe(({ data, errors }) => {

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -236,6 +236,7 @@ export class SummaryCardSettingsComponent
     if (this.customStyle) {
       this.customStyle.remove();
     }
+    super.ngOnDestroy();
   }
 
   /**

--- a/libs/shared/src/lib/models/resource.model.ts
+++ b/libs/shared/src/lib/models/resource.model.ts
@@ -13,6 +13,7 @@ export interface Resource {
   singleQueryName?: string;
   queryName?: string;
   forms?: Form[];
+  form?: Form;
   relatedForms?: Form[];
   createdAt?: Date;
   records?: Connection<Record>;

--- a/libs/shared/src/lib/models/resource.model.ts
+++ b/libs/shared/src/lib/models/resource.model.ts
@@ -13,7 +13,6 @@ export interface Resource {
   singleQueryName?: string;
   queryName?: string;
   forms?: Form[];
-  form?: Form;
   relatedForms?: Form[];
   createdAt?: Date;
   records?: Connection<Record>;

--- a/libs/shared/src/lib/services/grid-layout/graphql/queries.ts
+++ b/libs/shared/src/lib/services/grid-layout/graphql/queries.ts
@@ -17,11 +17,6 @@ export const GET_GRID_RESOURCE_META = gql`
         id
         name
       }
-      relatedForms {
-        id
-        name
-        fields
-      }
       layouts(first: $first, afterCursor: $afterCursor, ids: $ids) {
         edges {
           node {


### PR DESCRIPTION
# Description
refactor: grid widget **relatedForms** field in GetGridResourceMeta query (used to get the available resource templates for some of the action buttons). Now when opening the widget, the initial GetGridResourceMeta query doesn't get all the relatedForms data, only when opening one of the select menus in the action buttons that needs this data. The relatedForms data will only be re-fetched if the resource changes.

refactor: grid and summary card widget **layouts** and **aggregations** fields in GetGridResourceMeta query and layouts field of the GetResource query for the text widget.  If a widget uses a layout, fetching all the aggregations is useless, in the same way, if he uses aggregations and not layouts. So the new query args ignoreLayouts or ignoreAggregations is used so we don't always fetch the layout or aggregation full list, only when opening the add layout modal or the add aggregation modal, when the data is necessary. When creating new layouts or aggregations, the data is re-fetched, otherwise there's no need to always fetching the list when opening the select layout/aggregation modal, so the AddLayoutModalComponent and AddAggregationModalComponent were also refactored to work with a fixed data list using a common select menu instead of always using a graphql-seletc that re-fetch the data every time we open the modal.

refactor: summary card **metadata** field in GetGridResourceMeta query. This field is only used when the summary card widget uses a layout so we need the metadata info to build the fields, if the summary card doesn't have a layout (is using an aggregation, for example), fetch this data is useless.

refactor: grid and summary card widget **forms** field in GetGridResourceMeta query. Now the initial GetGridResourceMeta query only gets the template selected for the widget, if none is selected the forms field returns nothing instead of all the data. Only when opening the template select menu, all the resources templates are fetched.  The new query args ignoreForms is used to not fetch any form at all when the data is not necessary.

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83059
- Please insert link to back-end branch if any: https://github.com/ReliefApplications/ems-backend/pull/926

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Opening and editing the widgets, observing the query data and when the data is or not necessary to be fetched.

## Screenshots
Grid relatedForms field:
[grid-relatedForms.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/0493cf6c-b2dc-472a-8d54-519ef49725bc)

Grid forms field:
[grid-forms.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/a69e094c-4620-43b6-af14-092299b17837)

Grid layouts field:
[grid-layouts1.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/1ccfe2a6-a9a0-4ba7-8b12-c4e713d9f7f0)
[grid-layouts2.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/d408e316-20a5-4f16-9299-def528447ffb)

Summary cards  forms field:
[sm-forms.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/02200c10-5cd8-4f1c-92d5-620c638e6376)

Grid Aggregations fields:
[aggregations.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/dbfc8f21-ebc6-40de-b228-e517f23365b1)

Summary cards Aggregations fields:
[sm-aggreg.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/7a7c4fd3-48c1-4bfe-b795-6342f0e92e87)

Summary cards  metadata field:
[sm-metadata.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/cc302a76-6c89-463f-950b-546ed4f190fd)

Text layouts field:
[text-layouts.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/58cb45c5-db59-49f4-b35f-4c1e33d44923)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
