### PR TITLE
fix/AB#83434_select_menu_disabled_input_does_not_work

### DIFF
--- a/libs/ui/src/lib/select-menu/select-menu.component.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.component.ts
@@ -284,7 +284,8 @@ export class SelectMenuComponent
    * @param isDisabled is control disabled
    */
   public setDisabledState(isDisabled: boolean): void {
-    this.disabled = isDisabled;
+    // Check if the input is explicitly set, otherwise use the value passed to setDisabledState
+    this.disabled = this.disabled !== undefined ? this.disabled : isDisabled;
   }
 
   /**


### PR DESCRIPTION
# Description

Fix: ui-select-menu disabled input doesn't work, even if set to true, the select menu is never disabled.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83434)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Configured any ui-select-menu input "disabled" as true and verified if it's working correctly.

## Screenshots

![Captura de tela de 2024-01-15 17-59-58](https://github.com/ReliefApplications/ems-frontend/assets/56398308/12c6d1f2-20bb-4cb2-8700-b857a26b636b)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
