### PR TITLE
bugfix/AB#88157_SUI-clicking-in-a-point-of-an-expanded-cluster-should-open-the-country-based-on-the-latitude-longitude-of-the-point

### DIFF
--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -880,7 +880,14 @@ export class Layer implements LayerModel {
         // If it's actually one of the features within the cluster, then take that one
         e.propagatedFrom.feature
       ) {
-        const { latitude, longitude } = e.propagatedFrom.feature.properties;
+        const latitude = get(
+          e.propagatedFrom.feature,
+          'geometry.coordinates[1]'
+        );
+        const longitude = get(
+          e.propagatedFrom.feature,
+          'geometry.coordinates[0]'
+        );
         event = { latlng: { lat: latitude, lng: longitude } };
       }
       for (const rule of (map as any)._rules) {

--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -874,8 +874,17 @@ export class Layer implements LayerModel {
       layer.off('clusterclick', this.rulesListener);
     }
     this.rulesListener = (e) => {
+      let event: any = e;
+      if (
+        get(this.layerDefinition, 'featureReduction.type') === 'cluster' &&
+        // If it's actually one of the features within the cluster, then take that one
+        e.propagatedFrom.feature
+      ) {
+        const { latitude, longitude } = e.propagatedFrom.feature.properties;
+        event = { latlng: { lat: latitude, lng: longitude } };
+      }
       for (const rule of (map as any)._rules) {
-        this.dashboardAutomationService?.executeAutomationRule(rule, e);
+        this.dashboardAutomationService?.executeAutomationRule(rule, event);
       }
     };
 


### PR DESCRIPTION
# Description

- feat: check if in cluster layers click event it's propagated from a child marker or just default layer, in the first case we will use the lat lng from the propagated marker, otherwise default event would be taken. This method it's easier than adding click events to all child markers, as we are handling just one event listener per marker groups, and there would be no conflict between cluster click or child marker click

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/88157)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please refer to video below

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/123092672/ed4523e7-d878-4c85-9271-2e602ef7764a

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
