### PR TITLE
Feat/ab#83311 : Add ability to view history as table

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -884,10 +884,7 @@
 			"range": {
 				"clear": "Clear range"
 			},
-			"view": {
-				"defaultView": "Switch to default view",
-				"tableView": "Switch to table view"
-			}
+			"useTableMode": "Use table mode"
 		},
 		"icon": {
 			"modal": {

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -865,6 +865,15 @@
 				"to": "to",
 				"withValue": "with value"
 			},
+			"columns": {
+				"action": "Action taken",
+				"date": "Date of modification",
+				"modifiedValue": "Modified variable value",
+				"originalValue": "Original variable value",
+				"person": "Who modified",
+				"signalId": "Signal Id",
+				"variable": "Variable modified"
+			},
 			"download": "Download history",
 			"empty": "No activity detected",
 			"field": {
@@ -874,6 +883,10 @@
 			"preview": "Preview and revert",
 			"range": {
 				"clear": "Clear range"
+			},
+			"view": {
+				"defaultView": "Switch to default view",
+				"tableView": "Switch to table view"
 			}
 		},
 		"icon": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -876,6 +876,15 @@
 				"to": "à",
 				"withValue": "avec valeur"
 			},
+			"columns": {
+				"action": "Type d'action",
+				"date": "Date de modification",
+				"modifiedValue": "Valeur modifiée de la variable",
+				"originalValue": "Valeur originelle de la variable",
+				"person": "Modification effectuée par",
+				"signalId": "Id du record",
+				"variable": "Variable modifiée"
+			},
 			"download": "Télécharger l'historique",
 			"empty": "Aucune activité détectée",
 			"field": {
@@ -885,6 +894,10 @@
 			"preview": "Prévisualiser et revenir",
 			"range": {
 				"clear": "Effacer la plage de données"
+			},
+			"view": {
+				"defaultView": "Voir vue par défault",
+				"tableView": "Voir vue en table"
 			}
 		},
 		"icon": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -895,10 +895,7 @@
 			"range": {
 				"clear": "Effacer la plage de données"
 			},
-			"view": {
-				"defaultView": "Voir vue par défault",
-				"tableView": "Voir vue en table"
-			}
+			"useTableMode": "Afficher en table"
 		},
 		"icon": {
 			"modal": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -865,6 +865,15 @@
 				"to": "******",
 				"withValue": "******"
 			},
+			"columns": {
+				"action": "******",
+				"date": "******",
+				"modifiedValue": "******",
+				"originalValue": "******",
+				"person": "******",
+				"signalId": "******",
+				"variable": "******"
+			},
 			"download": "******",
 			"empty": "******",
 			"field": {
@@ -874,6 +883,10 @@
 			"preview": "******",
 			"range": {
 				"clear": "******"
+			},
+			"view": {
+				"defaultView": "******",
+				"tableView": "******"
 			}
 		},
 		"icon": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -884,10 +884,7 @@
 			"range": {
 				"clear": "******"
 			},
-			"view": {
-				"defaultView": "******",
-				"tableView": "******"
-			}
+			"useTableMode": "******"
 		},
 		"icon": {
 			"modal": {

--- a/libs/shared/src/lib/components/record-history/record-history.component.html
+++ b/libs/shared/src/lib/components/record-history/record-history.component.html
@@ -76,8 +76,8 @@
       <button uiMenuItem (click)="onDownload('xlsx')">.xlsx</button>
     </ui-menu>
     <ui-button (click)="switchView()"
-      ><div *ngIf="!defaultView">Switch to default view</div>
-      <div *ngIf="defaultView">Switch to table view</div></ui-button
+      ><div *ngIf="!defaultView">{{ 'components.history.view.defaultView' | translate }}</div>
+      <div *ngIf="defaultView">{{ 'components.history.view.tableView' | translate }}</div></ui-button
     >
   </div>
 </div>
@@ -87,7 +87,7 @@
     <div *ngIf="!defaultView" class="overflow-x-auto m-3">
       <table cdk-table uiTableWrapper [dataSource]="historyForTable">
         <ng-container cdkColumnDef="id">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">Signal Id</th>
+          <th uiCellHeader *cdkHeaderCellDef scope="col">{{ 'components.history.columns.signalId' | translate }}</th>
           <td
             uiCell
             *cdkCellDef="let element"
@@ -97,7 +97,7 @@
           </td>
         </ng-container>
         <ng-container cdkColumnDef="variable">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">Variable modified</th>
+          <th uiCellHeader *cdkHeaderCellDef scope="col">{{ 'components.history.columns.variable' | translate }}</th>
           <td
             uiCell
             *cdkCellDef="let element"
@@ -108,7 +108,7 @@
         </ng-container>
         <ng-container cdkColumnDef="date">
           <th uiCellHeader *cdkHeaderCellDef scope="col">
-            Date of modification
+            {{ 'components.history.columns.date' | translate }}
           </th>
           <td
             uiCell
@@ -120,7 +120,7 @@
           </td>
         </ng-container>
         <ng-container cdkColumnDef="person">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">Who modified</th>
+          <th uiCellHeader *cdkHeaderCellDef scope="col">{{ 'components.history.columns.person' | translate }}</th>
           <td
             uiCell
             *cdkCellDef="let element"
@@ -130,7 +130,7 @@
           </td>
         </ng-container>
         <ng-container cdkColumnDef="action">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">Action taken</th>
+          <th uiCellHeader *cdkHeaderCellDef scope="col">{{ 'components.history.columns.action' | translate }}</th>
           <td
             uiCell
             *cdkCellDef="let element"
@@ -141,7 +141,7 @@
         </ng-container>
         <ng-container cdkColumnDef="originalValue">
           <th uiCellHeader *cdkHeaderCellDef scope="col">
-            Original variable value
+            {{ 'components.history.columns.originalValue' | translate }}
           </th>
           <td
             uiCell
@@ -153,7 +153,7 @@
         </ng-container>
         <ng-container cdkColumnDef="modifiedValue">
           <th uiCellHeader *cdkHeaderCellDef scope="col">
-            Modified variable value
+            {{ 'components.history.columns.modifiedValue' | translate }}
           </th>
           <td
             uiCell

--- a/libs/shared/src/lib/components/record-history/record-history.component.html
+++ b/libs/shared/src/lib/components/record-history/record-history.component.html
@@ -22,15 +22,14 @@
           class="max-sm:!w-auto mb-3"
           variant="danger"
           (click)="clearDateFilters()"
-          *ngIf="filters.get('startDate')?.value || filters.get('endDate')?.value"
+          *ngIf="
+            filters.get('startDate')?.value || filters.get('endDate')?.value
+          "
         >
-            {{'components.history.range.clear' | translate}}
+          {{ 'components.history.range.clear' | translate }}
         </ui-button>
       </div>
-      <div
-        [uiDateWrapper]="calendar"
-        class="flex-col"
-      >
+      <div [uiDateWrapper]="calendar" class="flex-col">
         <input
           [uiDatePicker]
           formControlName="startDate"
@@ -46,10 +45,7 @@
     </div>
     <div uiFormFieldDirective>
       <label>{{ 'components.history.field.select' | translate }}</label>
-      <ui-select-menu
-        formControlName="fields"
-        [multiselect]="true"
-      >
+      <ui-select-menu formControlName="fields" [multiselect]="true">
         <ui-select-option
           *ngFor="let field of sortedFields"
           value="{{ field.name }}"
@@ -58,7 +54,10 @@
       </ui-select-menu>
       <ui-button
         uiSuffix
-        *ngIf="filters.get('fields')?.value && filters.get('fields')!.value!.length > 0"
+        *ngIf="
+          filters.get('fields')?.value &&
+          filters.get('fields')!.value!.length > 0
+        "
         (click)="filters.get('fields')?.setValue([]); $event.stopPropagation()"
         icon="close"
         [isIcon]="true"
@@ -68,7 +67,7 @@
     </div>
   </div>
   <!-- ACTIONS -->
-  <div class="flex flex-row justify-start text-end ml-auto">
+  <div class="flex flex-row justify-between text-end ml-auto">
     <ui-button category="secondary" variant="primary" [uiMenuTriggerFor]="menu">
       {{ 'components.history.download' | translate }}
     </ui-button>
@@ -76,12 +75,13 @@
       <button uiMenuItem (click)="onDownload('csv')">.csv</button>
       <button uiMenuItem (click)="onDownload('xlsx')">.xlsx</button>
     </ui-menu>
+    <ui-button (click)="switchView()" [disabled]="defaultView">Switch to default view</ui-button>
   </div>
 </div>
 <ng-container *ngIf="!loading; else loadingTmpl">
   <ng-container *ngIf="filterHistory.length; else emptyTmpl">
     <!-- HISTORY CHANGES -->
-    <div>
+    <div *ngIf="defaultView">
       <ng-container *ngFor="let item of filterHistory; let i = index">
         <ui-expansion-panel [index]="i" (closePanel)="showMore = false">
           <ng-container ngProjectAs="title">

--- a/libs/shared/src/lib/components/record-history/record-history.component.html
+++ b/libs/shared/src/lib/components/record-history/record-history.component.html
@@ -1,236 +1,271 @@
-<div class="items-center p-4 border-b" [formGroup]="filters">
-  <!-- HEADER -->
-  <div class="flex justify-between items-center mb-2" *ngIf="showHeader">
-    <h2 class="float-left mb-0">{{ 'common.history' | translate }}</h2>
-    <ui-button
-      [isIcon]="true"
-      icon="close"
-      class="float-right"
-      (click)="onCancel()"
-      [uiTooltip]="'common.close' | translate"
-    >
-    </ui-button>
-  </div>
-  <!-- FILTER -->
-  <div class="clear-both flex flex-col">
-    <div uiFormFieldDirective id="date-header">
-      <div class="flex items-center justify-between">
-        <label>
-          {{ 'common.input.dateRange' | translate }}
-        </label>
-        <ui-button
-          class="max-sm:!w-auto mb-3"
-          variant="danger"
-          (click)="clearDateFilters()"
-          *ngIf="
-            filters.get('startDate')?.value || filters.get('endDate')?.value
-          "
-        >
-          {{ 'components.history.range.clear' | translate }}
-        </ui-button>
-      </div>
-      <div [uiDateWrapper]="calendar" class="flex-col">
-        <input
-          [uiDatePicker]
-          formControlName="startDate"
-          [label]="'kendo.datepicker.startLabel' | translate"
-        />
-        <input
-          [uiDatePicker]
-          formControlName="endDate"
-          [label]="'kendo.datepicker.endLabel' | translate"
-        />
-        <ui-date-range #calendar> </ui-date-range>
-      </div>
-    </div>
-    <div uiFormFieldDirective>
-      <label>{{ 'components.history.field.select' | translate }}</label>
-      <ui-select-menu formControlName="fields" [multiselect]="true">
-        <ui-select-option
-          *ngFor="let field of sortedFields"
-          value="{{ field.name }}"
-          >{{ field.title || field.name }}</ui-select-option
-        >
-      </ui-select-menu>
+<div
+  class="max-w-[100vw] min-w-96"
+  [ngClass]="{
+    'w-96': !viewAsTable.value,
+    'w-[48rem]': viewAsTable.value
+  }"
+>
+  <div class="items-center p-4 border-b" [formGroup]="filters">
+    <!-- HEADER -->
+    <div class="flex justify-between items-center mb-2" *ngIf="showHeader">
+      <h2 class="float-left mb-0">{{ 'common.history' | translate }}</h2>
       <ui-button
-        uiSuffix
-        *ngIf="
-          filters.get('fields')?.value &&
-          filters.get('fields')!.value!.length > 0
-        "
-        (click)="filters.get('fields')?.setValue([]); $event.stopPropagation()"
-        icon="close"
         [isIcon]="true"
         variant="danger"
+        icon="close"
+        class="float-right"
+        (click)="onCancel()"
         [uiTooltip]="'common.close' | translate"
-      ></ui-button>
+      >
+      </ui-button>
     </div>
-  </div>
-  <!-- ACTIONS -->
-  <div class="flex flex-row justify-between text-end ml-auto">
-    <ui-button category="secondary" variant="primary" [uiMenuTriggerFor]="menu">
-      {{ 'components.history.download' | translate }}
-    </ui-button>
-    <ui-menu #menu>
-      <button uiMenuItem (click)="onDownload('csv')">.csv</button>
-      <button uiMenuItem (click)="onDownload('xlsx')">.xlsx</button>
-    </ui-menu>
-    <ui-button (click)="switchView()"
-      ><div *ngIf="!defaultView">{{ 'components.history.view.defaultView' | translate }}</div>
-      <div *ngIf="defaultView">{{ 'components.history.view.tableView' | translate }}</div></ui-button
+    <!-- FILTER -->
+    <div class="clear-both flex flex-col">
+      <div uiFormFieldDirective id="date-header">
+        <div class="flex items-center justify-between">
+          <label>
+            {{ 'common.input.dateRange' | translate }}
+          </label>
+          <ui-button
+            class="max-sm:!w-auto mb-3"
+            variant="danger"
+            (click)="clearDateFilters()"
+            *ngIf="
+              filters.get('startDate')?.value || filters.get('endDate')?.value
+            "
+          >
+            {{ 'components.history.range.clear' | translate }}
+          </ui-button>
+        </div>
+        <div [uiDateWrapper]="calendar" class="flex-col">
+          <input
+            [uiDatePicker]
+            formControlName="startDate"
+            [label]="'kendo.datepicker.startLabel' | translate"
+          />
+          <input
+            [uiDatePicker]
+            formControlName="endDate"
+            [label]="'kendo.datepicker.endLabel' | translate"
+          />
+          <ui-date-range #calendar> </ui-date-range>
+        </div>
+      </div>
+      <div uiFormFieldDirective>
+        <label>{{ 'components.history.field.select' | translate }}</label>
+        <ui-select-menu formControlName="fields" [multiselect]="true">
+          <ui-select-option
+            *ngFor="let field of sortedFields"
+            value="{{ field.name }}"
+            >{{ field.title || field.name }}</ui-select-option
+          >
+        </ui-select-menu>
+        <ui-button
+          uiSuffix
+          *ngIf="
+            filters.get('fields')?.value &&
+            filters.get('fields')!.value!.length > 0
+          "
+          (click)="
+            filters.get('fields')?.setValue([]); $event.stopPropagation()
+          "
+          icon="close"
+          [isIcon]="true"
+          variant="danger"
+          [uiTooltip]="'common.close' | translate"
+        ></ui-button>
+      </div>
+    </div>
+    <!-- ACTIONS -->
+    <div
+      class="flex flex-row justify-between text-end ml-auto items-center gap-2"
     >
-  </div>
-</div>
-<ng-container *ngIf="!loading; else loadingTmpl">
-  <ng-container *ngIf="filterHistory.length; else emptyTmpl">
-    <!-- HISTORY CHANGES -->
-    <div *ngIf="!defaultView" class="overflow-x-auto m-3">
-      <table cdk-table uiTableWrapper [dataSource]="historyForTable">
-        <ng-container cdkColumnDef="id">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">{{ 'components.history.columns.signalId' | translate }}</th>
-          <td
-            uiCell
-            *cdkCellDef="let element"
-            class="!text-gray-900 !font-medium max-w-[30vw]"
-          >
-            {{ element.id }}
-          </td>
-        </ng-container>
-        <ng-container cdkColumnDef="variable">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">{{ 'components.history.columns.variable' | translate }}</th>
-          <td
-            uiCell
-            *cdkCellDef="let element"
-            class="!text-gray-900 !font-medium max-w-[30vw]"
-          >
-            {{ element.displayName }}
-          </td>
-        </ng-container>
-        <ng-container cdkColumnDef="date">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">
-            {{ 'components.history.columns.date' | translate }}
-          </th>
-          <td
-            uiCell
-            *cdkCellDef="let element"
-            class="!text-gray-900 !font-medium max-w-[30vw]"
-          >
-            {{ element.createdAt | sharedDate : 'shortDate' }} -
-            {{ element.createdAt | sharedDate : 'shortTime' }}
-          </td>
-        </ng-container>
-        <ng-container cdkColumnDef="person">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">{{ 'components.history.columns.person' | translate }}</th>
-          <td
-            uiCell
-            *cdkCellDef="let element"
-            class="!text-gray-900 !font-medium max-w-[30vw]"
-          >
-            {{ element.createdBy }}
-          </td>
-        </ng-container>
-        <ng-container cdkColumnDef="action">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">{{ 'components.history.columns.action' | translate }}</th>
-          <td
-            uiCell
-            *cdkCellDef="let element"
-            class="!text-gray-900 !font-medium max-w-[30vw]"
-          >
-            <div [innerHTML]="getChipFromChange(element)"></div>
-          </td>
-        </ng-container>
-        <ng-container cdkColumnDef="originalValue">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">
-            {{ 'components.history.columns.originalValue' | translate }}
-          </th>
-          <td
-            uiCell
-            *cdkCellDef="let element"
-            class="!text-gray-900 !font-medium max-w-[30vw]"
-          >
-          {{ toReadableObjectValue(element.old) }}
-          </td>
-        </ng-container>
-        <ng-container cdkColumnDef="modifiedValue">
-          <th uiCellHeader *cdkHeaderCellDef scope="col">
-            {{ 'components.history.columns.modifiedValue' | translate }}
-          </th>
-          <td
-            uiCell
-            *cdkCellDef="let element"
-            class="!text-gray-900 !font-medium max-w-[30vw]"
-          >
-            {{ toReadableObjectValue(element.new) }}
-          </td>
-        </ng-container>
-
-        <tr cdk-header-row *cdkHeaderRowDef="displayedColumnsHistory"></tr>
-        <tr *cdkRowDef="let row; columns: displayedColumnsHistory" cdk-row></tr>
-      </table>
+      <ui-button
+        category="secondary"
+        variant="primary"
+        [uiMenuTriggerFor]="menu"
+      >
+        {{ 'components.history.download' | translate }}
+      </ui-button>
+      <ui-menu #menu>
+        <button uiMenuItem (click)="onDownload('csv')">.csv</button>
+        <button uiMenuItem (click)="onDownload('xlsx')">.xlsx</button>
+      </ui-menu>
+      <ui-toggle [formControl]="viewAsTable">
+        <ng-container ngProjectAs="label"> {{ 'components.history.useTableMode' | translate }} </ng-container>
+      </ui-toggle>
     </div>
-    <div *ngIf="defaultView">
-      <ng-container *ngFor="let item of filterHistory; let i = index">
-        <ui-expansion-panel [index]="i" (closePanel)="showMore = false">
+  </div>
+  <ng-container *ngIf="!loading; else loadingTmpl">
+    <ng-container *ngIf="filterHistory.length; else emptyTmpl">
+      <!-- HISTORY CHANGES -->
+      <ng-container *ngIf="viewAsTable.value; else cardsTmpl">
+        <ng-container *ngTemplateOutlet="tableTmpl"></ng-container>
+      </ng-container>
+    </ng-container>
+    <ng-template #emptyTmpl>
+      <shared-empty
+        [title]="'components.history.empty' | translate"
+      ></shared-empty>
+    </ng-template>
+  </ng-container>
+  <ng-template #loadingTmpl>
+    <!-- LOADING -->
+    <div class="grow overflow-y-auto">
+      <ng-container *ngFor="let _ of [].constructor(4); let i = index">
+        <ui-expansion-panel [index]="i">
           <ng-container ngProjectAs="title">
-            <span class="font-bold mr-2">{{
-              item.createdAt | sharedDate : 'shortDate'
-            }}</span>
-            {{ item.createdAt | sharedDate : 'shortTime' }}
-            <span class="history-user" *ngIf="item.createdBy">{{
-              item.createdBy
-            }}</span>
+            <kendo-skeleton width="50%"></kendo-skeleton>
+            <kendo-skeleton
+              class="history-user"
+              width="30%"
+              height="2em"
+            ></kendo-skeleton>
           </ng-container>
-
-          <div class="flex flex-col text-sm">
-            <div
-              class="changes-content"
-              *ngFor="
-                let value of showMore ? item.changes : item.changes.slice(0, 4)
-              "
-              [innerHTML]="getHTMLFromChange(value)"
-            ></div>
-            <div class="text-center mb-3">
-              <ui-button
-                variant="primary"
-                *ngIf="!showMore && item.changes.length > 4"
-                (click)="showMore = true"
-                >{{ 'common.pagination.loadMore' | translate }} ({{
-                  item.changes.length - 4
-                }})</ui-button
-              >
-            </div>
-            <ui-button
-              icon="update"
-              class="self-end"
-              (click)="onRevert(item.version)"
-              *ngIf="item.version"
-            >
-              {{ 'components.history.preview' | translate }}
-            </ui-button>
-          </div>
         </ui-expansion-panel>
       </ng-container>
     </div>
-  </ng-container>
-  <ng-template #emptyTmpl>
-    <shared-empty
-      [title]="'components.history.empty' | translate"
-    ></shared-empty>
   </ng-template>
-</ng-container>
-<ng-template #loadingTmpl>
-  <!-- LOADING -->
-  <div class="grow overflow-y-auto">
-    <ng-container *ngFor="let _ of [].constructor(4); let i = index">
-      <ui-expansion-panel [index]="i">
+</div>
+
+<!-- Display as table -->
+<ng-template #tableTmpl>
+  <div class="overflow-x-auto">
+    <table cdk-table uiTableWrapper [dataSource]="historyForTable">
+      <ng-container cdkColumnDef="id">
+        <th uiCellHeader *cdkHeaderCellDef scope="col">
+          {{ 'components.history.columns.signalId' | translate }}
+        </th>
+        <td
+          uiCell
+          *cdkCellDef="let element"
+          class="!text-gray-900 !font-medium max-w-[30vw]"
+        >
+          {{ element.id }}
+        </td>
+      </ng-container>
+      <ng-container cdkColumnDef="variable">
+        <th uiCellHeader *cdkHeaderCellDef scope="col">
+          {{ 'components.history.columns.variable' | translate }}
+        </th>
+        <td
+          uiCell
+          *cdkCellDef="let element"
+          class="!text-gray-900 !font-medium max-w-[30vw]"
+        >
+          {{ element.displayName }}
+        </td>
+      </ng-container>
+      <ng-container cdkColumnDef="date">
+        <th uiCellHeader *cdkHeaderCellDef scope="col">
+          {{ 'components.history.columns.date' | translate }}
+        </th>
+        <td
+          uiCell
+          *cdkCellDef="let element"
+          class="!text-gray-900 !font-medium max-w-[30vw]"
+        >
+          {{ element.createdAt | sharedDate : 'shortDate' }} -
+          {{ element.createdAt | sharedDate : 'shortTime' }}
+        </td>
+      </ng-container>
+      <ng-container cdkColumnDef="person">
+        <th uiCellHeader *cdkHeaderCellDef scope="col">
+          {{ 'components.history.columns.person' | translate }}
+        </th>
+        <td
+          uiCell
+          *cdkCellDef="let element"
+          class="!text-gray-900 !font-medium max-w-[30vw]"
+        >
+          {{ element.createdBy }}
+        </td>
+      </ng-container>
+      <ng-container cdkColumnDef="action">
+        <th uiCellHeader *cdkHeaderCellDef scope="col">
+          {{ 'components.history.columns.action' | translate }}
+        </th>
+        <td
+          uiCell
+          *cdkCellDef="let element"
+          class="!text-gray-900 !font-medium max-w-[30vw]"
+        >
+          <div [innerHTML]="getChipFromChange(element)"></div>
+        </td>
+      </ng-container>
+      <ng-container cdkColumnDef="originalValue">
+        <th uiCellHeader *cdkHeaderCellDef scope="col">
+          {{ 'components.history.columns.originalValue' | translate }}
+        </th>
+        <td
+          uiCell
+          *cdkCellDef="let element"
+          class="!text-gray-900 !font-medium max-w-[30vw]"
+        >
+          {{ toReadableObjectValue(element.old) }}
+        </td>
+      </ng-container>
+      <ng-container cdkColumnDef="modifiedValue">
+        <th uiCellHeader *cdkHeaderCellDef scope="col">
+          {{ 'components.history.columns.modifiedValue' | translate }}
+        </th>
+        <td
+          uiCell
+          *cdkCellDef="let element"
+          class="!text-gray-900 !font-medium max-w-[30vw]"
+        >
+          {{ toReadableObjectValue(element.new) }}
+        </td>
+      </ng-container>
+
+      <tr cdk-header-row *cdkHeaderRowDef="displayedColumnsHistory"></tr>
+      <tr *cdkRowDef="let row; columns: displayedColumnsHistory" cdk-row></tr>
+    </table>
+  </div>
+</ng-template>
+
+<!-- Display as cards -->
+<ng-template #cardsTmpl>
+  <div>
+    <ng-container *ngFor="let item of filterHistory; let i = index">
+      <ui-expansion-panel [index]="i" (closePanel)="showMore = false">
         <ng-container ngProjectAs="title">
-          <kendo-skeleton width="50%"></kendo-skeleton>
-          <kendo-skeleton
-            class="history-user"
-            width="30%"
-            height="2em"
-          ></kendo-skeleton>
+          <span class="font-bold mr-2">{{
+            item.createdAt | sharedDate : 'shortDate'
+          }}</span>
+          {{ item.createdAt | sharedDate : 'shortTime' }}
+          <span class="history-user" *ngIf="item.createdBy">{{
+            item.createdBy
+          }}</span>
         </ng-container>
+
+        <div class="flex flex-col text-sm">
+          <div
+            class="changes-content"
+            *ngFor="
+              let value of showMore ? item.changes : item.changes.slice(0, 4)
+            "
+            [innerHTML]="getHTMLFromChange(value)"
+          ></div>
+          <div class="text-center mb-3">
+            <ui-button
+              variant="primary"
+              *ngIf="!showMore && item.changes.length > 4"
+              (click)="showMore = true"
+              >{{ 'common.pagination.loadMore' | translate }} ({{
+                item.changes.length - 4
+              }})</ui-button
+            >
+          </div>
+          <ui-button
+            icon="update"
+            class="self-end"
+            (click)="onRevert(item.version)"
+            *ngIf="item.version"
+          >
+            {{ 'components.history.preview' | translate }}
+          </ui-button>
+        </div>
       </ui-expansion-panel>
     </ng-container>
   </div>

--- a/libs/shared/src/lib/components/record-history/record-history.component.html
+++ b/libs/shared/src/lib/components/record-history/record-history.component.html
@@ -75,7 +75,10 @@
       <button uiMenuItem (click)="onDownload('csv')">.csv</button>
       <button uiMenuItem (click)="onDownload('xlsx')">.xlsx</button>
     </ui-menu>
-    <ui-button (click)="switchView()" [disabled]="defaultView">Switch to default view</ui-button>
+    <ui-button (click)="switchView()"
+      ><div *ngIf="!defaultView">Switch to default view</div>
+      <div *ngIf="defaultView">Switch to table view</div></ui-button
+    >
   </div>
 </div>
 <ng-container *ngIf="!loading; else loadingTmpl">

--- a/libs/shared/src/lib/components/record-history/record-history.component.html
+++ b/libs/shared/src/lib/components/record-history/record-history.component.html
@@ -85,7 +85,7 @@
   <ng-container *ngIf="filterHistory.length; else emptyTmpl">
     <!-- HISTORY CHANGES -->
     <div *ngIf="!defaultView" class="overflow-x-auto m-3">
-      <table cdk-table uiTableWrapper [dataSource]="history">
+      <table cdk-table uiTableWrapper [dataSource]="historyForTable">
         <ng-container cdkColumnDef="id">
           <th uiCellHeader *cdkHeaderCellDef scope="col">Signal Id</th>
           <td
@@ -103,7 +103,7 @@
             *cdkCellDef="let element"
             class="!text-gray-900 !font-medium max-w-[30vw]"
           >
-            {{ element.field }}
+            {{ element.displayName }}
           </td>
         </ng-container>
         <ng-container cdkColumnDef="date">
@@ -135,7 +135,9 @@
             uiCell
             *cdkCellDef="let element"
             class="!text-gray-900 !font-medium max-w-[30vw]"
-          ></td>
+          >
+            <div [innerHTML]="getChipFromChange(element)"></div>
+          </td>
         </ng-container>
         <ng-container cdkColumnDef="originalValue">
           <th uiCellHeader *cdkHeaderCellDef scope="col">
@@ -145,7 +147,9 @@
             uiCell
             *cdkCellDef="let element"
             class="!text-gray-900 !font-medium max-w-[30vw]"
-          ></td>
+          >
+          {{ toReadableObjectValue(element.old) }}
+          </td>
         </ng-container>
         <ng-container cdkColumnDef="modifiedValue">
           <th uiCellHeader *cdkHeaderCellDef scope="col">
@@ -155,7 +159,9 @@
             uiCell
             *cdkCellDef="let element"
             class="!text-gray-900 !font-medium max-w-[30vw]"
-          ></td>
+          >
+            {{ toReadableObjectValue(element.new) }}
+          </td>
         </ng-container>
 
         <tr cdk-header-row *cdkHeaderRowDef="displayedColumnsHistory"></tr>

--- a/libs/shared/src/lib/components/record-history/record-history.component.html
+++ b/libs/shared/src/lib/components/record-history/record-history.component.html
@@ -84,6 +84,84 @@
 <ng-container *ngIf="!loading; else loadingTmpl">
   <ng-container *ngIf="filterHistory.length; else emptyTmpl">
     <!-- HISTORY CHANGES -->
+    <div *ngIf="!defaultView" class="overflow-x-auto m-3">
+      <table cdk-table uiTableWrapper [dataSource]="history">
+        <ng-container cdkColumnDef="id">
+          <th uiCellHeader *cdkHeaderCellDef scope="col">Signal Id</th>
+          <td
+            uiCell
+            *cdkCellDef="let element"
+            class="!text-gray-900 !font-medium max-w-[30vw]"
+          >
+            {{ element.id }}
+          </td>
+        </ng-container>
+        <ng-container cdkColumnDef="variable">
+          <th uiCellHeader *cdkHeaderCellDef scope="col">Variable modified</th>
+          <td
+            uiCell
+            *cdkCellDef="let element"
+            class="!text-gray-900 !font-medium max-w-[30vw]"
+          >
+            {{ element.field }}
+          </td>
+        </ng-container>
+        <ng-container cdkColumnDef="date">
+          <th uiCellHeader *cdkHeaderCellDef scope="col">
+            Date of modification
+          </th>
+          <td
+            uiCell
+            *cdkCellDef="let element"
+            class="!text-gray-900 !font-medium max-w-[30vw]"
+          >
+            {{ element.createdAt | sharedDate : 'shortDate' }} -
+            {{ element.createdAt | sharedDate : 'shortTime' }}
+          </td>
+        </ng-container>
+        <ng-container cdkColumnDef="person">
+          <th uiCellHeader *cdkHeaderCellDef scope="col">Who modified</th>
+          <td
+            uiCell
+            *cdkCellDef="let element"
+            class="!text-gray-900 !font-medium max-w-[30vw]"
+          >
+            {{ element.createdBy }}
+          </td>
+        </ng-container>
+        <ng-container cdkColumnDef="action">
+          <th uiCellHeader *cdkHeaderCellDef scope="col">Action taken</th>
+          <td
+            uiCell
+            *cdkCellDef="let element"
+            class="!text-gray-900 !font-medium max-w-[30vw]"
+          ></td>
+        </ng-container>
+        <ng-container cdkColumnDef="originalValue">
+          <th uiCellHeader *cdkHeaderCellDef scope="col">
+            Original variable value
+          </th>
+          <td
+            uiCell
+            *cdkCellDef="let element"
+            class="!text-gray-900 !font-medium max-w-[30vw]"
+          ></td>
+        </ng-container>
+        <ng-container cdkColumnDef="modifiedValue">
+          <th uiCellHeader *cdkHeaderCellDef scope="col">
+            Modified variable value
+          </th>
+          <td
+            uiCell
+            *cdkCellDef="let element"
+            class="!text-gray-900 !font-medium max-w-[30vw]"
+          ></td>
+        </ng-container>
+
+        <tr cdk-header-row *cdkHeaderRowDef="displayedColumnsHistory"></tr>
+        <tr *cdkRowDef="let row; columns: displayedColumnsHistory" cdk-row></tr>
+      </table>
+    </div>
     <div *ngIf="defaultView">
       <ng-container *ngFor="let item of filterHistory; let i = index">
         <ui-expansion-panel [index]="i" (closePanel)="showMore = false">

--- a/libs/shared/src/lib/components/record-history/record-history.component.scss
+++ b/libs/shared/src/lib/components/record-history/record-history.component.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   height: 100%;
   position: relative;
-  width: 328px;
+  width: 1528px;
 }
 
 .history-user {

--- a/libs/shared/src/lib/components/record-history/record-history.component.scss
+++ b/libs/shared/src/lib/components/record-history/record-history.component.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   height: 100%;
   position: relative;
-  width: 1528px;
+  width: 328px;
 }
 
 .history-user {

--- a/libs/shared/src/lib/components/record-history/record-history.component.scss
+++ b/libs/shared/src/lib/components/record-history/record-history.component.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   height: 100%;
   position: relative;
-  width: 328px;
 }
 
 .history-user {

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -252,24 +252,26 @@ export class RecordHistoryComponent
     this.cancel.emit(true);
   }
 
+  /**
+   * Get HTML for type chip
+   *
+   * @param change The field change object
+   * @returns the HTML for the chip
+   */
   getChipFromChange(change: Change) {
     switch (change.type) {
       case 'remove':
       case 'add':
         return `
-          <p>
             <span class="${change.type}-field">
             ${this.translations[change.type]}
             </span>
-          <p>
           `;
       case 'modify':
         return `
-          <p>
             <span class="${change.type}-field">
             ${this.translations[change.type]}
             </span>
-          <p>
           `;
     }
   }
@@ -303,9 +305,7 @@ export class RecordHistoryComponent
       case 'add':
         return `
           <p>
-            <span class="${change.type}-field">
-            ${this.translations[change.type]}
-            </span>
+            ${this.getChipFromChange(change)}
             <b> ${change.displayName} </b>
             ${this.translations.withValue}
             <b> ${change.type === 'add' ? newVal : oldVal}</b>
@@ -314,9 +314,7 @@ export class RecordHistoryComponent
       case 'modify':
         return `
           <p>
-            <span class="${change.type}-field">
-            ${this.translations[change.type]}
-            </span>
+          ${this.getChipFromChange(change)}
             <b> ${change.displayName} </b>
             ${this.translations.from}
             <b> ${oldVal}</b>

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -88,6 +88,8 @@ export class RecordHistoryComponent
   });
   /** Sorted fields */
   public sortedFields: any[] = [];
+  /** Switch views */
+  public defaultView = false;
 
   /** @returns filename from current date and record inc. id */
   get fileName(): string {
@@ -331,6 +333,10 @@ export class RecordHistoryComponent
         this.revert(version);
       }
     });
+  }
+
+  switchView(): void {
+    this.defaultView = true;
   }
 
   /**

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -184,15 +184,7 @@ export class RecordHistoryComponent
             this.historyForTable = [];
             this.history.map((elt) => {
               elt.changes.map((change) => {
-                this.historyForTable.push({
-                  id: this.id,
-                  displayName: change.displayName,
-                  new: change.new ? JSON.parse(change.new) : undefined,
-                  old: change.old ? JSON.parse(change.old) : undefined,
-                  type: change.type,
-                  createdAt: elt.createdAt,
-                  createdBy: elt.createdBy,
-                });
+                this.setHistoryForTableFromChange(change, elt);
               });
             });
             this.loading = false;
@@ -243,6 +235,12 @@ export class RecordHistoryComponent
             return newItem;
           });
       }
+      this.historyForTable = [];
+      this.filterHistory.map((elt) => {
+        elt.changes.map((change) => {
+          this.setHistoryForTableFromChange(change, elt);
+        });
+      });
     });
   }
 
@@ -251,6 +249,24 @@ export class RecordHistoryComponent
    */
   onCancel(): void {
     this.cancel.emit(true);
+  }
+
+  /**
+   * Push correct values to historyForTable list
+   *
+   * @param change Change to push
+   * @param filterHistoryElement Filter history element (used for createdAt and createdBy)
+   */
+  setHistoryForTableFromChange(change: Change, filterHistoryElement: any) {
+    this.historyForTable.push({
+      id: this.id,
+      displayName: change.displayName,
+      new: change.new ? JSON.parse(change.new) : undefined,
+      old: change.old ? JSON.parse(change.old) : undefined,
+      type: change.type,
+      createdAt: filterHistoryElement.createdAt,
+      createdBy: filterHistoryElement.createdBy,
+    });
   }
 
   /**

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -100,7 +100,7 @@ export class RecordHistoryComponent
     'originalValue',
     'modifiedValue',
   ];
-
+  /** Translations for chips */
   translations = {
     withValue: this.translate.instant('components.history.changes.withValue'),
     from: this.translate.instant('components.history.changes.from'),
@@ -109,7 +109,7 @@ export class RecordHistoryComponent
     remove: this.translate.instant('components.history.changes.remove'),
     modify: this.translate.instant('components.history.changes.modify'),
   };
-
+  /** Data source for history as a table */
   historyForTable: any[] = [];
 
   /** @returns filename from current date and record inc. id */
@@ -185,6 +185,7 @@ export class RecordHistoryComponent
             this.history.map((elt) => {
               elt.changes.map((change) => {
                 this.historyForTable.push({
+                  id: this.id,
                   displayName: change.displayName,
                   new: change.new ? JSON.parse(change.new) : undefined,
                   old: change.old ? JSON.parse(change.old) : undefined,

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -90,6 +90,16 @@ export class RecordHistoryComponent
   public sortedFields: any[] = [];
   /** Switch views */
   public defaultView = false;
+  /** Table columns */
+  public displayedColumnsHistory: string[] = [
+    'id',
+    'variable',
+    'date',
+    'person',
+    'action',
+    'originalValue',
+    'modifiedValue',
+  ];
 
   /** @returns filename from current date and record inc. id */
   get fileName(): string {
@@ -340,6 +350,7 @@ export class RecordHistoryComponent
    */
   switchView(): void {
     this.defaultView = !this.defaultView;
+    console.log('HERE', this.history);
   }
 
   /**

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -88,8 +88,6 @@ export class RecordHistoryComponent
   });
   /** Sorted fields */
   public sortedFields: any[] = [];
-  /** Switch views */
-  public defaultView = false;
   /** Table columns */
   public displayedColumnsHistory: string[] = [
     'id',
@@ -111,6 +109,8 @@ export class RecordHistoryComponent
   };
   /** Data source for history as a table */
   historyForTable: any[] = [];
+  /** Should view as table */
+  viewAsTable = new FormControl(true);
 
   /** @returns filename from current date and record inc. id */
   get fileName(): string {
@@ -394,13 +394,6 @@ export class RecordHistoryComponent
         this.revert(version);
       }
     });
-  }
-
-  /**
-   * Switch view from table to default and vice/versa
-   */
-  switchView(): void {
-    this.defaultView = !this.defaultView;
   }
 
   /**

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -335,8 +335,11 @@ export class RecordHistoryComponent
     });
   }
 
+  /**
+   * Switch view from table to default and vice/versa
+   */
   switchView(): void {
-    this.defaultView = true;
+    this.defaultView = !this.defaultView;
   }
 
   /**

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -101,6 +101,17 @@ export class RecordHistoryComponent
     'modifiedValue',
   ];
 
+  translations = {
+    withValue: this.translate.instant('components.history.changes.withValue'),
+    from: this.translate.instant('components.history.changes.from'),
+    to: this.translate.instant('components.history.changes.to'),
+    add: this.translate.instant('components.history.changes.add'),
+    remove: this.translate.instant('components.history.changes.remove'),
+    modify: this.translate.instant('components.history.changes.modify'),
+  };
+
+  historyForTable: any[] = [];
+
   /** @returns filename from current date and record inc. id */
   get fileName(): string {
     const today = new Date();
@@ -170,6 +181,19 @@ export class RecordHistoryComponent
               (item) => item.changes.length
             );
             this.filterHistory = this.history;
+            this.historyForTable = [];
+            this.history.map((elt) => {
+              elt.changes.map((change) => {
+                this.historyForTable.push({
+                  displayName: change.displayName,
+                  new: change.new ? JSON.parse(change.new) : undefined,
+                  old: change.old ? JSON.parse(change.old) : undefined,
+                  type: change.type,
+                  createdAt: elt.createdAt,
+                  createdBy: elt.createdBy,
+                });
+              });
+            });
             this.loading = false;
           }
         });
@@ -228,6 +252,28 @@ export class RecordHistoryComponent
     this.cancel.emit(true);
   }
 
+  getChipFromChange(change: Change) {
+    switch (change.type) {
+      case 'remove':
+      case 'add':
+        return `
+          <p>
+            <span class="${change.type}-field">
+            ${this.translations[change.type]}
+            </span>
+          <p>
+          `;
+      case 'modify':
+        return `
+          <p>
+            <span class="${change.type}-field">
+            ${this.translations[change.type]}
+            </span>
+          <p>
+          `;
+    }
+  }
+
   /**
    * Gets the HTML element from a change object
    *
@@ -235,15 +281,6 @@ export class RecordHistoryComponent
    * @returns the innerHTML for the listing
    */
   getHTMLFromChange(change: Change) {
-    const translations = {
-      withValue: this.translate.instant('components.history.changes.withValue'),
-      from: this.translate.instant('components.history.changes.from'),
-      to: this.translate.instant('components.history.changes.to'),
-      add: this.translate.instant('components.history.changes.add'),
-      remove: this.translate.instant('components.history.changes.remove'),
-      modify: this.translate.instant('components.history.changes.modify'),
-    };
-
     let oldVal = change.old ? JSON.parse(change.old) : undefined;
     let newVal = change.new ? JSON.parse(change.new) : undefined;
 
@@ -267,10 +304,10 @@ export class RecordHistoryComponent
         return `
           <p>
             <span class="${change.type}-field">
-            ${translations[change.type]}
+            ${this.translations[change.type]}
             </span>
             <b> ${change.displayName} </b>
-            ${translations.withValue}
+            ${this.translations.withValue}
             <b> ${change.type === 'add' ? newVal : oldVal}</b>
           <p>
           `;
@@ -278,12 +315,12 @@ export class RecordHistoryComponent
         return `
           <p>
             <span class="${change.type}-field">
-            ${translations[change.type]}
+            ${this.translations[change.type]}
             </span>
             <b> ${change.displayName} </b>
-            ${translations.from}
+            ${this.translations.from}
             <b> ${oldVal}</b>
-            ${translations.to}
+            ${this.translations.to}
             <b> ${newVal}</b>
           <p>
           `;
@@ -316,7 +353,6 @@ export class RecordHistoryComponent
         );
       });
     }
-
     return res;
   }
 
@@ -350,7 +386,6 @@ export class RecordHistoryComponent
    */
   switchView(): void {
     this.defaultView = !this.defaultView;
-    console.log('HERE', this.history);
   }
 
   /**

--- a/libs/shared/src/lib/components/record-history/record-history.module.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.module.ts
@@ -10,6 +10,7 @@ import {
   FormWrapperModule,
   TooltipModule,
   TableModule,
+  ToggleModule,
 } from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { DateModule } from '../../pipes/date/date.module';
@@ -40,6 +41,7 @@ import { FormsModule } from '@angular/forms';
     TooltipModule,
     FormsModule,
     TableModule,
+    ToggleModule,
   ],
   exports: [RecordHistoryComponent],
 })

--- a/libs/shared/src/lib/components/record-history/record-history.module.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.module.ts
@@ -9,6 +9,7 @@ import {
   DateModule as UiDateModule,
   FormWrapperModule,
   TooltipModule,
+  TableModule,
 } from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { DateModule } from '../../pipes/date/date.module';
@@ -38,6 +39,7 @@ import { FormsModule } from '@angular/forms';
     FormWrapperModule,
     TooltipModule,
     FormsModule,
+    TableModule,
   ],
   exports: [RecordHistoryComponent],
 })


### PR DESCRIPTION
# Description

Adds the possibility to view history as a table. Works with the same filter as default view.
Needs updated panel width to function correctly (done in another ticket).
No "revert" button was mentioned in the mock-up so I did not include one in the table

## Useful links

- Please insert link to ticket : https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83311

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested in back-office with panel width of 1528px

## Screenshots

![image](https://github.com/ReliefApplications/ems-frontend/assets/103029022/cac97de4-611a-4a0a-99f2-9e3a4220fee8)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
