### PR TITLE
bugfix/AB#86941_SUI-filters-only-region-based-countries-should-display-when-user-navigated-from-countries-page-by-region-selection

### DIFF
--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -130,6 +130,7 @@ export class DashboardFilterComponent
       )
       .subscribe(({ current }) => {
         this.survey.data = current;
+        this.survey.setPropertyValue('dataHasChanged', true);
       });
     this.contextService.filterOpened$
       .pipe(takeUntil(this.destroy$))

--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -130,7 +130,7 @@ export class DashboardFilterComponent
       )
       .subscribe(({ current }) => {
         this.survey.data = current;
-        this.survey.setPropertyValue('dataHasChanged', true);
+        this.survey.setPropertyValue('refreshData', true);
       });
     this.contextService.filterOpened$
       .pipe(takeUntil(this.destroy$))

--- a/libs/shared/src/lib/components/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/layout/layout.component.ts
@@ -550,7 +550,7 @@ export class LayoutComponent
         this.surveySharedQuestions = Array.from(new Set(surveyQuestions));
       }
       // Reset data change trigger on component detach
-      e.linkedSurvey?.setPropertyValue('dataHasChanged', false);
+      e.linkedSurvey?.setPropertyValue('refreshData', false);
       const newFilterValues: { [key: string]: any } = this.getViewFilterValue(
         e.linkedSurvey
       );

--- a/libs/shared/src/lib/components/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/layout/layout.component.ts
@@ -549,6 +549,8 @@ export class LayoutComponent
         });
         this.surveySharedQuestions = Array.from(new Set(surveyQuestions));
       }
+      // Reset data change trigger on component detach
+      e.linkedSurvey?.setPropertyValue('dataHasChanged', false);
       const newFilterValues: { [key: string]: any } = this.getViewFilterValue(
         e.linkedSurvey
       );

--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -61,7 +61,7 @@ export const init = (referenceDataService: ReferenceDataService): void => {
   const serializer: JsonMetadata = Serializer;
   // Property used to trigger value changes across tabs in web components for reference data
   serializer.addProperty('survey', {
-    name: 'dataHasChanged',
+    name: 'refreshData',
     default: true,
     category: 'general',
     visibleIndex: 0,
@@ -343,7 +343,7 @@ export const render = (
         updateReferenceDataChoicesFunc
       );
       (question.survey as SurveyModel).registerFunctionOnPropertyValueChanged(
-        'dataHasChanged',
+        'refreshData',
         updateReferenceDataChoicesFunc
       );
     }


### PR DESCRIPTION
# Description

fix: reference data linked list update when changing data property from survey adding a custom hasDataChanged property that would handle the even trigger

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/86941)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to the video below

## Screenshots


https://github.com/ReliefApplications/ems-frontend/assets/123092672/fbf8bee8-377c-410d-8e0d-a4b8a305eadd



# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
