### PR TITLE
AB#87701_ABC-see-if-possible-to-deactivate-cross-page-filtering-so-each-page-handles-its-own-filter

### DIFF
--- a/apps/web-widgets/src/environments/environment.shared.ts
+++ b/apps/web-widgets/src/environments/environment.shared.ts
@@ -25,4 +25,5 @@ export const sharedAzureEnvironment = {
         'Please contact <a class="underline text-primary-500 hover:text-primary-600" href="mailto:ems2@who.int">ems2@who.int</a> for more information.',
     },
   },
+  sharedFilters: ['regions'],
 };

--- a/libs/shared/src/lib/survey/widgets/dropdown-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/dropdown-widget.ts
@@ -88,19 +88,21 @@ export const init = (
         }
       );
       question.registerFunctionOnPropertyValueChanged('value', () => {
-        // We need this line for resource select
-        if (question.isPrimitiveValue) {
-          dropdownInstance.value = question.value;
-        } else {
-          if (question.visibleChoices.length > 0) {
-            if (has(question.value, 'text') && has(question.value, 'value')) {
-              dropdownInstance.value = question.visibleChoices.find((choice) =>
-                isEqual(choice.value, question.value.value)
-              );
-            } else {
-              dropdownInstance.value = question.visibleChoices.find((choice) =>
-                isEqual(choice.value, question.value)
-              );
+        if (!isEqual(question.value, dropdownInstance.value)) {
+          // We need this line for resource select
+          if (question.isPrimitiveValue) {
+            dropdownInstance.value = question.value;
+          } else {
+            if (question.visibleChoices.length > 0) {
+              if (has(question.value, 'text') && has(question.value, 'value')) {
+                dropdownInstance.value = question.visibleChoices.find(
+                  (choice) => isEqual(choice.value, question.value.value)
+                );
+              } else {
+                dropdownInstance.value = question.visibleChoices.find(
+                  (choice) => isEqual(choice.value, question.value)
+                );
+              }
             }
           }
         }

--- a/libs/shared/src/lib/survey/widgets/tagbox-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/tagbox-widget.ts
@@ -9,6 +9,7 @@ import {
 } from 'survey-core';
 import { debounceTime, map, tap } from 'rxjs';
 import updateChoices from './utils/common-list-filters';
+import { isEqual } from 'lodash';
 
 /**
  * Init tagbox question
@@ -175,9 +176,11 @@ export const init = (
       );
 
       question._valueChangeCallback = () => {
-        if (!question.isPrimitiveValue) {
-          tagboxInstance.value = question.value;
-          updateChoices(tagboxInstance, question, currentSearchValue);
+        if (!isEqual(question.value, tagboxInstance.value)) {
+          if (!question.isPrimitiveValue) {
+            tagboxInstance.value = question.value;
+            updateChoices(tagboxInstance, question, currentSearchValue);
+          }
         }
       };
       question.registerFunctionOnPropertyValueChanged(


### PR DESCRIPTION
# Description

- feat: avoid merge of current context filter value on survey first load for web-components 
- feat: disable share filters feature for dashboards in web-widgets

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/87701)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please refer to video below

## Screenshots


https://github.com/ReliefApplications/ems-frontend/assets/123092672/d2562eeb-220c-4365-8fac-fc440bd561a7


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
