### PR TITLE
fix/AB#84840_empty_block_appearing_when_graphql_variables_not_available

### DIFF
--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
@@ -32,6 +32,7 @@
       | translate
   }}</ui-alert>
   <div
+    *ngIf="availableQueryVariables.length > 0"
     mwlResizable
     class="flex flex-col relative h-[300px]"
     [ngStyle]="style"
@@ -40,7 +41,6 @@
   >
     <!-- JSON editor -->
     <ngx-monaco-editor
-      *ngIf="availableQueryVariables.length > 0"
       class="!h-full !w-full min-w-[200px]"
       [formControl]="control"
       [options]="editorOptions"


### PR DESCRIPTION
# Description

fix: Empty block appearing when graphql variables not available.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84840)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested accessing some widget, setting some graphql reference data, and checking if the block is not appearing anymore when we don't have graphql variables.

## Screenshots

![Captura de tela de 2024-01-31 14-39-05](https://github.com/ReliefApplications/ems-frontend/assets/56398308/5ba59024-4fd8-42d6-9729-809d10c85cb6)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
