### PR TITLE
Ab#83725 pass widget variables to the reference data graphql query

### DIFF
--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -236,10 +236,9 @@ export class SummaryCardComponent
       let mapping = JSON.parse(
         this.settings.card?.referenceDataVariableMapping || ''
       );
-      mapping = this.replaceMapping(mapping);
-      console.log(mapping);
       mapping = this.contextService.replaceContext(mapping);
       mapping = this.contextService.replaceFilter(mapping);
+      mapping = this.replaceMapping(mapping);
       this.contextService.removeEmptyPlaceholders(mapping);
       console.log(mapping);
       return mapping;
@@ -249,7 +248,7 @@ export class SummaryCardComponent
   }
 
   /**
-   * Replace {{widget}} placeholders in object, with context values
+   * Replace {{widget}} placeholders in object, with search value.
    *
    * @param object object with placeholders
    * @returns object with replaced placeholders

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -259,15 +259,9 @@ export class SummaryCardComponent
       return object;
     }
     return JSON.parse(
-      JSON.stringify(object, (key, value) => {
-        if (key === '{{widget.sortField}}') {
-          return sort.field;
-        }
-        if (key === '{{widget.sortOrder}}') {
-          return sort.order;
-        }
-        return value;
-      })
+      JSON.stringify(object)
+        .replace(/{{widget.sortField}}/g, sort.field)
+        .replace(/{{widget.sortOrder}}/g, sort.order)
     );
   }
 

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -236,13 +236,32 @@ export class SummaryCardComponent
       let mapping = JSON.parse(
         this.settings.card?.referenceDataVariableMapping || ''
       );
+      mapping = this.replaceMapping(mapping);
+      console.log(mapping);
       mapping = this.contextService.replaceContext(mapping);
       mapping = this.contextService.replaceFilter(mapping);
       this.contextService.removeEmptyPlaceholders(mapping);
+      console.log(mapping);
       return mapping;
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Replace {{widget}} placeholders in object, with context values
+   *
+   * @param object object with placeholders
+   * @returns object with replaced placeholders
+   */
+  public replaceMapping(object: any): any {
+    const search = this.searchControl.value;
+    if (!search) {
+      return object;
+    }
+    return JSON.parse(
+      JSON.stringify(object).replace(/{{widget.search}}/g, search)
+    );
   }
 
   /**
@@ -293,7 +312,15 @@ export class SummaryCardComponent
         takeUntil(this.destroy$)
       )
       .subscribe((value) => {
-        this.handleSearch(value || '');
+        if (this.graphqlVariables) {
+          this.onPage({
+            pageSize: this.pageInfo.pageSize,
+            skip: this.pageInfo.skip + this.pageInfo.pageSize,
+            previousPageIndex: this.pageInfo.pageIndex,
+            pageIndex: this.pageInfo.pageIndex + 1,
+            totalItems: this.pageInfo.length,
+          });
+        } else this.handleSearch(value || '');
       });
 
     // Listen to dashboard filters changes if it is necessary


### PR DESCRIPTION
# Description

The purpose of the ticket is to enable the injection of the search and sort field and sort order into the graphq variables.
## How it is working

On the settings screen, the general tab must be configured following the pattern below.
![image](https://github.com/ReliefApplications/ems-frontend/assets/55603259/337323c7-d86a-477f-9624-7445c6624de1)

In code, when a search or sort change occurs, the value will be dynamically injected and the page will be updated if pagination is used.

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83725)

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Some console logs were added by the system and the behavior of creating the injection of variables in graphql was observed.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
