### PR TITLE
Feat/ab#83099 load dashboard filter default value expression fix

### DIFF
--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -6,7 +6,7 @@ import {
   FilterDescriptor,
 } from '@progress/kendo-data-query';
 import { cloneDeep } from '@apollo/client/utilities';
-import { isNil, isEmpty, get, isEqual, isObject, merge, forEach } from 'lodash';
+import { isNil, isEmpty, get, isEqual, isObject, forEach, set } from 'lodash';
 import { DashboardService } from '../dashboard/dashboard.service';
 import {
   Dashboard,
@@ -45,6 +45,8 @@ export class ContextService {
   public filterStructure = new BehaviorSubject<any>(null);
   /** To update/keep the current filter position  */
   public filterPosition = new BehaviorSubject<any>(null);
+  /** To keep the history of previous dashboard filter values */
+  public filterValues = new BehaviorSubject<any>(null);
   /** Is filter opened */
   public filterOpened = new BehaviorSubject<boolean>(false);
   /** Regex used to allow widget refresh */
@@ -92,6 +94,11 @@ export class ContextService {
   /** @returns filterPosition value as observable */
   get filterPosition$() {
     return this.filterPosition.asObservable();
+  }
+
+  /** @returns filterValues value as observable */
+  get filterValues$() {
+    return this.filterValues.asObservable();
   }
 
   /** @returns filterOpened value as observable */
@@ -298,24 +305,22 @@ export class ContextService {
     const surveyStructure = this.filterStructure.getValue();
     const survey = this.formBuilderService.createSurvey(surveyStructure);
 
-    // get questions default value
-    const data = survey
-      .getAllQuestions()
-      .reduce(function (result: any, question: any) {
-        if (question.defaultValue !== undefined) {
-          result[question.name] = question.defaultValue;
-        }
-        return result;
-      }, {});
-
-    // merge filter values with default values
-    if (!isEmpty(this.filter.getValue())) {
-      merge(data, this.filter.getValue());
-    }
     // set each question value manually otherwise the defaultValueExpression is not loaded
-    forEach(data, (value, key) => {
-      survey.getQuestionByName(key).value = value;
+    forEach(this.filterValues.getValue(), (value, key) => {
+      if (survey.getQuestionByName(key)) {
+        survey.getQuestionByName(key).value = value;
+      }
     });
+
+    // prevent the default value from being applied when a question has been intentionally cleared
+    const handleValueChanged = (sender: any, options: any) => {
+      const history = this.filterValues.getValue() ?? {};
+      set(history, options.name, options.value);
+      this.filterValues.next(history);
+    };
+
+    survey.onValueChanged.add(handleValueChanged);
+
     return survey;
   }
 


### PR DESCRIPTION
# Description

This pull request is a fix for a previous one (view links). The logic was correct but it attempted to assign values even if the object property didn't exist. I added a verification step to prevent anys bugs. In my previous pull request, I decided to change the code to initialize each question one by one; otherwise, it was not taking into account the defaultValueExpression. I discovered that it was also preventing to use of defaultValues. Due to the logic change, I could removed some code as well (get questions default value).

I also noticed that my previous work was causing an issue with sending values from one dashboard filter to another. The n-2 values were lost. I added `filterValues` which acts like an history. Moreover, I added an event listener to avoid unwanted behavior. If you chose to unselect all checkboxes for a question, change the dashboard, and then come back, the checkboxes should remain unchecked and not revert to using the defaultValues. If the property is empty, it is not sent and the defaultValues are used. Here I send an empty object instead of nothing.

As a new page loads without survey actions, I couldn't remove the event listener. It's possible that it remains active somewhere.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83099)
- [Previous PR](https://github.com/ReliefApplications/ems-frontend/pull/2288)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created multiple dashboards with filters. I checked if the data were passed from one to another. I also checked if defaultValue were unused when unselecting all values of a question.

## Screenshots

![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/5c78b2d4-016a-4fc4-86b4-7902075ef5aa)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
