### PR TITLE
Ab#90645 default position for map and minor UI

### DIFF
--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-controls/map-controls.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-controls/map-controls.component.html
@@ -75,6 +75,7 @@
     <ui-button
       uiSuffix
       (click)="this.form.get('lastUpdate')?.setValue(null);"
+      *ngIf="this.form.get('lastUpdate')?.value"
       [isIcon]="true"
       icon="close"
       variant="danger"

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -54,7 +54,10 @@
           <ui-divider></ui-divider>
           <!-- Default view -->
           <ng-container
-            *ngIf="!form.controls.initialState.value.useWebMapInitialState"
+            *ngIf="
+              !form.controls.arcGisWebMap.value ||
+              !form.controls.initialState.value.useWebMapInitialState
+            "
           >
             <div class="w-full" formGroupName="initialState">
               <div class="flex flex-col flex-1" formGroupName="viewpoint">

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/webmap-select/webmap-select.component.html
@@ -19,6 +19,7 @@
   <ui-button
     uiSuffix
     (click)="selectionOnChange(null); $event.stopPropagation()"
+    *ngIf="ngControl.control?.value"
     [isIcon]="true"
     icon="close"
     variant="danger"


### PR DESCRIPTION
# Description

Remove cross button for two controls when no value.
Re allow default position when no webmap

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/90645)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create map and go brrr.

## Screenshots

![image](https://github.com/ReliefApplications/ems-frontend/assets/59645813/632e7318-c9e0-404d-a5c7-40cf0409dddd)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
