### PR TITLE
Fix/ab#85861 infinite scrolling not triggered when elements take less space than height

### DIFF
--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -50,12 +50,14 @@
         }}</span>
       </ng-container>
       <ng-template uiTabContent>
-        <shared-summary-card
-          id="widgetPreview"
-          [settings]="widgetFormGroup.value"
-          [widget]="widget"
-        >
-        </shared-summary-card>
+        <div class="max-h-[80vh]">
+          <shared-summary-card
+            id="widgetPreview"
+            [settings]="widgetFormGroup.value"
+            [widget]="widget"
+          >
+          </shared-summary-card>
+        </div>
       </ng-template>
     </ui-tab>
     <!-- Available actions -->

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.scss
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.scss
@@ -4,7 +4,6 @@
   gap: 16px;
   grid-auto-flow: row;
   background-color: unset;
-  max-height: 80vh;
 
   .k-card {
     border: none;

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -364,6 +364,9 @@ export class SummaryCardComponent
     if (this.scrollEventBindTimeout) {
       clearTimeout(this.scrollEventListener);
     }
+    if (this.timeoutListener) {
+      clearTimeout(this.timeoutListener);
+    }
   }
 
   /**
@@ -975,7 +978,7 @@ export class SummaryCardComponent
   /**
    * Load more items on init to enable scrolling behavior
    */
-  checkDataLengthForScrolling() {
+  private checkDataLengthForScrolling() {
     if (this.settings.widgetDisplay?.usePagination) return;
     if (this.timeoutListener) {
       clearTimeout(this.timeoutListener);
@@ -992,6 +995,7 @@ export class SummaryCardComponent
    * Load more items on scroll.
    *
    * @param e scroll event
+   * @param initLoad used on init to enable scrolling behavior
    */
   private loadOnScroll(e: any, initLoad: boolean = false): void {
     /** If scroll is reaching bottom of scrolling height, trigger card load */

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -383,10 +383,11 @@ export class SummaryCardComponent
         // On switching views, summary card element ref is destroyed
         // and all events attached to it are not working as they are bind to
         // previous element, therefor we have to set them again
-        this.scrollEventBindTimeout = setTimeout(
-          () => this.bindCardsScrollListener(),
-          0
-        );
+        this.scrollEventBindTimeout = setTimeout(() => {
+          this.scrolling = false;
+          this.bindCardsScrollListener();
+          this.checkDataLengthForScrolling();
+        }, 0);
       } else {
         // Clean previously attached scroll listener as the element ref is destroyed
         if (this.scrollEventListener) {


### PR DESCRIPTION
# Description

I created a function to fetch more data if the cards height takes up less space than the container height when using infinite scrolling.  

I noticed a bug related padding when scrolling to the bottom of the container. This was caused by the `max-height` property. I moved it, as it is only used by the preview in the settings.

Additionally, I noticed an issue with resource loading when using infinite scrolling which I fixed by sending the query result along with the binding.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/85861/)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created a dashboard with the grid type option set to `fit`. I created a summary cards widget based on data with hundred of lines, that uses `infinite scrolling`. I styled the cards to have a minimum height so that at least 25 cards don't take up the full space. I checked if more cards were loaded (until the scrollbar appeared).
 
## Screenshots

![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/52d0ebb4-2efc-42b5-a75d-9995a39fee5e)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
