### PR TITLE
Feat/ab#83099 load dashboard filter default value expression

### DIFF
--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -6,7 +6,7 @@ import {
   FilterDescriptor,
 } from '@progress/kendo-data-query';
 import { cloneDeep } from '@apollo/client/utilities';
-import { isNil, isEmpty, get, isEqual, isObject, merge } from 'lodash';
+import { isNil, isEmpty, get, isEqual, isObject, merge, forEach } from 'lodash';
 import { DashboardService } from '../dashboard/dashboard.service';
 import {
   Dashboard,
@@ -302,7 +302,9 @@ export class ContextService {
     const data = survey
       .getAllQuestions()
       .reduce(function (result: any, question: any) {
-        result[question.name] = question.defaultValue;
+        if (question.defaultValue !== undefined) {
+          result[question.name] = question.defaultValue;
+        }
         return result;
       }, {});
 
@@ -310,8 +312,10 @@ export class ContextService {
     if (!isEmpty(this.filter.getValue())) {
       merge(data, this.filter.getValue());
     }
-
-    survey.data = data;
+    // set each question value manually otherwise the defaultValueExpression is not loaded
+    forEach(data, (value, key) => {
+      survey.getQuestionByName(key).value = value;
+    });
     return survey;
   }
 


### PR DESCRIPTION
# Description

The default value expressions weren't working for dashboard filters. In order to transfer data from one dashboard filter to another, the survey loaded the respective values during creation. If the data wasn't filled, "undefined" was assigned to the value, making the default value expression unused.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83099)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

I created a dashboard filter with default expression value: 
- today()
- today(-365)

## Screenshots

![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/7da19a0a-8f66-45c3-a15f-92ac8510d77f)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
