### PR TITLE
fix:AB#85255_update-filter-structure-on-save

### DIFF
--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -68,8 +68,6 @@ export class DashboardFilterComponent
   public containerLeftOffset!: string;
   /** Filter template */
   public survey: Model = new Model();
-  /** Filter template structure */
-  public surveyStructure: any = {};
   /** Quick filter display */
   public quickFilters: QuickFilter[] = [];
   /** Indicate empty status of filter */
@@ -130,6 +128,13 @@ export class DashboardFilterComponent
           this.setFilterContainerDimensions();
         }
       );
+    // Updates the survey with the latest filter structure
+    this.contextService.filterStructure$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.initSurvey();
+      });
+
     if (!this.variant) {
       this.variant = 'default';
     }
@@ -140,7 +145,6 @@ export class DashboardFilterComponent
       this.setFilterContainerDimensions();
     }
     if (changes.dashboard) {
-      this.surveyStructure = this.dashboard?.filter?.structure || '';
       this.initSurvey();
     }
   }


### PR DESCRIPTION
# Description

Fix issue where updating the survey structure wouldn't automatically change the current filter survey.

Ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/85255

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

See bellow

## Screenshots

before

https://github.com/ReliefApplications/ems-frontend/assets/102038450/6c2ea27e-947d-4b18-a1a0-e72d3a2738a8

after
https://github.com/ReliefApplications/ems-frontend/assets/102038450/7e682ec3-43bc-493d-b16b-eddd74d69cf9



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
