### PR TITLE
feat/AB#83384-fit-zoom-on-country-when-passed-to-map

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1760,8 +1760,8 @@
 							"timedimension": "Time dimension",
 							"title": "Visible Map Controls"
 						},
-						"countryField": "Country field",
-						"geographicExtentValue": "Use geographic extent",
+						"geographicExtent": "Geographic extent",
+						"geographicExtentValue": "Geographic extent value",
 						"latitude": "Map center latitude",
 						"longitude": "Map center longitude",
 						"setByMap": "Set By Map",
@@ -1788,7 +1788,8 @@
 							"latitude": "Set the default latitude of the center of the map. You can use 'Set By Map' to use the latitude of the preview map.",
 							"longitude": "Set the default longitude of the center of the map. You can use 'Set By Map' to use the longitude of the preview map.",
 							"zoom": "Select a default zoom for the map display"
-						}
+						},
+						"geographicExtent": "You can input a static value, or use {{context}} or {{filter}} notation to dynamically inject a value"
 					}
 				},
 				"style": {

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1750,8 +1750,8 @@
 							"timedimension": "Time dimension",
 							"title": "Visible Map Controls"
 						},
-						"geographicExtent": "Use geographic extent",
-						"geographicExtentField": "Geographic extent field",
+						"countryField": "Country field",
+						"geographicExtentValue": "Use geographic extent",
 						"latitude": "Map center latitude",
 						"longitude": "Map center longitude",
 						"setByMap": "Set By Map",

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1750,6 +1750,8 @@
 							"timedimension": "Time dimension",
 							"title": "Visible Map Controls"
 						},
+						"geographicExtent": "Use geographic extent",
+						"geographicExtentField": "Geographic extent field",
 						"latitude": "Map center latitude",
 						"longitude": "Map center longitude",
 						"setByMap": "Set By Map",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1763,6 +1763,8 @@
 							"timedimension": "Dimension temporelle",
 							"title": "Contrôles de la carte"
 						},
+						"geographicExtent": "Utiliser l'étendue géographique",
+						"geographicExtentField": "Champ d'étendue géographique",
 						"latitude": "Latitude du centre de la carte",
 						"longitude": "Longitude du centre de la carte",
 						"setByMap": "Utiliser la vue actuelle",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1773,8 +1773,8 @@
 							"timedimension": "Dimension temporelle",
 							"title": "Contrôles de la carte"
 						},
-						"countryField": "Champ Pays",
-						"geographicExtentValue": "Utiliser l'étendue géographique",
+						"geographicExtent": "Type d'étendue",
+						"geographicExtentValue": "Valeur de l'étendue",
 						"latitude": "Latitude du centre de la carte",
 						"longitude": "Longitude du centre de la carte",
 						"setByMap": "Utiliser la vue actuelle",
@@ -1801,7 +1801,8 @@
 							"latitude": "Définissez la latitude par défaut du centre de la carte. 'Utiliser la vue actuelle' sauvegardera la latitude de la carte d'aperçu.",
 							"longitude": "Définissez la longitude par défaut du centre de la carte. 'Utiliser la vue actuelle' sauvegardera la longitude de la carte d'aperçu.",
 							"zoom": "Sélectionnez un zoom par défaut"
-						}
+						},
+						"geographicExtent": "Vous pouvez entrer une valeur statique, ou utiliser les notations {{context}} ou {{filter}} pour injecter la valeur"
 					}
 				},
 				"style": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1763,8 +1763,8 @@
 							"timedimension": "Dimension temporelle",
 							"title": "Contrôles de la carte"
 						},
-						"geographicExtent": "Utiliser l'étendue géographique",
-						"geographicExtentField": "Champ d'étendue géographique",
+						"countryField": "Champ Pays",
+						"geographicExtentValue": "Utiliser l'étendue géographique",
 						"latitude": "Latitude du centre de la carte",
 						"longitude": "Longitude du centre de la carte",
 						"setByMap": "Utiliser la vue actuelle",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1750,8 +1750,8 @@
 							"timedimension": "******",
 							"title": "******"
 						},
-						"geographicExtent": "******",
-						"geographicExtentField": "******",
+						"countryField": "******",
+						"geographicExtentValue": "******",
 						"latitude": "******",
 						"longitude": "******",
 						"setByMap": "******",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1760,7 +1760,7 @@
 							"timedimension": "******",
 							"title": "******"
 						},
-						"countryField": "******",
+						"geographicExtent": "******",
 						"geographicExtentValue": "******",
 						"latitude": "******",
 						"longitude": "******",
@@ -1788,7 +1788,8 @@
 							"latitude": "******",
 							"longitude": "******",
 							"zoom": "******"
-						}
+						},
+						"geographicExtent": "****** {{context}} ****** {{filter}} ******"
 					}
 				},
 				"style": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1750,6 +1750,8 @@
 							"timedimension": "******",
 							"title": "******"
 						},
+						"geographicExtent": "******",
+						"geographicExtentField": "******",
 						"latitude": "******",
 						"longitude": "******",
 						"setByMap": "******",

--- a/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
+++ b/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
@@ -27,8 +27,8 @@ export interface MapConstructorSettings {
   pmIgnore?: boolean;
   controls: MapControls;
   arcGisWebMap?: string;
-  geographicExtent?: string;
-  geographicExtentField?: string;
+  geographicExtentValue?: string;
+  countryField?: string;
 }
 
 /** Available leaflet event types. */

--- a/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
+++ b/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
@@ -27,6 +27,8 @@ export interface MapConstructorSettings {
   pmIgnore?: boolean;
   controls: MapControls;
   arcGisWebMap?: string;
+  geographicExtent?: string;
+  geographicExtentField?: string;
 }
 
 /** Available leaflet event types. */

--- a/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
+++ b/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
@@ -28,7 +28,7 @@ export interface MapConstructorSettings {
   controls: MapControls;
   arcGisWebMap?: string;
   geographicExtentValue?: string;
-  countryField?: string;
+  geographicExtent?: string;
 }
 
 /** Available leaflet event types. */

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -63,6 +63,7 @@ import {
 import { MapPopupService } from './map-popup/map-popup.service';
 import { Platform } from '@angular/cdk/platform';
 import { ContextService } from '../../../services/context/context.service';
+import { MapPolygonsService } from '../../../services/map/map-polygons.service';
 import { DOCUMENT } from '@angular/common';
 import { ShadowDomService } from '@oort-front/ui';
 
@@ -182,7 +183,8 @@ export class MapComponent
    * @param platform Platform
    * @param injector Injector containing all needed providers
    * @param {ShadowDomService} shadowDomService Shadow dom service containing the current DOM host
-   * @param el Element reference
+   * @param el Element reference,
+   * @param mapPolygonsService Shared map polygons service
    */
   constructor(
     @Inject(DOCUMENT) private document: Document,
@@ -196,7 +198,8 @@ export class MapComponent
     private platform: Platform,
     public injector: Injector,
     private shadowDomService: ShadowDomService,
-    public el: ElementRef
+    public el: ElementRef,
+    private mapPolygonsService: MapPolygonsService
   ) {
     super();
     this.esriApiKey = environment.esriApiKey;
@@ -234,7 +237,7 @@ export class MapComponent
       .map((layer: any) => JSON.stringify(layer.contextFilters))
       .join('');
 
-    // Listen to dashboard filters changes if it is necessary
+    // Listen to dashboard filters changes to apply layers filter, if it is necessary
     if (this.contextService.filterRegex.test(allContextFilters)) {
       this.contextService.filter$
         .pipe(
@@ -274,6 +277,26 @@ export class MapComponent
       };
       return new Promise(checkAgain);
     };
+
+    // To zoom on getGeographicExtentValue, if necessary
+    const settings = this.extractSettings();
+    const geographicExtentValue = settings.geographicExtentValue;
+    const countryField = settings.countryField;
+
+    // Check if has initial getGeographicExtentValue to zoom on country
+    this.zoomOn(countryField as string);
+
+    const fieldValue = geographicExtentValue?.match(
+      this.contextService.filterRegex
+    );
+    if (fieldValue) {
+      // Listen to dashboard filters changes to apply getGeographicExtentValue values changes
+      this.contextService.filter$
+        .pipe(debounceTime(500), takeUntil(this.destroy$))
+        .subscribe(() => {
+          this.zoomOn(countryField as string);
+        });
+    }
   }
 
   override ngOnDestroy(): void {
@@ -362,12 +385,12 @@ export class MapComponent
     const zoomControl = get(mapSettings, 'zoomControl', false);
     const controls = get(mapSettings, 'controls', DefaultMapControls);
     const arcGisWebMap = get(mapSettings, 'arcGisWebMap', undefined);
-    const geographicExtent = get(mapSettings, 'geographicExtent', undefined);
-    const geographicExtentField = get(
+    const geographicExtentValue = get(
       mapSettings,
-      'geographicExtentField',
-      'admin0'
+      'geographicExtentValue',
+      undefined
     );
+    const countryField = get(mapSettings, 'countryField', 'admin0');
     const layers = get(mapSettings, 'layers', []);
 
     return {
@@ -381,8 +404,8 @@ export class MapComponent
       layers,
       controls,
       arcGisWebMap,
-      geographicExtent,
-      geographicExtentField,
+      geographicExtentValue,
+      countryField,
     };
   }
 
@@ -701,12 +724,7 @@ export class MapComponent
         const children = layer.getChildren();
         const childrenPromisse = children.map((Childrenlayer) => {
           return this.mapLayersService
-            .createLayersFromId(
-              Childrenlayer,
-              this.injector,
-              this.extractSettings(),
-              this.map
-            )
+            .createLayersFromId(Childrenlayer, this.injector)
             .then(async (sublayer) => {
               if (sublayer.type === 'GroupLayer') {
                 const layer = await sublayer.getLayer();
@@ -746,12 +764,7 @@ export class MapComponent
     return new Promise<{ layers: L.Control.Layers.TreeObject[] }>((resolve) => {
       const layerPromises = layerIds.map((id) => {
         return this.mapLayersService
-          .createLayersFromId(
-            id,
-            this.injector,
-            this.extractSettings(),
-            this.map
-          )
+          .createLayersFromId(id, this.injector)
           .then((layer) => {
             return parseTreeNode(layer);
           });
@@ -1143,6 +1156,56 @@ export class MapComponent
     } else {
       this.lastUpdateControl?.remove();
       this.lastUpdateControl = undefined;
+    }
+  }
+
+  /**
+   * Get the geographic extent value depending on the dashboard filter or dashboard context
+   *
+   * @returns geographic extent value
+   */
+  private getGeographicExtentValue(): string | false {
+    const mapSettings = this.extractSettings();
+    const geographicExtentValue = mapSettings.geographicExtentValue;
+    if (geographicExtentValue) {
+      const fieldValue = geographicExtentValue?.match(
+        this.contextService.filterRegex
+      );
+      if (fieldValue) {
+        // If geographic extent is dynamic and in the format {{filter., try to replace it by dashboard filter value, if any
+        const replacedFilter = this.contextService.replaceFilter(mapSettings);
+        return replacedFilter.replaced
+          ? replacedFilter.object.geographicExtentValue
+          : false;
+      }
+      const contextValue = geographicExtentValue?.match(
+        this.contextService.contextRegex
+      );
+      // If geographic extent is dynamic and in the format {{context., context dashboard is not set
+      if (contextValue) {
+        return false;
+      }
+      // As the dashboard context value is automatically replaced on dashboard init,
+      // and the geographicExtentValue can also be static, return the value directly
+      return geographicExtentValue as string;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * If geographicExtentValue exists, calls mapPolygonsService to zoom on it
+   *
+   * @param  countryField country field
+   */
+  private zoomOn(countryField: string): void {
+    const geographicExtentValue = this.getGeographicExtentValue();
+    if (geographicExtentValue) {
+      this.mapPolygonsService.zoomOn(
+        geographicExtentValue,
+        countryField,
+        this.map
+      );
     }
   }
 }

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -362,6 +362,12 @@ export class MapComponent
     const zoomControl = get(mapSettings, 'zoomControl', false);
     const controls = get(mapSettings, 'controls', DefaultMapControls);
     const arcGisWebMap = get(mapSettings, 'arcGisWebMap', undefined);
+    const geographicExtent = get(mapSettings, 'geographicExtent', undefined);
+    const geographicExtentField = get(
+      mapSettings,
+      'geographicExtentField',
+      'admin0'
+    );
     const layers = get(mapSettings, 'layers', []);
 
     return {
@@ -375,6 +381,8 @@ export class MapComponent
       layers,
       controls,
       arcGisWebMap,
+      geographicExtent,
+      geographicExtentField,
     };
   }
 
@@ -693,7 +701,12 @@ export class MapComponent
         const children = layer.getChildren();
         const childrenPromisse = children.map((Childrenlayer) => {
           return this.mapLayersService
-            .createLayersFromId(Childrenlayer, this.injector)
+            .createLayersFromId(
+              Childrenlayer,
+              this.injector,
+              this.extractSettings(),
+              this.map
+            )
             .then(async (sublayer) => {
               if (sublayer.type === 'GroupLayer') {
                 const layer = await sublayer.getLayer();
@@ -733,7 +746,12 @@ export class MapComponent
     return new Promise<{ layers: L.Control.Layers.TreeObject[] }>((resolve) => {
       const layerPromises = layerIds.map((id) => {
         return this.mapLayersService
-          .createLayersFromId(id, this.injector)
+          .createLayersFromId(
+            id,
+            this.injector,
+            this.extractSettings(),
+            this.map
+          )
           .then((layer) => {
             return parseTreeNode(layer);
           });

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -281,11 +281,9 @@ export class MapComponent
     // To zoom on getGeographicExtentValue, if necessary
     const settings = this.extractSettings();
     const geographicExtentValue = settings.geographicExtentValue;
-    const countryField = settings.countryField;
+    const geographicExtent = settings.geographicExtent;
 
     // Check if has initial getGeographicExtentValue to zoom on country
-    this.zoomOn(countryField as string);
-
     const fieldValue = geographicExtentValue?.match(
       this.contextService.filterRegex
     );
@@ -294,7 +292,7 @@ export class MapComponent
       this.contextService.filter$
         .pipe(debounceTime(500), takeUntil(this.destroy$))
         .subscribe(() => {
-          this.zoomOn(countryField as string);
+          this.zoomOn(geographicExtent as string);
         });
     }
   }
@@ -390,7 +388,7 @@ export class MapComponent
       'geographicExtentValue',
       undefined
     );
-    const countryField = get(mapSettings, 'countryField', 'admin0');
+    const geographicExtent = get(mapSettings, 'geographicExtent', 'admin0');
     const layers = get(mapSettings, 'layers', []);
 
     return {
@@ -405,7 +403,7 @@ export class MapComponent
       controls,
       arcGisWebMap,
       geographicExtentValue,
-      countryField,
+      geographicExtent,
     };
   }
 
@@ -426,6 +424,7 @@ export class MapComponent
       arcGisWebMap,
       layers,
       controls,
+      geographicExtent,
     } = this.extractSettings();
 
     if (initMap) {
@@ -466,6 +465,8 @@ export class MapComponent
 
       // Set the needed map instance for it's popup service instance
       this.mapPopupService.setMap = this.map;
+
+      this.zoomOn(geographicExtent as string);
     } else {
       // If value changes for the map we would change in order to not trigger map events unnecessarily
       if (this.map.getMaxZoom() !== maxZoom) {
@@ -1196,14 +1197,14 @@ export class MapComponent
   /**
    * If geographicExtentValue exists, calls mapPolygonsService to zoom on it
    *
-   * @param  countryField country field
+   * @param  geographicExtent geographic extent (admin0)
    */
-  private zoomOn(countryField: string): void {
+  private zoomOn(geographicExtent: string): void {
     const geographicExtentValue = this.getGeographicExtentValue();
     if (geographicExtentValue) {
       this.mapPolygonsService.zoomOn(
         geographicExtentValue,
-        countryField,
+        geographicExtent,
         this.map
       );
     }

--- a/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
@@ -48,7 +48,7 @@ const DEFAULT_MAP: Nullable<MapConstructorSettings> = {
   controls: DefaultMapControls,
   arcGisWebMap: null,
   geographicExtentValue: null,
-  countryField: 'admin0',
+  geographicExtent: 'admin0',
 };
 
 /** Default gradient for heatmap */
@@ -553,7 +553,9 @@ export const createMapWidgetFormGroup = (id: any, value?: any): FormGroup => {
     geographicExtentValue: [
       get(value, 'geographicExtentValue', DEFAULT_MAP.geographicExtentValue),
     ],
-    countryField: [get(value, 'countryField', DEFAULT_MAP.countryField)],
+    geographicExtent: [
+      get(value, 'geographicExtent', DEFAULT_MAP.geographicExtent),
+    ],
     // popupFields: [get(value, 'popupFields', DEFAULT_MAP.popupFields)],
     // onlineLayers: [get(value, 'onlineLayers', DEFAULT_MAP.onlineLayers)],
     layers: [get(value, 'layers', [])] as string[],

--- a/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
@@ -47,8 +47,8 @@ const DEFAULT_MAP: Nullable<MapConstructorSettings> = {
   layers: [],
   controls: DefaultMapControls,
   arcGisWebMap: null,
-  geographicExtent: null,
-  geographicExtentField: 'admin0',
+  geographicExtentValue: null,
+  countryField: 'admin0',
 };
 
 /** Default gradient for heatmap */
@@ -550,12 +550,10 @@ export const createMapWidgetFormGroup = (id: any, value?: any): FormGroup => {
       }),
     }),
     basemap: [get(value, 'basemap', DEFAULT_MAP.basemap)],
-    geographicExtent: [
-      get(value, 'geographicExtent', DEFAULT_MAP.geographicExtent),
+    geographicExtentValue: [
+      get(value, 'geographicExtentValue', DEFAULT_MAP.geographicExtentValue),
     ],
-    geographicExtentField: [
-      get(value, 'geographicExtentField', DEFAULT_MAP.geographicExtentField),
-    ],
+    countryField: [get(value, 'countryField', DEFAULT_MAP.countryField)],
     // popupFields: [get(value, 'popupFields', DEFAULT_MAP.popupFields)],
     // onlineLayers: [get(value, 'onlineLayers', DEFAULT_MAP.onlineLayers)],
     layers: [get(value, 'layers', [])] as string[],

--- a/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
@@ -47,6 +47,8 @@ const DEFAULT_MAP: Nullable<MapConstructorSettings> = {
   layers: [],
   controls: DefaultMapControls,
   arcGisWebMap: null,
+  geographicExtent: null,
+  geographicExtentField: 'admin0',
 };
 
 /** Default gradient for heatmap */
@@ -548,6 +550,12 @@ export const createMapWidgetFormGroup = (id: any, value?: any): FormGroup => {
       }),
     }),
     basemap: [get(value, 'basemap', DEFAULT_MAP.basemap)],
+    geographicExtent: [
+      get(value, 'geographicExtent', DEFAULT_MAP.geographicExtent),
+    ],
+    geographicExtentField: [
+      get(value, 'geographicExtentField', DEFAULT_MAP.geographicExtentField),
+    ],
     // popupFields: [get(value, 'popupFields', DEFAULT_MAP.popupFields)],
     // onlineLayers: [get(value, 'onlineLayers', DEFAULT_MAP.onlineLayers)],
     layers: [get(value, 'layers', [])] as string[],

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -139,17 +139,17 @@
           <div class="flex flex-wrap gap-2 mt-2">
             <!-- Fit & zoom on country polygon -->
             <div uiFormFieldDirective class="flex-1">
-              <label>{{ 'components.widget.settings.map.properties.geographicExtent' | translate }}</label>
-              <input formControlName="geographicExtent" type="string" />
+              <label>{{ 'components.widget.settings.map.properties.geographicExtentValue' | translate }}</label>
+              <input formControlName="geographicExtentValue" type="string" />
             </div>
             <ui-divider></ui-divider>
             <!-- Geographic extent field ("admin0" (by default) and region) -->
             <div uiFormFieldDirective class="flex-1">
               <label>{{
-                'components.widget.settings.map.properties.geographicExtentField' | translate
+                'components.widget.settings.map.properties.countryField' | translate
               }}</label>
-              <ui-select-menu formControlName="geographicExtentField" [disabled]="true">
-                <ui-select-option *ngFor="let field of geographicExtentFields" [value]="field">
+              <ui-select-menu formControlName="countryField" [disabled]="true">
+                <ui-select-option *ngFor="let field of countryFields" [value]="field">
                   {{ field }}
                 </ui-select-option>
               </ui-select-menu>

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -136,7 +136,25 @@
               'components.widget.settings.map.properties.setByMap' | translate
             }}
           </ui-button>
-          <ui-divider></ui-divider>
+          <div class="flex flex-wrap gap-2 mt-2">
+            <!-- Fit & zoom on country polygon -->
+            <div uiFormFieldDirective class="flex-1">
+              <label>{{ 'components.widget.settings.map.properties.geographicExtent' | translate }}</label>
+              <input formControlName="geographicExtent" type="string" />
+            </div>
+            <ui-divider></ui-divider>
+            <!-- Geographic extent field ("admin0" (by default) and region) -->
+            <div uiFormFieldDirective class="flex-1">
+              <label>{{
+                'components.widget.settings.map.properties.geographicExtentField' | translate
+              }}</label>
+              <ui-select-menu formControlName="geographicExtentField" [disabled]="true">
+                <ui-select-option *ngFor="let field of geographicExtentFields" [value]="field">
+                  {{ field }}
+                </ui-select-option>
+              </ui-select-menu>
+            </div>
+          </div>
           <!-- Map controls -->
           <shared-map-controls
             formGroupName="controls"

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -139,17 +139,38 @@
           <div class="flex flex-wrap gap-2 mt-2">
             <!-- Fit & zoom on country polygon -->
             <div uiFormFieldDirective class="flex-1">
-              <label>{{ 'components.widget.settings.map.properties.geographicExtentValue' | translate }}</label>
+              <label>{{
+                'components.widget.settings.map.properties.geographicExtentValue'
+                  | translate
+              }}</label>
               <input formControlName="geographicExtentValue" type="string" />
+              <ui-icon
+                uiSuffix
+                icon="info_outline"
+                class="cursor-pointer"
+                [uiTooltip]="
+                  'components.widget.settings.map.tooltip.geographicExtent'
+                    | translate
+                "
+                [size]="18"
+                variant="grey"
+              ></ui-icon>
             </div>
             <ui-divider></ui-divider>
             <!-- Geographic extent field ("admin0" (by default) and region) -->
             <div uiFormFieldDirective class="flex-1">
               <label>{{
-                'components.widget.settings.map.properties.countryField' | translate
+                'components.widget.settings.map.properties.geographicExtent'
+                  | translate
               }}</label>
-              <ui-select-menu formControlName="countryField" [disabled]="true">
-                <ui-select-option *ngFor="let field of countryFields" [value]="field">
+              <ui-select-menu
+                formControlName="geographicExtent"
+                [disabled]="true"
+              >
+                <ui-select-option
+                  *ngFor="let field of geographicExtents"
+                  [value]="field"
+                >
                   {{ field }}
                 </ui-select-option>
               </ui-select-menu>

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -155,6 +155,7 @@
               </ui-select-menu>
             </div>
           </div>
+          <ui-divider></ui-divider>
           <!-- Map controls -->
           <shared-map-controls
             formGroupName="controls"

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
@@ -23,7 +23,7 @@ export class MapPropertiesComponent extends UnsubscribeComponent {
   /** Available base maps */
   public baseMaps = BASEMAPS;
   /** Available geographic extent fields */
-  public geographicExtentFields = ['admin0', 'region'];
+  public countryFields = ['admin0', 'region'];
 
   /** @returns the form group for the map controls */
   get controlsFormGroup() {

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
@@ -23,7 +23,7 @@ export class MapPropertiesComponent extends UnsubscribeComponent {
   /** Available base maps */
   public baseMaps = BASEMAPS;
   /** Available geographic extent fields */
-  public countryFields = ['admin0', 'region'];
+  public geographicExtents = ['admin0'];
 
   /** @returns the form group for the map controls */
   get controlsFormGroup() {

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.ts
@@ -22,6 +22,8 @@ export class MapPropertiesComponent extends UnsubscribeComponent {
   @Input() mapPortal?: DomPortal;
   /** Available base maps */
   public baseMaps = BASEMAPS;
+  /** Available geographic extent fields */
+  public geographicExtentFields = ['admin0', 'region'];
 
   /** @returns the form group for the map controls */
   get controlsFormGroup() {

--- a/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -156,6 +156,14 @@ export class MapSettingsComponent
           layers: value,
         } as MapConstructorSettings)
       );
+    this.widgetFormGroup
+      .get('geographicExtent')
+      ?.valueChanges.pipe(debounceTime(1000), takeUntil(this.destroy$))
+      .subscribe((value) =>
+        this.updateMapSettings({
+          geographicExtent: value,
+        } as MapConstructorSettings)
+      );
   }
 
   /**

--- a/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -165,11 +165,11 @@ export class MapSettingsComponent
         } as MapConstructorSettings)
       );
     this.widgetFormGroup
-      .get('countryField')
+      .get('geographicExtent')
       ?.valueChanges.pipe(debounceTime(1000), takeUntil(this.destroy$))
       .subscribe((value) =>
         this.updateMapSettings({
-          countryField: value,
+          geographicExtent: value,
         } as MapConstructorSettings)
       );
   }

--- a/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-settings.component.ts
@@ -157,11 +157,19 @@ export class MapSettingsComponent
         } as MapConstructorSettings)
       );
     this.widgetFormGroup
-      .get('geographicExtent')
+      .get('geographicExtentValue')
       ?.valueChanges.pipe(debounceTime(1000), takeUntil(this.destroy$))
       .subscribe((value) =>
         this.updateMapSettings({
-          geographicExtent: value,
+          geographicExtentValue: value,
+        } as MapConstructorSettings)
+      );
+    this.widgetFormGroup
+      .get('countryField')
+      ?.valueChanges.pipe(debounceTime(1000), takeUntil(this.destroy$))
+      .subscribe((value) =>
+        this.updateMapSettings({
+          countryField: value,
         } as MapConstructorSettings)
       );
   }

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -49,6 +49,8 @@ export class ContextService {
   public filterOpened = new BehaviorSubject<boolean>(false);
   /** Regex used to allow widget refresh */
   public filterRegex = /{{filter\.[^}]+}}/;
+  /** Context regex */
+  public contextRegex = /{{context\.(.*?)}}/g;
   /** Dashboard object */
   public dashboard?: Dashboard;
   /** Available filter positions */
@@ -191,13 +193,34 @@ export class ContextService {
     if (!context) {
       return object;
     }
-    const regex = /{{context\.(.*?)}}/g;
     return JSON.parse(
-      JSON.stringify(object).replace(regex, (match) => {
+      JSON.stringify(object).replace(this.contextRegex, (match) => {
         const field = match.replace('{{context.', '').replace('}}', '');
         return get(context, field) || match;
       })
     );
+  }
+
+  /**
+   * Replace {{filter}} placeholders in object, with filter values
+   *
+   * @param object object with placeholders
+   * @returns object with replaced placeholders
+   */
+  public replaceFilter(object: any): { object: any; replaced: boolean } {
+    const filter = this.availableFilterFieldsValue;
+    if (isEmpty(filter)) {
+      return { object, replaced: false };
+    }
+    return {
+      object: JSON.parse(
+        JSON.stringify(object).replace(this.filterRegex, (match) => {
+          const field = match.replace('{{filter.', '').replace('}}', '');
+          return get(filter, field) || match;
+        })
+      ),
+      replaced: true,
+    };
   }
 
   /**

--- a/libs/shared/src/lib/services/map/map-layers.service.ts
+++ b/libs/shared/src/lib/services/map/map-layers.service.ts
@@ -35,8 +35,6 @@ import { omitBy, isNil, get } from 'lodash';
 import { ContextService } from '../context/context.service';
 import { DOCUMENT } from '@angular/common';
 import { MapPolygonsService } from './map-polygons.service';
-import { MapConstructorSettings } from '../../components/ui/map/interfaces/map.interface';
-import * as L from 'leaflet';
 
 /**
  * Shared map layer service
@@ -319,15 +317,11 @@ export class MapLayersService {
    *
    * @param layerIds layer settings saved from the layer editor
    * @param injector Injector containing all needed providers for layer class
-   * @param mapSettings map settings
-   * @param leafletMap leaflet map
    * @returns Observable of LayerSettingsI
    */
   async createLayersFromId(
     layerIds: string,
-    injector: Injector,
-    mapSettings?: MapConstructorSettings,
-    leafletMap?: L.Map
+    injector: Injector
   ): Promise<Layer> {
     const promise: Promise<Layer> = lastValueFrom(
       this.getLayerById(layerIds).pipe(
@@ -336,7 +330,7 @@ export class MapLayersService {
             // Get the current layer + its geojson
             return forkJoin({
               layer: of(layer),
-              geojson: this.getLayerGeoJson(layer, mapSettings, leafletMap),
+              geojson: this.getLayerGeoJson(layer),
             });
           } else {
             return of({
@@ -391,15 +385,9 @@ export class MapLayersService {
    * Get layer geojson from definition
    *
    * @param layer layer model
-   * @param mapSettings map settings
-   * @param leafletMap leaflet map
    * @returns Layer GeoJSON query
    */
-  async getLayerGeoJson(
-    layer: LayerModel,
-    mapSettings?: MapConstructorSettings,
-    leafletMap?: L.Map
-  ) {
+  async getLayerGeoJson(layer: LayerModel) {
     const contextFilters = layer.contextFilters
       ? this.contextService.injectContext(JSON.parse(layer.contextFilters))
       : {};
@@ -428,24 +416,10 @@ export class MapLayersService {
             map((value) => {
               // When using adminField mapping, update the feature so geometry is replaced with according polygons
               if (layer.datasource?.adminField) {
-                const geojson = this.mapPolygonsService.assignPolygons(
+                return this.mapPolygonsService.assignPolygons(
                   value,
                   layer.datasource.adminField as any
                 );
-                if (mapSettings && leafletMap) {
-                  const geographicExtentValue = isNil(
-                    mapSettings?.geographicExtent
-                  )
-                    ? false
-                    : this.getGeographicExtent(
-                        mapSettings?.geographicExtent as string,
-                        mapSettings
-                      );
-                  if (geographicExtentValue) {
-                    this.zoomOnCountry(geojson, mapSettings, leafletMap);
-                  }
-                }
-                return geojson;
               } else {
                 // Else, directly returns the feature layer
                 return value;
@@ -495,53 +469,4 @@ export class MapLayersService {
     }
     return false;
   };
-
-  /**
-   * Fit bounds & zoom on country
-   *
-   * @param geojson polygon geometry
-   * @param mapSettings map settings
-   * @param map leaflet map
-   */
-  private zoomOnCountry(
-    geojson: any,
-    mapSettings: MapConstructorSettings,
-    map: L.Map
-  ): void {
-    // Only admin0 is available so far
-    if (mapSettings.geographicExtentField === 'admin0') {
-      const feature = L.geoJson(geojson);
-      map.flyToBounds(feature.getBounds());
-    }
-  }
-
-  /**
-   * Get the geographic extent value depending on the dashboard filter or dashboard context
-   *
-   * @param geographicExtent geographic extent
-   * @param mapSettings map settings
-   * @returns geographic extent value
-   */
-  private getGeographicExtent(
-    geographicExtent: string,
-    mapSettings: MapConstructorSettings
-  ): string | boolean {
-    const fieldValue = geographicExtent.match(this.contextService.filterRegex);
-    if (fieldValue) {
-      // If geographic extent is in the format {{filter., try to replace it by dashboard filter value, if any
-      const replacedFilter = this.contextService.replaceFilter(mapSettings);
-      return replacedFilter.replaced
-        ? replacedFilter.object.geographicExtent
-        : false;
-    }
-    const contextValue = geographicExtent.match(
-      this.contextService.contextRegex
-    );
-    // If geographic extent is in the format {{context., context dashboard is not set
-    if (contextValue) {
-      return false;
-    }
-    // As the dashboard context value is automatically replaced on dashboard init, return the value directly
-    return geographicExtent;
-  }
 }

--- a/libs/shared/src/lib/services/map/map-polygons.service.ts
+++ b/libs/shared/src/lib/services/map/map-polygons.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { RestService } from '../rest/rest.service';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, first } from 'rxjs';
 import { EMPTY_FEATURE_COLLECTION } from '../../components/ui/map/layer';
 import set from 'lodash/set';
 import { flattenDeep, get, isNil, isObject, uniq } from 'lodash';
+import * as L from 'leaflet';
 
 /** Available admin identifiers */
 type AdminIdentifier = 'admin0.iso2code' | 'admin0.iso3code' | 'admin0.id';
@@ -107,6 +108,34 @@ export class MapPolygonsService {
       );
     } else {
       return EMPTY_FEATURE_COLLECTION;
+    }
+  }
+
+  /**
+   * Fit bounds & zoom on country
+   *
+   * @param geographicExtentValue geographic extent value
+   * @param countryField country field
+   * @param map leaflet map
+   */
+  public zoomOn(
+    geographicExtentValue: string,
+    countryField: string,
+    map: L.Map
+  ): void {
+    // Only admin0 is available so far
+    if (countryField === 'admin0') {
+      this.admin0sReady$.pipe(first((v) => v)).subscribe(() => {
+        const admin0 = this.admin0s.find(
+          (data) =>
+            data.iso2code === geographicExtentValue ||
+            data.iso3code === geographicExtentValue ||
+            data.name === geographicExtentValue
+        );
+        if (admin0) {
+          map.setView([admin0.centerlatitude, admin0.centerlongitude], 3);
+        }
+      });
     }
   }
 }

--- a/libs/shared/src/lib/services/map/map-polygons.service.ts
+++ b/libs/shared/src/lib/services/map/map-polygons.service.ts
@@ -115,16 +115,16 @@ export class MapPolygonsService {
    * Fit bounds & zoom on country
    *
    * @param geographicExtentValue geographic extent value
-   * @param countryField country field
+   * @param geographicExtent geographic extent (admin0)
    * @param map leaflet map
    */
   public zoomOn(
     geographicExtentValue: string,
-    countryField: string,
+    geographicExtent: string,
     map: L.Map
   ): void {
     // Only admin0 is available so far
-    if (countryField === 'admin0') {
+    if (geographicExtent === 'admin0') {
       this.admin0sReady$.pipe(first((v) => v)).subscribe(() => {
         const admin0 = this.admin0s.find(
           (data) =>
@@ -133,7 +133,15 @@ export class MapPolygonsService {
             data.name === geographicExtentValue
         );
         if (admin0) {
-          map.setView([admin0.centerlatitude, admin0.centerlongitude], 3);
+          const layer = L.geoJSON({
+            type: 'Feature',
+            geometry: admin0.polygons,
+            properties: {},
+          } as any);
+          // Timeout seems to be needed for first load of the map.
+          setTimeout(() => {
+            map.fitBounds(layer.getBounds());
+          }, 500);
         }
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15802,7 +15802,8 @@
     },
     "node_modules/@turf/bbox": {
       "version": "6.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
       "dependencies": {
         "@turf/helpers": "^6.5.0",
         "@turf/meta": "^6.5.0"
@@ -50677,6 +50678,8 @@
     },
     "@turf/bbox": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
       "requires": {
         "@turf/helpers": "^6.5.0",
         "@turf/meta": "^6.5.0"


### PR DESCRIPTION
# Description
In the map-proprieties component added input for field geographicExtentValue "Use geographic extent" (could be {{context.code}} or {{filter.code}}, for example) and select for the "Country field" (can be admin0 or region). The select menu doesn't seem like disabled in the screenshot because of a bug not related to the ticket (a ticket already created for this).

In the MapComponent, in the initFilters() the new method getGeographicExtentValue() will check if the getGeographicExtentValue exists (dynamic or static) and call the onZoom() method of the MapPolygonsService to get the admin0 info to zoom on it. For {{filter. getGeographicExtentValue we listen to the filter changes, for static values and {{contex. values this is not necessary, the initFilters() is always called and covers it.

The zoom level is on 2 at the moment because the info we have in the admin0 (centerlatitude and centerlongitude) is not enough to fit the bounds around the selected country, too high zoom levels will incorrectly zoom on too big countries.

Added to the ContextService the method replaceFilter() to replace the {{filter}} placeholders in the object, with the filter values.

## Useful links
- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83384

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Create a dashboard with context and a map widget where the layer has a context filter fitting the data by country code. 
Or create a dashboard with a filter and a map widget where the layer has a context filter fitting the data by country code.
Dashboard samples: [context](https://oort-dev.oortcloud.tech/admin/applications/65a4f64193ef59cc3514660f/dashboard/65a4f65893ef59cc351466ef) and [filter](https://oort-dev.oortcloud.tech/admin/applications/63c5682cb956ff752087cf0a/dashboard/65a53b0fe8ac409d722d87ae)

## Screenshots
![image](https://github.com/ReliefApplications/ems-frontend/assets/28535394/db0a80f5-db04-4b19-b117-985a260349ae)

Dashboard context and map with layers:
[context-layers.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/a7ab83a6-3be5-4de6-815c-464038938ab5)

Dashboard context and map without layers:
[context-no-layers.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/8838dd75-b6e7-44fa-b82d-57fc31f02d5a)

Dashboard filter and map without layers:
[filter-no-layers.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/084319d7-86bb-4787-8e24-7ec12edb8199)

Dashboard filter and map with layers:
[filter-layers.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/7bb4cd8b-3dbb-413e-8702-4f40b831c23f)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
