### PR TITLE
fix/AB#84582 missing trad for question clear icon

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1900,6 +1900,7 @@
 	},
 	"kendo": {
 		"combobox": {
+			"clearTitle": "Clear value",
 			"noDataText": "No available choice"
 		},
 		"datepicker": {
@@ -2056,6 +2057,7 @@
 			"unstick": "Unstick"
 		},
 		"multiselect": {
+			"clearTitle": "Clear value",
 			"noDataText": "No available choice"
 		},
 		"pager": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1913,6 +1913,7 @@
 	},
 	"kendo": {
 		"combobox": {
+			"clearTitle": "Supprimer la valeur",
 			"noDataText": "No available choice"
 		},
 		"datepicker": {
@@ -2069,6 +2070,7 @@
 			"unstick": "Désépingler"
 		},
 		"multiselect": {
+			"clearTitle": "Supprimer la valeur",
 			"noDataText": "No available choice"
 		},
 		"pager": {

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1900,6 +1900,7 @@
 	},
 	"kendo": {
 		"combobox": {
+			"clearTitle": "******",
 			"noDataText": "******"
 		},
 		"datepicker": {
@@ -2056,6 +2057,7 @@
 			"unstick": "******"
 		},
 		"multiselect": {
+			"clearTitle": "******",
 			"noDataText": "******"
 		},
 		"pager": {


### PR DESCRIPTION
# Description

Some translations were missing for the question clear icon, affecting multiselect and combobox questions.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84582/)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created a form and dashboard filters with multiselect and combobox questions. I checked in both English and French that the text value of the clear button was correctly translated.

## Screenshots

![image](https://github.com/ReliefApplications/ems-frontend/assets/65243509/9755ceb1-2c62-4e8f-a76e-111db7b13460)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
