### PR TITLE
AB#84023-add-in-and-notIn-operator-for-dashboard-filters

### DIFF
--- a/libs/shared/src/lib/utils/filter/reference-data-filter.util.ts
+++ b/libs/shared/src/lib/utils/filter/reference-data-filter.util.ts
@@ -78,7 +78,6 @@ export const filterReferenceData = (item: any, filter: any) => {
           return isNil(value) || !value.includes(filter.value);
         }
       case 'in':
-        console.log(value, filter.value);
         if (typeof value === 'string') {
           const regex = new RegExp(value, 'i');
           if (typeof filter.value === 'string') {

--- a/libs/shared/src/lib/utils/filter/reference-data-filter.util.ts
+++ b/libs/shared/src/lib/utils/filter/reference-data-filter.util.ts
@@ -77,6 +77,29 @@ export const filterReferenceData = (item: any, filter: any) => {
         } else {
           return isNil(value) || !value.includes(filter.value);
         }
+      case 'in':
+        console.log(value, filter.value);
+        if (typeof value === 'string') {
+          const regex = new RegExp(value, 'i');
+          if (typeof filter.value === 'string') {
+            return !isNil(filter.value) && regex.test(filter.value);
+          } else {
+            return !isNil(filter.value) && filter.value.includes(value);
+          }
+        } else {
+          return !isNil(filter.value) && filter.value.includes(value);
+        }
+      case 'notin':
+        if (typeof value === 'string') {
+          const regex = new RegExp(value, 'i');
+          if (typeof filter.value === 'string') {
+            return isNil(filter.value) || !regex.test(filter.value);
+          } else {
+            return isNil(filter.value) || !filter.value.includes(value);
+          }
+        } else {
+          return isNil(filter.value) || !filter.value.includes(value);
+        }
       default:
         return false;
     }


### PR DESCRIPTION
# Description

Support for in and notin operators for reference data

## Useful links

[Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84023)
- [Please insert link to back-end branch if any](https://github.com/ReliefApplications/ems-backend/pull/951)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Created ref data with both arrays and strings and tested.

## Screenshots


# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
