### PR TITLE
Ab#84318 - unresponsive paginator in summary cards dropdown

### DIFF
--- a/libs/ui/src/lib/paginator/paginator.component.scss
+++ b/libs/ui/src/lib/paginator/paginator.component.scss
@@ -36,6 +36,14 @@ kendo-datapager {
     }
   }
 
+  kendo-datapager.k-pager-mobile-md kendo-datapager-page-sizes {
+    display: block !important;
+  }
+
+  kendo-datapager.k-pager-mobile-sm kendo-datapager-page-sizes {
+    display: block !important;
+  }
+
   // Hide last border ( duplicated )
   kendo-datapager-next-buttons button:last-child {
     border-right: 0 !important;

--- a/libs/ui/src/lib/paginator/paginator.component.scss
+++ b/libs/ui/src/lib/paginator/paginator.component.scss
@@ -36,14 +36,6 @@ kendo-datapager {
     }
   }
 
-  kendo-datapager.k-pager-mobile-md kendo-datapager-page-sizes {
-    display: block !important;
-  }
-
-  kendo-datapager.k-pager-mobile-sm kendo-datapager-page-sizes {
-    display: block !important;
-  }
-
   // Hide last border ( duplicated )
   kendo-datapager-next-buttons button:last-child {
     border-right: 0 !important;

--- a/libs/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/ui/src/lib/paginator/paginator.component.ts
@@ -55,7 +55,7 @@ export class PaginatorComponent implements OnChanges, AfterViewInit, OnDestroy {
   private resizeObserver!: ResizeObserver;
 
   /**
-   * Constructor
+   * Core paginator element
    *
    * @param renderer Renderer reference
    * @param el Element reference


### PR DESCRIPTION
# Description


The documented problem is related to hiding the option for number of elements per page.

The second point raised is about the presentation format when it is on a reduced screen of tabs (numbers).

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/84318)
- [Kendo page documentation](https://docs.telerik.com/kendo-ui/controls/pager/responsive)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] I resized the screen in several ways and observed the behavior.

## Screenshots

![image](https://github.com/ReliefApplications/ems-frontend/assets/55603259/9a3abb4c-5cee-4a76-9692-66ec1f6b541d)

![image](https://github.com/ReliefApplications/ems-frontend/assets/55603259/e62a16b1-b0f9-4875-bf8c-bbce38ab94cf)

![image](https://github.com/ReliefApplications/ems-frontend/assets/55603259/da91d92e-3f2b-456a-a95b-4d6f24ce8729)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
