### PR TITLE
feat/AB#83237_use_regex_when_using_reference_data_and_dashboard_filter

### DIFF
--- a/libs/shared/src/lib/utils/filter/reference-data-filter.util.ts
+++ b/libs/shared/src/lib/utils/filter/reference-data-filter.util.ts
@@ -16,7 +16,8 @@ export const filterReferenceData = (item: any, filter: any) => {
       ? results.every(Boolean)
       : results.some(Boolean);
   } else {
-    const value = get(item, filter.field);
+    const value = get(item, filter.field.toLowerCase());
+    const regex = new RegExp(filter.value);
     let intValue: number | null;
     try {
       intValue = Number(filter.value);
@@ -54,9 +55,13 @@ export const filterReferenceData = (item: any, filter: any) => {
       case 'endswith':
         return !isNil(value) && value.endsWith(filter.value);
       case 'contains':
-        return !isNil(value) && value.includes(filter.value);
+        return (
+          !isNil(value) && (value.includes(filter.value) || regex.test(value))
+        );
       case 'doesnotcontain':
-        return isNil(value) || !value.includes(filter.value);
+        return (
+          isNil(value) || (!value.includes(filter.value) && !regex.test(value))
+        );
       default:
         return false;
     }

--- a/libs/shared/src/lib/utils/filter/reference-data-filter.util.ts
+++ b/libs/shared/src/lib/utils/filter/reference-data-filter.util.ts
@@ -16,8 +16,8 @@ export const filterReferenceData = (item: any, filter: any) => {
       ? results.every(Boolean)
       : results.some(Boolean);
   } else {
-    const value = get(item, filter.field.toLowerCase());
-    const regex = new RegExp(filter.value);
+    const value = get(item, filter.field);
+    const regex = new RegExp(filter.value, 'i');
     let intValue: number | null;
     try {
       intValue = Number(filter.value);
@@ -55,13 +55,13 @@ export const filterReferenceData = (item: any, filter: any) => {
       case 'endswith':
         return !isNil(value) && value.endsWith(filter.value);
       case 'contains':
-        return (
-          !isNil(value) && (value.includes(filter.value) || regex.test(value))
-        );
+        if (value == 'France' || value === 'Brazil') {
+          console.log(value);
+          console.log(regex);
+        }
+        return !isNil(value) && regex.test(value);
       case 'doesnotcontain':
-        return (
-          isNil(value) || (!value.includes(filter.value) && !regex.test(value))
-        );
+        return isNil(value) || !regex.test(value);
       default:
         return false;
     }


### PR DESCRIPTION
# Description

Feat: Added possibility to use  regex when using reference data & dashboard filter "contains" operator ( and "doesnotcontain" )

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83237)
[backend](https://github.com/ReliefApplications/ems-backend/pull/935)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

As the attached video.
To reproduce the configurations please access the app here https://oort-dev.oortcloud.tech/admin/applications/659fea9a835d98501340e275/dashboard/659fec87835d98501340fb48

## Screenshots

![Peek 11-01-2024 15-16](https://github.com/ReliefApplications/ems-frontend/assets/56398308/6f37ece9-229a-4c89-832e-ddc3a7e349f1)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
