### PR TITLE
AB#82974 : Highlight aggregate card when selected

### DIFF
--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -138,6 +138,24 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
           this.setHtml();
         });
     }
+
+    this.contextService.filter$
+      .pipe(debounceTime(500), takeUntil(this.destroy$))
+      .subscribe((elt) => {
+        const htmlElement = document.createElement('div');
+        htmlElement.innerHTML = this.settings.text;
+
+        for (const [key, value] of Object.entries(elt)) {
+          const filteredFields = htmlElement.querySelectorAll(
+            '[data-filter-field="' +
+              key +
+              '"][data-filter-value="' +
+              value +
+              '"]'
+          );
+          console.log(filteredFields);
+        }
+      });
   }
 
   /**

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -124,6 +124,14 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     this.setHtml();
 
+    // Necessary because ViewChild is not initialized immediately
+    setTimeout(() => {
+      this.toggleActiveFilters(
+        this.contextService.filter.getValue(),
+        this.htmlContentComponent.el.nativeElement
+      );
+    }, 100);
+
     // Gather all context filters in a single text value
     const allContextFilters = this.aggregations
       .map((aggregation: any) => aggregation.contextFilters)
@@ -137,27 +145,31 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
           this.loading = true;
           this.setHtml();
         }
-        const toggleActiveFilters = (node: any) => {
-          if (get(node, 'dataset.filterField')) {
-            if (
-              isEqual(
-                get(node, 'dataset.filterValue'),
-                get(value, node.dataset.filterField)
-              )
-            ) {
-              node.dataset.filterActive = true;
-            } else {
-              node.dataset.filterActive = false;
-            }
-          }
-          for (let i = 0; i < node.childNodes.length; i++) {
-            const child = node.childNodes[i];
-            toggleActiveFilters(child);
-          }
-        };
-        toggleActiveFilters(this.htmlContentComponent.el.nativeElement);
+        this.toggleActiveFilters(
+          value,
+          this.htmlContentComponent?.el.nativeElement
+        );
       });
   }
+
+  private toggleActiveFilters = (value: any, node: any) => {
+    if (get(node, 'dataset.filterField')) {
+      if (
+        isEqual(
+          get(node, 'dataset.filterValue'),
+          get(value, node.dataset.filterField)
+        )
+      ) {
+        node.dataset.filterActive = true;
+      } else {
+        node.dataset.filterActive = false;
+      }
+    }
+    for (let i = 0; i < node.childNodes.length; i++) {
+      const child = node.childNodes[i];
+      this.toggleActiveFilters(value, child);
+    }
+  };
 
   /**
    * Set widget html.

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -152,13 +152,21 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
       });
   }
 
-  private toggleActiveFilters = (value: any, node: any) => {
+  /**
+   * Set the elements as active if matching dashboard filter
+   *
+   * @param filterValue value of the current dashboard filter
+   * @param node HTML element
+   */
+  private toggleActiveFilters = (filterValue: any, node: any) => {
     if (get(node, 'dataset.filterField')) {
       if (
         isEqual(
           get(node, 'dataset.filterValue'),
-          get(value, node.dataset.filterField)
-        )
+          get(filterValue, node.dataset.filterField)
+        ) ||
+        (get(node, 'dataset.filterValue') === '' &&
+          isNil(get(filterValue, node.dataset.filterField)))
       ) {
         node.dataset.filterActive = true;
       } else {
@@ -167,7 +175,7 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
     }
     for (let i = 0; i < node.childNodes.length; i++) {
       const child = node.childNodes[i];
-      this.toggleActiveFilters(value, child);
+      this.toggleActiveFilters(filterValue, child);
     }
   };
 

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -14,7 +14,7 @@ import {
   GET_LAYOUT,
   GET_RESOURCE_METADATA,
 } from '../summary-card/graphql/queries';
-import { clone, get, isNil, set } from 'lodash';
+import { clone, get, isEqual, isNil, set } from 'lodash';
 import { QueryBuilderService } from '../../../services/query-builder/query-builder.service';
 import { DataTemplateService } from '../../../services/data-template/data-template.service';
 import { Dialog } from '@angular/cdk/dialog';
@@ -138,23 +138,28 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
           this.setHtml();
         });
     }
-
     this.contextService.filter$
       .pipe(debounceTime(500), takeUntil(this.destroy$))
-      .subscribe((elt) => {
-        const htmlElement = document.createElement('div');
-        htmlElement.innerHTML = this.settings.text;
-
-        for (const [key, value] of Object.entries(elt)) {
-          const filteredFields = htmlElement.querySelectorAll(
-            '[data-filter-field="' +
-              key +
-              '"][data-filter-value="' +
-              value +
-              '"]'
-          );
-          console.log(filteredFields);
-        }
+      .subscribe((value) => {
+        const toggleActiveFilters = (node: any) => {
+          if (get(node, 'dataset.filterField')) {
+            if (
+              isEqual(
+                get(node, 'dataset.filterValue'),
+                get(value, node.dataset.filterField)
+              )
+            ) {
+              node.dataset.filterActive = true;
+            } else {
+              node.dataset.filterActive = false;
+            }
+          }
+          for (let i = 0; i < node.childNodes.length; i++) {
+            const child = node.childNodes[i];
+            toggleActiveFilters(child);
+          }
+        };
+        toggleActiveFilters(this.htmlContentComponent.el.nativeElement);
       });
   }
 

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -129,18 +129,14 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
       .map((aggregation: any) => aggregation.contextFilters)
       .join('');
     // Listen to dashboard filters changes if it is necessary
-    if (this.contextService.filterRegex.test(allContextFilters)) {
-      this.contextService.filter$
-        .pipe(debounceTime(500), takeUntil(this.destroy$))
-        .subscribe(() => {
-          this.refresh$.next(true);
-          this.loading = true;
-          this.setHtml();
-        });
-    }
     this.contextService.filter$
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe((value) => {
+        if (this.contextService.filterRegex.test(allContextFilters)) {
+          this.refresh$.next(true);
+          this.loading = true;
+          this.setHtml();
+        }
         const toggleActiveFilters = (node: any) => {
           if (get(node, 'dataset.filterField')) {
             if (


### PR DESCRIPTION
# Description

In text widget, sets html element as "active" when the filter/filter value they are linked to is chosen
For initialization, not pretty solution, I tried a lot of things (ngAfterViewInit, viewchildren instead of viewchild etc.) but could not make it work without a setTimeout

## Useful links

- Please insert link to ticket : https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82974

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested in back-office with configuration close to the one used by WHO

## Screenshots

![82974](https://github.com/ReliefApplications/ems-frontend/assets/103029022/f331e607-bfd4-4f19-b878-542ae7271f99)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
