### PR TITLE
AB#84318 -  Unresponsive paginator in summary cards

### DIFF
--- a/libs/ui/src/lib/paginator/paginator.component.html
+++ b/libs/ui/src/lib/paginator/paginator.component.html
@@ -6,56 +6,17 @@
   ></div>
   <kendo-datapager
     class="!border-none"
+    [ngClass]="{ 'hide-first-last': hideFirstLastButtons }"
     [attr.aria-label]="ariaLabel"
     [attr.aria-controls]="paginatorId"
     [style.width.%]="100"
     [pageSize]="pageSize"
     [skip]="skip"
     [total]="totalItems"
+    [buttonCount]="displayedPageNumbers"
+    [pageSizeValues]="pageSizeOptions"
+    [info]="true"
     (pageChange)="onPageChange($event)"
   >
-    <ng-template
-      kendoDataPagerTemplate
-      let-totalPages="totalPages"
-      let-currentPage="currentPage"
-    >
-      <div class="w-full flex justify-between">
-        <div class="hidden sm:flex" *ngIf="showTotalItems && isScreenCondensed">
-          <!-- Page info -->
-          <kendo-datapager-messages
-            page="{{ 'components.paginator.page' | translate }}"
-            of="{{ 'components.paginator.of' | translate }}"
-            items="{{ 'components.paginator.items' | translate }}"
-            itemsPerPage="{{ 'components.paginator.itemsPerPage' | translate }}"
-          >
-          </kendo-datapager-messages>
-          <kendo-datapager-info></kendo-datapager-info>
-        </div>
-      
-        <div class="flex w-full sm:w-auto ml-auto">
-          <!-- Page size -->
-          <kendo-datapager-page-sizes
-            class="hidden sm:flex text-gray-700"
-            *ngIf="showPageSizes && isScreenCondensed"
-            [pageSizes]="pageSizeOptions"
-          ></kendo-datapager-page-sizes>
-          <!-- Page buttons -->
-          <div
-            class="border shadow-sm k-pager-numbers-wrap rounded-md ml-auto sm:ml-4"
-          >
-            <kendo-datapager-prev-buttons
-              [class.hide-first]="hideFirstLastButtons"
-            ></kendo-datapager-prev-buttons>
-            <kendo-datapager-numeric-buttons
-              *ngIf="displayedPageNumbers && isScreenCondensed"
-              [buttonCount]="displayedPageNumbers"
-            ></kendo-datapager-numeric-buttons>
-            <kendo-datapager-next-buttons
-              [class.hide-last]="hideFirstLastButtons"
-            ></kendo-datapager-next-buttons>
-          </div>
-        </div>
-      </div>
-    </ng-template>
   </kendo-datapager>
 </div>

--- a/libs/ui/src/lib/paginator/paginator.component.html
+++ b/libs/ui/src/lib/paginator/paginator.component.html
@@ -20,7 +20,7 @@
       let-currentPage="currentPage"
     >
       <div class="w-full flex justify-between">
-        <div class="hidden sm:flex" *ngIf="showTotalItems">
+        <div class="hidden sm:flex" *ngIf="showTotalItems && isScreenCondensed">
           <!-- Page info -->
           <kendo-datapager-messages
             page="{{ 'components.paginator.page' | translate }}"
@@ -31,11 +31,12 @@
           </kendo-datapager-messages>
           <kendo-datapager-info></kendo-datapager-info>
         </div>
+      
         <div class="flex w-full sm:w-auto ml-auto">
           <!-- Page size -->
           <kendo-datapager-page-sizes
             class="hidden sm:flex text-gray-700"
-            *ngIf="showPageSizes"
+            *ngIf="showPageSizes && isScreenCondensed"
             [pageSizes]="pageSizeOptions"
           ></kendo-datapager-page-sizes>
           <!-- Page buttons -->
@@ -46,7 +47,7 @@
               [class.hide-first]="hideFirstLastButtons"
             ></kendo-datapager-prev-buttons>
             <kendo-datapager-numeric-buttons
-              *ngIf="displayedPageNumbers"
+              *ngIf="displayedPageNumbers && isScreenCondensed"
               [buttonCount]="displayedPageNumbers"
             ></kendo-datapager-numeric-buttons>
             <kendo-datapager-next-buttons

--- a/libs/ui/src/lib/paginator/paginator.component.scss
+++ b/libs/ui/src/lib/paginator/paginator.component.scss
@@ -1,31 +1,75 @@
-:host kendo-datapager {
-  @apply p-3 pr-0 bg-white border-l-0 border-b-0 border-r-0 border-t;
+kendo-datapager {
+  @apply p-3 bg-white border-l-0 border-b-0 border-r-0 border-t;
 }
 
-:host ::ng-deep .k-pager-md .k-pager-numbers-wrap .k-button {
-  --tw-border-opacity: 1 !important;
-  border-color: rgb(212 212 212 / var(--tw-border-opacity)) !important;
-  @apply h-full text-base border-r border-l-0 border-t-0 border-b-0;
-}
+:host ::ng-deep {
+  .k-pager-md .k-pager-numbers-wrap .k-button {
+    --tw-border-opacity: 1 !important;
+    border-color: rgb(212 212 212 / var(--tw-border-opacity)) !important;
+    @apply h-full text-base border-r border-l-0 border-t-0 border-b-0;
+  }
 
-:host ::ng-deep .hide-last button:last-child,
-:host ::ng-deep .hide-first button:first-child {
-  display: none !important;
-}
+  // When cursor pagination, hide first & last buttons
+  .hide-first-last {
+    kendo-datapager-prev-buttons {
+      .k-pager-first {
+        display: none !important;
+      }
+    }
+    kendo-datapager-next-buttons {
+      .k-pager-last {
+        display: none !important;
+      }
+      button:first-child {
+        border-right: 0 !important;
+      }
+    }
+  }
 
-:host ::ng-deep kendo-datapager-next-buttons button:first-child {
-  border-right: 0 !important;
-}
+  kendo-datapager.k-pager-mobile-sm {
+    &:not(.hide-first-last) {
+      kendo-datapager-next-buttons {
+        button:first-child {
+          border-left-width: 1px !important;
+        }
+      }
+    }
+  }
 
-:host ::ng-deep kendo-dropdownlist {
-  background-image: none !important;
-  @apply border-0 border-b border-neutral-500 bg-inherit;
-}
+  // Hide last border ( duplicated )
+  kendo-datapager-next-buttons button:last-child {
+    border-right: 0 !important;
+  }
 
-:host ::ng-deep kendo-datapager-info {
-  @apply text-sm text-gray-700;
-}
+  kendo-dropdownlist,
+  select {
+    background-image: none !important;
+    @apply border-0 border-b border-neutral-500 bg-inherit;
+  }
 
-:host ::ng-deep .k-pager {
-  @apply border-0 focus:shadow-none;
+  k-pager {
+    @apply border-0 focus:shadow-none;
+  }
+
+  kendo-datapager-info {
+    order: 1;
+    @apply text-sm text-gray-700;
+    justify-content: flex-start;
+  }
+
+  // Change native order of elements
+  kendo-datapager-page-sizes {
+    order: 2;
+  }
+
+  .k-pager-numbers-wrap {
+    order: 3;
+    @apply border rounded-md ml-auto;
+  }
+
+  kendo-datapager-numeric-buttons {
+    select {
+      margin: 0 !important;
+    }
+  }
 }

--- a/libs/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/src/lib/paginator/paginator.component.ts
@@ -1,11 +1,8 @@
 import {
   Component,
-  ElementRef,
   EventEmitter,
   Input,
   OnChanges,
-  OnDestroy,
-  OnInit,
   Output,
   SimpleChanges,
 } from '@angular/core';
@@ -22,7 +19,7 @@ import { UIPageChangeEvent } from './interfaces/paginator.interfaces';
   templateUrl: './paginator.component.html',
   styleUrls: ['./paginator.component.scss'],
 })
-export class PaginatorComponent implements OnChanges, OnInit, OnDestroy {
+export class PaginatorComponent implements OnChanges {
   /** Disable pagination */
   @Input() disabled = false;
   /** Number of items */
@@ -45,50 +42,14 @@ export class PaginatorComponent implements OnChanges, OnInit, OnDestroy {
   @Input() pageIndex = 0;
   /** Number of pages to show */
   @Input() displayedPageNumbers = 0;
-  /** Controls whether the page will be shown condensed based on screen size  */
-  public isScreenCondensed = true;
-  /** Observer resize changes */
-  private resizeObserver!: ResizeObserver;
   /** Page change event */
   @Output() pageChange: EventEmitter<UIPageChangeEvent> = new EventEmitter();
   /** Generate random unique identifier for each paginator component */
   public paginatorId = uuidv4();
 
-  /**
-   * Constructor
-   *
-   * @param elementRef Element reference
-   */
-  constructor(private elementRef: ElementRef) {}
-
-  ngOnInit(): void {
-    if (this.elementRef.nativeElement.parentElement) {
-      this.updateShowDisplayedPageNumbers(
-        this.elementRef.nativeElement.parentElement.clientWidth
-      );
-      this.resizeObserver = new ResizeObserver(() => {
-        this.updateShowDisplayedPageNumbers(
-          this.elementRef.nativeElement.parentElement.clientWidth
-        );
-      });
-      this.resizeObserver.observe(this.elementRef.nativeElement.parentElement);
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.resizeObserver?.disconnect();
-  }
-
-  /**
-   * Update show displayed page numbers
-   *
-   * @param width Width of the paginator
-   */
-  updateShowDisplayedPageNumbers(width: number) {
-    if (width < 600) {
-      this.isScreenCondensed = false;
-    } else {
-      this.isScreenCondensed = true;
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['pageIndex']) {
+      this.skip = changes['pageIndex'].currentValue * this.pageSize;
     }
   }
 
@@ -110,11 +71,5 @@ export class PaginatorComponent implements OnChanges, OnInit, OnDestroy {
       previousPageIndex: this.pageIndex,
     });
     this.pageIndex = currentPage;
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['pageIndex']) {
-      this.skip = changes['pageIndex'].currentValue * this.pageSize;
-    }
   }
 }

--- a/libs/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/src/lib/paginator/paginator.component.ts
@@ -1,8 +1,11 @@
 import {
   Component,
+  ElementRef,
   EventEmitter,
   Input,
   OnChanges,
+  OnDestroy,
+  OnInit,
   Output,
   SimpleChanges,
 } from '@angular/core';
@@ -19,7 +22,7 @@ import { UIPageChangeEvent } from './interfaces/paginator.interfaces';
   templateUrl: './paginator.component.html',
   styleUrls: ['./paginator.component.scss'],
 })
-export class PaginatorComponent implements OnChanges {
+export class PaginatorComponent implements OnChanges, OnInit, OnDestroy {
   /** Disable pagination */
   @Input() disabled = false;
   /** Number of items */
@@ -42,10 +45,52 @@ export class PaginatorComponent implements OnChanges {
   @Input() pageIndex = 0;
   /** Number of pages to show */
   @Input() displayedPageNumbers = 0;
+  /** Controls whether the page will be shown condensed based on screen size  */
+  public isScreenCondensed = true;
+  /** Observer resize changes */
+  private resizeObserver!: ResizeObserver;
   /** Page change event */
   @Output() pageChange: EventEmitter<UIPageChangeEvent> = new EventEmitter();
   /** Generate random unique identifier for each paginator component */
   public paginatorId = uuidv4();
+
+  /**
+   * Constructor
+   *
+   * @param elementRef Element reference
+   */
+  constructor(private elementRef: ElementRef) {}
+
+  ngOnInit(): void {
+    if (this.elementRef.nativeElement.parentElement) {
+      this.updateShowDisplayedPageNumbers(
+        this.elementRef.nativeElement.parentElement.clientWidth
+      );
+      this.resizeObserver = new ResizeObserver(() => {
+        this.updateShowDisplayedPageNumbers(
+          this.elementRef.nativeElement.parentElement.clientWidth
+        );
+      });
+      this.resizeObserver.observe(this.elementRef.nativeElement.parentElement);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
+  }
+
+  /**
+   * Update show displayed page numbers
+   *
+   * @param width Width of the paginator
+   */
+  updateShowDisplayedPageNumbers(width: number) {
+    if (width < 600) {
+      this.isScreenCondensed = false;
+    } else {
+      this.isScreenCondensed = true;
+    }
+  }
 
   /**
    * Update page data on page change


### PR DESCRIPTION
# Description

Analyzing how the grid widget works (it was written in the ticket to use this example screen), I realized that it uses its own library to control responsiveness, kendo-grid.

To resolve the ticket, I created an observer that checks when the screen size was changed and omitted some information based on that.

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84318)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] I reduced the screen size and observed the behavior of the components.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/55603259/dd82087e-3a77-406b-b010-83899d264ff7


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
