### PR TITLE
Fix/ab#83183 default value not working with ref data

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -807,6 +807,10 @@
 			}
 		},
 		"formBuilder": {
+			"choicesTabAlert": {
+				"confirmationMessage": "The opening of this new tab will erase your current choices.\nAre you sure you want to continue and clear your configuration?",
+				"expandTab": "Tab change"
+			},
 			"errors": {
 				"duplicatedRelatedName": "Duplicated related name for question {{question}} on page {{page}}. Please provide a unique related name (snake case format) to save the form.",
 				"incorrectJSON": "JSON is invalid in JSON Editor, changes haven't been saved",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -818,6 +818,10 @@
 			}
 		},
 		"formBuilder": {
+			"choicesTabAlert": {
+				"confirmationMessage": "L'ouverture de ce nouvel onglet entraînera la suppression de vos choix actuels.\nVoulez-vous vraiment continuer et effacer votre configuration ?",
+				"expandTab": "Changement d'onglet"
+			},
 			"errors": {
 				"duplicatedRelatedName": "Nom lié en double pour la question {{question}} à la page {{page}}. Veuillez fournir un nom lié unique (au format snake_case) pour sauvegarder le formulaire.",
 				"incorrectJSON": "Le JSON est invalide dans le JSON Editor, les changements n'ont pas été sauvegardés",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -807,6 +807,10 @@
 			}
 		},
 		"formBuilder": {
+			"choicesTabAlert": {
+				"confirmationMessage": "******",
+				"expandTab": "******"
+			},
 			"errors": {
 				"duplicatedRelatedName": "****** {{question}} ****** {{page}} ******",
 				"incorrectJSON": "******",

--- a/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
@@ -234,6 +234,12 @@ export class FilterBuilderModalComponent
       }
     });
 
+    // Set content
+    const survey = new SurveyModel(
+      this.data?.surveyStructure || DEFAULT_STRUCTURE
+    );
+    this.surveyCreator.JSON = survey.toJSON();
+
     // add the rendering of custom properties
     this.surveyCreator.survey.onAfterRenderQuestion.add(
       renderGlobalProperties(this.referenceDataService) as any
@@ -244,12 +250,6 @@ export class FilterBuilderModalComponent
           renderGlobalProperties(this.referenceDataService)
         )
     );
-
-    // Set content
-    const survey = new SurveyModel(
-      this.data?.surveyStructure || DEFAULT_STRUCTURE
-    );
-    this.surveyCreator.JSON = survey.toJSON();
   }
 
   /**

--- a/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/filter-builder-modal/filter-builder-modal.component.ts
@@ -172,7 +172,7 @@ export class FilterBuilderModalComponent
   /** Survey creator instance */
   surveyCreator!: SurveyCreatorModel;
   /** Current expanded choices panel */
-  private expandedChoicesPanel: PanelModel | null = null;
+  private expandedChoicesPanel: PanelModel | undefined = undefined;
 
   /**
    * Dialog component to build the filter
@@ -291,7 +291,7 @@ export class FilterBuilderModalComponent
   private initChoicesPanels() {
     // expand a panel, collapse and clear the others
     const handleChoicesPanelExpansion = (
-      panelToExpand: any,
+      panelToExpand: PanelModel,
       panels: PanelModel[],
       question: Question
     ) => {
@@ -338,7 +338,8 @@ export class FilterBuilderModalComponent
           (panel) => panel.name === currentPanelName
         );
         // expand the corresponding panel
-        handleChoicesPanelExpansion(panelToExpand, choicesPanels, question);
+        this.expandedChoicesPanel = panelToExpand;
+        panelToExpand?.expand();
 
         // add an eventListener for each choices panel
         choicesPanels.forEach((panel: PanelModel) => {

--- a/libs/shared/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/shared/src/lib/components/form-builder/form-builder.component.ts
@@ -336,12 +336,19 @@ export class FormBuilderComponent
     );
 
     // open the correct choices panel (tab) and set eventListeners
-    this.initChoicesPanels();
+    // this.initChoicesPanels();
 
     this.surveyCreator.survey.locale = surveyLocalization.currentLocale; // -> set the defaultLanguage property also
 
     // add move up/down buttons
     this.addAdorners();
+
+    this.surveyCreator.onPropertyGridShowModal.add(
+      (sender: any, options: any) => {
+        options.obj.choices = options.obj.visibleChoices;
+        console.log(options);
+      }
+    );
   }
 
   /**

--- a/libs/shared/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/shared/src/lib/components/form-builder/form-builder.component.ts
@@ -134,7 +134,7 @@ export class FormBuilderComponent
   /** Timeout to survey creator */
   private timeoutListener!: NodeJS.Timeout;
   /** Current expanded choices panel */
-  private expandedChoicesPanel: PanelModel | null = null;
+  private expandedChoicesPanel: PanelModel | undefined = undefined;
 
   /**
    * The constructor function is a special function that is called when a new instance of the class is
@@ -350,7 +350,7 @@ export class FormBuilderComponent
   private initChoicesPanels() {
     // expand a panel, collapse and clear the others
     const handleChoicesPanelExpansion = (
-      panelToExpand: any,
+      panelToExpand: PanelModel,
       panels: PanelModel[],
       question: Question
     ) => {
@@ -397,7 +397,8 @@ export class FormBuilderComponent
           (panel) => panel.name === currentPanelName
         );
         // expand the corresponding panel
-        handleChoicesPanelExpansion(panelToExpand, choicesPanels, question);
+        this.expandedChoicesPanel = panelToExpand;
+        panelToExpand?.expand();
 
         // add an eventListener for each choices panel
         choicesPanels.forEach((panel: PanelModel) => {

--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -242,10 +242,8 @@ export const render = (
             filter
           )
           .then((choices) => {
-            question.choices = [];
-            // this is to avoid that the choices appear on the 'choices' tab
             question.setPropertyValue(
-              'visibleChoices',
+              'choices',
               choices.map((choice) => new ItemValue(choice))
             );
             // manually set the selected option (not done by default)

--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -242,8 +242,9 @@ export const render = (
             filter
           )
           .then((choices) => {
+            question.choices = [];
             question.setPropertyValue(
-              'choices',
+              'visibleChoices',
               choices.map((choice) => new ItemValue(choice))
             );
             // manually set the selected option (not done by default)


### PR DESCRIPTION
# Description

When using reference data for a question, the default value popup was not working correctly. The data was being stored in `.visibleChoices` instead of `.choices` to prevent the loaded data from appearing in the choices tab. Unfortunately, the default value pop up is based on `.choices` and as a result, nothing was displayed. It is a surveyjs feature and it cannot be replaced.

While there are no issues if reference data choices appear in the choices tab, it may not be very intuitive. We looked for a solution with Matthis. Here are the results:
- Allow only one "choices" tab expansion at a time
- By default, the current one will be opened and won't be closable
- When clicking on other "choices" tab, previous values will be cleared
- A confirmation pop-up will inform the user of this behavior

SurveyCreator and PanelModel don't have an event that listens for expanding or collapsing tabs, so I used `PanelModel.onPropertyChanged`. Since I couldn't listen before expanding a tab, I had to collapse it again. This approach may seem less than ideal, but I haven't found a better solution.

I moved the `new SurveyModel` of the filter-builder-modal above the `renderGlobalProperties()` because reference data weren't loaded.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83183/)
- [PanelModel.onPropertyChanged](https://surveyjs.io/form-library/documentation/api-reference/panel-model#onPropertyChanged)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Bug fix: I created a form with questions linked to reference data and checked if the default value modal was loading correctly.
New feature: I created a form with a dropdown question and switched between choices tabs to control the behavior.

## Screenshots

Bug fix

![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/0047bdd4-b5d9-4b4c-85b6-9abf988c9dbc)

New feature

![peek2](https://github.com/ReliefApplications/ems-frontend/assets/65243509/bb485f81-63ee-4316-8753-1d12db3e2fa5)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
