### PR TITLE
feat/AB#88032_ABC-disable-cross-page-filtering-in-the-app-builder-as-well

### DIFF
--- a/apps/back-office/src/app/app-preview/pages/dashboard/dashboard.component.ts
+++ b/apps/back-office/src/app/app-preview/pages/dashboard/dashboard.component.ts
@@ -70,6 +70,7 @@ export class DashboardComponent
     this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
       this.loading = true;
       this.id = params.id;
+      this.dashboardService.currentDashboardId = this.id;
       this.apollo
         .query<DashboardQueryResponse>({
           query: GET_DASHBOARD_BY_ID,

--- a/apps/back-office/src/app/application/application.component.ts
+++ b/apps/back-office/src/app/application/application.component.ts
@@ -7,6 +7,7 @@ import {
   ApplicationService,
   ConfirmService,
   UnsubscribeComponent,
+  ContextService,
 } from '@oort-front/shared';
 import get from 'lodash/get';
 import { takeUntil, map } from 'rxjs/operators';
@@ -49,13 +50,15 @@ export class ApplicationComponent
    * @param router Angular router
    * @param translate Angular translate service
    * @param confirmService Shared confirmation service
+   * @param contextService ContextService
    */
   constructor(
     private applicationService: ApplicationService,
     public route: ActivatedRoute,
     private router: Router,
     private translate: TranslateService,
-    private confirmService: ConfirmService
+    private confirmService: ConfirmService,
+    private contextService: ContextService
   ) {
     super();
     this.largeDevice = window.innerWidth > 1024;
@@ -270,12 +273,16 @@ export class ApplicationComponent
       return dialogRef.closed.pipe(
         map((confirm) => {
           if (confirm) {
+            // Clear any context filter history from current application
+            this.contextService.filterHistory.clear();
             return true;
           }
           return false;
         })
       );
     }
+    // Clear any context filter history from current application
+    this.contextService.filterHistory.clear();
     return true;
   }
 

--- a/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/dashboard/dashboard.component.ts
@@ -249,6 +249,7 @@ export class DashboardComponent
       .then(({ data }) => {
         if (data.dashboard) {
           this.id = data.dashboard.id || id;
+          this.dashboardService.currentDashboardId = this.id;
           this.dashboard = data.dashboard;
           this.gridOptions = {
             ...omit(this.gridOptions, ['gridType', 'minimumHeight']), // Prevent issue when gridType or minimumHeight was not set

--- a/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
+++ b/libs/shared/src/lib/components/dashboard-filter/dashboard-filter.component.ts
@@ -326,9 +326,7 @@ export class DashboardFilterComponent
     const currentSurveyQuestions = this.survey.getAllQuestions();
     const nextFilterValue: any = surveyData;
     // Don't merge current context filter values to the filter if survey has init and it's used in web component
-    if (
-      !(this.surveyInit && this.contextService.shadowDomService.isShadowRoot)
-    ) {
+    if (!this.surveyInit) {
       const currentFilterValue = this.contextService.filter.value;
       const filterKeys = Object.keys(currentFilterValue);
       filterKeys

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -36,6 +36,7 @@ import { ApplicationService } from '../application/application.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordQueryResponse } from '../../models/record.model';
 import { GET_RECORD_BY_ID } from './graphql/queries';
+import { DashboardService } from '../dashboard/dashboard.service';
 
 /**
  * Dashboard context service
@@ -139,6 +140,7 @@ export class ContextService {
    * @param applicationService Shared application service
    * @param router Angular router
    * @param {ShadowDomService} shadowDomService Shadow dom service containing the current DOM host
+   * @param dashboardService Shared dashboard service
    */
   constructor(
     private dialog: Dialog,
@@ -148,7 +150,8 @@ export class ContextService {
     private formBuilderService: FormBuilderService,
     private applicationService: ApplicationService,
     private router: Router,
-    public shadowDomService: ShadowDomService
+    public shadowDomService: ShadowDomService,
+    private dashboardService: DashboardService
   ) {
     this.filterPosition$.subscribe(
       (value: { position: FilterPosition; dashboardId: string } | null) => {
@@ -419,27 +422,26 @@ export class ContextService {
    */
   public initSurvey(structure: any): SurveyModel {
     const survey = this.formBuilderService.createSurvey(structure);
-    // Create unique identifier key using current question names
-    const surveyModelQuestions = JSON.stringify(
-      survey.getAllQuestions().map((qu) => qu.name) ?? {}
-    );
+
     if (!this.shadowDomService.isShadowRoot) {
-      if (this.filterHistory.has(surveyModelQuestions)) {
-        const previousSurveyValue =
-          this.filterHistory.get(surveyModelQuestions);
+      if (this.filterHistory.has(this.dashboardService.currentDashboardId)) {
+        const previousSurveyValue = this.filterHistory.get(
+          this.dashboardService.currentDashboardId
+        );
         survey.data = previousSurveyValue;
       } else {
-        this.filterHistory.set(surveyModelQuestions, {
+        this.filterHistory.set(this.dashboardService.currentDashboardId, {
           ...survey.data,
         });
       }
     }
     // prevent the default value from being applied when a question has been intentionally cleared
     const handleValueChanged = (sender: any, options: any) => {
-      if (this.filterHistory.has(surveyModelQuestions)) {
-        const previousSurveyValue =
-          this.filterHistory.get(surveyModelQuestions);
-        this.filterHistory.set(surveyModelQuestions, {
+      if (this.filterHistory.has(this.dashboardService.currentDashboardId)) {
+        const previousSurveyValue = this.filterHistory.get(
+          this.dashboardService.currentDashboardId
+        );
+        this.filterHistory.set(this.dashboardService.currentDashboardId, {
           ...previousSurveyValue,
           [options.name]: options.value,
         });

--- a/libs/shared/src/lib/services/dashboard/dashboard.service.ts
+++ b/libs/shared/src/lib/services/dashboard/dashboard.service.ts
@@ -31,6 +31,8 @@ export class DashboardService {
   public widgets: BehaviorSubject<any[]> = new BehaviorSubject<any[]>([]);
   /** Observable of current loaded dashboard widgets */
   public widgets$ = this.widgets.asObservable();
+  /** Current dashboard id in the view */
+  public currentDashboardId = '';
 
   /** @returns To listen when dashboard widgets that can be hidden refreshes its contents */
   get widgetContentRefreshed$(): Observable<any> {


### PR DESCRIPTION
# Description

- feat: add Map to set any filter values for each one of the dashboards of the application in the app builder, filters are set only for each dashboard now 
- feat: clean Map once the user exits application remove: filterValues$ observable as is not used

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/88032)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please refer to video below

## Screenshots


https://github.com/ReliefApplications/ems-frontend/assets/123092672/f1ffc6d8-5368-4f19-aba7-874921013953



# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
