### PR TITLE
bugfix/AB#86242_ABC-dashboard-filter-should-be-opened-by-default-in-web-element

### DIFF
--- a/apps/web-widgets/src/app/widgets/app-widget/application/pages/dashboard/dashboard.component.html
+++ b/apps/web-widgets/src/app/widgets/app-widget/application/pages/dashboard/dashboard.component.html
@@ -2,7 +2,8 @@
   *ngIf="!loading && showFilter && !isFullScreen"
   [isFullScreen]="isFullScreen"
   variant="modern"
-  [opened]="true"
+  [opened]="$any(dashboard?.filter?.show)"
+  [closable]="$any(dashboard?.filter?.closable)"
   [dashboard]="dashboard"
   [structure]="dashboard?.filter?.structure"
 ></shared-dashboard-filter>
@@ -17,7 +18,8 @@
     *ngIf="!loading && showFilter && isFullScreen"
     [editable]="true"
     [isFullScreen]="isFullScreen"
-    [opened]="true"
+    [opened]="$any(dashboard?.filter?.show)"
+    [closable]="$any(dashboard?.filter?.closable)"
     [dashboard]="dashboard"
     [structure]="dashboard?.filter?.structure"
   ></shared-dashboard-filter>


### PR DESCRIPTION
# Description

feat: add closeable property to false in the dashboard-filter component for web-widgets to avoid close event and keep it open by default

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/86242)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to video below

## Screenshots

Filter show and closable based on dashboard config


https://github.com/ReliefApplications/ems-frontend/assets/123092672/0317f577-8aec-4bca-a413-d0c472106dd6





# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
