### PR TITLE
feat/AB#87701_ABC-deactivate-cross-page-filtering-so-each-page-handles-its-own-filter

### DIFF
--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -72,6 +72,8 @@ export class DashboardFilterComponent
   public containerLeftOffset!: string;
   /** Filter template */
   public survey: Model = new Model();
+  /** Survey init flag */
+  private surveyInit = true;
   /** Quick filter display */
   public quickFilters: QuickFilter[] = [];
   /** Indicate empty status of filter */
@@ -227,6 +229,7 @@ export class DashboardFilterComponent
       renderGlobalProperties(this.referenceDataService, this.http);
     });
     this.onValueChange();
+    this.surveyInit = false;
   }
 
   /**
@@ -320,15 +323,20 @@ export class DashboardFilterComponent
         };
         return acc;
       }, {});
-    const currentFilterValue = this.contextService.filter.value;
     const currentSurveyQuestions = this.survey.getAllQuestions();
     const nextFilterValue: any = surveyData;
-    const filterKeys = Object.keys(currentFilterValue);
-    filterKeys
-      .filter((key) => !currentSurveyQuestions.find((sq) => sq.name === key))
-      .forEach((key) => {
-        nextFilterValue[key] = currentFilterValue[key];
-      });
+    // Don't merge current context filter values to the filter if survey has init and it's used in web component
+    if (
+      !(this.surveyInit && this.contextService.shadowDomService.isShadowRoot)
+    ) {
+      const currentFilterValue = this.contextService.filter.value;
+      const filterKeys = Object.keys(currentFilterValue);
+      filterKeys
+        .filter((key) => !currentSurveyQuestions.find((sq) => sq.name === key))
+        .forEach((key) => {
+          nextFilterValue[key] = currentFilterValue[key];
+        });
+    }
     this.contextService.filter.next(nextFilterValue);
     this.ngZone.run(() => {
       this.quickFilters = displayValues

--- a/libs/shared/src/lib/components/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/layout/layout.component.ts
@@ -28,8 +28,8 @@ import { takeUntil } from 'rxjs/operators';
 import { Breadcrumb, UILayoutService } from '@oort-front/ui';
 import { BreadcrumbService } from '../../services/breadcrumb/breadcrumb.service';
 import { ContextService } from '../../services/context/context.service';
-import { isEqual } from 'lodash';
-import { Model } from 'survey-core';
+// import { isEqual } from 'lodash';
+// import { Model } from 'survey-core';
 
 /**
  * Component for the main layout of the platform
@@ -151,9 +151,9 @@ export class LayoutComponent
   public breadcrumbs: Breadcrumb[] = [];
 
   /** Timeout listeners */
-  private attachViewFilterTriggerListener!: NodeJS.Timeout;
+  // private attachViewFilterTriggerListener!: NodeJS.Timeout;
   /** Survey shared questions names on web component to track shared values when switching views */
-  private surveySharedQuestions!: string[];
+  // private surveySharedQuestions!: string[];
 
   /**
    * Gets URI of the other office
@@ -449,36 +449,36 @@ export class LayoutComponent
    * @param survey Current active filter survey in the SUI
    * @returns object with merged values from
    */
-  private getViewFilterValue(survey: Model): { [key: string]: any } {
-    const newFilterValues: { [key: string]: any } = {
-      ...this.contextService.filter.value,
-    };
-    const filterKeys = Object.keys(this.contextService.filter.value);
-    const currentSurveyQuestions = survey.getAllQuestions();
-    // Include by default all the filter values that are present as questions in the current activated survey
-    // But context filter values have priority over any value in the survey(shared question value changed from other dashboard)
-    filterKeys
-      .filter((fk) => currentSurveyQuestions.find((sq) => sq.name === fk))
-      .forEach((filterKey) => {
-        newFilterValues[filterKey] =
-          this.contextService.filter.value[filterKey];
-      });
-    // Include all the survey question values that are not shared, not present in the current context filter value and contains a value to be set
-    currentSurveyQuestions.forEach((qu: any) => {
-      if (
-        !this.surveySharedQuestions.includes(qu.name) &&
-        !filterKeys.includes(qu.name) &&
-        ((!Array.isArray(qu.value) && qu.value) ||
-          (Array.isArray(qu.value) && qu.value.length))
-      ) {
-        // Values as array contains properties from survey question that if not casted to array spread, will make the tagbox or any question using array values to not trigger the survey value change
-        newFilterValues[qu.name] = Array.isArray(qu.value)
-          ? [...qu.value]
-          : qu.value;
-      }
-    });
-    return newFilterValues;
-  }
+  // private getViewFilterValue(survey: Model): { [key: string]: any } {
+  //   const newFilterValues: { [key: string]: any } = {
+  //     ...this.contextService.filter.value,
+  //   };
+  //   const filterKeys = Object.keys(this.contextService.filter.value);
+  //   const currentSurveyQuestions = survey.getAllQuestions();
+  //   // Include by default all the filter values that are present as questions in the current activated survey
+  //   // But context filter values have priority over any value in the survey(shared question value changed from other dashboard)
+  //   filterKeys
+  //     .filter((fk) => currentSurveyQuestions.find((sq) => sq.name === fk))
+  //     .forEach((filterKey) => {
+  //       newFilterValues[filterKey] =
+  //         this.contextService.filter.value[filterKey];
+  //     });
+  //   // Include all the survey question values that are not shared, not present in the current context filter value and contains a value to be set
+  //   currentSurveyQuestions.forEach((qu: any) => {
+  //     if (
+  //       !this.surveySharedQuestions.includes(qu.name) &&
+  //       !filterKeys.includes(qu.name) &&
+  //       ((!Array.isArray(qu.value) && qu.value) ||
+  //         (Array.isArray(qu.value) && qu.value.length))
+  //     ) {
+  //       // Values as array contains properties from survey question that if not casted to array spread, will make the tagbox or any question using array values to not trigger the survey value change
+  //       newFilterValues[qu.name] = Array.isArray(qu.value)
+  //         ? [...qu.value]
+  //         : qu.value;
+  //     }
+  //   });
+  //   return newFilterValues;
+  // }
 
   /**
    * On attach component ( only used in web elements, with reuse strategy )
@@ -486,24 +486,24 @@ export class LayoutComponent
    * @param e Event thrown in the attach event of the router outlet containing the lastStateOfContextFilters when it was detached
    */
   onAttach(e: any) {
-    if (this.contextService.shadowDomService.isShadowRoot) {
-      if (e.linkedSurvey) {
-        const newFilterValues: { [key: string]: any } = this.getViewFilterValue(
-          e.linkedSurvey
-        );
-        this.contextService.filter.getValue();
-        // If attached view context filter state and current context filter state are different we set the force trigger refresh to true and trigger the filter event again
-        if (!isEqual(e.lastStateOfContextFilters, newFilterValues)) {
-          if (this.attachViewFilterTriggerListener) {
-            clearTimeout(this.attachViewFilterTriggerListener);
-          }
-          this.attachViewFilterTriggerListener = setTimeout(() => {
-            this.contextService.filter.next(e.lastStateOfContextFilters);
-            this.contextService.filter.next(newFilterValues);
-          }, 0);
-        }
-      }
-    }
+    // if (this.contextService.shadowDomService.isShadowRoot) {
+    //   if (e.linkedSurvey) {
+    //     const newFilterValues: { [key: string]: any } = this.getViewFilterValue(
+    //       e.linkedSurvey
+    //     );
+    //     // this.contextService.filter.getValue();
+    //     // If attached view context filter state and current context filter state are different we set the force trigger refresh to true and trigger the filter event again
+    //     if (!isEqual(e.lastStateOfContextFilters, newFilterValues)) {
+    //       if (this.attachViewFilterTriggerListener) {
+    //         clearTimeout(this.attachViewFilterTriggerListener);
+    //       }
+    //       this.attachViewFilterTriggerListener = setTimeout(() => {
+    //         this.contextService.filter.next(e.lastStateOfContextFilters);
+    //         this.contextService.filter.next(newFilterValues);
+    //       }, 0);
+    //     }
+    //   }
+    // }
     if (e.onAttach) {
       e.onAttach();
     }
@@ -515,60 +515,60 @@ export class LayoutComponent
    * @param e Event thrown in the detach event of the router outlet where we set lastStateOfContextFilters value for next attach to update context filter trigger
    */
   onDetach(e: any) {
-    if (this.contextService.shadowDomService.isShadowRoot) {
-      // If no linked survey to the view is set, it means it's first view load
-      if (!e.linkedSurvey) {
-        e.linkedSurvey =
-          this.contextService.webComponentsFilterSurvey[
-            this.contextService.webComponentsFilterSurvey.length - 1
-          ];
-        // Any time a new view is set, we update the surveySharedQuestions value with the questions from the new survey
-        const surveyQuestions: string[] = [];
-        this.contextService.webComponentsFilterSurvey.forEach((survey) => {
-          const otherSurveys =
-            this.contextService.webComponentsFilterSurvey.filter(
-              (sur) => !isEqual(sur, survey)
-            );
-          survey
-            .getAllQuestions()
-            // Get all questions from the survey to check that their question is not already set in the shared questions property
-            .filter((qu) => !surveyQuestions.includes(qu.name))
-            .forEach((qu) => {
-              let isFoundQuestion = false;
-              otherSurveys.forEach((sur) => {
-                if (
-                  sur
-                    .getAllQuestions()
-                    .find((question) => question.name === qu.name)
-                ) {
-                  isFoundQuestion = true;
-                  return;
-                }
-              });
-              if (isFoundQuestion) {
-                surveyQuestions.push(qu.name);
-              }
-            });
-        });
-        this.surveySharedQuestions = Array.from(new Set(surveyQuestions));
-      }
-      // Reset data change trigger on component detach
-      e.linkedSurvey?.setPropertyValue('refreshData', false);
-      const newFilterValues: { [key: string]: any } = this.getViewFilterValue(
-        e.linkedSurvey
-      );
-      e.currentStateOfContextFilters = newFilterValues;
-      e.lastStateOfContextFilters = e.currentStateOfContextFilters;
-    }
+    // if (this.contextService.shadowDomService.isShadowRoot) {
+    // If no linked survey to the view is set, it means it's first view load
+    // if (!e.linkedSurvey) {
+    //   e.linkedSurvey =
+    //     this.contextService.webComponentsFilterSurvey[
+    //       this.contextService.webComponentsFilterSurvey.length - 1
+    //     ];
+    //   // Any time a new view is set, we update the surveySharedQuestions value with the questions from the new survey
+    //   const surveyQuestions: string[] = [];
+    //   this.contextService.webComponentsFilterSurvey.forEach((survey) => {
+    //     const otherSurveys =
+    //       this.contextService.webComponentsFilterSurvey.filter(
+    //         (sur) => !isEqual(sur, survey)
+    //       );
+    //     survey
+    //       .getAllQuestions()
+    //       // Get all questions from the survey to check that their question is not already set in the shared questions property
+    //       .filter((qu) => !surveyQuestions.includes(qu.name))
+    //       .forEach((qu) => {
+    //         let isFoundQuestion = false;
+    //         otherSurveys.forEach((sur) => {
+    //           if (
+    //             sur
+    //               .getAllQuestions()
+    //               .find((question) => question.name === qu.name)
+    //           ) {
+    //             isFoundQuestion = true;
+    //             return;
+    //           }
+    //         });
+    //         if (isFoundQuestion) {
+    //           surveyQuestions.push(qu.name);
+    //         }
+    //       });
+    //   });
+    //   this.surveySharedQuestions = Array.from(new Set(surveyQuestions));
+    // }
+    // // Reset data change trigger on component detach
+    // e.linkedSurvey?.setPropertyValue('refreshData', false);
+    // const newFilterValues: { [key: string]: any } = this.getViewFilterValue(
+    //   e.linkedSurvey
+    // );
+    // e.currentStateOfContextFilters = newFilterValues;
+    // e.lastStateOfContextFilters = e.currentStateOfContextFilters;
+    // }
     if (e.onDetach) {
       e.onDetach();
     }
   }
 
-  override ngOnDestroy(): void {
-    super.ngOnDestroy();
-    if (this.attachViewFilterTriggerListener) {
-      clearTimeout(this.attachViewFilterTriggerListener);
-    }
-  }
+  // override ngOnDestroy(): void {
+  //   super.ngOnDestroy();
+  //   if (this.attachViewFilterTriggerListener) {
+  //     clearTimeout(this.attachViewFilterTriggerListener);
+  //   }
+  // }
 }

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -423,11 +423,13 @@ export class ContextService {
   public initSurvey(structure: any): SurveyModel {
     const survey = this.formBuilderService.createSurvey(structure);
     // set each question value manually otherwise the defaultValueExpression is not loaded
-    forEach(this.filterValues.getValue(), (value, key) => {
-      if (survey.getQuestionByName(key)) {
-        survey.getQuestionByName(key).value = value;
-      }
-    });
+    if (!this.shadowDomService.isShadowRoot) {
+      forEach(this.filterValues.getValue(), (value, key) => {
+        if (survey.getQuestionByName(key)) {
+          survey.getQuestionByName(key).value = value;
+        }
+      });
+    }
 
     // prevent the default value from being applied when a question has been intentionally cleared
     const handleValueChanged = (sender: any, options: any) => {


### PR DESCRIPTION
# Description

- feat: avoid merge of current context filter value on survey first load for web-components 
- feat: disable share filters feature for dashboards in web-widgets

## Useful links

- Please insert link to ticket
- Please insert link to back-end branch if any
- Please insert any useful link ( documentation you used for example )

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
