### PR TITLE
AB#85981 - In email preview, use same logic than in grid export to replace {{dataset}} and attach export files

### DIFF
--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -498,7 +498,9 @@ export class GridWidgetComponent
             },
             this.grid.sortField || undefined,
             this.grid.sortOrder || undefined,
-            options.export
+            options.export,
+            this.settings.resource,
+            Intl.DateTimeFormat().resolvedOptions().timeZone
           );
         }
       }

--- a/libs/shared/src/lib/services/email/email.service.ts
+++ b/libs/shared/src/lib/services/email/email.service.ts
@@ -9,6 +9,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { RestService } from '../rest/rest.service';
 import { SnackbarService } from '@oort-front/ui';
 import { flatDeep } from '../../utils/array-filter';
+import { Resource } from 'tinymce';
 
 /** Snackbar duration in ms */
 const SNACKBAR_DURATION = 1000;
@@ -176,6 +177,8 @@ export class EmailService {
    * @param sortOrder Sort order (optional).
    * @param attachment Whether an excel with the dataset is attached to the mail
    * or not (optional).
+   * @param resource Resource for the email.
+   * @param timezone Timezone for the email.
    */
   public async previewMail(
     recipient: string[],
@@ -188,7 +191,9 @@ export class EmailService {
     },
     sortField?: string,
     sortOrder?: string,
-    attachment?: boolean
+    attachment?: boolean,
+    resource?: Resource,
+    timezone?: string
   ): Promise<void> {
     const snackBarRef = this.snackBar.openComponentSnackBar(
       SnackbarSpinnerComponent,
@@ -219,6 +224,8 @@ export class EmailService {
           sortField,
           sortOrder,
           attachment,
+          resource,
+          timezone,
         },
         { headers }
       )


### PR DESCRIPTION
# Description

The necessary parameters were created for the new grid data search format in the email preview.

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/85981)
- [Link to back-end branch](https://github.com/ReliefApplications/ems-backend/pull/984)

## Type of change

Please delete options that are not relevant.

- [X] Improvement (refactor or addition to existing functionality)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] I created a preview email with {{dataset}} configured and observed system behavior

## Screenshots


https://github.com/ReliefApplications/ems-frontend/assets/55603259/d244516f-3dc9-4566-ba26-225acd332191


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
