### PR TITLE
feat/AB#83067_paginated-refData

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
@@ -710,7 +710,7 @@ export class DashboardComponent
     if ('refData' in context) {
       this.refDataService.loadReferenceData(context.refData).then((refData) => {
         this.refDataValueField = refData.valueField || '';
-        this.refDataService.fetchItems(refData).then((items) => {
+        this.refDataService.fetchItems(refData).then(({ items }) => {
           this.refDataElements = items;
         });
       });

--- a/apps/back-office/src/app/dashboard/pages/reference-data/graphql/mutations.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/graphql/mutations.ts
@@ -15,6 +15,7 @@ export const EDIT_REFERENCE_DATA = gql`
     $data: JSON
     $graphQLFilter: String
     $permissions: JSON
+    $pageInfo: PageInfoInput
   ) {
     editReferenceData(
       id: $id
@@ -28,6 +29,7 @@ export const EDIT_REFERENCE_DATA = gql`
       data: $data
       graphQLFilter: $graphQLFilter
       permissions: $permissions
+      pageInfo: $pageInfo
     ) {
       id
       name
@@ -54,6 +56,15 @@ export const EDIT_REFERENCE_DATA = gql`
           id
           title
         }
+      }
+      pageInfo {
+        strategy
+        cursorField
+        cursorVar
+        offsetVar
+        pageVar
+        pageSizeVar
+        totalCountField
       }
       canSee
       canUpdate

--- a/apps/back-office/src/app/dashboard/pages/reference-data/graphql/queries.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/graphql/queries.ts
@@ -32,6 +32,15 @@ export const GET_REFERENCE_DATA = gql`
           title
         }
       }
+      pageInfo {
+        strategy
+        cursorField
+        cursorVar
+        offsetVar
+        pageVar
+        pageSizeVar
+        totalCountField
+      }
       canSee
       canUpdate
       canDelete

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
@@ -79,7 +79,7 @@
       <!-- Boolean for use pagination -->
       <ui-toggle
         formControlName="usePagination"
-        *ngIf="type !== 'static'"
+        *ngIf="type === 'graphql'"
         class="mb-4"
       >
         <ng-container ngProjectAs="label">

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
@@ -99,7 +99,7 @@
       <div
         class="flex flex-col gap-2"
         *ngIf="referenceForm.get('usePagination')?.value === true"
-        formGroupName="paginationInfo"
+        formGroupName="pageInfo"
       >
         <div class="flex flex-row gap-2">
           <!-- Dropdown with the list of pagination strategies -->
@@ -121,9 +121,7 @@
           <div
             uiFormFieldDirective
             class="grow"
-            *ngIf="
-              referenceForm.get('paginationInfo.strategy')?.value === 'cursor'
-            "
+            *ngIf="referenceForm.get('pageInfo.strategy')?.value === 'cursor'"
           >
             <label>{{
               'pages.referenceData.pagination.cursorPath' | translate
@@ -146,9 +144,7 @@
           <div
             uiFormFieldDirective
             class="grow"
-            *ngIf="
-              referenceForm.get('paginationInfo.strategy')?.value === 'cursor'
-            "
+            *ngIf="referenceForm.get('pageInfo.strategy')?.value === 'cursor'"
           >
             <label>
               {{ 'pages.referenceData.pagination.cursorVariable' | translate }}
@@ -167,9 +163,7 @@
           <div
             uiFormFieldDirective
             class="grow"
-            *ngIf="
-              referenceForm.get('paginationInfo.strategy')?.value === 'offset'
-            "
+            *ngIf="referenceForm.get('pageInfo.strategy')?.value === 'offset'"
           >
             <label>
               {{ 'pages.referenceData.pagination.offsetVariable' | translate }}
@@ -188,9 +182,7 @@
           <div
             uiFormFieldDirective
             class="grow"
-            *ngIf="
-              referenceForm.get('paginationInfo.strategy')?.value === 'page'
-            "
+            *ngIf="referenceForm.get('pageInfo.strategy')?.value === 'page'"
           >
             <label>
               {{ 'pages.referenceData.pagination.pageVariable' | translate }}

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
@@ -76,6 +76,173 @@
           </div>
         </ng-template>
       </div>
+      <!-- Boolean for use pagination -->
+      <ui-toggle
+        formControlName="usePagination"
+        *ngIf="type !== 'static'"
+        class="mb-4"
+      >
+        <ng-container ngProjectAs="label">
+          {{ 'pages.referenceData.pagination.usePagination.text' | translate }}
+          <ui-icon
+            class="ml-1 cursor-help self-center"
+            variant="grey"
+            [size]="18"
+            icon="info_outline"
+            [uiTooltip]="
+              'pages.referenceData.pagination.usePagination.hint' | translate
+            "
+          ></ui-icon
+        ></ng-container>
+      </ui-toggle>
+      <!-- Further pagination configuration -->
+      <div
+        class="flex flex-col gap-2"
+        *ngIf="referenceForm.get('usePagination')?.value === true"
+        formGroupName="paginationInfo"
+      >
+        <div class="flex flex-row gap-2">
+          <!-- Dropdown with the list of pagination strategies -->
+          <div uiFormFieldDirective class="grow">
+            <label>
+              {{ 'pages.referenceData.pagination.strategy' | translate }}
+            </label>
+            <ui-select-menu formControlName="strategy">
+              <ui-select-option
+                *ngFor="let strategy of paginationStrategies"
+                [value]="strategy"
+              >
+                {{ strategy }}
+              </ui-select-option>
+            </ui-select-menu>
+          </div>
+
+          <!-- If the pagination strategy is "cursor", show the path to the cursor question -->
+          <div
+            uiFormFieldDirective
+            class="grow"
+            *ngIf="
+              referenceForm.get('paginationInfo.strategy')?.value === 'cursor'
+            "
+          >
+            <label>{{
+              'pages.referenceData.pagination.cursorPath' | translate
+            }}</label>
+            <input
+              formControlName="cursorField"
+              type="text"
+              [placeholder]="'pages.referenceData.path.placeholder' | translate"
+            />
+            <ui-icon
+              icon="info_outline"
+              class="cursor-pointer"
+              variant="grey"
+              uiSuffix
+              [uiTooltip]="'pages.referenceData.tooltip.path' | translate"
+            ></ui-icon>
+          </div>
+
+          <!-- If the pagination strategy is "cursor", show the cursor variable mapping dropdown -->
+          <div
+            uiFormFieldDirective
+            class="grow"
+            *ngIf="
+              referenceForm.get('paginationInfo.strategy')?.value === 'cursor'
+            "
+          >
+            <label>
+              {{ 'pages.referenceData.pagination.cursorVariable' | translate }}
+            </label>
+            <ui-select-menu formControlName="cursorVar">
+              <ui-select-option
+                *ngFor="let variable of queryVariables"
+                [value]="variable"
+              >
+                {{ variable }}
+              </ui-select-option>
+            </ui-select-menu>
+          </div>
+
+          <!-- If the pagination strategy is "offset", show the offset variable mapping dropdown -->
+          <div
+            uiFormFieldDirective
+            class="grow"
+            *ngIf="
+              referenceForm.get('paginationInfo.strategy')?.value === 'offset'
+            "
+          >
+            <label>
+              {{ 'pages.referenceData.pagination.offsetVariable' | translate }}
+            </label>
+            <ui-select-menu formControlName="offsetVar">
+              <ui-select-option
+                *ngFor="let variable of queryVariables"
+                [value]="variable"
+              >
+                {{ variable }}
+              </ui-select-option>
+            </ui-select-menu>
+          </div>
+
+          <!-- If the pagination strategy is "page", show the page variable mapping dropdown -->
+          <div
+            uiFormFieldDirective
+            class="grow"
+            *ngIf="
+              referenceForm.get('paginationInfo.strategy')?.value === 'page'
+            "
+          >
+            <label>
+              {{ 'pages.referenceData.pagination.pageVariable' | translate }}
+            </label>
+            <ui-select-menu formControlName="pageVar">
+              <ui-select-option
+                *ngFor="let variable of queryVariables"
+                [value]="variable"
+              >
+                {{ variable }}
+              </ui-select-option>
+            </ui-select-menu>
+          </div>
+        </div>
+        <div class="flex flex-row gap-2">
+          <!-- Page size variable mapping dropdown -->
+          <div uiFormFieldDirective class="grow">
+            <label>
+              {{
+                'pages.referenceData.pagination.pageSizeVariable' | translate
+              }}
+            </label>
+            <ui-select-menu formControlName="pageSizeVar">
+              <ui-select-option
+                *ngFor="let variable of queryVariables"
+                [value]="variable"
+              >
+                {{ variable }}
+              </ui-select-option>
+            </ui-select-menu>
+          </div>
+
+          <!-- Input for the total count path -->
+          <div uiFormFieldDirective class="grow">
+            <label>{{
+              'pages.referenceData.pagination.totalCountPath' | translate
+            }}</label>
+            <input
+              formControlName="totalCountField"
+              type="text"
+              [placeholder]="'pages.referenceData.path.placeholder' | translate"
+            />
+            <ui-icon
+              icon="info_outline"
+              class="cursor-pointer"
+              variant="grey"
+              uiSuffix
+              [uiTooltip]="'pages.referenceData.tooltip.path' | translate"
+            ></ui-icon>
+          </div>
+        </div>
+      </div>
       <div class="flex gap-x-2">
         <!-- Path -->
         <div
@@ -83,11 +250,11 @@
           uiFormFieldDirective
           *ngIf="['rest', 'graphql'].includes(type)"
         >
-          <label>{{ 'pages.referenceData.path' | translate }}</label>
+          <label>{{ 'pages.referenceData.path.title' | translate }}</label>
           <input
             formControlName="path"
             type="text"
-            [placeholder]="'common.placeholder.name' | translate"
+            [placeholder]="'pages.referenceData.path.placeholder' | translate"
           />
           <ui-icon
             icon="info_outline"
@@ -100,6 +267,7 @@
         <!-- Value field to be displayed -->
         <ng-container *ngTemplateOutlet="valueFieldTmpl"></ng-container>
       </div>
+
       <ui-alert class="mb-4">{{
         'pages.referenceData.fields.help' | translate
       }}</ui-alert>
@@ -229,25 +397,9 @@
       <!-- Value field to be displayed -->
       <ng-container *ngTemplateOutlet="valueFieldTmpl"></ng-container>
     </div>
+
     <ui-spinner *ngIf="csvLoading"></ui-spinner>
-    <!-- For graphql -->
-    <!-- <div uiFormFieldDirective *ngIf="type === 'graphql'">
-      <label>{{ 'pages.referenceData.graphQLFilter' | translate }} </label>
-      <input
-        formControlName="graphQLFilter"
-        type="text"
-        [placeholder]="
-          'pages.referenceData.placeholder.graphQLFilter' | translate
-        "
-      />
-      <ui-icon
-        icon="info_outline"
-        class="cursor-pointer"
-        variant="grey"
-        uiSuffix
-        [uiTooltip]="'pages.referenceData.tooltip.graphQLFilter' | translate"
-      ></ui-icon>
-    </div> -->
+
     <!-- Kendo grid to preview data on static type -->
     <div *ngIf="!csvLoading && csvValue && type === 'static'">
       <kendo-grid [data]="newData">

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.ts
@@ -68,33 +68,30 @@ export class ReferenceDataComponent
   extends UnsubscribeComponent
   implements OnInit, OnDestroy
 {
-  // === DATA ===
-  /**
-   * Loading state
-   */
+  /** Reference to the field input.*/
+  @ViewChild('fieldInput') fieldInput?: ElementRef<HTMLInputElement>;
+  /** Reference to the csv data input. */
+  @ViewChild('csvData') csvData?: TextareaComponent;
+  /** Reference to the kendo grid. */
+  @ViewChild(GridComponent) kendoGrid!: GridComponent;
+  /** Loading state */
   public loading = true;
   /** Reference data id */
   public id = '';
   /** Reference data */
   public referenceData?: ReferenceData;
-
-  // === FORM ===
   /** Reference data form */
   public referenceForm!: ReturnType<typeof this.getRefDataForm>;
   /** Reference data types */
   public referenceTypeChoices = Object.values(referenceDataType);
   /** Pagination methods */
   public paginationStrategies = Object.values(paginationStrategy);
-
-  // === API ===
   /** Selected API configuration */
   public selectedApiConfiguration?: ApiConfiguration;
   /** Api configurations query */
   public apiConfigurationsQuery!: QueryRef<ApiConfigurationsQueryResponse>;
   /** List of query variables */
   public queryVariables: string[] = [];
-
-  // === FIELDS ===
   /** Value fields */
   public valueFields: NonNullable<ReferenceData['fields']> = [];
   /** Payload */
@@ -126,34 +123,19 @@ export class ReferenceDataComponent
   public csvLoading = false;
   /** CSV separator */
   public separator = new FormControl(',');
+  /** Editor options */
+  public editorOptions = {
+    theme: 'vs-dark',
+    language: 'graphql',
+    formatOnPaste: true,
+    fixedOverflowWidgets: true,
+  };
   /** Timeout to form */
   private formTimeoutListener!: NodeJS.Timeout;
   /** Timeout to init editor */
   private initEditorTimeoutListener!: NodeJS.Timeout;
   /** Timeout to add an object to the chip list. */
   private addChipListTimeoutListener!: NodeJS.Timeout;
-
-  /**
-   * Reference to the field input.
-   */
-  @ViewChild('fieldInput') fieldInput?: ElementRef<HTMLInputElement>;
-  /**
-   * Reference to the csv data input.
-   */
-  @ViewChild('csvData') csvData?: TextareaComponent;
-  /**
-   * Reference to the kendo grid.
-   */
-  @ViewChild(GridComponent) kendoGrid!: GridComponent;
-
-  // === MONACO EDITOR ===
-  /** Editor options */
-  public editorOptions = {
-    theme: 'vs-dark',
-    language: 'graphql',
-    formatOnPaste: true,
-  };
-
   /** Outside click listener for inline edition */
   private inlineEditionOutsideClickListener!: any;
 
@@ -266,6 +248,7 @@ export class ReferenceDataComponent
     };
 
     const handleQueryChange = (queryStr: string, resetFields = true) => {
+      console.log('ici');
       // Clear the fields
       if (resetFields) {
         clearFields();
@@ -274,6 +257,7 @@ export class ReferenceDataComponent
       // Update the query variables
       try {
         const query = gql(queryStr ?? '');
+        console.log(query);
         query.definitions.forEach((definition) => {
           if (definition.kind === 'OperationDefinition') {
             this.queryVariables = (definition.variableDefinitions ?? []).map(
@@ -281,39 +265,6 @@ export class ReferenceDataComponent
             );
           }
         });
-
-        // Try to guess the page size variable
-        const pageSizeVar = this.queryVariables.find((x) =>
-          ['pageSize', 'take', 'size'].includes(x)
-        );
-
-        if (pageSizeVar) {
-          controls.pageSizeVar.setValue(pageSizeVar);
-        } else {
-          controls.pageSizeVar.setValue(null);
-        }
-
-        // Try to guess strategy and other pagination variables
-        const offsetVar = this.queryVariables.find((x) =>
-          ['first', 'offset', 'skip'].includes(x)
-        );
-        const pageVar = this.queryVariables.find((x) =>
-          ['page', 'pageNumber'].includes(x)
-        );
-        const cursorVar = this.queryVariables.find((x) =>
-          ['cursor', 'afterCursor'].includes(x)
-        );
-
-        if (offsetVar) {
-          controls.strategy.setValue('offset' as paginationStrategy);
-          controls.offsetVar.setValue(offsetVar);
-        } else if (pageVar) {
-          controls.strategy.setValue('page' as paginationStrategy);
-          controls.pageVar.setValue(pageVar);
-        } else if (cursorVar) {
-          controls.strategy.setValue('cursor' as paginationStrategy);
-          controls.cursorVar.setValue(cursorVar);
-        }
       } catch {
         this.queryVariables = [];
         controls.pageSizeVar.setValue(null);

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.ts
@@ -248,7 +248,6 @@ export class ReferenceDataComponent
     };
 
     const handleQueryChange = (queryStr: string, resetFields = true) => {
-      console.log('ici');
       // Clear the fields
       if (resetFields) {
         clearFields();
@@ -257,7 +256,6 @@ export class ReferenceDataComponent
       // Update the query variables
       try {
         const query = gql(queryStr ?? '');
-        console.log(query);
         query.definitions.forEach((definition) => {
           if (definition.kind === 'OperationDefinition') {
             this.queryVariables = (definition.variableDefinitions ?? []).map(

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.ts
@@ -240,7 +240,6 @@ export class ReferenceDataComponent
       controls.offsetVar.optional();
       controls.pageVar.optional();
       controls.pageSizeVar.optional();
-      controls.totalCountField.optional();
 
       const usePagination = !!form.get('usePagination')?.value;
       if (!usePagination) {
@@ -249,7 +248,6 @@ export class ReferenceDataComponent
       }
 
       // Set common validator to all pagination strategies
-      controls.totalCountField.require();
       controls.strategy.require();
 
       // Set specific validators to each pagination strategy

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.ts
@@ -85,8 +85,6 @@ export class ReferenceDataComponent
   public referenceTypeChoices = Object.values(referenceDataType);
   /** Pagination methods */
   public paginationStrategies = Object.values(paginationStrategy);
-  /** Currently selected strategy */
-  private currStrategy?: paginationStrategy | null = null;
 
   // === API ===
   /** Selected API configuration */
@@ -237,7 +235,6 @@ export class ReferenceDataComponent
     /** Updates the requirement of the cursor field field */
     const setPaginationValidators = () => {
       // All optional by default
-      controls.strategy.optional();
       controls.cursorVar.optional();
       controls.cursorField.optional();
       controls.offsetVar.optional();
@@ -247,6 +244,7 @@ export class ReferenceDataComponent
 
       const usePagination = !!form.get('usePagination')?.value;
       if (!usePagination) {
+        controls.strategy.optional();
         return;
       }
 
@@ -379,12 +377,8 @@ export class ReferenceDataComponent
       form
         .get('pageInfo.strategy')
         ?.valueChanges.pipe(takeUntil(this.destroy$))
-        .subscribe((val) => {
-          const strategy = (val as typeof this.currStrategy) ?? null;
-          if (strategy !== this.currStrategy) {
-            this.currStrategy = strategy;
-            setPaginationValidators();
-          }
+        .subscribe(() => {
+          setPaginationValidators();
         });
 
       form

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.form.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.form.ts
@@ -1,0 +1,143 @@
+import { get } from 'lodash';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import {
+  ReferenceData,
+  paginationStrategy,
+  referenceDataType,
+} from '@oort-front/shared';
+
+/**
+ * Creates a ReferenceData form from a ReferenceData, if available
+ *
+ * @param refData Reference data to create the form from
+ * @returns ReferenceData form
+ */
+export const createRefDataForm = (refData?: ReferenceData) => {
+  const strategy = get(refData, 'pageInfo.strategy') as paginationStrategy;
+
+  // Create the form group
+  const form = new FormGroup({
+    name: new FormControl(get(refData, 'name', ''), Validators.required),
+    type: new FormControl(
+      get(refData, 'type', 'static' as referenceDataType),
+      Validators.required
+    ),
+    valueField: new FormControl(
+      get(refData, 'valueField'),
+      Validators.required
+    ),
+    fields: new FormControl(get(refData, 'fields', []), Validators.required),
+    apiConfiguration: new FormControl(get(refData, 'apiConfiguration.id')),
+    query: new FormControl(get(refData, 'query')),
+    path: new FormControl(get(refData, 'path')),
+    data: new FormControl(get(refData, 'data')),
+    usePagination: new FormControl(!!get(refData, 'pageInfo.strategy')),
+    pageInfo: new FormGroup({
+      strategy: new FormControl(get(refData, 'pageInfo.strategy')),
+      totalCountField: new FormControl(
+        get(refData, 'pageInfo.totalCountField')
+      ),
+      pageSizeVar: new FormControl(get(refData, 'pageInfo.pageSizeVar')),
+      cursorVar: new FormControl(
+        strategy === 'cursor' ? get(refData, 'pageInfo.cursorVar') || '' : null
+      ),
+      cursorField: new FormControl(
+        strategy === 'cursor'
+          ? get(refData, 'pageInfo.cursorField') || ''
+          : null
+      ),
+      offsetVar: new FormControl(
+        strategy === 'offset' ? get(refData, 'pageInfo.offsetVar') || '' : null
+      ),
+      pageVar: new FormControl(
+        strategy === 'page' ? get(refData, 'pageInfo.pageVar') || '' : null
+      ),
+    }),
+  });
+
+  // Form control for the pagination fields
+  const controls: any = {
+    strategy: {
+      getValue: () => form.get('pageInfo.strategy')?.value,
+      setValue: (value: paginationStrategy | null) => {
+        form.get('pageInfo.strategy')?.setValue(value);
+      },
+    },
+    offsetVar: {
+      getValue: () => form.get('pageInfo.offsetVar')?.value,
+      setValue: (value: string | null) => {
+        form.get('pageInfo.offsetVar')?.setValue(value);
+      },
+    },
+    cursorVar: {
+      getValue: () => form.get('pageInfo.cursorVar')?.value,
+      setValue: (value: string | null) => {
+        form.get('pageInfo.cursorVar')?.setValue(value);
+      },
+    },
+    cursorField: {
+      getValue: () => form.get('pageInfo.cursorField')?.value,
+      setValue: (value: string | null) => {
+        form.get('pageInfo.cursorField')?.setValue(value);
+      },
+    },
+    pageVar: {
+      getValue: () => form.get('pageInfo.pageVar')?.value,
+      setValue: (value: string | null) => {
+        form.get('pageInfo.pageVar')?.setValue(value);
+      },
+    },
+    pageSizeVar: {
+      getValue: () => form.get('pageInfo.pageSizeVar')?.value,
+      setValue: (value: string | null) => {
+        form.get('pageInfo.pageSizeVar')?.setValue(value);
+      },
+    },
+    totalCountField: {
+      getValue: () => form.get('pageInfo.totalCountField')?.value,
+      setValue: (value: string | null) => {
+        form.get('pageInfo.totalCountField')?.setValue(value);
+      },
+    },
+  };
+
+  Object.keys(controls).forEach((key) => {
+    // Add required validator
+    controls[key].require = () => {
+      // Get the corresponding control
+      const control = form.get(`pageInfo.${key}`);
+      if (!control) {
+        return;
+      }
+
+      // If already required, no need to add the validator
+      const isRequired = control.hasValidator(Validators.required);
+      if (isRequired) {
+        return;
+      }
+
+      control.addValidators(Validators.required);
+      control.updateValueAndValidity();
+    };
+
+    // Remove required validator
+    controls[key].optional = () => {
+      // Get the corresponding control
+      const control = form.get(`pageInfo.${key}`);
+      if (!control) {
+        return;
+      }
+
+      // If already optional, no need to remove the validator
+      const isOptional = !control.hasValidator(Validators.required);
+      if (isOptional) {
+        return;
+      }
+
+      control.removeValidators([Validators.required]);
+      control.updateValueAndValidity();
+    };
+  });
+
+  return { form, controls };
+};

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.module.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.module.ts
@@ -8,6 +8,7 @@ import {
   GraphQLSelectModule,
   IconModule,
   SpinnerModule,
+  ToggleModule,
 } from '@oort-front/ui';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -54,6 +55,7 @@ import { DropDownsModule } from '@progress/kendo-angular-dropdowns';
     AlertModule,
     InputsModule,
     DropDownsModule,
+    ToggleModule,
   ],
 })
 export class ReferenceDataModule {}

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1787,6 +1787,11 @@
 					"card": {
 						"dataSource": {
 							"layoutStyles": {
+								"queryFilters": {
+									"noVariables": "No variables defined",
+									"title": "GraphQL variable mapping",
+									"tooltip": "Set values for the GraphQL variables defined in the reference data query. You can get values from the filters using the {{filter.<question-name>}} templates. E.g.: { \"region\": {{filter.region}} }"
+								},
 								"title": "Layout styles",
 								"use": "Use layout styles",
 								"wholeRow": {

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -2430,7 +2430,23 @@
 				"title": "Field"
 			},
 			"graphQLFilter": "GraphQL query parameters",
-			"path": "Path",
+			"pagination": {
+				"cursorPath": "Cursor path",
+				"cursorVariable": "Cursor query variable",
+				"offsetVariable": "Offset query variable",
+				"pageSizeVariable": "Page size query variable",
+				"pageVariable": "Page number query variable",
+				"strategy": "Pagination strategy",
+				"totalCountPath": "Total items count path",
+				"usePagination": {
+					"hint": "Depends on API support, allows fetching data by page",
+					"text": "Use pagination"
+				}
+			},
+			"path": {
+				"placeholder": "Enter a valid JSONPath",
+				"title": "Data path"
+			},
 			"payload": {
 				"label": "Payload",
 				"show": "Show payload"

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -2444,7 +2444,23 @@
 				"title": "Champ"
 			},
 			"graphQLFilter": "Paramètres de la requête GraphQL",
-			"path": "Chemin",
+			"pagination": {
+				"cursorPath": "Chemin du curseur",
+				"cursorVariable": "Variable de requête de curseur",
+				"offsetVariable": "Variable de requête de décalage",
+				"pageSizeVariable": "Variable de requête de taille de page",
+				"pageVariable": "Variable de requête de numéro de page",
+				"strategy": "Stratégie de pagination",
+				"totalCountPath": "Chemin du nombre total d'articles",
+				"usePagination": {
+					"hint": "Dépend de la prise en charge de l'API, permet de récupérer des données par page",
+					"text": "Utiliser la pagination"
+				}
+			},
+			"path": {
+				"placeholder": "Entrez un JSONPath valide",
+				"title": "Chemin de données"
+			},
 			"payload": {
 				"label": "Réponse de l'API",
 				"show": "Afficher la réponse de l'API"

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1800,6 +1800,11 @@
 					"card": {
 						"dataSource": {
 							"layoutStyles": {
+								"queryFilters": {
+									"noVariables": "Aucune variable définie",
+									"title": "Mappage de variables GraphQL",
+									"tooltip": "Définissez les valeurs des variables GraphQL définies dans la requête de données de référence. Vous pouvez obtenir les valeurs des filtres à l'aide des modèles {{filter.<question-name>}}. Par exemple : { \"region\": {{filter.region}} }"
+								},
 								"title": "Styles de mise en page",
 								"use": "Utiliser les styles de mise en page",
 								"wholeRow": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -2430,7 +2430,23 @@
 				"title": "******"
 			},
 			"graphQLFilter": "******",
-			"path": "******",
+			"pagination": {
+				"cursorPath": "******",
+				"cursorVariable": "******",
+				"offsetVariable": "******",
+				"pageSizeVariable": "******",
+				"pageVariable": "******",
+				"strategy": "******",
+				"totalCountPath": "******",
+				"usePagination": {
+					"hint": "******",
+					"text": "******"
+				}
+			},
+			"path": {
+				"placeholder": "******",
+				"title": "******"
+			},
 			"payload": {
 				"label": "******",
 				"show": "******"

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1787,6 +1787,11 @@
 					"card": {
 						"dataSource": {
 							"layoutStyles": {
+								"queryFilters": {
+									"noVariables": "******",
+									"title": "******",
+									"tooltip": "****** {{filter.<question-name>}} ****** { ****** {{filter.region}} ****** }"
+								},
 								"title": "******",
 								"use": "******",
 								"wholeRow": {

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
@@ -1,0 +1,30 @@
+<span class="flex gap-2 mb-4 items-center">
+  <h3 class="mb-0">
+    {{
+      'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.title'
+        | translate
+    }}
+  </h3>
+  <ui-icon
+    icon="info_outline"
+    variant="grey"
+    [size]="18"
+    class="cursor-help"
+    [uiTooltip]="
+      'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.tooltip'
+        | translate
+    "
+  ></ui-icon>
+</span>
+<ngx-monaco-editor
+  *ngIf="availableQueryVariables.length > 0"
+  [formControl]="control"
+  [options]="editorOptions"
+></ngx-monaco-editor>
+<shared-empty
+  *ngIf="availableQueryVariables.length === 0"
+  [title]="
+    'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.noVariables'
+      | translate
+  "
+></shared-empty>

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.spec.ts
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GraphqlVariablesMappingComponent } from './graphql-variables-mapping.component';
+
+describe('GraphqlVariablesMappingComponent', () => {
+  let component: GraphqlVariablesMappingComponent;
+  let fixture: ComponentFixture<GraphqlVariablesMappingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GraphqlVariablesMappingComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GraphqlVariablesMappingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
@@ -72,10 +72,6 @@ export class GraphqlVariablesMappingComponent implements OnChanges {
         (v) => ![cursorVar, offsetVar, pageVar, pageSizeVar].includes(v)
       );
 
-      console.log(availableVariables);
-
-      console.log(this.control);
-
       // Checks if the variable mapping is null or empty.
       if (!this.control.value) {
         // If so, generate a template with the variables being keys of a json object.

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
@@ -1,0 +1,97 @@
+import { Component, Input, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import { IconModule, TooltipModule } from '@oort-front/ui';
+import { EmptyModule } from '../../../ui/empty/empty.module';
+import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
+import { ReferenceData } from '../../../../models/reference-data.model';
+import { gql } from '@apollo/client';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+/**
+ * Graphql variables mapping, for widgets using graphql reference data.
+ */
+@Component({
+  selector: 'shared-graphql-variables-mapping',
+  standalone: true,
+  imports: [
+    CommonModule,
+    TranslateModule,
+    IconModule,
+    TooltipModule,
+    EmptyModule,
+    MonacoEditorModule,
+    FormsModule,
+    ReactiveFormsModule,
+  ],
+  templateUrl: './graphql-variables-mapping.component.html',
+  styleUrls: ['./graphql-variables-mapping.component.scss'],
+})
+export class GraphqlVariablesMappingComponent implements OnChanges {
+  /** Reference data */
+  @Input() referenceData!: ReferenceData;
+  /** Form control storing variables mapping */
+  @Input() control!: FormControl;
+  /** List of available variables to inject data */
+  public availableQueryVariables: string[] = [];
+  /** Monaco editor configuration, for raw edition */
+  public editorOptions = {
+    theme: 'vs-dark',
+    language: 'json',
+    fixedOverflowWidgets: true,
+  };
+
+  ngOnChanges(): void {
+    this.setAvailableQueryVariables();
+  }
+
+  /** Parses que refData query and gets the available variable names, excluding the pagination ones */
+  private setAvailableQueryVariables(): void {
+    if (this.referenceData?.type !== 'graphql') {
+      this.availableQueryVariables = [];
+      return;
+    }
+
+    try {
+      const query = gql(this.referenceData.query ?? '');
+      const definition = query.definitions[0];
+      if (definition?.kind !== 'OperationDefinition') {
+        this.availableQueryVariables = [];
+        return;
+      }
+
+      const variableDefinitions = (definition.variableDefinitions ?? []).map(
+        (variable) => variable.variable.name.value
+      );
+
+      const { cursorVar, offsetVar, pageVar, pageSizeVar } =
+        (this.referenceData.pageInfo as any) ?? {};
+
+      // Do not show pagination variables
+      const availableVariables = variableDefinitions.filter(
+        (v) => ![cursorVar, offsetVar, pageVar, pageSizeVar].includes(v)
+      );
+
+      console.log(availableVariables);
+
+      console.log(this.control);
+
+      // Checks if the variable mapping is null or empty.
+      if (!this.control.value) {
+        // If so, generate a template with the variables being keys of a json object.
+        const template = JSON.stringify(
+          availableVariables.reduce((acc, curr) => {
+            acc[curr] = null;
+            return acc;
+          }, {} as Record<string, any>),
+          null,
+          2
+        );
+        this.control.setValue(template);
+      }
+      this.availableQueryVariables = availableVariables;
+    } catch (_) {
+      this.availableQueryVariables = [];
+    }
+  }
+}

--- a/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/record-selection-tab/record-selection-tab.component.ts
@@ -53,9 +53,9 @@ export class RecordSelectionTabComponent
     if (this.form.get('referenceData')?.value) {
       this.referenceDataService
         .cacheItems(this.form.get('referenceData')?.value as string)
-        .then((value) => {
-          if (value) {
-            this.refDataElements = value;
+        .then(({ items }) => {
+          if (items) {
+            this.refDataElements = items;
           }
         });
     }
@@ -65,9 +65,9 @@ export class RecordSelectionTabComponent
         if (value) {
           this.referenceDataService
             .cacheItems(this.form.get('referenceData')?.value as string)
-            .then((value) => {
-              if (value) {
-                this.refDataElements = value;
+            .then(({ items }) => {
+              if (items) {
+                this.refDataElements = items;
               }
             });
         } else {

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -178,7 +178,7 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
         Promise.all([
           new Promise<void>((resolve) => {
             this.referenceDataService
-              .cacheItems(this.settings.referenceData, true)
+              .cacheItems(this.settings.referenceData)
               .then(({ items, referenceData }) => {
                 this.referenceData = referenceData;
                 this.fields = (referenceData.fields || [])

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/graphql/queries.ts
@@ -50,6 +50,14 @@ export const GET_REFERENCE_DATA = gql`
       id
       name
       fields
+      query
+      type
+      pageInfo {
+        cursorVar
+        offsetVar
+        pageVar
+        pageSizeVar
+      }
     }
   }
 `;

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
@@ -29,6 +29,11 @@
             [uiTooltip]="'common.remove' | translate"
           ></ui-button>
         </div>
+        <ngx-monaco-editor
+          formControlName="referenceDataVariableMapping"
+          [options]="editorOptions"
+          *ngIf="availableQueryVariables.length > 0"
+        ></ngx-monaco-editor>
         <ui-divider
           class="max-w-xs m-auto"
           [text]="'common.or' | translate"

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
@@ -31,35 +31,16 @@
         </div>
 
         <!-- GraphQL variable mapping -->
-        <div class="flex-1">
-          <span class="flex gap-2 mb-4">
-            <h2 class="mb-0">
-              {{
-                'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.title'
-                  | translate
-              }}
-            </h2>
-            <ui-icon
-              icon="info"
-              variant="grey"
-              [uiTooltip]="
-                'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.tooltip'
-                  | translate
-              "
-            ></ui-icon>
-          </span>
-          <ngx-monaco-editor
-            *ngIf="availableQueryVariables.length > 0"
-            formControlName="referenceDataVariableMapping"
-            [options]="editorOptions"
-          ></ngx-monaco-editor>
-          <shared-empty
-            *ngIf="availableQueryVariables.length === 0"
-            [title]="
-              'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.noVariables'
-                | translate
+        <div
+          class="flex-1"
+          *ngIf="referenceData && referenceData.type === 'graphql'"
+        >
+          <shared-graphql-variables-mapping
+            [referenceData]="referenceData"
+            [control]="
+              formGroup.controls.card.controls.referenceDataVariableMapping
             "
-          ></shared-empty>
+          ></shared-graphql-variables-mapping>
         </div>
         <ui-divider
           class="max-w-xs m-auto"

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
@@ -29,11 +29,38 @@
             [uiTooltip]="'common.remove' | translate"
           ></ui-button>
         </div>
-        <ngx-monaco-editor
-          formControlName="referenceDataVariableMapping"
-          [options]="editorOptions"
-          *ngIf="availableQueryVariables.length > 0"
-        ></ngx-monaco-editor>
+
+        <!-- GraphQL variable mapping -->
+        <div class="flex-1">
+          <span class="flex gap-2 mb-4">
+            <h2 class="mb-0">
+              {{
+                'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.title'
+                  | translate
+              }}
+            </h2>
+            <ui-icon
+              icon="info"
+              variant="grey"
+              [uiTooltip]="
+                'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.tooltip'
+                  | translate
+              "
+            ></ui-icon>
+          </span>
+          <ngx-monaco-editor
+            *ngIf="availableQueryVariables.length > 0"
+            formControlName="referenceDataVariableMapping"
+            [options]="editorOptions"
+          ></ngx-monaco-editor>
+          <shared-empty
+            *ngIf="availableQueryVariables.length === 0"
+            [title]="
+              'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.noVariables'
+                | translate
+            "
+          ></shared-empty>
+        </div>
         <ui-divider
           class="max-w-xs m-auto"
           [text]="'common.or' | translate"

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.ts
@@ -81,6 +81,7 @@ export class SummaryCardGeneralComponent
   /** Monaco editor configuration, for raw edition */
   public editorOptions = {
     theme: 'vs-dark',
+    language: 'json',
     fixedOverflowWidgets: true,
     lineNumbers: 'off',
     minimap: { enabled: false },

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.forms.ts
@@ -125,6 +125,11 @@ const createCardForm = (value?: any) => {
     {
       title: get<string>(value, 'title', 'New Card'),
       referenceData: get<string | null>(value, 'referenceData', null),
+      referenceDataVariableMapping: get<string | null>(
+        value,
+        'referenceDataVariableMapping',
+        null
+      ),
       resource: get<string | null>(value, 'resource', null),
       template: get<string | null>(value, 'template', null),
       layout: get<string | null>(value, 'layout', null),

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -43,6 +43,9 @@
       [pageSize]="pageInfo.pageSize"
       [hideFirstLastButtons]="false"
       [pageSizeOptions]="[10, 25, 50, 100]"
+      [showPageSizes]="
+        refData?.pageInfo?.strategy ? !!refData?.pageInfo?.pageSizeVar : true
+      "
       [totalItems]="pageInfo.length"
       [displayedPageNumbers]="5"
       [ariaLabel]="'components.notifications.paginator.ariaLabel' | translate"

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -18,17 +18,19 @@
               shape: 'rectangle'
             "
           >
-            <shared-summary-card-item
-              *ngFor="let card of cards; let i = index"
-              class="k-tilelayout-item k-card flex flex-col"
-              [style.order]="i"
-              style.grid-column-end="{{
-                'span ' + (2 > colsNumber ? colsNumber : 2)
-              }}"
-              style.grid-row-end="{{ 'span ' + 2 }}"
-              [card]="card"
-            >
-            </shared-summary-card-item>
+            <ng-container *ngFor="let card of cards; let i = index">
+              <shared-summary-card-item
+                *ngIf="!!cards[i]"
+                class="k-tilelayout-item k-card flex flex-col"
+                [style.order]="i"
+                style.grid-column-end="{{
+                  'span ' + (2 > colsNumber ? colsNumber : 2)
+                }}"
+                style.grid-row-end="{{ 'span ' + 2 }}"
+                [card]="card"
+              >
+              </shared-summary-card-item>
+            </ng-container>
           </ng-container>
         </div>
       </kendo-pdf-export>
@@ -41,13 +43,18 @@
       [pageIndex]="pageInfo.pageIndex"
       [skip]="pageInfo.skip"
       [pageSize]="pageInfo.pageSize"
-      [hideFirstLastButtons]="false"
+      [hideFirstLastButtons]="
+        !totalItemsKnown || refData?.pageInfo?.strategy === 'cursor'
+      "
       [pageSizeOptions]="[10, 25, 50, 100]"
       [showPageSizes]="
         refData?.pageInfo?.strategy ? !!refData?.pageInfo?.pageSizeVar : true
       "
       [totalItems]="pageInfo.length"
-      [displayedPageNumbers]="5"
+      [showTotalItems]="totalItemsKnown"
+      [displayedPageNumbers]="
+        refData?.pageInfo?.strategy === 'cursor' ? 0 : totalItemsKnown ? 5 : 0
+      "
       [ariaLabel]="'components.notifications.paginator.ariaLabel' | translate"
       (pageChange)="onPage($event)"
     >

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -232,37 +232,17 @@ export class SummaryCardComponent
 
   /** @returns the graphql query variables object */
   get graphqlVariables() {
-    const filters = this.contextService.filter.getValue();
-    let mapping = this.settings.card?.referenceDataVariableMapping || '';
-
-    Object.keys(filters).forEach((key) => {
-      mapping = mapping
-        ?.split(`{{filter.${key}}}`)
-        .join(JSON.stringify(filters[key]));
-    });
-
-    // If there are any still to be replaced, replace them with null
-    mapping =
-      mapping.match(/{{filter\..*?}}/gim)?.reduce((acc, curr) => {
-        return acc.replace(curr, '"__REMOVE__"');
-      }, mapping) || mapping;
-
-    const obj = (() => {
-      try {
-        return JSON.parse(mapping);
-      } catch (_) {
-        return null;
-      }
-    })();
-
-    // Remove the keys that were not replaced
-    Object.keys(obj).forEach((key) => {
-      if (JSON.stringify(obj[key]).includes('__REMOVE__')) {
-        delete obj[key];
-      }
-    });
-
-    return obj;
+    try {
+      let mapping = JSON.parse(
+        this.settings.card?.referenceDataVariableMapping || ''
+      );
+      mapping = this.contextService.replaceContext(mapping);
+      mapping = this.contextService.replaceFilter(mapping).object;
+      this.contextService.removeEmptyPlaceholders(mapping);
+      return mapping;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -96,7 +96,7 @@ export class SummaryCardComponent
     lastCursor: null as any,
   };
   /** Reference data datasource */
-  private refData: ReferenceData | null = null;
+  public refData: ReferenceData | null = null;
   /** Loading indicators */
   public loading = true;
   /** Available cards */

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -977,7 +977,6 @@ export class SummaryCardComponent
             ...(this.graphqlVariables ?? {}),
           })
           .then(({ items, pageInfo }) => {
-            console.log(items);
             this.updateReferenceDataCards(items, pageInfo);
             this.loading = false;
           });

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -732,12 +732,20 @@ export class SummaryCardComponent
   ) {
     this.loading = true;
     if (card.referenceData) {
-      const { items, referenceData, pageInfo } =
-        await this.referenceDataService.cacheItems(
-          card.referenceData as string
-        );
-      this.refData = referenceData;
-      const metadata = (referenceData?.fields || [])
+      this.refData = await this.referenceDataService.loadReferenceData(
+        card.referenceData as string
+      );
+
+      const { items, pageInfo } = await this.referenceDataService.cacheItems(
+        card.referenceData as string,
+        Object.assign(
+          {},
+          this.refData.pageInfo?.pageSizeVar && {
+            [this.refData.pageInfo.pageSizeVar]: DEFAULT_PAGE_SIZE,
+          }
+        )
+      );
+      const metadata = (this.refData?.fields || [])
         .filter((field: any) => field && typeof field !== 'string')
         .map((field: any) => {
           return {
@@ -755,7 +763,7 @@ export class SummaryCardComponent
       })) as CardT[];
 
       this.pageInfo.pageIndex = 0;
-      if (referenceData.pageInfo?.strategy && pageInfo) {
+      if (this.refData.pageInfo?.strategy && pageInfo) {
         // If using pagination, set the page size and total count
         // according to the response of the first page
         this.pageInfo.length = pageInfo.totalCount;

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -977,6 +977,7 @@ export class SummaryCardComponent
             ...(this.graphqlVariables ?? {}),
           })
           .then(({ items, pageInfo }) => {
+            console.log(items);
             this.updateReferenceDataCards(items, pageInfo);
             this.loading = false;
           });

--- a/libs/shared/src/lib/models/reference-data.model.ts
+++ b/libs/shared/src/lib/models/reference-data.model.ts
@@ -10,6 +10,13 @@ export enum referenceDataType {
   rest = 'rest',
 }
 
+/** Enum of the available pagination methods */
+export enum paginationStrategy {
+  offset = 'offset',
+  cursor = 'cursor',
+  page = 'page',
+}
+
 /** Model for Reference data object. */
 export interface ReferenceData {
   id?: string;
@@ -29,6 +36,34 @@ export interface ReferenceData {
   canUpdate?: boolean;
   canDelete?: boolean;
   aggregations?: Connection<Aggregation>;
+  // Pagination strategies
+  //  offset: The client will send the offset (how many items to skip)
+  //  cursor: The client will send the cursor of the last item
+  //  page: The client will send the page number
+  pageInfo?: {
+    // JSON path that when queried to the API response will return the total number of items
+    totalCountField: string;
+    // Name of the query variable that corresponds to the page size
+    pageSizeVar?: string;
+  } & (
+    | {
+        strategy: 'offset';
+        // Name of the query variable to be used for determining the offset
+        offsetVar: string;
+      }
+    | {
+        strategy: 'cursor';
+        // JSON path that when queried to the API response will return the cursor
+        cursorField: string;
+        // Name of the query variable to be used for determining the cursor
+        cursorVar: string;
+      }
+    | {
+        strategy: 'page';
+        // Name of the query variable that corresponds to the page number
+        pageVar: string;
+      }
+  );
 }
 
 /** Model for reference data graphql query response */

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -6,7 +6,16 @@ import {
   FilterDescriptor,
 } from '@progress/kendo-data-query';
 import { cloneDeep } from '@apollo/client/utilities';
-import { isNil, isEmpty, get, isEqual, isObject, forEach, set } from 'lodash';
+import {
+  isNil,
+  isEmpty,
+  get,
+  isEqual,
+  isObject,
+  forEach,
+  set,
+  has,
+} from 'lodash';
 import { DashboardService } from '../dashboard/dashboard.service';
 import {
   Dashboard,
@@ -228,6 +237,23 @@ export class ContextService {
       ),
       replaced: true,
     };
+  }
+
+  public removeEmptyPlaceholders(obj: any) {
+    for (const key in obj) {
+      if (has(obj, key)) {
+        if (typeof obj[key] === 'object') {
+          // Recursively call the function for nested objects
+          this.removeEmptyPlaceholders(obj[key]);
+        } else if (
+          typeof obj[key] === 'string' &&
+          obj[key].startsWith('{{') &&
+          obj[key].endsWith('}}')
+        ) {
+          delete obj[key];
+        }
+      }
+    }
   }
 
   /**

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -59,7 +59,7 @@ export class ContextService {
   /** Is filter opened */
   public filterOpened = new BehaviorSubject<boolean>(false);
   /** Regex used to allow widget refresh */
-  public filterRegex = /{{filter\.[^}]+}}/;
+  public filterRegex = /{{filter\.(.*?)}}/g;
   /** Context regex */
   public contextRegex = /{{context\.(.*?)}}/g;
   /** Dashboard object */
@@ -239,6 +239,11 @@ export class ContextService {
     };
   }
 
+  /**
+   * Remove placeholders from object
+   *
+   * @param obj object to clean
+   */
   public removeEmptyPlaceholders(obj: any) {
     for (const key in obj) {
       if (has(obj, key)) {

--- a/libs/shared/src/lib/services/reference-data/graphql/queries.ts
+++ b/libs/shared/src/lib/services/reference-data/graphql/queries.ts
@@ -20,6 +20,15 @@ export const GET_REFERENCE_DATA_BY_ID = gql`
       path
       data
       graphQLFilter
+      pageInfo {
+        strategy
+        totalCountField
+        pageSizeVar
+        offsetVar
+        cursorField
+        cursorVar
+        pageVar
+      }
     }
   }
 `;

--- a/libs/shared/src/lib/services/reference-data/reference-data.service.ts
+++ b/libs/shared/src/lib/services/reference-data/reference-data.service.ts
@@ -183,6 +183,7 @@ export class ReferenceDataService {
         referenceData,
         pageInfo
       );
+      console.log('ici :', i);
       items = i;
       paginationRes = p;
       // Cache items and timestamp

--- a/libs/shared/src/lib/services/reference-data/reference-data.service.ts
+++ b/libs/shared/src/lib/services/reference-data/reference-data.service.ts
@@ -182,7 +182,6 @@ export class ReferenceDataService {
         referenceData,
         variables
       );
-      console.log('ici :', i);
       items = i;
       paginationRes = p;
       // Cache items and timestamp

--- a/libs/shared/src/lib/services/reference-data/reference-data.service.ts
+++ b/libs/shared/src/lib/services/reference-data/reference-data.service.ts
@@ -93,12 +93,11 @@ export class ReferenceDataService {
       a[displayField] > b[displayField] ? 1 : -1;
 
     // get items
-    const stored = (await localForage.getItem(referenceDataID)) as CachedItems;
-    const items_ = stored?.items || [];
-    const valueField = stored?.valueField || '';
+    const { items, referenceData } = await this.cacheItems(referenceDataID);
+    const valueField = referenceData?.valueField || '';
 
     // sort items by displayField
-    const items = items_.sort(sortByDisplayField);
+    items.sort(sortByDisplayField);
     const foreignIsMultiselect = Array.isArray(filter?.foreignValue);
     // if we ask to filter and there is a value in foreign field
     if (

--- a/libs/shared/src/lib/services/reference-data/reference-data.service.ts
+++ b/libs/shared/src/lib/services/reference-data/reference-data.service.ts
@@ -266,11 +266,13 @@ export class ReferenceDataService {
    *
    * @param referenceData Reference data item
    * @param type Reference data request type
+   * @param pageInfo Page info for pagination
    * @returns processed items by the request type
    */
   private async processItemsByRequestType(
     referenceData: ReferenceData,
-    type: referenceDataType
+    type: referenceDataType,
+    pageInfo: any = {}
   ) {
     let data!: any;
     if (type === referenceDataType.graphql) {
@@ -278,7 +280,8 @@ export class ReferenceDataService {
         this.apiProxy.baseUrl +
         (referenceData.apiConfiguration?.name ?? '') +
         (referenceData.apiConfiguration?.graphQLEndpoint ?? '');
-      const body = { query: this.processQuery(referenceData) };
+      const query = this.processQuery(referenceData);
+      const body = { query, variables: pageInfo };
       data = (await this.apiProxy.buildPostRequest(url, body)) as any;
     } else if (type === referenceDataType.rest) {
       const url =

--- a/libs/shared/src/lib/services/reference-data/reference-data.service.ts
+++ b/libs/shared/src/lib/services/reference-data/reference-data.service.ts
@@ -305,12 +305,19 @@ export class ReferenceDataService {
 
     // Build page info
     if (referenceData.pageInfo?.strategy) {
+      // If the api doesn't tell us the total count,
+      // we hide it along with the paginator pages and only update it
+      // again when we get a page smaller than the previous one
+      // indicating that we reached the end of the list
       const totalCount =
-        jsonpath.query(data, referenceData.pageInfo.totalCountField)[0] ??
-        Number.MAX_SAFE_INTEGER;
+        (referenceData.pageInfo.totalCountField
+          ? jsonpath.query(data, referenceData.pageInfo.totalCountField)[0]
+          : null) ?? Number.MAX_SAFE_INTEGER;
+
       const pageSize = referenceData.pageInfo.pageSizeVar
-        ? jsonpath.query(pageInfo, referenceData.pageInfo.pageSizeVar)[0] ?? 0
+        ? pageInfo[referenceData.pageInfo.pageSizeVar] ?? 0
         : items?.length || 0;
+
       let lastCursor = null;
       if (referenceData.pageInfo?.strategy === 'cursor') {
         const cursors = jsonpath.query(

--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -242,6 +242,8 @@ export const render = (
             filter
           )
           .then((choices) => {
+            console.log('ici');
+            console.log(choices);
             question.choices = [];
             // this is to avoid that the choices appear on the 'choices' tab
             question.setPropertyValue(

--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -242,8 +242,6 @@ export const render = (
             filter
           )
           .then((choices) => {
-            console.log('ici');
-            console.log(choices);
             question.choices = [];
             // this is to avoid that the choices appear on the 'choices' tab
             question.setPropertyValue(

--- a/libs/shared/src/lib/survey/widgets/dropdown-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/dropdown-widget.ts
@@ -2,7 +2,7 @@ import { ComboBoxComponent } from '@progress/kendo-angular-dropdowns';
 import { DomService } from '../../services/dom/dom.service';
 import { Question } from '../types';
 import { CustomWidgetCollection, QuestionDropdownModel } from 'survey-core';
-import { isArray, isObject } from 'lodash';
+import { has, isArray, isEqual, isObject } from 'lodash';
 import { debounceTime, map, tap } from 'rxjs';
 import updateChoices from './utils/common-list-filters';
 
@@ -77,7 +77,22 @@ export const init = (
         question._propertyValueChangedVirtual
       );
       question.registerFunctionOnPropertyValueChanged('value', () => {
-        dropdownInstance.value = question.value;
+        // We need this line for resource select
+        if (question.isPrimitiveValue) {
+          dropdownInstance.value = question.value;
+        } else {
+          if (question.visibleChoices.length > 0) {
+            if (has(question.value, 'text') && has(question.value, 'value')) {
+              dropdownInstance.value = question.visibleChoices.find((choice) =>
+                isEqual(choice.value, question.value.value)
+              );
+            } else {
+              dropdownInstance.value = question.visibleChoices.find((choice) =>
+                isEqual(choice.value, question.value)
+              );
+            }
+          }
+        }
       });
       question.registerFunctionOnPropertyValueChanged(
         'readOnly',

--- a/libs/ui/src/lib/form-wrapper/form-wrapper.directive.ts
+++ b/libs/ui/src/lib/form-wrapper/form-wrapper.directive.ts
@@ -271,8 +271,8 @@ export class FormWrapperDirective
   }
 
   ngAfterContentInit() {
-    // Manage form control status changes
     if (this.control) {
+      // Manage form control status changes
       this.control.control.statusChanges
         .pipe(takeUntil(this.destroy$))
         .subscribe({
@@ -291,9 +291,27 @@ export class FormWrapperDirective
                 this.removeInvalidState();
               }
             }
+            // Required state
+            const isRequired = this.control?.control?.hasValidator(
+              Validators.required
+            );
+            const labelHasRequired =
+              this.currentLabelElement?.textContent?.endsWith(' *');
+
+            if (isRequired && !labelHasRequired) {
+              this.renderer.appendChild(
+                this.currentLabelElement,
+                this.renderer.createText(' *')
+              );
+            } else if (!isRequired && labelHasRequired) {
+              // remove the ' *' from the innerText
+              this.currentLabelElement.innerText =
+                this.currentLabelElement.innerText.replace(' *', '');
+            }
           },
         });
     }
+
     // Get inner input and label elements
     this.currentInputElement =
       this.elementRef.nativeElement.querySelector('input');

--- a/libs/ui/src/lib/paginator/paginator.component.html
+++ b/libs/ui/src/lib/paginator/paginator.component.html
@@ -35,6 +35,7 @@
           <!-- Page size -->
           <kendo-datapager-page-sizes
             class="hidden sm:flex text-gray-700"
+            *ngIf="showPageSizes"
             [pageSizes]="pageSizeOptions"
           ></kendo-datapager-page-sizes>
           <!-- Page buttons -->

--- a/libs/ui/src/lib/paginator/paginator.component.html
+++ b/libs/ui/src/lib/paginator/paginator.component.html
@@ -20,7 +20,7 @@
       let-currentPage="currentPage"
     >
       <div class="w-full flex justify-between">
-        <div class="hidden sm:flex">
+        <div class="hidden sm:flex" *ngIf="showTotalItems">
           <!-- Page info -->
           <kendo-datapager-messages
             page="{{ 'components.paginator.page' | translate }}"
@@ -31,7 +31,7 @@
           </kendo-datapager-messages>
           <kendo-datapager-info></kendo-datapager-info>
         </div>
-        <div class="flex w-full sm:w-auto">
+        <div class="flex w-full sm:w-auto ml-auto">
           <!-- Page size -->
           <kendo-datapager-page-sizes
             class="hidden sm:flex text-gray-700"

--- a/libs/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/src/lib/paginator/paginator.component.ts
@@ -28,6 +28,8 @@ export class PaginatorComponent implements OnChanges {
   @Input() pageSize = 10;
   /** Available page size */
   @Input() pageSizeOptions = [5, 10, 15];
+  /** If should allow user to change page size */
+  @Input() showPageSizes = true;
   /** Allow buttons to go to first & last pages */
   @Input() hideFirstLastButtons = true;
   /** Aria label */

--- a/libs/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/src/lib/paginator/paginator.component.ts
@@ -24,6 +24,8 @@ export class PaginatorComponent implements OnChanges {
   @Input() disabled = false;
   /** Number of items */
   @Input() totalItems = 0;
+  /** Show total items */
+  @Input() showTotalItems = true;
   /** Current page size */
   @Input() pageSize = 10;
   /** Available page size */


### PR DESCRIPTION
# Description

This PR adds support to pagination on summary cards with reference data datasource.

On the reference data definition, a few options about pagination were added:
* usePagination: if the refData in question uses pagination
* strategy: 'offset', 'cursor' or 'page'
* other options based on the strategy (those and the strategy itself can be auto-filled based on the query variable names)
On the summary cards:
* selecting reference data as datasource allows the user to map values to the available query variables using the dashboard filters templates
* moving between pages will properly fetch data using our proxy and handles pagination for each strategy


## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83067
- Please insert link to back-end branch if any: https://github.com/ReliefApplications/ems-backend/pull/932

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Reference datas (and api configurations) tested: 

```json
[
  {
    "name": "r&m_episodes",
    "apiConfiguration": {
      "name": "rick_and_morty",
      "status": "active",
      "authType": "public",
      "endpoint": "https://rickandmortyapi.graphcdn.app/",
      "graphQLEndpoint": "/",
      "pingUrl": ""
    },
    "type": "graphql",
    "query": "# You can use {{lastUpdate}} to dynamically get the last fetch date in SQL format.\n\nquery Episodes($page: Int, $episodeName: String) {\n  episodes(page: $page, filter: {name: $episodeName}) {\n    results {\n      id\n      name\n    }\n    info {\n      pages\n      count\n      next\n      prev\n    }\n  }\n}\n",
    "valueField": "id",
    "path": "$.data.episodes.results.*",
    "pageInfo": {
      "strategy": "page",
      "pageVar": "page",
      "totalCountField": "$.data.episodes.info.count"
    }
  },
  {
    "name": "sw_planets",
    "apiConfiguration": {
      "name": "star_wars",
      "status": "active",
      "authType": "public",
      "endpoint": "https://swapi-graphql.netlify.app/.netlify/functions/index/",
      "pingUrl": "/",
      "graphQLEndpoint": "/"
    },
    "type": "graphql",
    "query": "query Planets($cursor: String, $pageSize: Int) {\n  allPlanets(after: $cursor, first: $pageSize) {\n    edges {\n      node {\n        id\n        name\n        diameter\n        gravity\n      }\n      cursor\n    }\n    totalCount\n  }\n}",
    "valueField": "id",
    "path": "$.data.allPlanets.edges.*.node",
    "pageInfo": {
      "strategy": "cursor",
      "cursorField": "$.data.allPlanets.edges.*.cursor",
      "cursorVar": "cursor",
      "pageSizeVar": "pageSize",
      "totalCountField": "$.data.allPlanets.totalCount"
    }
  },
  {
    "name": "pokemon_list",
    "apiConfiguration": {
      "name": "pokemon",
      "status": "active",
      "authType": "public",
      "endpoint": "https://beta.pokeapi.co/graphql/v1beta/",
      "pingUrl": null,
      "graphQLEndpoint": "/"
    },
    "type": "graphql",
    "query": "query Pokemon($pageSize: Int, $offset: Int) {\n  pokemon_v2_pokemonform(limit: $pageSize, offset: $offset) {\n    id\n    name\n  }\n}\n",
    "valueField": "id",
    "path": "$.data.pokemon_v2_pokemonform.*",
    "pageInfo": {
      "strategy": "offset",
      "offsetVar": "offset",
      "pageSizeVar": "pageSize",
      "totalCountField": null
    }
  }
]

```

## Screenshots

![Peek 2023-12-08 00-12](https://github.com/ReliefApplications/ems-frontend/assets/102038450/747ed7db-5dab-4eaa-8833-1a0cdd99a773)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
