### PR TITLE
feat/AB#84016_prevent_graphql_variable_mapping_inject_variables_whenever_open_the_settings

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1807,6 +1807,7 @@
 							"layoutStyles": {
 								"queryFilters": {
 									"noVariables": "No variables defined",
+									"refreshVariables": "Refresh variables",
 									"title": "GraphQL variable mapping",
 									"tooltip": "Set values for the GraphQL variables defined in the reference data query. You can get values from the filters using the {{filter.<question-name>}} templates. E.g.: { \"region\": {{filter.region}} }"
 								},

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1806,8 +1806,9 @@
 						"dataSource": {
 							"layoutStyles": {
 								"queryFilters": {
+									"help": "Make sure to remove all unused variables, to prevent null arguments to be sent.",
 									"noVariables": "No variables defined",
-									"refreshVariables": "Refresh variables",
+									"refresh": "See all graphQL variables",
 									"title": "GraphQL variable mapping",
 									"tooltip": "Set values for the GraphQL variables defined in the reference data query. You can get values from the filters using the {{filter.<question-name>}} templates. E.g.: { \"region\": {{filter.region}} }"
 								},

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1820,6 +1820,7 @@
 							"layoutStyles": {
 								"queryFilters": {
 									"noVariables": "Aucune variable définie",
+									"refreshVariables": "Actualiser les variables",
 									"title": "Mappage de variables GraphQL",
 									"tooltip": "Définissez les valeurs des variables GraphQL définies dans la requête de données de référence. Vous pouvez obtenir les valeurs des filtres à l'aide des modèles {{filter.<question-name>}}. Par exemple : { \"region\": {{filter.region}} }"
 								},

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1819,8 +1819,9 @@
 						"dataSource": {
 							"layoutStyles": {
 								"queryFilters": {
+									"help": "N'oubliez pas de supprimer les variables non utilisées.",
 									"noVariables": "Aucune variable définie",
-									"refreshVariables": "Actualiser les variables",
+									"refresh": "Afficher toutes les variables graphQL",
 									"title": "Mappage de variables GraphQL",
 									"tooltip": "Définissez les valeurs des variables GraphQL définies dans la requête de données de référence. Vous pouvez obtenir les valeurs des filtres à l'aide des modèles {{filter.<question-name>}}. Par exemple : { \"region\": {{filter.region}} }"
 								},

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1807,6 +1807,7 @@
 							"layoutStyles": {
 								"queryFilters": {
 									"noVariables": "******",
+									"refreshVariables": "******",
 									"title": "******",
 									"tooltip": "****** {{filter.<question-name>}} ****** { ****** {{filter.region}} ****** }"
 								},

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1806,8 +1806,9 @@
 						"dataSource": {
 							"layoutStyles": {
 								"queryFilters": {
+									"help": "******",
 									"noVariables": "******",
-									"refreshVariables": "******",
+									"refresh": "******",
 									"title": "******",
 									"tooltip": "****** {{filter.<question-name>}} ****** { ****** {{filter.region}} ****** }"
 								},

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
@@ -15,10 +15,17 @@
         | translate
     "
   ></ui-icon>
-  <ui-button category="secondary" (click)="setAvailableQueryVariables(true, true)">
-    {{ 'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.refreshVariables' | translate }}
+  <ui-button class="ml-auto" category="secondary" (click)="refresh(true, true)">
+    {{
+      'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.refresh'
+        | translate
+    }}
   </ui-button>
 </span>
+<ui-alert *ngIf="availableQueryVariables.length > 0">{{
+  'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.help'
+    | translate
+}}</ui-alert>
 <ngx-monaco-editor
   *ngIf="availableQueryVariables.length > 0"
   [formControl]="control"

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
@@ -15,6 +15,9 @@
         | translate
     "
   ></ui-icon>
+  <ui-button category="secondary" (click)="setAvailableQueryVariables(true, true)">
+    {{ 'components.widget.settings.summaryCard.card.dataSource.layoutStyles.queryFilters.refreshVariables' | translate }}
+  </ui-button>
 </span>
 <ngx-monaco-editor
   *ngIf="availableQueryVariables.length > 0"

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
@@ -1,7 +1,12 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { IconModule, TooltipModule, ButtonModule } from '@oort-front/ui';
+import {
+  IconModule,
+  TooltipModule,
+  ButtonModule,
+  AlertModule,
+} from '@oort-front/ui';
 import { EmptyModule } from '../../../ui/empty/empty.module';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { ReferenceData } from '../../../../models/reference-data.model';
@@ -24,6 +29,7 @@ import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
     FormsModule,
     ReactiveFormsModule,
     ButtonModule,
+    AlertModule,
   ],
   templateUrl: './graphql-variables-mapping.component.html',
   styleUrls: ['./graphql-variables-mapping.component.scss'],
@@ -45,23 +51,20 @@ export class GraphqlVariablesMappingComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     // changed only reference data
     if (changes['referenceData'] && !changes['control']) {
-      this.setAvailableQueryVariables(true);
+      this.refresh(true);
       // started the component
     } else {
-      this.setAvailableQueryVariables();
+      this.refresh();
     }
   }
 
   /**
-   * Parses que refData query and gets the available variable names, excluding the pagination ones
+   * Refresh editor, updating template & variables if needed.
    *
    * @param restoreTemplate boolean to indicate if should restore variables template
-   * @param refreshVariables boolean to indicate if should refresh variables that is not used
+   * @param keepVariables boolean to indicate if should keep used variables
    */
-  public setAvailableQueryVariables(
-    restoreTemplate?: boolean,
-    refreshVariables?: boolean
-  ): void {
+  public refresh(restoreTemplate?: boolean, keepVariables?: boolean): void {
     if (this.referenceData?.type !== 'graphql') {
       this.availableQueryVariables = [];
       return;
@@ -102,7 +105,7 @@ export class GraphqlVariablesMappingComponent implements OnChanges {
           2
         );
         // if should restore variables keep the current variables and add the deleted ones
-        if (refreshVariables) {
+        if (keepVariables) {
           this.control.setValue(
             JSON.stringify(
               {
@@ -114,6 +117,7 @@ export class GraphqlVariablesMappingComponent implements OnChanges {
             )
           );
         } else {
+          console.log(template);
           this.control.setValue(template);
         }
       }


### PR DESCRIPTION
# Description

Feat: 
- Prevented the graphql variables to appear by default ( the ones that are not used ).
- Refresh of the graphql variables only is made when reference data changed.
- Added a refresh button next to the info icon, that could do the same logic, meaning that you would still see the previous mapping, and also the graphql variables that are still not used.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84016)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

As the attached video.

## Screenshots

![Peek 22-01-2024 15-16](https://github.com/ReliefApplications/ems-frontend/assets/56398308/d870e7ec-9d21-4c1f-84be-0584f1b3ea20)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
