### PR TITLE
AB#85463 - Create some space between expand button & zoom controls on map

### DIFF
--- a/libs/shared/src/lib/components/widget/widget.component.html
+++ b/libs/shared/src/lib/components/widget/widget.component.html
@@ -58,7 +58,7 @@
       expanded ? 
       ('models.widget.tooltip.expandButton.restore'  | translate) 
       : ('models.widget.tooltip.expandButton.expand'  | translate)"
-    class="bg-white absolute right-0 top-[50%] border-gray-300 hidden group-hover:block z-10 py-1 rounded-l-lg border-y border-l"
+    class="bg-white absolute right-0 top-[77%] border-gray-300 hidden group-hover:block z-10 py-1 rounded-l-lg border-y border-l"
   >
     <ui-icon [icon]="expanded ? 'chevron_left' : 'chevron_right'"></ui-icon>
   </button>


### PR DESCRIPTION
# Description

Modified position of widget expand button.

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories/?workitem=85463)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] Checked the positioning of the button on the screen.

## Screenshots

![4cf01b75-3671-4eda-a268-aa5bd95eeab9](https://github.com/ReliefApplications/ems-frontend/assets/55603259/456c7195-80e8-4c51-9b5c-8ba05df0a750)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
