### PR TITLE
Bugfix/ab#87992 SUI using automation and filtering can sometimes draw twice a layer

### DIFF
--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -875,7 +875,10 @@ export class Layer implements LayerModel {
     }
     this.rulesListener = (e) => {
       for (const rule of (map as any)._rules) {
-        this.dashboardAutomationService?.executeAutomationRule(rule, e);
+        this.dashboardAutomationService?.executeRuleQueue.next({
+          rule,
+          value: e,
+        });
       }
     };
 

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -332,7 +332,10 @@ export class MapComponent
             (this.map as any)._rules = [rule];
           }
           this.map.on('click', (e) => {
-            this.dashboardAutomationService?.executeAutomationRule(rule, e);
+            this.dashboardAutomationService?.executeRuleQueue.next({
+              rule,
+              value: e,
+            });
           });
         }
       }
@@ -1115,6 +1118,7 @@ export class MapComponent
 
   /** Set the new layers based on the filter value */
   private async filterLayers() {
+    this.contextService.areLayersFiltering.next(true);
     this.cancelRefresh$.next();
     const { layers: layersToGet, controls } = this.extractSettings();
 
@@ -1176,6 +1180,7 @@ export class MapComponent
             flatten(this.overlaysTree)
           );
         }
+        this.contextService.areLayersFiltering.next(false);
       });
   }
 

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -159,7 +159,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
         (rule: any) => rule.id === ruleTarget
       );
       if (rule) {
-        this.dashboardAutomationService?.executeAutomationRule(rule);
+        this.dashboardAutomationService?.executeRuleQueue.next({ rule });
       }
     }
 

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card-item-content/summary-card-item-content.component.ts
@@ -118,7 +118,7 @@ export class SummaryCardItemContentComponent
         (rule: any) => rule.id === ruleTarget
       );
       if (rule) {
-        this.dashboardAutomationService?.executeAutomationRule(rule);
+        this.dashboardAutomationService?.executeRuleQueue.next({ rule });
       }
     }
 

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -126,6 +126,14 @@ export class ContextService {
     return this.isFilterEnabled.asObservable();
   }
 
+  /** Used to update the state of map layers filtering state */
+  public areLayersFiltering = new BehaviorSubject<boolean>(false);
+
+  /** @returns  areLayersFiltering value as observable */
+  get areLayersFiltering$() {
+    return this.areLayersFiltering.asObservable();
+  }
+
   /** Current dashboard context */
   public context: {
     [key: string]: any;


### PR DESCRIPTION
# Description

- feat: add custom observable triggerSubscriptionOn in order to queue given rules from automation and hold them up in case layer filtering happens in one map, if not default case is send rule as it enters.
- refactor: replace execute rule methods as convenient in all the related components for the aforementioned reason

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/87992)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to video below

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/123092672/9b0da963-1a19-4438-9a33-bb467f7c92b7

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
