### PR TITLE
fix/AB#85512_workflow_goes_to_empty_page_when_clicking_twice

### DIFF
--- a/apps/back-office/src/app/application/pages/workflow/workflow.component.ts
+++ b/apps/back-office/src/app/application/pages/workflow/workflow.component.ts
@@ -102,9 +102,9 @@ export class WorkflowComponent extends UnsubscribeComponent implements OnInit {
         takeUntil(this.destroy$)
       )
       .subscribe(() => {
-        this.loading = true;
         const id = this.route.snapshot.paramMap.get('id');
         if (id) {
+          this.loading = true;
           this.id = id;
           this.workflowService.loadWorkflow(this.id);
         }
@@ -128,9 +128,14 @@ export class WorkflowComponent extends UnsubscribeComponent implements OnInit {
               workflow.steps &&
               workflow.steps.length > (this.workflow.steps || []).length
             ) {
+              // After add new step, go to last/new step
               this.activeStep = workflow.steps.length - 1;
             }
-            this.loadStep(this.activeStep);
+            const currentUrl = this.router.url;
+            // Check if the current URL ends with 'add-step'
+            if (!currentUrl.endsWith('add-step')) {
+              this.loadStep(this.activeStep);
+            }
           }
           this.workflow = workflow;
           this.canEditName = this.workflow?.page?.canUpdate || false;

--- a/apps/front-office/src/app/application/pages/workflow/workflow.component.ts
+++ b/apps/front-office/src/app/application/pages/workflow/workflow.component.ts
@@ -1,6 +1,6 @@
 import { Apollo } from 'apollo-angular';
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import {
   ContentType,
   Step,
@@ -10,7 +10,7 @@ import {
 } from '@oort-front/shared';
 import { GET_WORKFLOW_BY_ID } from './graphql/queries';
 import { TranslateService } from '@ngx-translate/core';
-import { takeUntil } from 'rxjs/operators';
+import { filter, startWith, takeUntil } from 'rxjs/operators';
 import { SnackbarService } from '@oort-front/ui';
 import { Subscription } from 'rxjs';
 
@@ -59,68 +59,79 @@ export class WorkflowComponent extends UnsubscribeComponent implements OnInit {
    * Subscribes to the route to load the workflow accordingly.
    */
   ngOnInit(): void {
-    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
-      this.loading = true;
-      this.id = params.id;
-      this.apollo
-        .watchQuery<WorkflowQueryResponse>({
-          query: GET_WORKFLOW_BY_ID,
-          variables: {
-            id: this.id,
-          },
-        })
-        .valueChanges.pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: ({ data, loading }) => {
-            if (data.workflow) {
-              this.workflow = data.workflow;
-              this.steps = data.workflow.steps || [];
-              this.loading = loading;
-              if (this.steps.length > 0) {
-                const currentStepId = this.router.url.split('/').pop();
-                // If redirect to the workflow beginning, just go to the firstStep
-                const firstStep = this.steps[0];
-                const firstStepIsForm = firstStep.type === ContentType.form;
-                let currentActiveStep = 0;
-                if (
-                  !(firstStepIsForm
-                    ? firstStep.id === currentStepId
-                    : firstStep.content === currentStepId)
-                ) {
-                  // If not, URL contains the step id so redirect to the selected step (used for when refresh page or shared dashboard step link)
-                  data.workflow?.steps?.forEach((step: Step, index: number) => {
-                    const stepIsForm = step.type === ContentType.form;
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        startWith(this.router), // initialize
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        this.loading = true;
+        const id = this.route.snapshot.paramMap.get('id');
+        if (id) {
+          this.id = id;
+          this.apollo
+            .watchQuery<WorkflowQueryResponse>({
+              query: GET_WORKFLOW_BY_ID,
+              variables: {
+                id: this.id,
+              },
+            })
+            .valueChanges.pipe(takeUntil(this.destroy$))
+            .subscribe({
+              next: ({ data, loading }) => {
+                if (data.workflow) {
+                  this.workflow = data.workflow;
+                  this.steps = data.workflow.steps || [];
+                  this.loading = loading;
+                  if (this.steps.length > 0) {
+                    const currentStepId = this.router.url.split('/').pop();
+                    // If redirect to the workflow beginning, just go to the firstStep
+                    const firstStep = this.steps[0];
+                    const firstStepIsForm = firstStep.type === ContentType.form;
+                    let currentActiveStep = 0;
                     if (
-                      (stepIsForm && step.id === currentStepId) ||
-                      step.content === currentStepId
+                      !(firstStepIsForm
+                        ? firstStep.id === currentStepId
+                        : firstStep.content === currentStepId)
                     ) {
-                      currentActiveStep = index;
-                      return;
+                      // If not, URL contains the step id so redirect to the selected step (used for when refresh page or shared dashboard step link)
+                      data.workflow?.steps?.forEach(
+                        (step: Step, index: number) => {
+                          const stepIsForm = step.type === ContentType.form;
+                          if (
+                            (stepIsForm && step.id === currentStepId) ||
+                            step.content === currentStepId
+                          ) {
+                            currentActiveStep = index;
+                            return;
+                          }
+                        }
+                      );
                     }
-                  });
-                }
-                this.onOpenStep(currentActiveStep);
-              }
-            } else {
-              this.snackBar.openSnackBar(
-                this.translate.instant(
-                  'common.notifications.accessNotProvided',
-                  {
-                    type: this.translate
-                      .instant('common.workflow.one')
-                      .toLowerCase(),
-                    error: '',
+                    this.onOpenStep(currentActiveStep);
                   }
-                ),
-                { error: true }
-              );
-            }
-          },
-          error: (err) => {
-            this.snackBar.openSnackBar(err.message, { error: true });
-          },
-        });
-    });
+                } else {
+                  this.snackBar.openSnackBar(
+                    this.translate.instant(
+                      'common.notifications.accessNotProvided',
+                      {
+                        type: this.translate
+                          .instant('common.workflow.one')
+                          .toLowerCase(),
+                        error: '',
+                      }
+                    ),
+                    { error: true }
+                  );
+                }
+              },
+              error: (err) => {
+                this.snackBar.openSnackBar(err.message, { error: true });
+              },
+            });
+        }
+      });
   }
 
   /**

--- a/libs/shared/src/lib/services/workflow/workflow.service.ts
+++ b/libs/shared/src/lib/services/workflow/workflow.service.ts
@@ -53,7 +53,6 @@ export class WorkflowService {
    * @param id workflow id.
    */
   loadWorkflow(id: any): void {
-    this.workflow.next(null);
     this.apollo
       .query<WorkflowQueryResponse>({
         query: GET_WORKFLOW_BY_ID,
@@ -61,8 +60,14 @@ export class WorkflowService {
           id,
         },
       })
-      .subscribe(({ data }) => {
-        this.workflow.next(data.workflow);
+      .subscribe({
+        next: ({ data }) => {
+          this.workflow.next(data.workflow);
+        },
+        error: (err) => {
+          this.workflow.next(null);
+          this.snackBar.openSnackBar(err.message, { error: true });
+        },
       });
   }
 


### PR DESCRIPTION
# Description
Alternative solution for the ticket: replaced use of this.route.params with this.router.events. [First PR](https://github.com/ReliefApplications/ems-frontend/pull/2375).

## Useful links

- Please insert link to ticket; https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/85512/

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Went to both back-office and front-office and checked whether clicking does not return you to homepage.

## Screenshots
Example in the front-office:
[front-office.webm](https://github.com/ReliefApplications/ems-frontend/assets/28535394/9b6c4b72-4ff7-450b-bc6f-170b8a5af427)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
