### PR TITLE
Feat/ab#84013 min height for dashboard and tabs widget

### DIFF
--- a/apps/back-office/src/app/components/view-settings-modal/view-settings-modal.component.html
+++ b/apps/back-office/src/app/components/view-settings-modal/view-settings-modal.component.html
@@ -197,7 +197,9 @@
             <div
               uiFormFieldDirective
               [outline]="false"
-              *ngIf="this.dashboard.gridOptions.gridType !== gridType.Fit"
+              *ngIf="
+                settingsForm.get('gridOptions.gridType')?.value !== gridType.Fit
+              "
             >
               <label class="flex items-center gap-1">
                 {{
@@ -226,6 +228,48 @@
                   settingsForm
                     .get('gridOptions.fixedRowHeight')
                     ?.setValue(defaultGridOptions.fixedRowHeight)
+                "
+                [uiTooltip]="
+                  'components.application.dashboard.settings.tooltip.reset'
+                    | translate
+                "
+              ></ui-icon>
+            </div>
+            <!-- Change the minimum height of the container -->
+            <div
+              uiFormFieldDirective
+              [outline]="false"
+              *ngIf="
+                settingsForm.get('gridOptions.gridType')?.value === gridType.Fit
+              "
+            >
+              <label class="flex items-center gap-1">
+                {{
+                  'components.application.dashboard.settings.minimumHeight'
+                    | translate
+                }}
+                <!-- Tooltip -->
+                <ui-icon
+                  class="cursor-help self-center"
+                  icon="info_outline"
+                  variant="grey"
+                  [size]="18"
+                  [uiTooltip]="
+                    'components.application.dashboard.settings.tooltip.minimumHeight'
+                      | translate
+                  "
+                ></ui-icon>
+              </label>
+              <input type="number" formControlName="minimumHeight" min="50" />
+              <ui-icon
+                uiSuffix
+                class="cursor-pointer"
+                icon="restart_alt"
+                variant="grey"
+                (click)="
+                  settingsForm
+                    .get('gridOptions.minimumHeight')
+                    ?.setValue(defaultGridOptions.minimumHeight)
                 "
                 [uiTooltip]="
                   'components.application.dashboard.settings.tooltip.reset'

--- a/apps/back-office/src/app/components/view-settings-modal/view-settings-modal.component.html
+++ b/apps/back-office/src/app/components/view-settings-modal/view-settings-modal.component.html
@@ -260,7 +260,7 @@
                   "
                 ></ui-icon>
               </label>
-              <input type="number" formControlName="minimumHeight" min="50" />
+              <input type="number" formControlName="minimumHeight" min="0" />
               <ui-icon
                 uiSuffix
                 class="cursor-pointer"

--- a/apps/back-office/src/app/components/view-settings-modal/view-settings-modal.component.ts
+++ b/apps/back-office/src/app/components/view-settings-modal/view-settings-modal.component.ts
@@ -99,6 +99,7 @@ export class ViewSettingsModalComponent
   public defaultGridOptions = {
     minCols: 8,
     fixedRowHeight: 200,
+    minimumHeight: 0,
     margin: 10,
     gridType: GridType.VerticalFixed,
   };
@@ -285,6 +286,14 @@ export class ViewSettingsModalComponent
               this.defaultGridOptions.fixedRowHeight
             ),
             Validators.min(50)
+          ),
+          minimumHeight: this.fb.control(
+            get<number>(
+              this.dashboard.gridOptions,
+              'minimumHeight',
+              this.defaultGridOptions.minimumHeight
+            ),
+            Validators.min(0)
           ),
           margin: this.fb.control(
             get<number>(

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -561,7 +561,7 @@
 						"fixedRowHeight": "Size of rows in pixels.\nMust be greater or equal to 50.",
 						"margin": "Gap in pixels between widgets.\nMust be a positive integer.",
 						"minCols": "Number of columns.\nMust be an integer between 4 and 24.",
-						"minimumHeight": "Minimum size of the grid in pixels.\nMust be greater or equal to 0.",
+						"minimumHeight": "Minimum height of the grid in pixels.\nMust be greater than or equal to 0. \nThe dashboard won't automatically fit to the screen if its height is below this number.",
 						"reset": "Reset to default"
 					}
 				}

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -556,10 +556,12 @@
 					},
 					"margin": "Margin between widgets",
 					"minCols": "Number of columns",
+					"minimumHeight": "Minimum height",
 					"tooltip": {
 						"fixedRowHeight": "Size of rows in pixels.\nMust be greater or equal to 50.",
 						"margin": "Gap in pixels between widgets.\nMust be a positive integer.",
 						"minCols": "Number of columns.\nMust be an integer between 4 and 24.",
+						"minimumHeight": "Minimum size of the grid in pixels.\nMust be greater or equal to 0.",
 						"reset": "Reset to default"
 					}
 				}

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -556,10 +556,12 @@
 					},
 					"margin": "Marge entre les widgets",
 					"minCols": "Nombre de colonnes",
+					"minimumHeight": "Hauteur minimum",
 					"tooltip": {
 						"fixedRowHeight": "Taille des lignes en pixels.\nDoit être supérieur ou égal à 50.",
 						"margin": "Marge entre les widgets.\nDoit être un entier positif.",
 						"minCols": "Nombre de colonnes.\nDoit être compris entre 4 et 24.",
+						"minimumHeight": "Taille minimale de la grille en pixels.\nDoit être supérieur ou égal à 0.",
 						"reset": "Réinitialiser la valeur"
 					},
 					"tooltips": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -556,10 +556,12 @@
 					},
 					"margin": "******",
 					"minCols": "******",
+					"minimumHeight": "******",
 					"tooltip": {
 						"fixedRowHeight": "******",
 						"margin": "******",
 						"minCols": "******",
+						"minimumHeight": "******",
 						"reset": "******"
 					}
 				}

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
@@ -62,7 +62,8 @@
       </ng-template>
     </gridster-item>
   </gridster>
-  <div class="pb-[32px]"></div>
+  <!-- Manually creating a padding because the grid overlaps the default behavior -->
+  <div *ngIf="gridOptions.minimumHeight" class="h-[32px]"></div>
 </ng-container>
 <!-- LOADING INDICATOR -->
 <ng-template #emptyTemplate>

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
@@ -13,57 +13,68 @@
     >
     </shared-widget-choice>
   </div>
-  <gridster
-    [options]="gridOptions"
-    class="!w-full"
-    [ngStyle]="{ 'min-height.px': gridOptions.minimumHeight }"
+
+  <!-- Using an additional div to prevent the grid from overlapping the parent's padding -->
+  <div
+    class="h-full"
+    [ngClass]="{
+      'pb-[32px] mb-[-32px] box-content': isMinHeightEnabled
+    }"
   >
-    <gridster-item
-      [item]="widget"
-      class="max-w-full"
-      *ngFor="let widget of widgets; let i = index"
+    <gridster
+      [options]="gridOptions"
+      class="!w-full"
+      [ngStyle]="{
+        'min-height.px': isMinHeightEnabled ? gridOptions.minimumHeight : 0
+      }"
     >
-      <shared-widget
-        #widgetElement
-        [widget]="widget"
-        (changeStep)="triggerChangeStepAction($event)"
-        (edit)="onEditWidget($event)"
-        [canUpdate]="canUpdate"
-        [headerLeftTemplate]="headerLeftTemplate"
-        [headerRightTemplate]="headerRightTemplate"
-      ></shared-widget>
-      <!-- Left header template -->
-      <ng-template #headerLeftTemplate>
-        <!-- Drag n drop indicator -->
-        <ui-icon
-          *ngIf="canUpdate"
-          icon="drag_indicator"
-          class="cursor-grab drag-handler flex items-center justify-center h-[40px] w-[40px] -ml-3 bg-white/70 rounded-2xl pointer-events-auto"
-          variant="grey"
-          [uiTooltip]="'common.tooltip.dragDrop' | translate"
-        >
-        </ui-icon>
-      </ng-template>
-      <!-- Right header template -->
-      <ng-template #headerRightTemplate let-id>
-        <!-- Widget actions -->
-        <shared-widget-actions
-          class="-mr-3 bg-white/70 rounded-2xl pointer-events-auto"
-          [id]="id"
-          [canUpdate]="canUpdate"
-          [collapsed]="widgetElement.elementRef.nativeElement.clientWidth < 500"
+      <gridster-item
+        [item]="widget"
+        class="max-w-full"
+        *ngFor="let widget of widgets; let i = index"
+      >
+        <shared-widget
+          #widgetElement
           [widget]="widget"
+          (changeStep)="triggerChangeStepAction($event)"
           (edit)="onEditWidget($event)"
-          (delete)="onDeleteWidget($event)"
-          (expand)="onExpandWidget($event)"
-          (style)="onStyleWidget($event)"
-        >
-        </shared-widget-actions>
-      </ng-template>
-    </gridster-item>
-  </gridster>
-  <!-- Manually creating a padding because the grid overlaps the default behavior -->
-  <div *ngIf="gridOptions.minimumHeight" class="h-[32px]"></div>
+          [canUpdate]="canUpdate"
+          [headerLeftTemplate]="headerLeftTemplate"
+          [headerRightTemplate]="headerRightTemplate"
+        ></shared-widget>
+        <!-- Left header template -->
+        <ng-template #headerLeftTemplate>
+          <!-- Drag n drop indicator -->
+          <ui-icon
+            *ngIf="canUpdate"
+            icon="drag_indicator"
+            class="cursor-grab drag-handler flex items-center justify-center h-[40px] w-[40px] -ml-3 bg-white/70 rounded-2xl pointer-events-auto"
+            variant="grey"
+            [uiTooltip]="'common.tooltip.dragDrop' | translate"
+          >
+          </ui-icon>
+        </ng-template>
+        <!-- Right header template -->
+        <ng-template #headerRightTemplate let-id>
+          <!-- Widget actions -->
+          <shared-widget-actions
+            class="-mr-3 bg-white/70 rounded-2xl pointer-events-auto"
+            [id]="id"
+            [canUpdate]="canUpdate"
+            [collapsed]="
+              widgetElement.elementRef.nativeElement.clientWidth < 500
+            "
+            [widget]="widget"
+            (edit)="onEditWidget($event)"
+            (delete)="onDeleteWidget($event)"
+            (expand)="onExpandWidget($event)"
+            (style)="onStyleWidget($event)"
+          >
+          </shared-widget-actions>
+        </ng-template>
+      </gridster-item>
+    </gridster>
+  </div>
 </ng-container>
 <!-- LOADING INDICATOR -->
 <ng-template #emptyTemplate>

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.html
@@ -13,8 +13,11 @@
     >
     </shared-widget-choice>
   </div>
-  <!-- GRID OF WIDGETS -->
-  <gridster [options]="gridOptions" class="!w-full">
+  <gridster
+    [options]="gridOptions"
+    class="!w-full"
+    [ngStyle]="{ 'min-height.px': gridOptions.minimumHeight }"
+  >
     <gridster-item
       [item]="widget"
       class="max-w-full"
@@ -59,6 +62,7 @@
       </ng-template>
     </gridster-item>
   </gridster>
+  <div class="pb-[32px]"></div>
 </ng-container>
 <!-- LOADING INDICATOR -->
 <ng-template #emptyTemplate>

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
@@ -22,6 +22,7 @@ import {
   CompactType,
   DisplayGrid,
   GridType,
+  GridsterComponentInterface,
   GridsterConfig,
   GridsterItem,
 } from 'angular-gridster2';
@@ -86,6 +87,8 @@ export class WidgetGridComponent
   private gridOptionsTimeoutListener!: NodeJS.Timeout;
   /** Subscribe to structure changes */
   private changesSubscription?: Subscription;
+  /** Determines whether we need to use a minimum height */
+  public isMinHeightEnabled?: boolean;
 
   /**
    * Indicate if the widget grid can be deactivated or not.
@@ -131,6 +134,11 @@ export class WidgetGridComponent
         this.setGridOptions();
       });
     this.setGridOptions();
+
+    // Initialize and listen grid size changes to determine whether the minimum height should be used
+    this.gridOptions.gridSizeChangedCallback = (grid) =>
+      this.enableMinHeight(grid);
+    this.enableMinHeight();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -188,6 +196,11 @@ export class WidgetGridComponent
     return MAX_COL_SPAN;
   }
 
+  private enableMinHeight(grid: GridsterComponentInterface | null = null) {
+    this.isMinHeightEnabled =
+      this.gridOptions.gridType === GridType.Fit && !grid?.mobile;
+  }
+
   /**
    * Set Gridster options.
    *
@@ -232,10 +245,6 @@ export class WidgetGridComponent
       keepFixedHeightInMobile: true,
       ...this.options,
     };
-
-    if (this.gridOptions.gridType !== GridType.Fit) {
-      this.gridOptions.minimumHeight = 0;
-    }
 
     // Set maxCols at the end, based on widgets & existing max
     this.gridOptions.maxCols = Math.max(

--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
@@ -209,6 +209,7 @@ export class WidgetGridComponent
       minItemRows: 1, // min item number of rows
       minCols: this.colsNumber,
       fixedRowHeight: 200,
+      minimumHeight: 0,
       draggable: {
         enabled: this.canUpdate,
         ignoreContentClass: 'gridster-item-content',
@@ -231,6 +232,11 @@ export class WidgetGridComponent
       keepFixedHeightInMobile: true,
       ...this.options,
     };
+
+    if (this.gridOptions.gridType !== GridType.Fit) {
+      this.gridOptions.minimumHeight = 0;
+    }
+
     // Set maxCols at the end, based on widgets & existing max
     this.gridOptions.maxCols = Math.max(
       this.maxCols,

--- a/libs/shared/src/lib/components/widgets/tabs-settings/tab-grid-settings-modal/tab-grid-settings-modal.component.html
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tab-grid-settings-modal/tab-grid-settings-modal.component.html
@@ -138,7 +138,7 @@
               "
             ></ui-icon>
           </label>
-          <input type="number" formControlName="minimumHeight" min="50" />
+          <input type="number" formControlName="minimumHeight" min="0" />
           <ui-icon
             uiSuffix
             class="cursor-pointer"
@@ -146,7 +146,7 @@
             variant="grey"
             (click)="
               formGroup
-                .get('gridOptions.minimumHeight')
+                .get('minimumHeight')
                 ?.setValue(defaultGridOptions.minimumHeight)
             "
             [uiTooltip]="

--- a/libs/shared/src/lib/components/widgets/tabs-settings/tab-grid-settings-modal/tab-grid-settings-modal.component.html
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tab-grid-settings-modal/tab-grid-settings-modal.component.html
@@ -115,6 +115,46 @@
             "
           ></ui-icon>
         </div>
+        <!-- Change the minimum height of the container -->
+        <div
+          uiFormFieldDirective
+          [outline]="false"
+          *ngIf="formGroup.get('gridType')?.value === gridType.Fit"
+        >
+          <label class="flex items-center gap-1">
+            {{
+              'components.application.dashboard.settings.minimumHeight'
+                | translate
+            }}
+            <!-- Tooltip -->
+            <ui-icon
+              class="cursor-help self-center"
+              icon="info_outline"
+              variant="grey"
+              [size]="18"
+              [uiTooltip]="
+                'components.application.dashboard.settings.tooltip.minimumHeight'
+                  | translate
+              "
+            ></ui-icon>
+          </label>
+          <input type="number" formControlName="minimumHeight" min="50" />
+          <ui-icon
+            uiSuffix
+            class="cursor-pointer"
+            icon="restart_alt"
+            variant="grey"
+            (click)="
+              formGroup
+                .get('gridOptions.minimumHeight')
+                ?.setValue(defaultGridOptions.minimumHeight)
+            "
+            [uiTooltip]="
+              'components.application.dashboard.settings.tooltip.reset'
+                | translate
+            "
+          ></ui-icon>
+        </div>
         <!-- Specify inner gap -->
         <div uiFormFieldDirective>
           <label class="flex items-center gap-1"

--- a/libs/shared/src/lib/components/widgets/tabs-settings/tab-grid-settings-modal/tab-grid-settings-modal.component.ts
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tab-grid-settings-modal/tab-grid-settings-modal.component.ts
@@ -55,6 +55,7 @@ export class TabGridSettingsModalComponent {
   public defaultGridOptions = {
     minCols: 8,
     fixedRowHeight: 200,
+    minimumHeight: 0,
     margin: 10,
   };
 

--- a/libs/shared/src/lib/components/widgets/tabs-settings/tabs-settings.form.ts
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tabs-settings.form.ts
@@ -49,7 +49,7 @@ export const createTabFormGroup = (value?: any) => {
           'minimumHeight',
           DEFAULT_GRID_OPTIONS.minimumHeight
         ),
-        Validators.min(100)
+        Validators.min(0)
       ),
       margin: fb.control(
         get<number>(value.gridOptions, 'margin', DEFAULT_GRID_OPTIONS.margin),

--- a/libs/shared/src/lib/components/widgets/tabs-settings/tabs-settings.form.ts
+++ b/libs/shared/src/lib/components/widgets/tabs-settings/tabs-settings.form.ts
@@ -9,6 +9,7 @@ const fb = new FormBuilder();
 const DEFAULT_GRID_OPTIONS = {
   minCols: 8,
   fixedRowHeight: 200,
+  minimumHeight: 0,
   margin: 10,
   gridType: GridType.VerticalFixed,
 };
@@ -41,6 +42,14 @@ export const createTabFormGroup = (value?: any) => {
           DEFAULT_GRID_OPTIONS.fixedRowHeight
         ),
         Validators.min(50)
+      ),
+      minimumHeight: fb.control(
+        get<number>(
+          value.gridOptions,
+          'minimumHeight',
+          DEFAULT_GRID_OPTIONS.minimumHeight
+        ),
+        Validators.min(100)
       ),
       margin: fb.control(
         get<number>(value.gridOptions, 'margin', DEFAULT_GRID_OPTIONS.margin),


### PR DESCRIPTION
# Description

I added a min-height property to the dashboard and tabs widget. It is configurable from the settings when the grid mode is set to `fit`. 

I added an additional div to prevent the grid from overlapping the parent's padding. This issue occurred when the scrollbar was visible. The `height` defined as 100% of the gridster causes the element to extend to the height of the parent, including the padding. To prevent this, I used a little CSS trick involving `box-content` and `margin`. It's the only solution I found that covers all situations at once. 
- when the gridster is larger or smaller than the default height of the dashboard
- when both grid types are used
- when the tabs widget is used

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

I created a dashboard and filled it with widgets, including a tabs widget. I tried to configure both grid types for the dashboard as well as for the tabs widget. I checked the behavior with the new minimum height feature.

## Screenshots

![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/c533d36a-dcc1-46f5-8877-a07d0596a001)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
