### PR TITLE
Ab#91932 admin0 would have no popup

### DIFF
--- a/libs/shared/src/lib/services/map/map-polygons.service.ts
+++ b/libs/shared/src/lib/services/map/map-polygons.service.ts
@@ -92,7 +92,7 @@ export class MapPolygonsService {
           ? admin0.polygons
           : {
               type: 'Point',
-              coordinates: [admin0.centerlongitude, admin0.centerlatitude],
+              coordinates: [+admin0.centerlongitude, +admin0.centerlatitude],
             }
       );
     }


### PR DESCRIPTION
# Description

Just converted string to number, as the problem came from centroid telling 'must have numbers'

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/91932)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Went on Signals page from DEV, and checked that popups worked

## Screenshots

![image](https://github.com/ReliefApplications/ems-frontend/assets/59645813/10f4c805-0694-4470-b1f4-eba2e32d7971)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
