### PR TITLE
Fix/ab#84761 changing aggregation reset graphql variables

### DIFF
--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
@@ -13,6 +13,7 @@ import { ReferenceData } from '../../../../models/reference-data.model';
 import { gql } from '@apollo/client';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ResizableModule, ResizeEvent } from 'angular-resizable-element';
+import isEqual from 'lodash/isEqual';
 
 /**
  * Graphql variables mapping, for widgets using graphql reference data.
@@ -59,12 +60,13 @@ export class GraphqlVariablesMappingComponent implements OnChanges {
     if (changes['referenceData'] && !changes['control']) {
       // if the reference data doesn't change
       if (
-        changes.referenceData.currentValue?.id ==
-        changes.referenceData.previousValue?.id
+        !isEqual(
+          changes.referenceData.currentValue?.id,
+          changes.referenceData.previousValue?.id
+        )
       ) {
-        return;
+        this.refresh(true);
       }
-      this.refresh(true);
     } else {
       // init the mapping
       this.refresh();

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
@@ -55,11 +55,18 @@ export class GraphqlVariablesMappingComponent implements OnChanges {
   public style: any = {};
 
   ngOnChanges(changes: SimpleChanges): void {
-    // changed only reference data
+    // if the mapping is already loaded
     if (changes['referenceData'] && !changes['control']) {
+      // if the reference data doesn't change
+      if (
+        changes.referenceData.currentValue?.id ==
+        changes.referenceData.previousValue?.id
+      ) {
+        return;
+      }
       this.refresh(true);
-      // started the component
     } else {
+      // init the mapping
       this.refresh();
     }
   }


### PR DESCRIPTION
# Description

Prevent aggregations changes from resetting graphql variables. I added a condition to check if the previous reference data id is equal to the current reference data id.

I have observed a weird behavior, and I am uncertain if it is intentional. When you load a ref data with graphql variables configuration, load another ref data and reload the first one, the graphql variables are cleared. Also, if you load a ref data, load another one with a larger configuration, load a ref data without mapping and reload the first one, it will use the last configuration (the larger one).

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84761/)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tried to update ref data and aggregations to see if graphql variables were reset. 

## Screenshots

Demonstration
![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/717a8c58-be07-4b06-b2af-f8fdfc3ac935)

Potential bug
![peek2](https://github.com/ReliefApplications/ems-frontend/assets/65243509/60cd7b29-eef4-4297-85d3-8f82e08718cf)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
