### PR TITLE
Feat/ab#84617 allow custom styling sidenav resizing

### DIFF
--- a/apps/back-office/src/app/components/custom-style/custom-style.component.html
+++ b/apps/back-office/src/app/components/custom-style/custom-style.component.html
@@ -1,4 +1,15 @@
-<div class="w-80 h-full flex flex-col">
+<div
+  class="h-full flex flex-col w-[30vw]"
+  mwlResizable
+  (resizing)="onResizing($event)"
+  [ngStyle]="navbarStyle"
+  [validateResize]="validate.bind(this)"
+>
+  <div
+    class="cursor-col-resize absolute h-full left-0 w-1.5 z-10"
+    mwlResizeHandle
+    [resizeEdges]="{ left: true }"
+  ></div>
   <!-- Header -->
   <div class="items-center p-4 border-b">
     <div class="flex justify-between items-center mb-2">

--- a/apps/back-office/src/app/components/custom-style/custom-style.component.ts
+++ b/apps/back-office/src/app/components/custom-style/custom-style.component.ts
@@ -268,7 +268,7 @@ export class CustomStyleComponent
   onResizing(event: ResizeEvent): void {
     this.navbarStyle = {
       width: `${event.rectangle.width}px`,
-      height: `${event.rectangle.height}px`,
+      // height: `${event.rectangle.height}px`,
     };
   }
 
@@ -279,10 +279,17 @@ export class CustomStyleComponent
    * @returns boolean
    */
   validate(event: ResizeEvent): boolean {
-    const dashboardNavbar = this.document.getElementsByTagName('shared-navbar');
+    const dashboardNavbars =
+      this.document.getElementsByTagName('shared-navbar');
     let dashboardNavbarWidth = 0;
-    if (dashboardNavbar[0]) {
-      dashboardNavbarWidth = (dashboardNavbar[0] as any).offsetWidth;
+    if (dashboardNavbars[0]) {
+      if (
+        (dashboardNavbars[0] as any).offsetWidth <
+        this.document.documentElement.clientWidth
+      ) {
+        // Only if the sidenav is not horizontal
+        dashboardNavbarWidth = (dashboardNavbars[0] as any).offsetWidth;
+      }
     }
     // set the min width as 30% of the screen size available
     const minWidth = Math.round(

--- a/apps/back-office/src/app/components/custom-style/custom-style.component.ts
+++ b/apps/back-office/src/app/components/custom-style/custom-style.component.ts
@@ -29,6 +29,8 @@ import {
 } from '@oort-front/ui';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { DOCUMENT } from '@angular/common';
+import { ResizeEvent } from 'angular-resizable-element';
+import { ResizableModule } from 'angular-resizable-element';
 
 /** Default css style example to initialize the form and editor */
 const DEFAULT_STYLE = '';
@@ -46,6 +48,7 @@ const DEFAULT_STYLE = '';
     ButtonModule,
     SpinnerModule,
     TooltipModule,
+    ResizableModule,
   ],
   templateUrl: './custom-style.component.html',
   styleUrls: ['./custom-style.component.scss'],
@@ -64,6 +67,7 @@ export class CustomStyleComponent
   @Output() cancel = new EventEmitter();
   /** Editor options */
   public editorOptions = {
+    automaticLayout: true,
     theme: 'vs-dark',
     language: 'scss',
     fixedOverflowWidgets: false,
@@ -76,6 +80,8 @@ export class CustomStyleComponent
   public loading = false;
   /** Timeout to init editor */
   private timeoutListener!: NodeJS.Timeout;
+  /** Navbar size style */
+  public navbarStyle: any = {};
 
   /**
    * Creates an instance of CustomStyleComponent, form and updates.
@@ -252,5 +258,46 @@ export class CustomStyleComponent
       this.applicationService.customStyleEdited = false;
       this.applicationService.customStyle.innerText = this.savedStyle;
     }
+  }
+
+  /**
+   * On resize action
+   *
+   * @param event resize event
+   */
+  onResizing(event: ResizeEvent): void {
+    this.navbarStyle = {
+      width: `${event.rectangle.width}px`,
+      height: `${event.rectangle.height}px`,
+    };
+  }
+
+  /**
+   * Check if resize event is valid
+   *
+   * @param event resize event
+   * @returns boolean
+   */
+  validate(event: ResizeEvent): boolean {
+    const dashboardNavbar = this.document.getElementsByTagName('shared-navbar');
+    let dashboardNavbarWidth = 0;
+    if (dashboardNavbar[0]) {
+      dashboardNavbarWidth = (dashboardNavbar[0] as any).offsetWidth;
+    }
+    // set the min width as 30% of the screen size available
+    const minWidth = Math.round(
+      (this.document.documentElement.clientWidth - dashboardNavbarWidth) * 0.3
+    );
+    // set the max width as 95% of the screen size available
+    const maxWidth = Math.round(
+      (this.document.documentElement.clientWidth - dashboardNavbarWidth) * 0.95
+    );
+    if (
+      event.rectangle.width &&
+      (event.rectangle.width < minWidth || event.rectangle.width > maxWidth)
+    ) {
+      return false;
+    }
+    return true;
   }
 }

--- a/apps/back-office/src/environments/environment.ts
+++ b/apps/back-office/src/environments/environment.ts
@@ -3,18 +3,29 @@ import { theme } from '../themes/default/default.local';
 import { sharedEnvironment } from './environment.shared';
 import { Environment } from './environment.type';
 
+// const authConfig: AuthConfig = {
+//   issuer:
+//     'https://login.microsoftonline.com/fbacd48d-ccf4-480d-baf0-31048368055f/v2.0',
+//   redirectUri: 'http://localhost:4200/',
+//   postLogoutRedirectUri: 'http://localhost:4200/auth/',
+//   clientId: 'd62083d8-fdc0-4a6a-8618-652380eebdb9',
+//   scope: 'openid profile email offline_access',
+//   responseType: 'code',
+//   showDebugInformation: true,
+//   strictDiscoveryDocumentValidation: false,
+// };
+
+/**
+ * Authentication configuration
+ */
 const authConfig: AuthConfig = {
-  issuer:
-    'https://login.microsoftonline.com/f610c0b7-bd24-4b39-810b-3dc280afb590/v2.0',
+  issuer: 'https://id-dev.oortcloud.tech/auth/realms/oort',
   redirectUri: 'http://localhost:4200/',
   postLogoutRedirectUri: 'http://localhost:4200/auth/',
-  clientId: '021202ac-d23b-4757-83e3-f6ecde12266b',
-  scope:
-    'openid profile email offline_access offline_access api://75deca06-ae07-4765-85c0-23e719062833/access_as_user',
-  // Last scope is used to authenticate against Common Services
+  clientId: 'oort-client',
+  scope: 'openid profile email offline_access',
   responseType: 'code',
   showDebugInformation: true,
-  strictDiscoveryDocumentValidation: false,
 };
 
 /**

--- a/apps/back-office/src/environments/environment.ts
+++ b/apps/back-office/src/environments/environment.ts
@@ -3,29 +3,18 @@ import { theme } from '../themes/default/default.local';
 import { sharedEnvironment } from './environment.shared';
 import { Environment } from './environment.type';
 
-// const authConfig: AuthConfig = {
-//   issuer:
-//     'https://login.microsoftonline.com/fbacd48d-ccf4-480d-baf0-31048368055f/v2.0',
-//   redirectUri: 'http://localhost:4200/',
-//   postLogoutRedirectUri: 'http://localhost:4200/auth/',
-//   clientId: 'd62083d8-fdc0-4a6a-8618-652380eebdb9',
-//   scope: 'openid profile email offline_access',
-//   responseType: 'code',
-//   showDebugInformation: true,
-//   strictDiscoveryDocumentValidation: false,
-// };
-
-/**
- * Authentication configuration
- */
 const authConfig: AuthConfig = {
-  issuer: 'https://id-dev.oortcloud.tech/auth/realms/oort',
+  issuer:
+    'https://login.microsoftonline.com/f610c0b7-bd24-4b39-810b-3dc280afb590/v2.0',
   redirectUri: 'http://localhost:4200/',
   postLogoutRedirectUri: 'http://localhost:4200/auth/',
-  clientId: 'oort-client',
-  scope: 'openid profile email offline_access',
+  clientId: '021202ac-d23b-4757-83e3-f6ecde12266b',
+  scope:
+    'openid profile email offline_access offline_access api://75deca06-ae07-4765-85c0-23e719062833/access_as_user',
+  // Last scope is used to authenticate against Common Services
   responseType: 'code',
   showDebugInformation: true,
+  strictDiscoveryDocumentValidation: false,
 };
 
 /**

--- a/libs/shared/src/lib/components/custom-widget-style/custom-widget-style.component.html
+++ b/libs/shared/src/lib/components/custom-widget-style/custom-widget-style.component.html
@@ -1,4 +1,15 @@
-<div class="w-80 h-full flex flex-col">
+<div
+  class="h-full flex flex-col w-[30vw]"
+  mwlResizable
+  (resizing)="onResizing($event)"
+  [ngStyle]="navbarStyle"
+  [validateResize]="validate.bind(this)"
+>
+  <div
+    class="cursor-col-resize absolute h-full left-0 w-1.5 z-10"
+    mwlResizeHandle
+    [resizeEdges]="{ left: true }"
+  ></div>
   <!-- Header -->
   <div class="items-center p-4 border-b">
     <div class="flex justify-between items-center mb-2">
@@ -29,7 +40,7 @@
   <!-- Style editor -->
   <div class="grow overflow-y-auto overflow-x-hidden">
     <ngx-monaco-editor
-      class="!h-full"
+      class="!h-full !w-full"
       (onInit)="initEditor($event)"
       [options]="editorOptions"
       [formControl]="formControl"

--- a/libs/shared/src/lib/components/custom-widget-style/custom-widget-style.component.ts
+++ b/libs/shared/src/lib/components/custom-widget-style/custom-widget-style.component.ts
@@ -208,7 +208,7 @@ export class CustomWidgetStyleComponent
   onResizing(event: ResizeEvent): void {
     this.navbarStyle = {
       width: `${event.rectangle.width}px`,
-      height: `${event.rectangle.height}px`,
+      // height: `${event.rectangle.height}px`,
     };
   }
 
@@ -219,10 +219,17 @@ export class CustomWidgetStyleComponent
    * @returns boolean
    */
   validate(event: ResizeEvent): boolean {
-    const dashboardNavbar = this.document.getElementsByTagName('shared-navbar');
+    const dashboardNavbars =
+      this.document.getElementsByTagName('shared-navbar');
     let dashboardNavbarWidth = 0;
-    if (dashboardNavbar[0]) {
-      dashboardNavbarWidth = (dashboardNavbar[0] as any).offsetWidth;
+    if (dashboardNavbars[0]) {
+      if (
+        (dashboardNavbars[0] as any).offsetWidth <
+        this.document.documentElement.clientWidth
+      ) {
+        // Only if the sidenav is not horizontal
+        dashboardNavbarWidth = (dashboardNavbars[0] as any).offsetWidth;
+      }
     }
     // set the min width as 30% of the screen size available
     const minWidth = Math.round(

--- a/libs/shared/src/lib/components/custom-widget-style/custom-widget-style.component.ts
+++ b/libs/shared/src/lib/components/custom-widget-style/custom-widget-style.component.ts
@@ -19,6 +19,8 @@ import { RestService } from '../../services/rest/rest.service';
 import { ConfirmService } from '../../services/confirm/confirm.service';
 import { UnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component';
 import { DOCUMENT } from '@angular/common';
+import { ResizeEvent } from 'angular-resizable-element';
+import { ResizableModule } from 'angular-resizable-element';
 
 /** Default css style example to initialize the form and editor */
 const DEFAULT_STYLE = '';
@@ -35,6 +37,7 @@ const DEFAULT_STYLE = '';
     TranslateModule,
     ButtonModule,
     TooltipModule,
+    ResizableModule,
   ],
   templateUrl: './custom-widget-style.component.html',
   styleUrls: ['./custom-widget-style.component.scss'],
@@ -49,6 +52,7 @@ export class CustomWidgetStyleComponent
   @Output() cancel = new EventEmitter();
   /** Editor options */
   public editorOptions = {
+    automaticLayout: true,
     theme: 'vs-dark',
     language: 'scss',
     fixedOverflowWidgets: false,
@@ -67,6 +71,8 @@ export class CustomWidgetStyleComponent
   @Input() save!: (widget: any) => void;
   /** Timeout to init editor */
   private initEditorTimeoutListener!: NodeJS.Timeout;
+  /** Navbar size style */
+  public navbarStyle: any = {};
 
   /**
    * Creates an instance of CustomStyleComponent, form and updates.
@@ -192,5 +198,46 @@ export class CustomWidgetStyleComponent
     if (this.initEditorTimeoutListener) {
       clearTimeout(this.initEditorTimeoutListener);
     }
+  }
+
+  /**
+   * On resize action
+   *
+   * @param event resize event
+   */
+  onResizing(event: ResizeEvent): void {
+    this.navbarStyle = {
+      width: `${event.rectangle.width}px`,
+      height: `${event.rectangle.height}px`,
+    };
+  }
+
+  /**
+   * Check if resize event is valid
+   *
+   * @param event resize event
+   * @returns boolean
+   */
+  validate(event: ResizeEvent): boolean {
+    const dashboardNavbar = this.document.getElementsByTagName('shared-navbar');
+    let dashboardNavbarWidth = 0;
+    if (dashboardNavbar[0]) {
+      dashboardNavbarWidth = (dashboardNavbar[0] as any).offsetWidth;
+    }
+    // set the min width as 30% of the screen size available
+    const minWidth = Math.round(
+      (this.document.documentElement.clientWidth - dashboardNavbarWidth) * 0.3
+    );
+    // set the max width as 95% of the screen size available
+    const maxWidth = Math.round(
+      (this.document.documentElement.clientWidth - dashboardNavbarWidth) * 0.95
+    );
+    if (
+      event.rectangle.width &&
+      (event.rectangle.width < minWidth || event.rectangle.width > maxWidth)
+    ) {
+      return false;
+    }
+    return true;
   }
 }

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -267,7 +267,7 @@ export class RecordHistoryComponent
   onResizing(event: ResizeEvent): void {
     this.style = {
       width: `${event.rectangle.width}px`,
-      height: `${event.rectangle.height}px`,
+      // height: `${event.rectangle.height}px`,
     };
   }
 
@@ -278,14 +278,21 @@ export class RecordHistoryComponent
    * @returns boolean
    */
   validate(event: ResizeEvent): boolean {
-    const dashboardNavbar = this.document.getElementsByTagName('shared-navbar');
+    const dashboardNavbars =
+      this.document.getElementsByTagName('shared-navbar');
     let dashboardNavbarWidth = 0;
-    if (dashboardNavbar[0] && !this.dialog) {
-      dashboardNavbarWidth = (dashboardNavbar[0] as any).offsetWidth;
+    if (dashboardNavbars[0]) {
+      if (
+        (dashboardNavbars[0] as any).offsetWidth <
+        this.document.documentElement.clientWidth
+      ) {
+        // Only if the sidenav is not horizontal
+        dashboardNavbarWidth = (dashboardNavbars[0] as any).offsetWidth;
+      }
     }
-    // set the min width as 40% of the screen size available
+    // set the min width as 30% of the screen size available
     const minWidth = Math.round(
-      (this.document.documentElement.clientWidth - dashboardNavbarWidth) * 0.4
+      (this.document.documentElement.clientWidth - dashboardNavbarWidth) * 0.3
     );
     // set the max width as 95% of the screen size available
     const maxWidth = Math.round(


### PR DESCRIPTION
# Description

Enable the resizing of the custom styling sidenav, similar to what has been implemented for the records history. 

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84617)

Related tickets
- [feat/AB#84481_allow_user_vertically_resize_code_editor_in_reference_data](https://github.com/ReliefApplications/ems-frontend/pull/2343)
- [feat/AB#83312_make_the_width_history_view_resizeable](https://github.com/ReliefApplications/ems-frontend/pull/2314)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

I tried to resize the custom styling sidenav for both the application and for the widgets.

## Screenshots

![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/ec7fd81d-d483-4b76-a008-59b73a4fe79e)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
