### PR TITLE
feat/AB#83716-default-zoom-after-removing-country-zoom

### DIFF
--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -168,6 +168,8 @@ export class MapComponent
   private overlaysTree: L.Control.Layers.TreeObject[][] = [];
   /** Refreshing layers. When true, should prevent layers to be duplicated  */
   private refreshingLayers = new BehaviorSubject<boolean>(true);
+  /** If should get back to default zoom & bounds after removing country filter */
+  private removeFilterZoom = false;
 
   /**
    * Map widget component
@@ -291,8 +293,19 @@ export class MapComponent
       // Listen to dashboard filters changes to apply getGeographicExtentValue values changes
       this.contextService.filter$
         .pipe(debounceTime(500), takeUntil(this.destroy$))
-        .subscribe(() => {
-          this.zoomOn(geographicExtent as string);
+        .subscribe((filter) => {
+          // Check if filter changes has geographicExtentValue
+          const filterField = geographicExtentValue?.match(
+            this.contextService.filterValueRegex
+          )?.[0];
+          const fieldOnFilter = filterField && filterField in filter;
+          // Only set zoom on country if geographicExtentValue changed in the filter
+          if (fieldOnFilter) {
+            this.zoomOn(geographicExtent as string);
+          } else if (this.removeFilterZoom) {
+            // If geographicExtentValue filter unselected, set default zoom
+            this.setDefaultZoom();
+          }
         });
     }
   }
@@ -1175,9 +1188,11 @@ export class MapComponent
       if (fieldValue) {
         // If geographic extent is dynamic and in the format {{filter., try to replace it by dashboard filter value, if any
         const replacedFilter = this.contextService.replaceFilter(mapSettings);
-        return replacedFilter.replaced
-          ? replacedFilter.object.geographicExtentValue
-          : false;
+        return replacedFilter.geographicExtentValue?.match(
+          this.contextService.filterRegex
+        )
+          ? false
+          : replacedFilter.geographicExtentValue;
       }
       const contextValue = geographicExtentValue?.match(
         this.contextService.contextRegex
@@ -1202,11 +1217,24 @@ export class MapComponent
   private zoomOn(geographicExtent: string): void {
     const geographicExtentValue = this.getGeographicExtentValue();
     if (geographicExtentValue) {
+      this.removeFilterZoom = true;
       this.mapPolygonsService.zoomOn(
         geographicExtentValue,
         geographicExtent,
         this.map
       );
+    } else if (this.removeFilterZoom) {
+      this.setDefaultZoom();
     }
+  }
+
+  /**
+   * Set the default center and zoom level
+   */
+  private setDefaultZoom(): void {
+    this.removeFilterZoom = false;
+    const { center, zoom } = this.extractSettings().initialState.viewpoint;
+    this.currentZoom = zoom;
+    this.map.setView([center.latitude, center.longitude], zoom);
   }
 }

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -237,7 +237,7 @@ export class SummaryCardComponent
         this.settings.card?.referenceDataVariableMapping || ''
       );
       mapping = this.contextService.replaceContext(mapping);
-      mapping = this.contextService.replaceFilter(mapping).object;
+      mapping = this.contextService.replaceFilter(mapping);
       this.contextService.removeEmptyPlaceholders(mapping);
       return mapping;
     } catch {

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -51,6 +51,8 @@ export class ContextService {
   public filterOpened = new BehaviorSubject<boolean>(false);
   /** Regex used to allow widget refresh */
   public filterRegex = /{{filter\.[^}]+}}/;
+  /** Regex to detect the value of {{filter.}} in object */
+  public filterValueRegex = /(?<={{filter\.)(.*?)(?=}})/gim;
   /** Context regex */
   public contextRegex = /{{context\.(.*?)}}/g;
   /** Dashboard object */
@@ -214,20 +216,17 @@ export class ContextService {
    * @param object object with placeholders
    * @returns object with replaced placeholders
    */
-  public replaceFilter(object: any): { object: any; replaced: boolean } {
+  public replaceFilter(object: any): any {
     const filter = this.availableFilterFieldsValue;
     if (isEmpty(filter)) {
-      return { object, replaced: false };
+      return object;
     }
-    return {
-      object: JSON.parse(
-        JSON.stringify(object).replace(this.filterRegex, (match) => {
-          const field = match.replace('{{filter.', '').replace('}}', '');
-          return get(filter, field) || match;
-        })
-      ),
-      replaced: true,
-    };
+    return JSON.parse(
+      JSON.stringify(object).replace(this.filterRegex, (match) => {
+        const field = match.replace('{{filter.', '').replace('}}', '');
+        return get(filter, field) || match;
+      })
+    );
   }
 
   /**
@@ -245,7 +244,7 @@ export class ContextService {
     //   return filter;
     // }
     // Regex to detect {{filter.}} in object
-    const filterRegex = /(?<={{filter\.)(.*?)(?=}})/gim;
+    const filterRegex = this.filterValueRegex;
     // Regex to detect {{context.}} in object
     const contextRegex = /(?<={{context\.)(.*?)(?=}})/gim;
 


### PR DESCRIPTION
# Description

feat: in the map-component:
- created the method setDefaultZoom() to get the settings initialState of the map and set it after unselecting a country
- added removeFilterZoom propriety to check if zoomOn country was applied
- in the initFilters()  method, where we listen to changes on dashboard filters when geographicExtentValue is using it, added a check to only zoomOn country when the field of the {{filter.field}} geographicExtentValue is available in the filter

fix: the method getGeographicExtentValue() in the map-component used the replaceFilter() method in context-service  to replace the  {{filter. by the filter values, but it was always returning that the "replaced " flag as true if any of the filter fields was enabled in the dashboard filter, so now the getGeographicExtentValue() checks if the geographicExtentValue has a value and the replaced flag was removed.

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83716

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Dashboard samples: [context](https://oort-dev.oortcloud.tech/admin/applications/65a4f64193ef59cc3514660f/dashboard/65a4f65893ef59cc351466ef) and [filter](https://oort-dev.oortcloud.tech/admin/applications/63c5682cb956ff752087cf0a/dashboard/65a53b0fe8ac409d722d87ae)

## Screenshots
Back-office:
[back-office.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/6a413b8a-246f-462b-9dca-ccc16b408ea3)

Front-office:
[front-office.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/d5c51b7f-5809-4245-865c-0c426018c36b)

Filters test: when the map has layers, the filterLayers() method is always called when updating the dashboard filter. Check the consoles in the video
[filter.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/3c647b94-5504-4a48-a08c-55d076e7ab41)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
