### PR TITLE
Fix/ab#84407 form configuration bug when using old ref data

### DIFF
--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -65,7 +65,9 @@ export const init = (referenceDataService: ReferenceDataService): void => {
           referenceDataService
             .loadReferenceData(obj.referenceData)
             .then((referenceData) =>
-              choicesCallback(referenceData.fields?.map((x) => x.name) || [])
+              choicesCallback(
+                referenceData.fields?.map((x) => x?.name ?? x) || []
+              )
             );
         }
       },
@@ -140,7 +142,9 @@ export const init = (referenceDataService: ReferenceDataService): void => {
             referenceDataService
               .loadReferenceData(foreignQuestion.referenceData)
               .then((referenceData) =>
-                choicesCallback((referenceData.fields || []).map((x) => x.name))
+                choicesCallback(
+                  referenceData.fields?.map((x) => x?.name ?? x) || []
+                )
               );
           }
         }
@@ -187,7 +191,9 @@ export const init = (referenceDataService: ReferenceDataService): void => {
           referenceDataService
             .loadReferenceData(obj.referenceData)
             .then((referenceData) =>
-              choicesCallback((referenceData.fields || []).map((x) => x.name))
+              choicesCallback(
+                referenceData.fields?.map((x) => x?.name ?? x) || []
+              )
             );
         }
       },


### PR DESCRIPTION
# Description

It seems that static reference data has evolved over time and survey questions with choices from refdata were implemented more recently. The first created reference data are now bugged (cf screenshots), which are causing issues during their loading into questions. Their format is different, including only the name of the field, but now we have more information and we use an object to stock them. I added a format check before loading the ref data from choices.

It would have been better to update each ref data, but I assume some of them are still in use by the client, then it is more complicated than expected.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84407/)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tried to select an "old" ref data from a survey question to see if it loaded correctly.

## Screenshots

![image](https://github.com/ReliefApplications/ems-frontend/assets/65243509/6b6d150b-56ca-4a8c-a9f3-b35d0f4b9a51)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
