### PR TITLE
feat/AB#84288-prevent-interpreting-values-when-using-data-as-expressions

### DIFF
--- a/libs/shared/src/lib/utils/parser/utils.ts
+++ b/libs/shared/src/lib/utils/parser/utils.ts
@@ -160,7 +160,7 @@ const replaceRecordFields = (
         if (attributeName && dataFieldName) {
           // Replace the attribute with the corresponding value
           const value = get(fieldsValue, dataFieldName);
-          return value !== undefined ? `${attributeName}="${value}"` : match;
+          return !isNil(value) ? `${attributeName}="${value}"` : match;
         } else {
           // Return the original match if not a data binding attribute
           return match;

--- a/libs/shared/src/lib/utils/parser/utils.ts
+++ b/libs/shared/src/lib/utils/parser/utils.ts
@@ -148,6 +148,26 @@ const replaceRecordFields = (
 ): string => {
   let formattedHtml = html;
   if (fields) {
+    // Regular expression for detecting when ="{{data.*}}" is used and
+    // we should not interpret it, but keep the default attribute value
+    const attributeRegex = /([a-zA-Z]+)="{{data\.(.*?)}}"/g;
+
+    // Replace attributes with data binding expressions
+    formattedHtml = formattedHtml.replace(
+      attributeRegex,
+      (match, attributeName, dataFieldName) => {
+        // Check if it's an attribute with data binding
+        if (attributeName && dataFieldName) {
+          // Replace the attribute with the corresponding value
+          const value = get(fieldsValue, dataFieldName);
+          return value !== undefined ? `${attributeName}="${value}"` : match;
+        } else {
+          // Return the original match if not a data binding attribute
+          return match;
+        }
+      }
+    );
+
     const links = formattedHtml.match(`href=["]?[^" >]+`);
 
     // We check for LIST fields and duplicate their only element for each subfield


### PR DESCRIPTION
# Description
Updated replaceRecordFields: before checking if {{data.*}} need to be interpreted and replaced by an html, added attributeRegex to check if `="{{data.*}}"` is used and we should not be interpret it, but keep the default field value

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84288

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
You can use these dashboards to test: [text widget](https://oort-dev.oortcloud.tech/admin/applications/63c5682cb956ff752087cf0a/dashboard/65834257eb7c9f3f996f53e8) and [summary card widget](https://oort-dev.oortcloud.tech/admin/applications/63c5682cb956ff752087cf0a/dashboard/65770da37fe17393ef1dafcc)

## Screenshots
![text](https://github.com/ReliefApplications/ems-frontend/assets/28535394/33ea6246-1033-4c0b-859c-441a572a0e85)

[summary-card.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/417a6471-4dc2-4f44-876a-e14614ae9063)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
