### PR TITLE
Fix/ab#84971 bug filters with boolean

### DIFF
--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -170,7 +170,10 @@ export class SummaryCardComponent
         filters: this.layout?.query.filter ? [this.layout?.query.filter] : [],
       };
     }
-    return filter;
+    return {
+      logic: 'and',
+      filters: [filter, this.contextService.injectContext(this.contextFilters)],
+    };
   }
 
   /** @returns does the card use resource aggregation */
@@ -485,9 +488,6 @@ export class SummaryCardComponent
           skip: 0,
           first: this.pageInfo.pageSize,
           filter: this.queryFilter,
-          contextFilters: this.contextService.injectContext(
-            this.contextFilters
-          ),
           sortField: this.sortOptions.field,
           sortOrder: this.sortOptions.order,
           ...(this.settings.at && {
@@ -818,9 +818,6 @@ export class SummaryCardComponent
               variables: {
                 first: this.pageInfo.pageSize,
                 filter: this.queryFilter,
-                contextFilters: this.contextService.injectContext(
-                  this.contextFilters
-                ),
                 sortField: this.sortOptions.field,
                 sortOrder: this.sortOptions.order,
                 styles: layoutQuery.style || null,
@@ -1014,9 +1011,6 @@ export class SummaryCardComponent
           first: this.pageInfo.pageSize,
           skip: event.skip,
           filter: this.queryFilter,
-          contextFilters: this.contextService.injectContext(
-            this.contextFilters
-          ),
           sortField: this.sortOptions.field,
           sortOrder: this.sortOptions.order,
           styles: layoutQuery?.style || null,
@@ -1118,9 +1112,6 @@ export class SummaryCardComponent
           .refetch({
             first: this.pageInfo.pageSize,
             filter: this.queryFilter,
-            contextFilters: this.contextService.injectContext(
-              this.contextFilters
-            ),
             sortField: this.sortOptions.field,
             sortOrder: this.sortOptions.order,
             ...(this.settings.at && {

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -643,35 +643,37 @@ export class SummaryCardComponent
       })) as CardT[])
     );
 
+    // Client side filtering
+    const contextFilters = this.contextService.injectContext(
+      this.contextFilters
+    );
+
+    if (contextFilters.filters.length) {
+      this.sortedCachedCards = cloneDeep(this.cachedCards).filter((x) =>
+        filterReferenceData(x.rawValue, contextFilters)
+      );
+    } else {
+      this.sortedCachedCards = cloneDeep(this.cachedCards);
+    }
+
+    if (this.searchControl.value) {
+      this.sortedCachedCards = this.sortedCachedCards.filter((card: any) => {
+        return (
+          JSON.stringify(card.rawValue)
+            .replace(/("\w+":)/g, '')
+            .toLowerCase()
+            .indexOf((this.searchControl.value as string).toLowerCase()) !== -1
+        );
+      });
+    }
+
     const isPaginated = !!strategy && !!pageInfo;
     if (isPaginated) {
       // If using pagination, set the page size and total count
       // according to the response of the first page
       this.setPaginationInfo(pageInfo);
-      this.sortedCachedCards = cloneDeep(this.cachedCards);
       this.checkIfFinalPage(totalCountConfigured, items);
     } else {
-      // Client side filtering
-      const contextFilters = this.contextService.injectContext(
-        this.contextFilters
-      );
-
-      this.sortedCachedCards = cloneDeep(this.cachedCards).filter((x) =>
-        filterReferenceData(x.rawValue, contextFilters)
-      );
-
-      if (this.searchControl.value) {
-        this.sortedCachedCards = this.sortedCachedCards.filter((card: any) => {
-          return (
-            JSON.stringify(card.rawValue)
-              .replace(/("\w+":)/g, '')
-              .toLowerCase()
-              .indexOf((this.searchControl.value as string).toLowerCase()) !==
-            -1
-          );
-        });
-      }
-
       // If not, all the items are already loaded
       this.pageInfo.length = this.cachedCards.length;
     }

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -288,7 +288,7 @@ export class ContextService {
           .replace(/["']?\{\{filter\./, '')
           .replace(/\}\}["']?/, '');
         const fieldValue = get(filter, field);
-        return fieldValue ? JSON.stringify(fieldValue) : match;
+        return !isNil(fieldValue) ? JSON.stringify(fieldValue) : match;
       }
     );
     const parsed = JSON.parse(replaced);


### PR DESCRIPTION
# Description

- I refactored the logic that was preventing reference data from being filtered
- Context filters weren't being applied to summary cars with resources, I fixed it
- If a boolean question was set to false as the first value, it wasn't being read. I changed the condition to check if the value is not null

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84971/)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created a dashboard with a boolean filter and a summary cards widget. I checked the consistency of the filtering system's behavior.

## Screenshots

![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/988265e6-5ae1-4e17-8348-9597211f249a)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
