### PR TITLE
Ab#86371 date min and max dynamic change

### DIFF
--- a/libs/shared/src/lib/survey/widgets/text-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/text-widget.ts
@@ -165,15 +165,10 @@ export const init = (
             }
             const originalInput = el.querySelector('input');
             if (originalInput) {
-              const updatePickerInstance = (attribute: string) => {
-                if ((originalInput as any)[attribute]) {
-                  (pickerInstance as any)[attribute] = getDateDisplay(
-                    (originalInput as any)[attribute],
-                    question.inputType
-                  );
-                } else {
-                  (pickerInstance as any)[attribute] = null;
-                }
+              const updatePickerInstance = (attribute: 'min' | 'max') => {
+                (pickerInstance as any)[attribute] = originalInput[attribute]
+                  ? getDateDisplay(originalInput[attribute], question.inputType)
+                  : null; //using as any because otherwise we cannot set to null
               };
 
               updatePickerInstance('min');
@@ -185,7 +180,9 @@ export const init = (
                     ['min', 'max'].includes(mutation.attributeName || '')
                   )
                   .forEach((mutation) => {
-                    updatePickerInstance(mutation.attributeName || '');
+                    updatePickerInstance(
+                      mutation.attributeName as 'min' | 'max'
+                    );
                   });
               });
               observer.observe(originalInput, { attributes: true });

--- a/libs/shared/src/lib/survey/widgets/text-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/text-widget.ts
@@ -163,18 +163,34 @@ export const init = (
               // https://www.telerik.com/kendo-angular-ui/components/dateinputs/api/DatePickerComponent/#toc-valuechange
               button.classList.remove('hidden');
             }
-            if (el.querySelector('input')?.min) {
-              pickerInstance.min = getDateDisplay(
-                el.querySelector('input')?.min,
-                question.inputType
-              );
+            const originalInput = el.querySelector('input');
+            if (originalInput) {
+              const updatePickerInstance = (attribute: string) => {
+                if ((originalInput as any)[attribute]) {
+                  (pickerInstance as any)[attribute] = getDateDisplay(
+                    (originalInput as any)[attribute],
+                    question.inputType
+                  );
+                } else {
+                  (pickerInstance as any)[attribute] = null;
+                }
+              };
+
+              updatePickerInstance('min');
+              updatePickerInstance('max');
+
+              const observer = new MutationObserver((mutationsList) => {
+                mutationsList
+                  .filter((mutation) =>
+                    ['min', 'max'].includes(mutation.attributeName || '')
+                  )
+                  .forEach((mutation) => {
+                    updatePickerInstance(mutation.attributeName || '');
+                  });
+              });
+              observer.observe(originalInput, { attributes: true });
             }
-            if (el.querySelector('input')?.max) {
-              pickerInstance.max = getDateDisplay(
-                el.querySelector('input')?.max,
-                question.inputType
-              );
-            }
+
             pickerInstance.readonly = question.isReadOnly;
             pickerInstance.disabled = question.isReadOnly;
 


### PR DESCRIPTION
# Description

date min and max could not be fetched dynamically, added an observer so that when min or max changes in the original input, it reflects in the kendo input.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/86371)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created a filter with two date questions, one depending on the other.

## Screenshots

![min_and_max_taken_into_account](https://github.com/ReliefApplications/ems-frontend/assets/59645813/ba5ff879-4dcf-4847-bfe6-d86cc6471347)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
