### PR TITLE
Ab#85318 allow aggreg preview on creation

### DIFF
--- a/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
+++ b/libs/shared/src/lib/components/ui/aggregation-builder/aggregation-builder.component.ts
@@ -289,15 +289,6 @@ export class AggregationBuilderComponent
     if (this.loadingAggregationRecords) {
       return;
     }
-    if (!this.aggregationForm.value.id) {
-      this.snackBar.openSnackBar(
-        this.translateService.instant(
-          'pages.aggregation.preview.missingAggregation'
-        ),
-        { error: true }
-      );
-      return;
-    }
     // get the aggregation data
     this.loadingAggregationRecords = true;
     const query$ = this.aggregationService.aggregationDataQuery({
@@ -307,6 +298,7 @@ export class AggregationBuilderComponent
       sourceFields: this.aggregationForm.value.sourceFields,
       pipeline: this.aggregationForm.value.pipeline,
       first: -1,
+      aggregationPreview: true,
     });
 
     const { data: aggregationData, errors } = await firstValueFrom(query$);

--- a/libs/shared/src/lib/services/aggregation/aggregation.service.ts
+++ b/libs/shared/src/lib/services/aggregation/aggregation.service.ts
@@ -125,6 +125,7 @@ export class AggregationService {
    * @param options.at 'at' argument value, if any
    * @param options.first number of records to fetch, -1 if all of them
    * @param options.graphQLVariables graphql variables (optional)
+   * @param options.aggregationPreview boolean whether we are previewing an aggregation
    * @returns Aggregation query
    */
   aggregationDataQuery(options: {
@@ -138,6 +139,7 @@ export class AggregationService {
     at?: Date;
     first?: number;
     graphQLVariables?: any;
+    aggregationPreview?: boolean;
   }): Observable<
     ApolloQueryResult<
       AggregationDataQueryResponse | ReferenceDataAggregationQueryResponse
@@ -157,6 +159,7 @@ export class AggregationService {
             : {},
           at: options.at,
           first: options.first,
+          aggregationPreview: options.aggregationPreview,
         },
       });
     } else {
@@ -174,6 +177,7 @@ export class AggregationService {
           graphQLVariables: options.graphQLVariables,
           at: options.at,
           first: options.first,
+          aggregationPreview: options.aggregationPreview,
         },
       });
     }

--- a/libs/shared/src/lib/services/aggregation/graphql/queries.ts
+++ b/libs/shared/src/lib/services/aggregation/graphql/queries.ts
@@ -68,6 +68,7 @@ export const GET_RESOURCE_AGGREGATION_DATA = gql`
     $at: Date
     $sortOrder: String
     $sortField: String
+    $aggregationPreview: Boolean
   ) {
     recordsAggregation(
       resource: $resource
@@ -81,6 +82,7 @@ export const GET_RESOURCE_AGGREGATION_DATA = gql`
       at: $at
       sortOrder: $sortOrder
       sortField: $sortField
+      aggregationPreview: $aggregationPreview
     )
   }
 `;
@@ -100,6 +102,7 @@ export const GET_REFERENCE_DATA_AGGREGATION_DATA = gql`
     $at: Date
     $sortOrder: String
     $sortField: String
+    $aggregationPreview: Boolean
   ) {
     referenceDataAggregation(
       referenceData: $referenceData
@@ -114,6 +117,7 @@ export const GET_REFERENCE_DATA_AGGREGATION_DATA = gql`
       at: $at
       sortOrder: $sortOrder
       sortField: $sortField
+      aggregationPreview: $aggregationPreview
     )
   }
 `;


### PR DESCRIPTION
# Description

Add support to load aggregation without aggregation id when previewing. When no datasource selected, still returns an error. Removed previous error message because the current one seems accurate to me

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/85318)
-[ Please insert link to back-end branch if any](https://github.com/ReliefApplications/ems-backend/pull/971)


## Type of change


- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Tested on reference data and resources.

## Screenshots

![aggregpreview](https://github.com/ReliefApplications/ems-frontend/assets/59645813/f8a7db61-adad-40b3-a6d5-588ae7cb632b)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
