### PR TITLE
AB#83184 - Reference data not appearing in form builder.

### DIFF
--- a/libs/shared/src/lib/survey/components/reference-data-dropdown/reference-data-dropdown.component.ts
+++ b/libs/shared/src/lib/survey/components/reference-data-dropdown/reference-data-dropdown.component.ts
@@ -73,6 +73,7 @@ export class ReferenceDataDropdownComponent
           this.control.setValue(this.model.obj.referenceData, {
             emitEvent: false,
           });
+          this.changeDetectorRef.detectChanges();
         });
     }
   }


### PR DESCRIPTION
# Description

To fix the problem, I update the component when the referencedata search query ends.

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83184)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] A reference data was added to questionnaires and the screen behavior was observed.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/55603259/e47b91d6-e59a-4390-8187-58285b2c3547

# Checklist:




( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
