### PR TITLE
Fix/ab#86018 ref data focus on form builder init

### DIFF
--- a/libs/shared/src/lib/survey/widgets/utils/common-list-filters.ts
+++ b/libs/shared/src/lib/survey/widgets/utils/common-list-filters.ts
@@ -63,6 +63,5 @@ function updateChoices(
 
   widget.loading = false;
   widget.disabled = surveyQuestion.isReadOnly;
-  widget.wrapper.nativeElement.click();
 }
 export default updateChoices;


### PR DESCRIPTION
# Description

I removed a line of code that was simulating a click on the question after it had been loaded. It was implemented a long time ago, and it doesn't seem useful anywhere (cf links)

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/86018/)
- [Previous commit](https://github.com/ReliefApplications/ems-frontend/commit/c06ad989b51e0163f63a9b84c3b962275308505a#diff-82e4df0246557c63a5e80351d81e3e75025fc3ddc34d40e6099b582dac4ce895)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created a form and questions with choices from reference data and checked if they were focused on the initialization of the form builder.

## Screenshots

![peek](https://github.com/ReliefApplications/ems-frontend/assets/65243509/c439bfe2-f4cb-4dec-9aaa-eaf80a600f53)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
