### PR TITLE
fix/AB#82564_aggregate_cards_unnecessarily_reloading

### DIFF
--- a/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
+++ b/libs/shared/src/lib/components/aggregation/aggregation-grid/aggregation-grid.component.ts
@@ -58,6 +58,8 @@ export class AggregationGridComponent
   public pagerSettings = PAGER_SETTINGS;
   /** Show filter */
   public showFilter = false;
+  /** Previous context filter value */
+  public previousContextFilter: any = {};
 
   /** Resource id */
   @Input() resourceId!: string;
@@ -114,8 +116,17 @@ export class AggregationGridComponent
     if (this.contextService.filterRegex.test(this.contextFilters as string)) {
       this.contextService.filter$
         .pipe(debounceTime(500), takeUntil(this.destroy$))
-        .subscribe(() => {
-          this.getAggregationData();
+        .subscribe((contextFilter: any) => {
+          if (
+            this.contextService.filterInWidgetFilter(
+              this.previousContextFilter,
+              contextFilter,
+              this.contextFilters as string
+            )
+          ) {
+            this.getAggregationData();
+          }
+          this.previousContextFilter = contextFilter;
         });
     }
     this.queryBuilder.isDoneLoading$.subscribe((doneLoading) => {

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -171,6 +171,8 @@ export class CoreGridComponent
   private dataQuery!: QueryRef<QueryResponse>;
   /** Meta query reference for fetching metadata. */
   private metaQuery!: any;
+  /** Previous context filter value */
+  public previousContextFilter: any = {};
 
   // === PAGINATION ===
   /** Number of items per page. */
@@ -366,9 +368,19 @@ export class CoreGridComponent
     this.environment = environment;
     contextService.filter$
       .pipe(debounceTime(500), takeUntil(this.destroy$))
-      .subscribe(() => {
+      .subscribe((contextFilter: any) => {
         if (contextService.filterRegex.test(this.settings.contextFilters)) {
-          if (this.dataQuery) this.reloadData();
+          if (
+            this.dataQuery &&
+            this.contextService.filterInWidgetFilter(
+              this.previousContextFilter,
+              contextFilter,
+              this.widget.settings.contextFilters
+            )
+          ) {
+            this.reloadData();
+          }
+          this.previousContextFilter = contextFilter;
         }
       });
   }

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -247,7 +247,15 @@ export class MapComponent
           takeUntil(this.destroy$)
         )
         .subscribe(() => {
-          this.filterLayers();
+          if (
+            this.contextService.filterInWidgetFilter(
+              this.appliedDashboardFilters,
+              this.contextService.filter.getValue(),
+              allContextFilters
+            )
+          ) {
+            this.filterLayers();
+          }
         });
     }
 

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -256,6 +256,7 @@ export class MapComponent
           ) {
             this.filterLayers();
           }
+          this.appliedDashboardFilters = this.contextService.filter.getValue();
         });
     }
 

--- a/libs/shared/src/lib/components/widgets/chart/chart.component.ts
+++ b/libs/shared/src/lib/components/widgets/chart/chart.component.ts
@@ -96,6 +96,8 @@ export class ChartComponent
   public selectedFilter: CompositeFilterDescriptor | null = null;
   /** Aggregation id */
   private aggregationId?: string;
+  /** Previous context filter value */
+  public previousContextFilter: any = {};
 
   /** @returns Context filters array */
   get contextFilters(): CompositeFilterDescriptor {
@@ -158,10 +160,19 @@ export class ChartComponent
     if (this.contextService.filterRegex.test(this.settings.contextFilters)) {
       this.contextService.filter$
         .pipe(takeUntil(this.destroy$))
-        .subscribe(() => {
-          this.series.next([]);
-          this.loadChart();
-          this.getOptions();
+        .subscribe((contextFilter: any) => {
+          if (
+            this.contextService.filterInWidgetFilter(
+              this.previousContextFilter,
+              contextFilter,
+              this.settings.contextFilters
+            )
+          ) {
+            this.series.next([]);
+            this.loadChart();
+            this.getOptions();
+          }
+          this.previousContextFilter = contextFilter;
         });
     }
   }

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -73,6 +73,8 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
   public refresh$: Subject<boolean> = new Subject<boolean>();
   /** Timeout to init active filter */
   private timeoutListener!: NodeJS.Timeout;
+  /** Previous context filter value */
+  public previousContextFilter: any = {};
 
   /** @returns does the card use reference data */
   get useReferenceData() {
@@ -134,11 +136,19 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
     this.contextService.filter$
       .pipe(debounceTime(500), takeUntil(this.destroy$))
       .subscribe((value) => {
-        if (this.contextService.filterRegex.test(allContextFilters)) {
+        if (
+          this.contextService.filterRegex.test(allContextFilters) &&
+          this.contextService.filterInWidgetFilter(
+            this.previousContextFilter,
+            value,
+            allContextFilters
+          )
+        ) {
           this.refresh$.next(true);
           this.loading = true;
           this.setHtml();
         }
+        this.previousContextFilter = value;
         this.toggleActiveFilters(
           value,
           this.htmlContentComponent?.el.nativeElement

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -137,6 +137,8 @@ export class SummaryCardComponent
   private scrollEventListener!: any;
   /** Timeout listener for summary card scroll bind set on view switch */
   private scrollEventBindTimeout!: NodeJS.Timeout;
+  /** Previous context filter value */
+  public previousContextFilter: any = {};
 
   /** @returns Get query filter */
   get queryFilter(): CompositeFilterDescriptor {
@@ -271,15 +273,23 @@ export class SummaryCardComponent
       .subscribe((value) => {
         this.handleSearch(value || '');
       });
-
     // Listen to dashboard filters changes if it is necessary
     if (
       this.contextService.filterRegex.test(this.widget.settings.contextFilters)
     ) {
       this.contextService.filter$
         .pipe(debounceTime(500), takeUntil(this.destroy$))
-        .subscribe(() => {
-          this.refresh();
+        .subscribe((contextFilter: any) => {
+          if (
+            this.contextService.filterInWidgetFilter(
+              this.previousContextFilter,
+              contextFilter,
+              this.widget.settings.contextFilters
+            )
+          ) {
+            this.refresh();
+          }
+          this.previousContextFilter = contextFilter;
         });
     }
   }

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -468,4 +468,50 @@ export class ContextService {
       );
     }
   }
+
+  /**
+   * Find Difference between two filter objects
+   *
+   * @param obj1 previous filter object
+   * @param obj2 current filter object
+   *
+   * @returns different key
+   */
+  findFilterDifference(obj1: any, obj2: any): any {
+    // Check if both objects are defined
+    if (!obj1 || !obj2) {
+      return null;
+    }
+
+    // Get all unique keys from both objects
+    const keys = Array.from(
+      new Set([...Object.keys(obj1), ...Object.keys(obj2)])
+    );
+
+    // Iterate through keys to find the first difference
+    for (const key of keys) {
+      if (obj1[key] !== obj2[key]) {
+        return key;
+      }
+    }
+
+    // If no difference is found
+    return null;
+  }
+
+  /**
+   * Verify if changed filter is in widget filter
+   *
+   * @param obj1 previous filter object
+   * @param obj2 current filter object
+   * @param contextFilters widget context filter
+   *
+   * @returns different key
+   */
+  filterInWidgetFilter(obj1: any, obj2: any, contextFilters: any): boolean {
+    const fieldFilterChanged = this.findFilterDifference(obj1, obj2);
+    // regex to check if in the contextFilter exists the changed key(filter field)
+    const regex = new RegExp(`{{filter\\.${fieldFilterChanged}[\\s\\S]*}}`);
+    return regex.test(contextFilters);
+  }
 }

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -488,15 +488,8 @@ export class ContextService {
       new Set([...Object.keys(obj1), ...Object.keys(obj2)])
     );
 
-    // Iterate through keys to find the first difference
-    for (const key of keys) {
-      if (obj1[key] !== obj2[key]) {
-        return key;
-      }
-    }
-
-    // If no difference is found
-    return null;
+    // Return key where modifications happened
+    return keys.find((key) => obj1[key] !== obj2[key]);
   }
 
   /**


### PR DESCRIPTION
# Description

Fix: Now if some field of the filter is selected and this field is not in the widget filter, it's not reloaded the widget.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82564)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

As the attached video.

## Screenshots

![Peek 15-01-2024 16-05](https://github.com/ReliefApplications/ems-frontend/assets/56398308/2dd0cc07-96a3-4040-96bf-54505b858c2c)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
