### PR TITLE
Ab#86022 min and max dates not taken into account

### DIFF
--- a/libs/shared/src/lib/survey/widgets/text-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/text-widget.ts
@@ -163,15 +163,15 @@ export const init = (
               // https://www.telerik.com/kendo-angular-ui/components/dateinputs/api/DatePickerComponent/#toc-valuechange
               button.classList.remove('hidden');
             }
-            if ((el.children[0]?.children[0] as any)?.min) {
+            if (el.querySelector('input')?.min) {
               pickerInstance.min = getDateDisplay(
-                (el.children[0]?.children[0] as any).min,
+                el.querySelector('input')?.min,
                 question.inputType
               );
             }
-            if ((el.children[0]?.children[0] as any)?.max) {
+            if (el.querySelector('input')?.max) {
               pickerInstance.max = getDateDisplay(
-                (el.children[0]?.children[0] as any).max,
+                el.querySelector('input')?.max,
                 question.inputType
               );
             }

--- a/libs/shared/src/lib/survey/widgets/text-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/text-widget.ts
@@ -163,15 +163,15 @@ export const init = (
               // https://www.telerik.com/kendo-angular-ui/components/dateinputs/api/DatePickerComponent/#toc-valuechange
               button.classList.remove('hidden');
             }
-            if (question.min) {
+            if ((el.children[0]?.children[0] as any).min) {
               pickerInstance.min = getDateDisplay(
-                question.min,
+                (el.children[0]?.children[0] as any).min,
                 question.inputType
               );
             }
-            if (question.max) {
+            if ((el.children[0]?.children[0] as any).max) {
               pickerInstance.max = getDateDisplay(
-                question.max,
+                (el.children[0]?.children[0] as any).max,
                 question.inputType
               );
             }

--- a/libs/shared/src/lib/survey/widgets/text-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/text-widget.ts
@@ -163,13 +163,13 @@ export const init = (
               // https://www.telerik.com/kendo-angular-ui/components/dateinputs/api/DatePickerComponent/#toc-valuechange
               button.classList.remove('hidden');
             }
-            if ((el.children[0]?.children[0] as any).min) {
+            if ((el.children[0]?.children[0] as any)?.min) {
               pickerInstance.min = getDateDisplay(
                 (el.children[0]?.children[0] as any).min,
                 question.inputType
               );
             }
-            if ((el.children[0]?.children[0] as any).max) {
+            if ((el.children[0]?.children[0] as any)?.max) {
               pickerInstance.max = getDateDisplay(
                 (el.children[0]?.children[0] as any).max,
                 question.inputType


### PR DESCRIPTION
# Description

Now getting min and max from the default input and applying to the kendo-datepicker.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/86022/)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested in a dashboard filter with date question, setting both min and max to values like today(-8) and today(4).

## Screenshots

![min_and_max_taken_into_account](https://github.com/ReliefApplications/ems-frontend/assets/59645813/d35888ca-ca1c-4d10-b30f-173034d3b48b)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
