### PR TITLE
Ab#89736 allow ignoring webmap default zoom

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1806,6 +1806,7 @@
 						"longitude": "Map center longitude",
 						"setByMap": "Set By Map",
 						"title": "Map Parameters",
+						"useWebmapZoom": "Use webmap default zoom",
 						"webmap": "WebMap",
 						"zoom": "Default zoom"
 					},

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1806,7 +1806,7 @@
 						"longitude": "Map center longitude",
 						"setByMap": "Set By Map",
 						"title": "Map Parameters",
-						"useWebmapZoom": "Use webmap default zoom",
+						"useWebMapInitialState": "Use WebMap initial state",
 						"webmap": "WebMap",
 						"zoom": "Default zoom"
 					},

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1819,7 +1819,7 @@
 						"longitude": "Longitude du centre de la carte",
 						"setByMap": "Utiliser la vue actuelle",
 						"title": "Affichage par défaut",
-						"useWebmapZoom": "Utiliser le zoom par défaut de la webmap",
+						"useWebMapInitialState": "Utiliser l'affichage par défaut de la webmap",
 						"webmap": "WebMap",
 						"zoom": "Zoom par défaut"
 					},

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1819,6 +1819,7 @@
 						"longitude": "Longitude du centre de la carte",
 						"setByMap": "Utiliser la vue actuelle",
 						"title": "Affichage par défaut",
+						"useWebmapZoom": "Utiliser le zoom par défaut de la webmap",
 						"webmap": "WebMap",
 						"zoom": "Zoom par défaut"
 					},

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1806,7 +1806,7 @@
 						"longitude": "******",
 						"setByMap": "******",
 						"title": "******",
-						"useWebmapZoom": "******",
+						"useWebMapInitialState": "******",
 						"webmap": "******",
 						"zoom": "******"
 					},

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1806,6 +1806,7 @@
 						"longitude": "******",
 						"setByMap": "******",
 						"title": "******",
+						"useWebmapZoom": "******",
 						"webmap": "******",
 						"zoom": "******"
 					},

--- a/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
+++ b/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
@@ -6,6 +6,7 @@ import * as L from 'leaflet';
 export interface MapConstructorSettings {
   title?: string;
   initialState: {
+    useWebmapZoom?: boolean;
     viewpoint: {
       center: {
         latitude: number;

--- a/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
+++ b/libs/shared/src/lib/components/ui/map/interfaces/map.interface.ts
@@ -6,7 +6,7 @@ import * as L from 'leaflet';
 export interface MapConstructorSettings {
   title?: string;
   initialState: {
-    useWebmapZoom?: boolean;
+    useWebMapInitialState?: boolean;
     viewpoint: {
       center: {
         latitude: number;

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -602,7 +602,7 @@ export class MapComponent
           this.setWebmap(settings.arcGisWebMap, {
             skipDefaultView:
               this.useContextZoom ||
-              !this.mapSettingsValue.initialState.useWebmapZoom,
+              !this.mapSettingsValue.initialState.useWebMapInitialState,
           })
         );
       } else {

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -600,7 +600,9 @@ export class MapComponent
         // Load arcgis webmap
         promises.push(
           this.setWebmap(settings.arcGisWebMap, {
-            skipDefaultView: this.useContextZoom,
+            skipDefaultView:
+              this.useContextZoom ||
+              !this.mapSettingsValue.initialState.useWebmapZoom,
           })
         );
       } else {

--- a/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
@@ -37,7 +37,7 @@ const DEFAULT_MAP: Nullable<MapConstructorSettings> = {
   title: null,
   basemap: null,
   initialState: {
-    useWebmapZoom: false,
+    useWebMapInitialState: true,
     viewpoint: {
       center: {
         latitude: 0,
@@ -542,11 +542,11 @@ export const createMapWidgetFormGroup = (id: any, value?: any): FormGroup => {
     id,
     title: [get(value, 'title', DEFAULT_MAP.title)],
     initialState: fb.group({
-      useWebmapZoom: [
+      useWebMapInitialState: [
         get(
           value,
-          'initialState.useWebmapZoom',
-          DEFAULT_MAP.initialState?.useWebmapZoom
+          'initialState.useWebMapInitialState',
+          DEFAULT_MAP.initialState?.useWebMapInitialState
         ),
       ],
       viewpoint: fb.group({

--- a/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
@@ -37,6 +37,7 @@ const DEFAULT_MAP: Nullable<MapConstructorSettings> = {
   title: null,
   basemap: null,
   initialState: {
+    useWebmapZoom: false,
     viewpoint: {
       center: {
         latitude: 0,
@@ -541,6 +542,13 @@ export const createMapWidgetFormGroup = (id: any, value?: any): FormGroup => {
     id,
     title: [get(value, 'title', DEFAULT_MAP.title)],
     initialState: fb.group({
+      useWebmapZoom: [
+        get(
+          value,
+          'initialState.useWebmapZoom',
+          DEFAULT_MAP.initialState?.useWebmapZoom
+        ),
+      ],
       viewpoint: fb.group({
         zoom: [
           get(

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -38,30 +38,47 @@
           <shared-webmap-select
             formControlName="arcGisWebMap"
           ></shared-webmap-select>
+          <ng-container
+            formGroupName="initialState"
+            *ngIf="form.controls.arcGisWebMap.value"
+          >
+            <ui-toggle formControlName="useWebmapZoom">
+              <ng-container ngProjectAs="label">
+                {{
+                  'components.widget.settings.map.properties.useWebmapZoom' | translate
+                }}
+              </ng-container>
+            </ui-toggle>
+          </ng-container>
           <ui-divider></ui-divider>
           <!-- Default view -->
           <div class="w-full" formGroupName="initialState">
             <div class="flex flex-col flex-1" formGroupName="viewpoint">
               <!-- Default zoom -->
-              <label class="flex gap-1 items-center">
-                {{
-                  'components.widget.settings.map.properties.zoom' | translate
-                }}
-                <ui-icon
-                  icon="info_outline"
-                  class="cursor-pointer"
-                  [uiTooltip]="
+              <ng-container
+                *ngIf="!form.controls.initialState.value.useWebmapZoom"
+              >
+                <label class="flex gap-1 items-center">
+                  {{
                     'components.widget.settings.map.properties.zoom' | translate
-                  "
-                  [size]="18"
-                  variant="grey"
-                ></ui-icon>
-              </label>
-              <ui-slider
-                formControlName="zoom"
-                [minValue]="2"
-                [maxValue]="18"
-              ></ui-slider>
+                  }}
+                  <ui-icon
+                    icon="info_outline"
+                    class="cursor-pointer"
+                    [uiTooltip]="
+                      'components.widget.settings.map.tooltip.default.zoom'
+                        | translate
+                    "
+                    [size]="18"
+                    variant="grey"
+                  ></ui-icon>
+                </label>
+                <ui-slider
+                  formControlName="zoom"
+                  [minValue]="2"
+                  [maxValue]="18"
+                ></ui-slider>
+              </ng-container>
               <div formGroupName="center" class="flex flex-wrap gap-2 mt-2">
                 <!-- Default latitude -->
                 <div

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -42,22 +42,23 @@
             formGroupName="initialState"
             *ngIf="form.controls.arcGisWebMap.value"
           >
-            <ui-toggle formControlName="useWebmapZoom">
+            <ui-toggle formControlName="useWebMapInitialState">
               <ng-container ngProjectAs="label">
                 {{
-                  'components.widget.settings.map.properties.useWebmapZoom' | translate
+                  'components.widget.settings.map.properties.useWebMapInitialState'
+                    | translate
                 }}
               </ng-container>
             </ui-toggle>
           </ng-container>
           <ui-divider></ui-divider>
           <!-- Default view -->
-          <div class="w-full" formGroupName="initialState">
-            <div class="flex flex-col flex-1" formGroupName="viewpoint">
-              <!-- Default zoom -->
-              <ng-container
-                *ngIf="!form.controls.initialState.value.useWebmapZoom"
-              >
+          <ng-container
+            *ngIf="!form.controls.initialState.value.useWebMapInitialState"
+          >
+            <div class="w-full" formGroupName="initialState">
+              <div class="flex flex-col flex-1" formGroupName="viewpoint">
+                <!-- Default zoom -->
                 <label class="flex gap-1 items-center">
                   {{
                     'components.widget.settings.map.properties.zoom' | translate
@@ -78,83 +79,85 @@
                   [minValue]="2"
                   [maxValue]="18"
                 ></ui-slider>
-              </ng-container>
-              <div formGroupName="center" class="flex flex-wrap gap-2 mt-2">
-                <!-- Default latitude -->
-                <div
-                  [uiErrorMessage]="
-                    'components.widget.settings.map.errors.latitude' | translate
-                  "
-                  [uiErrorMessageIf]="
-                    form.get('initialState.viewpoint.center.latitude')!.errors
-                  "
-                  uiFormFieldDirective
-                  class="flex-1"
-                >
-                  <label>
-                    {{
-                      'components.widget.settings.map.properties.latitude'
-                        | translate
-                    }}
-                  </label>
-                  <input type="number" formControlName="latitude" />
-                  <ui-icon
-                    uiSuffix
-                    icon="info_outline"
-                    class="cursor-pointer"
-                    [size]="18"
-                    variant="grey"
-                    [uiTooltip]="
-                      'components.widget.settings.map.tooltip.default.latitude'
+                <div formGroupName="center" class="flex flex-wrap gap-2 mt-2">
+                  <!-- Default latitude -->
+                  <div
+                    [uiErrorMessage]="
+                      'components.widget.settings.map.errors.latitude'
                         | translate
                     "
-                  ></ui-icon>
-                </div>
-                <!-- Default longitude -->
-                <div
-                  [uiErrorMessage]="
-                    'components.widget.settings.map.errors.longitude'
-                      | translate
-                  "
-                  [uiErrorMessageIf]="
-                    form.get('initialState.viewpoint.center.longitude')!.errors
-                  "
-                  uiFormFieldDirective
-                  class="flex-1"
-                >
-                  <label>
-                    {{
-                      'components.widget.settings.map.properties.longitude'
-                        | translate
-                    }}
-                  </label>
-                  <input type="number" formControlName="longitude" />
-                  <ui-icon
-                    uiSuffix
-                    icon="info_outline"
-                    class="cursor-pointer"
-                    [size]="18"
-                    variant="grey"
-                    [uiTooltip]="
-                      'components.widget.settings.map.tooltip.default.longitude'
+                    [uiErrorMessageIf]="
+                      form.get('initialState.viewpoint.center.latitude')!.errors
+                    "
+                    uiFormFieldDirective
+                    class="flex-1"
+                  >
+                    <label>
+                      {{
+                        'components.widget.settings.map.properties.latitude'
+                          | translate
+                      }}
+                    </label>
+                    <input type="number" formControlName="latitude" />
+                    <ui-icon
+                      uiSuffix
+                      icon="info_outline"
+                      class="cursor-pointer"
+                      [size]="18"
+                      variant="grey"
+                      [uiTooltip]="
+                        'components.widget.settings.map.tooltip.default.latitude'
+                          | translate
+                      "
+                    ></ui-icon>
+                  </div>
+                  <!-- Default longitude -->
+                  <div
+                    [uiErrorMessage]="
+                      'components.widget.settings.map.errors.longitude'
                         | translate
                     "
-                  ></ui-icon>
+                    [uiErrorMessageIf]="
+                      form.get('initialState.viewpoint.center.longitude')!
+                        .errors
+                    "
+                    uiFormFieldDirective
+                    class="flex-1"
+                  >
+                    <label>
+                      {{
+                        'components.widget.settings.map.properties.longitude'
+                          | translate
+                      }}
+                    </label>
+                    <input type="number" formControlName="longitude" />
+                    <ui-icon
+                      uiSuffix
+                      icon="info_outline"
+                      class="cursor-pointer"
+                      [size]="18"
+                      variant="grey"
+                      [uiTooltip]="
+                        'components.widget.settings.map.tooltip.default.longitude'
+                          | translate
+                      "
+                    ></ui-icon>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <!-- Use map to set properties -->
-          <ui-button
-            class="self-end flex-1"
-            (click)="onSetByMap()"
-            category="secondary"
-            variant="primary"
-          >
-            {{
-              'components.widget.settings.map.properties.setByMap' | translate
-            }}
-          </ui-button>
+            <!-- Use map to set properties -->
+            <ui-button
+              class="self-end flex-1"
+              (click)="onSetByMap()"
+              category="secondary"
+              variant="primary"
+            >
+              {{
+                'components.widget.settings.map.properties.setByMap' | translate
+              }}
+            </ui-button>
+          </ng-container>
           <div class="flex flex-col gap-2 mt-2">
             <div class="flex justify-between">
               <h3>

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.module.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.module.ts
@@ -11,6 +11,7 @@ import {
   DividerModule,
   CheckboxModule,
   AlertModule,
+  ToggleModule,
 } from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { MapControlsModule } from './map-controls/map-controls.module';
@@ -45,6 +46,7 @@ import { PortalModule } from '@angular/cdk/portal';
     ErrorMessageModule,
     PortalModule,
     AlertModule,
+    ToggleModule,
   ],
   exports: [MapPropertiesComponent],
 })


### PR DESCRIPTION
# Description

When webmap selected, toggle to check whether we want to use its default zoom. If true, disables the default zoom slider.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/89736/)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Created map with 'Test priority country' webmap.

## Screenshots

![toggleWebMapZoom](https://github.com/ReliefApplications/ems-frontend/assets/59645813/cd2220f5-4ab3-4801-9f45-61b89437c79b)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
