### PR TITLE
Ab#90349 increase gridster max rows

### DIFF
--- a/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
+++ b/libs/shared/src/lib/components/widget-grid/widget-grid.component.ts
@@ -254,6 +254,7 @@ export class WidgetGridComponent
       minItemCols: 1, // min item number of columns
       minItemRows: 1, // min item number of rows
       minCols: this.colsNumber,
+      maxRows: Infinity,
       fixedRowHeight: 200,
       minimumHeight: 0,
       draggable: {


### PR DESCRIPTION
# Description

No more weird behaviour when number of rows would exceed 100.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/90349)
- [Please insert any useful link ( documentation you used for example )](https://github.com/tiberiuzuld/angular-gridster2/issues/455)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created a [dashboard](https://ems-safe-dev.who.int/backoffice/applications/661e21765784386b912f1447/dashboard/661e21785784386b912f17ab) with more than 100 rows in DEV  => buggy, not all widgets appear.
Works in local (drag and drop, resizing and widgets visible).

## Screenshots

![infinite_row_number](https://github.com/ReliefApplications/ems-frontend/assets/59645813/88e88e31-a970-4b71-a2ed-4cdf774755a6)

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
