### PR TITLE
Fix/ab#85844 editor data filter reset not working as expected

### DIFF
--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -440,10 +440,24 @@ export class EditorComponent extends UnsubscribeComponent implements OnInit {
         }
       });
     }
-    // Handle data-filter-reset event
-    if (event.target.dataset.filterReset) {
+
+    let resetButtonIsClicked = !!event.target.dataset.filterReset;
+    currentNode = event.target;
+    if (!resetButtonIsClicked) {
+      // Check parent node if contains the dataset for filtering until we hit the host node or find the node with the filter dataset
+      while (
+        currentNode.localName !== 'shared-editor' &&
+        !resetButtonIsClicked
+      ) {
+        currentNode = this.renderer.parentNode(currentNode);
+        resetButtonIsClicked = !!currentNode.dataset.filterReset;
+      }
+    }
+    if (resetButtonIsClicked) {
       // Get all the fields that need to be cleared
-      const resetList = event.target.dataset.filterReset.split(';');
+      const resetList = currentNode.dataset.filterReset
+        .split(';')
+        .map((item: any) => item.trim());
       const updatedFilter: any = {};
       for (const [key, value] of Object.entries(
         this.contextService.filter.getValue()

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -186,7 +186,7 @@ export class SummaryCardItemContentComponent
     if (!resetButtonIsClicked) {
       // Check parent node if contains the dataset for filtering until we hit the host node or find the node with the filter dataset
       while (
-        currentNode.localName !== 'shared-editor' &&
+        currentNode.localName !== 'shared-summary-card-item-content' &&
         !resetButtonIsClicked
       ) {
         currentNode = this.renderer.parentNode(currentNode);

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -180,6 +180,35 @@ export class SummaryCardItemContentComponent
         }
       });
     }
+
+    let resetButtonIsClicked = !!event.target.dataset.filterReset;
+    currentNode = event.target;
+    if (!resetButtonIsClicked) {
+      // Check parent node if contains the dataset for filtering until we hit the host node or find the node with the filter dataset
+      while (
+        currentNode.localName !== 'shared-editor' &&
+        !resetButtonIsClicked
+      ) {
+        currentNode = this.renderer.parentNode(currentNode);
+        resetButtonIsClicked = !!currentNode.dataset.filterReset;
+      }
+    }
+    if (resetButtonIsClicked) {
+      // Get all the fields that need to be cleared
+      const resetList = currentNode.dataset.filterReset
+        .split(';')
+        .map((item: any) => item.trim());
+      const updatedFilter: any = {};
+      for (const [key, value] of Object.entries(
+        this.contextService.filter.getValue()
+      )) {
+        // If key is not in list of fields that need to be cleared, add to updated Filter
+        if (!resetList.includes(key)) {
+          updatedFilter[key] = value;
+        }
+      }
+      this.contextService.filter.next(updatedFilter);
+    }
   }
 
   /**

--- a/libs/shared/src/lib/const/tinymce.const.ts
+++ b/libs/shared/src/lib/const/tinymce.const.ts
@@ -219,7 +219,6 @@ export const WIDGET_EDITOR_CONFIG: RawEditorSettings = {
             const textElement = editor.selection.getNode();
             textElement.setAttribute('data-filter-field', data.filterField);
             textElement.setAttribute('data-filter-value', data.filterValue);
-            textElement.setAttribute('data-filter-reset', '');
             api.close();
           },
           buttons: [
@@ -238,11 +237,65 @@ export const WIDGET_EDITOR_CONFIG: RawEditorSettings = {
         });
       },
     });
-    editor.ui.registry.addContextToolbar('contextfilter', {
+
+    // Reset context filters
+    const iconResetFilters = createFontAwesomeIcon(
+      {
+        icon: 'broom',
+        color: 'none',
+        opacity: 1,
+        size: 21,
+      },
+      (editor.editorManager as any).DOM.doc
+    );
+
+    editor.ui.registry.addIcon('reset-icon', iconResetFilters.innerHTML);
+    editor.ui.registry.addButton('resetFilters', {
+      icon: 'reset-icon',
+      tooltip: 'Reset context filters',
+      onAction: async () => {
+        editor.windowManager.open({
+          title: 'Context filters to reset',
+          body: {
+            type: 'panel',
+            items: [
+              {
+                type: 'input',
+                name: 'filtersList',
+                label: 'Context filters list',
+                placeholder: 'name;type;date',
+              },
+            ],
+          },
+          initialData: {
+            filtersList: '',
+          },
+          onSubmit: (api) => {
+            const data = api.getData();
+            const textElement = editor.selection.getNode();
+            textElement.setAttribute('data-filter-reset', data.filtersList);
+            api.close();
+          },
+          buttons: [
+            {
+              text: 'Close',
+              type: 'cancel',
+            },
+            {
+              text: 'Save',
+              type: 'submit',
+              name: 'submit',
+              primary: true,
+            },
+          ],
+        });
+      },
+    });
+    editor.ui.registry.addContextToolbar('filters', {
       predicate: () => editor.selection.getContent()?.length > 0,
       scope: 'node',
       position: 'selection',
-      items: 'contextfilter',
+      items: 'contextFilter resetFilters',
     });
   },
 };


### PR DESCRIPTION
# Description

I fixed the two issues described in the ticket description:
- The reset action wasn't triggered when clicking on a child element
- The filter's name was sensitive to spaces

Additionally, I have added a visual interface to set the reset filters list, as suggested in the ticket.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/85844/)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created a text editor with context filters and a reset button. I checked that the event was correctly triggered. I did the same for summary cards.

## Screenshots

![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/b17b2923-df8f-4dc2-b1ab-9f98b6961be4)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
