### PR TITLE
AB Email Notification - Permissions

### DIFF
--- a/apps/back-office/src/app/app-preview/app-preview.component.ts
+++ b/apps/back-office/src/app/app-preview/app-preview.component.ts
@@ -51,6 +51,18 @@ const getAbilityForAppPreview = (app: Application, role: string) => {
     can(['create', 'read', 'update', 'delete', 'manage'], 'CustomNotification');
   }
 
+  // === Email Notifications ===
+  if (permissions.includes('can_see_email_notifications')) {
+    can('read', 'EmailNotification');
+  }
+  if (permissions.includes('can_manage_email_notifications')) {
+    can(['update', 'delete'], 'EmailNotification');
+  }
+
+  if (permissions.includes('can_create_email_notifications')) {
+    can('create', 'EmailNotification');
+  }
+
   return new AppAbility(rules);
 };
 
@@ -156,7 +168,25 @@ export class AppPreviewComponent
                 visible: x.visible ?? false,
               })) || [];
           const adminNavItems: any[] = [];
-          if (ability.can('manage', 'Template')) {
+          this.sideMenu = this.application?.sideMenu ?? true;
+          this.hideMenu = this.application?.hideMenu ?? false;
+          if (ability.can('read', 'User')) {
+            adminNavItems.push({
+              name: this.translate.instant('common.user.few'),
+              path: './settings/users',
+              icon: 'supervisor_account',
+              visible: true,
+            });
+          }
+          if (ability.can('read', 'Role')) {
+            adminNavItems.push({
+              name: this.translate.instant('common.role.few'),
+              path: './settings/roles',
+              icon: 'admin_panel_settings',
+              visible: true,
+            });
+          }
+          if (ability.can('read', 'EmailNotification')) {
             adminNavItems.push({
               name: this.translate.instant('common.email.notification.few'),
               path: './settings/email-notifications',

--- a/apps/back-office/src/app/application/application.component.ts
+++ b/apps/back-office/src/app/application/application.component.ts
@@ -7,6 +7,7 @@ import {
   ApplicationService,
   ConfirmService,
   UnsubscribeComponent,
+  AppAbility,
 } from '@oort-front/shared';
 import get from 'lodash/get';
 import { takeUntil, map } from 'rxjs/operators';
@@ -49,13 +50,15 @@ export class ApplicationComponent
    * @param router Angular router
    * @param translate Angular translate service
    * @param confirmService Shared confirmation service
+   * @param ability Shared app ability service
    */
   constructor(
     private applicationService: ApplicationService,
     public route: ActivatedRoute,
     private router: Router,
     private translate: TranslateService,
-    private confirmService: ConfirmService
+    private confirmService: ConfirmService,
+    private ability: AppAbility
   ) {
     super();
     this.largeDevice = window.innerWidth > 1024;
@@ -98,62 +101,62 @@ export class ApplicationComponent
                 },
               })) || [];
           if (application.canUpdate) {
-            this.adminNavItems = [
-              {
-                name: this.translate.instant('common.settings'),
-                path: './settings/edit',
-                icon: 'settings',
-              },
-              {
-                name: this.translate.instant('common.template.few'),
-                path: './settings/templates',
-                icon: 'description',
-                legacy: true,
-              },
-              {
-                name: this.translate.instant('common.distributionList.few'),
-                path: './settings/distribution-lists',
-                icon: 'mail',
-                legacy: true,
-              },
-              // {
-              //   name: this.translate.instant('common.customNotification.few'),
-              //   path: './settings/notifications',
-              //   icon: 'schedule_send',
-              // },
-              {
-                name: this.translate.instant('common.user.few'),
-                path: './settings/users',
-                icon: 'supervisor_account',
-              },
-              {
-                name: this.translate.instant('common.role.few'),
-                path: './settings/roles',
-                icon: 'verified_user',
-              },
-              {
-                name: this.translate.instant(
-                  'pages.application.positionAttributes.title'
-                ),
-                path: './settings/position',
-                icon: 'edit_attributes',
-              },
-              {
+            this.adminNavItems.push({
+              name: this.translate.instant('common.settings'),
+              path: './settings/edit',
+              icon: 'settings',
+            });
+            this.adminNavItems.push({
+              name: this.translate.instant('common.template.few'),
+              path: './settings/templates',
+              icon: 'description',
+              legacy: true,
+            });
+            this.adminNavItems.push({
+              name: this.translate.instant('common.distributionList.few'),
+              path: './settings/distribution-lists',
+              icon: 'mail',
+              legacy: true,
+            });
+            // {
+            //   name: this.translate.instant('common.customNotification.few'),
+            //   path: './settings/notifications',
+            //   icon: 'schedule_send',
+            // },
+            this.adminNavItems.push({
+              name: this.translate.instant('common.user.few'),
+              path: './settings/users',
+              icon: 'supervisor_account',
+            });
+            this.adminNavItems.push({
+              name: this.translate.instant('common.role.few'),
+              path: './settings/roles',
+              icon: 'verified_user',
+            });
+            this.adminNavItems.push({
+              name: this.translate.instant(
+                'pages.application.positionAttributes.title'
+              ),
+              path: './settings/position',
+              icon: 'edit_attributes',
+            });
+            if (this.ability.can('read', 'EmailNotification')) {
+              this.adminNavItems.push({
                 name: this.translate.instant('common.email.notification.few'),
                 path: './settings/email-notifications',
                 icon: 'mail',
-              },
-              {
-                name: this.translate.instant('common.channel.few'),
-                path: './settings/channels',
-                icon: 'dns',
-              },
-              {
-                name: this.translate.instant('common.subscription.few'),
-                path: './settings/subscriptions',
-                icon: 'add_to_queue',
-              },
-            ];
+              });
+            }
+            this.adminNavItems.push({
+              name: this.translate.instant('common.channel.few'),
+              path: './settings/channels',
+              icon: 'dns',
+            });
+            this.adminNavItems.push({
+              name: this.translate.instant('common.subscription.few'),
+              path: './settings/subscriptions',
+              icon: 'add_to_queue',
+            });
           }
           if (application.canUpdate) {
             this.adminNavItems.push({

--- a/libs/shared/src/lib/components/email/components/ems-template/ems-template.component.ts
+++ b/libs/shared/src/lib/components/email/components/ems-template/ems-template.component.ts
@@ -302,7 +302,7 @@ export class EmsTemplateComponent implements OnInit, OnDestroy {
    * Submission for sending and saving emails
    */
   saveAndSend(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       if (Object.keys(this.emailService.datasetsForm.value).length) {
         this.emailService.datasetsForm?.value?.dataSets?.forEach(
           (data: any) => {
@@ -344,19 +344,61 @@ export class EmsTemplateComponent implements OnInit, OnDestroy {
           }
           this.emailService
             .editEmailNotification(this.emailService.editId, queryData)
-            .subscribe((res) => {
-              this.emailService.configId =
-                res.data?.editAndGetEmailNotification?.id;
-              resolve();
-            }, reject);
+            .subscribe({
+              next: ({ errors, data }) => {
+                if (errors) {
+                  this.snackBar.openSnackBar(
+                    this.translate.instant(
+                      'common.notifications.objectNotUpdated',
+                      {
+                        type: this.translate.instant(
+                          'common.email.notification.one'
+                        ),
+                        error: errors ? errors[0].message : '',
+                      }
+                    ),
+                    { error: true }
+                  );
+                } else {
+                  if (data) {
+                    this.emailService.configId =
+                      data.editAndGetEmailNotification?.id;
+                    resolve();
+                  }
+                }
+              },
+              error: (err) => {
+                this.snackBar.openSnackBar(err.message, { error: true });
+              },
+            });
         } else {
           // For email notification create operation.
-          this.emailService
-            .addEmailNotification(queryData)
-            .subscribe((res: any) => {
-              this.emailService.configId = res.data?.addEmailNotification?.id;
-              resolve();
-            }, reject);
+          this.emailService.addEmailNotification(queryData).subscribe({
+            next: ({ errors, data }) => {
+              if (errors) {
+                this.snackBar.openSnackBar(
+                  this.translate.instant(
+                    'common.notifications.objectNotCreated',
+                    {
+                      type: this.translate
+                        .instant('common.email.notification.one')
+                        .toLowerCase(),
+                      error: errors ? errors[0].message : '',
+                    }
+                  ),
+                  { error: true }
+                );
+              } else {
+                if (data) {
+                  this.emailService.configId = data.addEmailNotification?.id;
+                  resolve();
+                }
+              }
+            },
+            error: (err) => {
+              this.snackBar.openSnackBar(err.message, { error: true });
+            },
+          });
         }
       } else {
         resolve();
@@ -405,30 +447,76 @@ export class EmsTemplateComponent implements OnInit, OnDestroy {
         }
         this.emailService
           .editEmailNotification(this.emailService.editId, queryData)
-          .subscribe((res: any) => {
-            this.emailService.isEdit = false;
-            this.emailService.editId = '';
-            this.emailService.configId =
-              res.data.editAndGetEmailNotification.id;
-            this.snackBar.openSnackBar(
-              this.translate.instant('pages.application.settings.emailEdited')
-            );
-            this.emailService.datasetsForm.reset();
-            this.navigateToEms.emit();
+          .subscribe({
+            next: ({ errors, data }) => {
+              if (errors) {
+                this.snackBar.openSnackBar(
+                  this.translate.instant(
+                    'common.notifications.objectNotUpdated',
+                    {
+                      type: this.translate.instant(
+                        'common.email.notification.one'
+                      ),
+                      error: errors ? errors[0].message : '',
+                    }
+                  ),
+                  { error: true }
+                );
+              } else {
+                if (data) {
+                  this.emailService.isEdit = false;
+                  this.emailService.editId = '';
+                  this.emailService.configId =
+                    data.editAndGetEmailNotification.id;
+                  this.snackBar.openSnackBar(
+                    this.translate.instant(
+                      'pages.application.settings.emailEdited'
+                    )
+                  );
+                  this.emailService.datasetsForm.reset();
+                  this.navigateToEms.emit();
+                }
+              }
+            },
+            error: (err) => {
+              this.snackBar.openSnackBar(err.message, { error: true });
+            },
           });
       } else {
         // For email notification create operation.
-        this.emailService
-          .addEmailNotification(queryData)
-          .subscribe((res: any) => {
-            this.emailService.configId = res.data.addEmailNotification.id;
+        this.emailService.addEmailNotification(queryData).subscribe({
+          next: ({ errors, data }) => {
+            if (errors) {
+              this.snackBar.openSnackBar(
+                this.translate.instant(
+                  'common.notifications.objectNotCreated',
+                  {
+                    type: this.translate
+                      .instant('common.email.notification.one')
+                      .toLowerCase(),
+                    error: errors ? errors[0].message : '',
+                  }
+                ),
+                { error: true }
+              );
+            } else {
+              if (data) {
+                this.emailService.configId = data.addEmailNotification.id;
 
-            this.snackBar.openSnackBar(
-              this.translate.instant('pages.application.settings.emailCreated')
-            );
-            this.emailService.datasetsForm.reset();
-            this.navigateToEms.emit();
-          });
+                this.snackBar.openSnackBar(
+                  this.translate.instant(
+                    'pages.application.settings.emailCreated'
+                  )
+                );
+                this.emailService.datasetsForm.reset();
+                this.navigateToEms.emit();
+              }
+            }
+          },
+          error: (err) => {
+            this.snackBar.openSnackBar(err.message, { error: true });
+          },
+        });
       }
     }
   }

--- a/libs/shared/src/lib/components/email/email.component.html
+++ b/libs/shared/src/lib/components/email/email.component.html
@@ -17,13 +17,14 @@
   </div>
 
   <ui-button
-    icon="add"
-    category="secondary"
-    variant="primary"
-    (click)="toggle(true)"
-  >
-    {{ 'components.email.notification.create' | translate }}
-  </ui-button>
+      icon="add"
+      category="secondary"
+      variant="primary"
+      (click)="toggle(true)"
+      *ngIf="this.ability.can('create', 'EmailNotification')"
+    >
+    {{  'components.email.notification.create' | translate  }}
+    </ui-button>
 </div>
 
 <div *ngIf="emailService.isExisting">
@@ -32,28 +33,28 @@
       <ng-container ngProjectAs="label">{{
         'components.email.notification.list' | translate
       }}</ng-container>
-      <div class="mt-4 overflow-x-hidden shadow-2lg">
-        <ng-container *ngIf="emailNotifications?.length; else emptyTmpl">
-          <div class="overflow-x-auto">
-            <table cdk-table uiTableWrapper [dataSource]="emailNotifications">
-              <ng-container cdkColumnDef="name">
-                <th uiCellHeader *cdkHeaderCellDef scope="col">
-                  <span class="headerTitle">
-                    {{ 'common.name' | translate }}
-                  </span>
-                </th>
-                <td uiCell *cdkCellDef="let element" class="max-w-[30vw]">
-                  {{ element.name }}
-                </td>
-              </ng-container>
-              <ng-container cdkColumnDef="alerttype">
-                <th uiCellHeader *cdkHeaderCellDef scope="col">
-                  <span class="headerTitle">
-                    {{ 'components.email.notification.type' | translate }}
-                  </span>
-                </th>
-                <td uiCell *cdkCellDef="let element">
-                  <button
+        <div class="mt-4 overflow-x-hidden shadow-2lg">
+          <ng-container *ngIf="emailNotifications?.length && this.ability.can('read', 'EmailNotification'); else emptyTmpl">
+            <div class="overflow-x-auto">
+              <table cdk-table uiTableWrapper [dataSource]="emailNotifications">
+                <ng-container cdkColumnDef="name">
+                  <th uiCellHeader *cdkHeaderCellDef scope="col">
+                    <span class="headerTitle">
+                      {{ 'common.name' | translate }}
+                    </span>
+                  </th>
+                  <td uiCell *cdkCellDef="let element" class="max-w-[30vw]">
+                    {{ element.name }}
+                  </td>
+                </ng-container>
+                <ng-container cdkColumnDef="alerttype">
+                  <th uiCellHeader *cdkHeaderCellDef scope="col">
+                    <span class="headerTitle">
+                      {{'components.email.notification.type' | translate}}
+                    </span>
+                  </th>
+                  <td uiCell *cdkCellDef="let element">
+                    <button
                     type="button"
                     class="cursor-text py-0.5 px-2 font-medium text-blue-600 rounded-full flex focus:ring-4 bg-blue-50 dark:border-blue-500"
                   >
@@ -76,90 +77,92 @@
                 </td>
               </ng-container>
 
-              <ng-container cdkColumnDef="createdby">
-                <th uiCellHeader *cdkHeaderCellDef scope="col">
-                  <span class="headerTitle">
-                    {{ 'models.customNotification.lastExecution' | translate }}
-                  </span>
-                </th>
-                <td uiCell *cdkCellDef="let element">
-                  {{ element?.createdBy?.name }}
-                </td>
-              </ng-container>
+                <ng-container cdkColumnDef="createdby">
+                  <th uiCellHeader *cdkHeaderCellDef scope="col">
+                    <span class="headerTitle">
+                      {{ 'models.customNotification.lastExecution' | translate }}
+                    </span>
+                  </th>
+                  <td uiCell *cdkCellDef="let element">
+                    {{element?.createdBy?.name}}
+                  </td>
+                </ng-container>
 
-              <ng-container cdkColumnDef="actions" [stickyEnd]="true">
-                <th
-                  uiCellHeader
-                  *cdkHeaderCellDef
-                  scope="col"
-                  class="w-16"
-                ></th>
-                <td uiCell *cdkCellDef="let element" class="flex items-center">
-                  <ng-container>
-                    <ui-button
-                      [variant]="'grey'"
-                      class="hide-icons hover:text-primary-600"
-                      [isIcon]="true"
-                      size="large"
-                      (click)="sendEmailList(element)"
-                      [icon]="'forward_to_inbox'"
-                      [uiTooltip]="'Send Email'"
-                    >
-                    </ui-button>
+                <div *ngIf="this.ability.can('update', 'EmailNotification'); else elseBlock">
+                  <ng-container cdkColumnDef="actions" [stickyEnd]="true">
+                    <th uiCellHeader *cdkHeaderCellDef scope="col" class="w-16"></th>
+                    <td uiCell *cdkCellDef="let element" class="flex items-center">
+                      <ng-container>
+                          <ui-button
+                            [variant]="'grey'"
+                            class="hide-icons hover:text-primary-600"
+                            [isIcon]="true"
+                            size="large"
+                            (click)="sendEmailList(element)"
+                            [icon]="'forward_to_inbox'"
+                            [uiTooltip]="'Send Email'"
+                          >
+                        </ui-button>
 
-                    <ui-button
-                      [variant]="'grey'"
-                      class="hide-icons hover:text-primary-600"
-                      [isIcon]="true"
-                      size="large"
-                      (click)="getEmailNotificationById(element.id)"
-                      [icon]="'edit'"
-                      [uiTooltip]="'Edit'"
-                    >
-                    </ui-button>
+                        <ui-button
+                            [variant]="'grey'"
+                            class="hide-icons hover:text-primary-600"
+                            [isIcon]="true"
+                            size="large"
+                            (click)="getEmailNotificationById(element.id)"
+                            [icon]="'edit'"
+                            [uiTooltip]="'Edit'"
+                          >
+                        </ui-button>
 
-                    <ui-button
-                      [variant]="'grey'"
-                      class="hide-icons hover:text-primary-600"
-                      [isIcon]="true"
-                      size="large"
-                      (click)="cloneEmailNotification(element)"
-                      [icon]="'content_copy'"
-                      [uiTooltip]="'Clone'"
-                    >
-                    </ui-button>
+                        <ui-button
+                            [variant]="'grey'"
+                            class="hide-icons hover:text-primary-600"
+                            [isIcon]="true"
+                            size="large"
+                            (click)="cloneEmailNotification(element)"
+                            [icon]="'content_copy'"
+                            [uiTooltip]="'Clone'"
+                          >
+                        </ui-button>
 
-                    <ui-button
-                      [variant]="'danger'"
-                      class="hide-icons hover:text-primary-600"
-                      [isIcon]="true"
-                      size="large"
-                      (click)="deleteEmailNotification(element)"
-                      [icon]="'delete'"
-                      [uiTooltip]="'Delete'"
-                    >
-                    </ui-button>
+                        <ui-button
+                            [variant]="'danger'"
+                            class="hide-icons hover:text-primary-600"
+                            [isIcon]="true"
+                            size="large"
+                            (click)="deleteEmailNotification(element)"
+                            [icon]="'delete'"
+                            [uiTooltip]="'Delete'"
+                          >
+                        </ui-button>
+                      </ng-container>
+                    </td>
                   </ng-container>
-                </td>
-              </ng-container>
+                </div>
 
-              <tr cdk-header-row *cdkHeaderRowDef="displayedColumns"></tr>
-              <tr cdk-row *cdkRowDef="let row; columns: displayedColumns"></tr>
-            </table>
-          </div>
-          <!-- Pagination -->
-          <ui-paginator
-            [disabled]="emailService.emailListLoading"
-            [pageIndex]="pageInfo.pageIndex"
-            [pageSize]="pageInfo.pageSize"
-            [pageSizeOptions]="[5, 10, 25, 50]"
-            [totalItems]="pageInfo.length"
-            [ariaLabel]="
-              'components.notifications.paginator.ariaLabel' | translate
-            "
-            (pageChange)="onPage($event)"
-          >
-          </ui-paginator>
+                <ng-template #elseBlock>
+                  <ng-container cdkColumnDef="actions" [stickyEnd]="true">
+                    <th uiCellHeader *cdkHeaderCellDef scope="col" class="w-16"></th>
+                    <td uiCell *cdkCellDef="let element" class="flex items-center"></td>
+                  </ng-container>
+                </ng-template>
+
+                <tr cdk-header-row *cdkHeaderRowDef="displayedColumns"></tr>
+                <tr cdk-row *cdkRowDef="let row; columns: displayedColumns"></tr>
+              </table>
+            </div>
+            <!-- Pagination -->
+              <ui-paginator
+              [disabled]="emailService.emailListLoading"
+              [pageIndex]="pageInfo.pageIndex"
+              [pageSize]="pageInfo.pageSize"
+              [pageSizeOptions]="[5, 10, 25, 50]"
+              [totalItems]="pageInfo.length"
+              [ariaLabel]="'components.notifications.paginator.ariaLabel' | translate"
+              (pageChange)="onPage($event)"
+            >
+            </ui-paginator>
         </ng-container>
         <ng-template #emptyTmpl>
           <!-- Empty indicator -->

--- a/libs/shared/src/lib/components/email/email.component.ts
+++ b/libs/shared/src/lib/components/email/email.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { EmailService } from './email.service';
 import { ApplicationService } from '../../services/application/application.service';
 import { UnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component';
+import { SnackbarService } from '@oort-front/ui';
 import {
   AbstractControl,
   FormArray,
@@ -13,7 +14,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { takeUntil } from 'rxjs';
 import { UIPageChangeEvent, handleTablePageEvent } from '@oort-front/ui';
 import { ApiConfiguration } from '../../models/api-configuration.model';
-import { AuthService } from '../../services/auth/auth.service';
+import { AppAbility, AuthService } from '../../services/auth/auth.service';
 import { DownloadService } from '../../services/download/download.service';
 
 /** Default number of items per request for pagination */
@@ -69,19 +70,23 @@ export class EmailComponent extends UnsubscribeComponent implements OnInit {
    * @param emailService The service for handling emails.
    * @param applicationService The service for handling applications.
    * @param formBuilder The builder for creating forms.
+   * @param snackBar Shared snackbar service.
    * @param confirmService The service for confirmation dialogs.
    * @param translate The service for translation.
    * @param authService The service for authentication.
    * @param downloadService The service for downloading files.
+   * @param ability The app ability
    */
   constructor(
     public emailService: EmailService,
     public applicationService: ApplicationService,
     public formBuilder: FormBuilder,
+    private snackBar: SnackbarService,
     private confirmService: ConfirmService,
     private translate: TranslateService,
     public authService: AuthService,
-    public downloadService: DownloadService
+    public downloadService: DownloadService,
+    public ability: AppAbility
   ) {
     super();
   }
@@ -606,15 +611,37 @@ export class EmailComponent extends UnsubscribeComponent implements OnInit {
     });
     dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value: any) => {
       if (value) {
-        this.emailService.emailListLoading = true;
         this.emailService
           .deleteEmailNotification(data.id, this.applicationId)
-          .subscribe(() => {
-            this.distributionLists = [];
-            this.emailNotifications = [];
-            this.templateActualData = [];
-            this.filterTemplateData = [];
-            this.getExistingTemplate();
+          .subscribe({
+            next: ({ errors, data }) => {
+              if (errors) {
+                this.snackBar.openSnackBar(
+                  this.translate.instant(
+                    'common.notifications.objectNotDeleted',
+                    {
+                      type: this.translate.instant(
+                        'common.email.notification.one'
+                      ),
+                      error: errors ? errors[0].message : '',
+                    }
+                  ),
+                  { error: true }
+                );
+              } else {
+                if (data) {
+                  this.emailService.emailListLoading = true;
+                  this.distributionLists = [];
+                  this.emailNotifications = [];
+                  this.templateActualData = [];
+                  this.filterTemplateData = [];
+                  this.getExistingTemplate();
+                }
+              }
+            },
+            error: (err) => {
+              this.snackBar.openSnackBar(err.message, { error: true });
+            },
           });
       }
     });

--- a/libs/shared/src/lib/components/email/email.service.ts
+++ b/libs/shared/src/lib/components/email/email.service.ts
@@ -732,10 +732,12 @@ export class EmailService {
    * @returns The edited Email notification.
    */
   editEmailNotification(id: string, data: any) {
+    const applicationId = data.applicationId;
     return this.apollo.query<any>({
       query: GET_AND_UPDATE_EMAIL_NOTIFICATION,
       variables: {
         notification: data,
+        applicationId: applicationId,
         editEmailNotificationId: id,
       },
     });
@@ -757,6 +759,7 @@ export class EmailService {
           applicationId: applicationId,
         },
         editEmailNotificationId: id,
+        applicationId: applicationId,
       },
     });
   }

--- a/libs/shared/src/lib/components/email/graphql/queries.ts
+++ b/libs/shared/src/lib/components/email/graphql/queries.ts
@@ -147,10 +147,12 @@ export const ADD_EMAIL_NOTIFICATION = gql`
 export const GET_AND_UPDATE_EMAIL_NOTIFICATION = gql`
   mutation EditEmailNotification(
     $editEmailNotificationId: ID!
+    $applicationId: ID!
     $notification: EmailNotificationInputType
   ) {
     editAndGetEmailNotification(
       id: $editEmailNotificationId
+      application: $applicationId
       notification: $notification
     ) {
       createdAt

--- a/libs/shared/src/lib/components/role-summary/role-summary.component.ts
+++ b/libs/shared/src/lib/components/role-summary/role-summary.component.ts
@@ -82,5 +82,8 @@ export class RoleSummaryComponent implements OnInit {
           this.loading = loading;
         }
       });
+
+    // Reload window to update permissions of user.
+    window.location.reload();
   }
 }

--- a/libs/shared/src/lib/components/roles/components/role-list/role-list.component.ts
+++ b/libs/shared/src/lib/components/roles/components/role-list/role-list.component.ts
@@ -146,6 +146,9 @@ export class RoleListComponent extends UnsubscribeComponent implements OnInit {
       if (value) {
         if (this.inApplication) {
           this.applicationService.addRole(value);
+
+          // Reload window to update roles list & application menu.
+          window.location.reload();
         } else {
           this.apollo
             .mutate<AddRoleMutationResponse>({

--- a/libs/shared/src/lib/services/auth/auth.service.ts
+++ b/libs/shared/src/lib/services/auth/auth.service.ts
@@ -51,7 +51,8 @@ type Subjects =
   | 'PullJob'
   | 'Group'
   | 'CustomNotification'
-  | 'Form';
+  | 'Form'
+  | 'EmailNotification';
 
 export type AppAbility = Ability<
   [Actions, Subjects | ForcedSubject<Subjects>],
@@ -481,6 +482,18 @@ export class AuthService {
           application: app.id,
         }
       );
+    }
+
+    // === Email Notifications ===
+    if (appPermissions.has('can_see_email_notifications')) {
+      can('read', 'EmailNotification');
+    }
+    if (appPermissions.has('can_manage_email_notifications')) {
+      can(['update', 'delete'], 'EmailNotification');
+    }
+
+    if (appPermissions.has('can_create_email_notifications')) {
+      can('create', 'EmailNotification');
     }
 
     this.ability.update(rules);


### PR DESCRIPTION
# Links 
[Base PR](https://github.com/ReliefApplications/ems-frontend/pull/2460)

Backend PR Related:
[Backend PR](https://github.com/ReliefApplications/ems-backend/pull/1029)

# Tickets

- [ ] Email Notifications in app permissions configured

# Description

Added permissions checks to resolvers of the editAndGet and add Email Notifications mutations. Manage, read and create permissions are applied to application roles which are then applied to users. These permissions allow the user to perform different actions on email notifications (such as see, manage, create [Read, edit, delete, create]). Front end changes change the visibility of these actions, and throw errors if these actions are accessed by a user with the incorrect permissions.

## Screenshots

Setting permissions in application roles:
![image](https://github.com/adappt/ems-frontend/assets/155634780/e7181bd2-4b9e-4798-bc5a-11603358ac6c)

No permissions:
![image](https://github.com/adappt/ems-frontend/assets/155634780/86caa599-42cb-4e48-ad0e-b100ada1702e)

Read permissions only:
![image](https://github.com/adappt/ems-frontend/assets/155634780/3eeff89b-5030-4237-82dc-d86a39366175)

Read & manage permissions:
![image](https://github.com/adappt/ems-frontend/assets/155634780/8bbc03b3-ce55-406c-b76a-358ad4df1d04)

Read & create permissions:
![image](https://github.com/adappt/ems-frontend/assets/155634780/f29c16a9-3bb3-49dc-a29d-250b2c4ce9d1)

All permissions:
![image](https://github.com/adappt/ems-frontend/assets/155634780/67cc0199-1a29-4166-a693-da6bb7b1a94c)
