### PR TITLE
Feat/ab#84920 give correct default texts to created at and modified at filters

### DIFF
--- a/libs/shared/src/lib/components/filter/filter.const.ts
+++ b/libs/shared/src/lib/components/filter/filter.const.ts
@@ -12,19 +12,19 @@ export const FILTER_OPERATORS = [
   },
   {
     value: 'gte',
-    label: 'kendo.grid.filterGteOperator',
+    label: 'kendo.grid.filterAfterOrEqualOperator',
   },
   {
     value: 'gt',
-    label: 'kendo.grid.filterGtOperator',
+    label: 'kendo.grid.filterAfterOperator',
   },
   {
     value: 'lte',
-    label: 'kendo.grid.filterLteOperator',
+    label: 'kendo.grid.filterBeforeOrEqualOperator',
   },
   {
     value: 'lt',
-    label: 'kendo.grid.filterLtOperator',
+    label: 'kendo.grid.filterBeforeOperator',
   },
   {
     value: 'isnull',

--- a/libs/shared/src/lib/components/filter/filter.const.ts
+++ b/libs/shared/src/lib/components/filter/filter.const.ts
@@ -12,19 +12,19 @@ export const FILTER_OPERATORS = [
   },
   {
     value: 'gte',
-    label: 'kendo.grid.filterAfterOrEqualOperator',
+    label: 'kendo.grid.filterGteOperator',
   },
   {
     value: 'gt',
-    label: 'kendo.grid.filterAfterOperator',
+    label: 'kendo.grid.filterGtOperator',
   },
   {
     value: 'lte',
-    label: 'kendo.grid.filterBeforeOrEqualOperator',
+    label: 'kendo.grid.filterLteOperator',
   },
   {
     value: 'lt',
-    label: 'kendo.grid.filterBeforeOperator',
+    label: 'kendo.grid.filterLtOperator',
   },
   {
     value: 'isnull',
@@ -69,6 +69,46 @@ export const FILTER_OPERATORS = [
   {
     value: 'notin',
     label: 'kendo.grid.filterIsNotInOperator',
+  },
+];
+
+/**
+ * Available date operators.
+ */
+export const DATE_FILTER_OPERATORS = [
+  {
+    value: 'eq',
+    label: 'kendo.grid.filterEqOperator',
+  },
+  {
+    value: 'neq',
+    label: 'kendo.grid.filterNotEqOperator',
+  },
+  {
+    value: 'gte',
+    label: 'kendo.grid.filterAfterOrEqualOperator',
+  },
+  {
+    value: 'gt',
+    label: 'kendo.grid.filterAfterOperator',
+  },
+  {
+    value: 'lte',
+    label: 'kendo.grid.filterBeforeOrEqualOperator',
+  },
+  {
+    value: 'lt',
+    label: 'kendo.grid.filterBeforeOperator',
+  },
+  {
+    value: 'isnull',
+    label: 'kendo.grid.filterIsNullOperator',
+    disableValue: true,
+  },
+  {
+    value: 'isnotnull',
+    label: 'kendo.grid.filterIsNotNullOperator',
+    disableValue: true,
   },
 ];
 

--- a/libs/shared/src/lib/components/ui/core-grid/date-filter-menu/date-filter-menu.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/date-filter-menu/date-filter-menu.component.ts
@@ -8,7 +8,10 @@ import {
 } from '@progress/kendo-angular-grid';
 import { PopupSettings } from '@progress/kendo-angular-dateinputs';
 import { takeUntil } from 'rxjs';
-import { FIELD_TYPES, DATE_FILTER_OPERATORS } from '../../../filter/filter.const';
+import {
+  FIELD_TYPES,
+  DATE_FILTER_OPERATORS,
+} from '../../../filter/filter.const';
 import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
 import { DOCUMENT } from '@angular/common';
 

--- a/libs/shared/src/lib/components/ui/core-grid/date-filter-menu/date-filter-menu.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/date-filter-menu/date-filter-menu.component.ts
@@ -108,11 +108,9 @@ export class DateFilterMenuComponent
     this.operatorsList = DATE_FILTER_OPERATORS.filter((x) =>
       type?.operators?.includes(x.value)
     );
-    console.log(this.operatorsList);
     this.operatorsList.forEach((o) => {
       o.text = this.translate.instant(o.label);
     });
-    console.log(this.operatorsList);
     popupService.onClose
       .pipe(takeUntil(this.destroy$))
       .subscribe((e: PopupCloseEvent) => {

--- a/libs/shared/src/lib/components/ui/core-grid/date-filter-menu/date-filter-menu.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/date-filter-menu/date-filter-menu.component.ts
@@ -8,7 +8,7 @@ import {
 } from '@progress/kendo-angular-grid';
 import { PopupSettings } from '@progress/kendo-angular-dateinputs';
 import { takeUntil } from 'rxjs';
-import { FIELD_TYPES, FILTER_OPERATORS } from '../../../filter/filter.const';
+import { FIELD_TYPES, DATE_FILTER_OPERATORS } from '../../../filter/filter.const';
 import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
 import { DOCUMENT } from '@angular/common';
 
@@ -102,12 +102,14 @@ export class DateFilterMenuComponent
   ) {
     super();
     const type = FIELD_TYPES.find((x) => x.editor === 'datetime');
-    this.operatorsList = FILTER_OPERATORS.filter((x) =>
+    this.operatorsList = DATE_FILTER_OPERATORS.filter((x) =>
       type?.operators?.includes(x.value)
     );
+    console.log(this.operatorsList);
     this.operatorsList.forEach((o) => {
       o.text = this.translate.instant(o.label);
     });
+    console.log(this.operatorsList);
     popupService.onClose
       .pipe(takeUntil(this.destroy$))
       .subscribe((e: PopupCloseEvent) => {


### PR DESCRIPTION
# Description

Feat:  Give correct default texts to createdAt and modifiedAt filters.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84920)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested checking if the filter text for createdAt and modifiedAt are correctly.

## Screenshots

![Captura de tela de 2024-02-01 14-44-29](https://github.com/ReliefApplications/ems-frontend/assets/56398308/ecc8ded8-0796-45ec-a245-a8147c3e2928)
![Captura de tela de 2024-02-01 14-44-17](https://github.com/ReliefApplications/ems-frontend/assets/56398308/24ab3669-1aa2-4375-9dba-937b75383c8a)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
