### PR TITLE
feat/AB#92196_CDN-for-admin0polygons-instead-of-backend-call-then-API-call

### DIFF
--- a/apps/back-office/src/environments/environment.shared.ts
+++ b/apps/back-office/src/environments/environment.shared.ts
@@ -8,4 +8,6 @@ export const sharedEnvironment = {
   version: require('../../../../package.json').version,
   esriApiKey:
     'AAPK6020068836884707b511570bfb55c042Y7JsUDJU7Dg19M1paHAURrcaX7rPUEnxZj1a_-rDCRSrzSSluutrv3vNaDRnpb9N',
+  admin0PolygonsUrl:
+    'https://ems2-dev.who.int/csadmin/geo/Detailed_Boundary_ADM0_7691616017328378072.geojson',
 };

--- a/apps/back-office/src/environments/environment.type.ts
+++ b/apps/back-office/src/environments/environment.type.ts
@@ -26,4 +26,5 @@ export interface Environment {
   sentry?: any;
   maxFileSize?: number;
   user?: UserConfiguration;
+  admin0PolygonsUrl: string;
 }

--- a/apps/front-office/src/environments/environment.shared.ts
+++ b/apps/front-office/src/environments/environment.shared.ts
@@ -8,4 +8,6 @@ export const sharedEnvironment = {
   version: require('../../../../package.json').version,
   esriApiKey:
     'AAPK6020068836884707b511570bfb55c042Y7JsUDJU7Dg19M1paHAURrcaX7rPUEnxZj1a_-rDCRSrzSSluutrv3vNaDRnpb9N',
+  admin0PolygonsUrl:
+    'https://ems2-dev.who.int/csadmin/geo/Detailed_Boundary_ADM0_7691616017328378072.geojson',
 };

--- a/apps/front-office/src/environments/environment.type.ts
+++ b/apps/front-office/src/environments/environment.type.ts
@@ -25,4 +25,5 @@ export interface Environment {
   sentry?: any;
   maxFileSize?: number;
   user?: UserConfiguration;
+  admin0PolygonsUrl: string;
 }

--- a/apps/web-widgets/src/environments/environment.shared.ts
+++ b/apps/web-widgets/src/environments/environment.shared.ts
@@ -25,4 +25,6 @@ export const sharedAzureEnvironment = {
         'Please contact <a class="underline text-primary-500 hover:text-primary-600" href="mailto:ems2@who.int">ems2@who.int</a> for more information.',
     },
   },
+  admin0PolygonsUrl:
+    'https://ems2-dev.who.int/csadmin/geo/Detailed_Boundary_ADM0_7691616017328378072.geojson',
 };

--- a/apps/web-widgets/src/environments/environment.type.ts
+++ b/apps/web-widgets/src/environments/environment.type.ts
@@ -27,4 +27,5 @@ export interface Environment {
   user?: UserConfiguration;
   tinymceBaseUrl: string;
   i18nUrl: string;
+  admin0PolygonsUrl: string;
 }

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1841,6 +1841,7 @@
 						"geographicExtent": {
 							"add": "Add new geographic extent",
 							"admin0": "Use either iso2code, iso3code or country name",
+							"admin0Error": "Failed to fetch admin0s for country {{iso3code}}: {{errorMessage}}",
 							"region": "Use region name",
 							"remove": "Remove geographic extent",
 							"value": "You can input a static value, or use {{context}} or {{filter}} notation to dynamically inject a value"

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1841,6 +1841,7 @@
 						"geographicExtent": {
 							"add": "Ajouter un nouveau type d'étendue",
 							"admin0": "Utiliez le code iso2, le code iso3, ou le nom du pays",
+							"admin0Error": "Échec de la récupération des  admin0s pour le pays {{iso3code}}: {{errorMessage}}",
 							"region": "Utilisez le nom de région",
 							"remove": "Supprimer le type d'étendue",
 							"value": "Vous pouvez entrer une valeur statique, ou utiliser les notations {{context}} ou {{filter}} pour injecter la valeur"

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1841,6 +1841,7 @@
 						"geographicExtent": {
 							"add": "******",
 							"admin0": "******",
+							"admin0Error": "****** {{iso3code}} ****** {{errorMessage}}",
 							"region": "******",
 							"remove": "******",
 							"value": "****** {{context}} ****** {{filter}} ******"

--- a/libs/shared/src/lib/services/map/map-polygons.service.ts
+++ b/libs/shared/src/lib/services/map/map-polygons.service.ts
@@ -9,8 +9,7 @@ import REGIONS from './regions';
 import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import { Feature, MultiPolygon, Polygon } from 'geojson';
 import { LayerDatasourceType } from '../../models/layer.model';
-import { AllGeoJSON, simplify } from '@turf/turf';
-import { parse } from 'wellknown';
+import { simplify } from '@turf/turf';
 import { TranslateService } from '@ngx-translate/core';
 
 /** Available admin identifiers */
@@ -77,33 +76,31 @@ export class MapPolygonsService {
         const mapping = [];
         for (const feature of value.features) {
           // Transform data to fit Admin0 type
-          if (feature.geometry) {
-            try {
-              mapping.push({
-                id: feature.id,
-                centerlatitude: feature.properties.CENTER_LAT.toString(),
-                centerlongitude: feature.properties.CENTER_LON.toString(),
-                iso2code: feature.properties.ISO_2_CODE,
-                iso3code: feature.properties.ISO_3_CODE,
-                name: feature.properties.ADM0_VIZ_NAME,
-                // Reduction of the GeoJSON object into a simplified version
-                polygons: simplify(parse(feature.geometry) as AllGeoJSON, {
-                  tolerance: 0.1,
-                  highQuality: true,
-                  mutate: true,
-                }) as Polygon | MultiPolygon | Feature<Polygon | MultiPolygon>,
-              });
-            } catch (err: any) {
-              console.log(
-                this.translate.instant(
-                  'components.widget.settings.map.tooltip.geographicExtent.admin0Error',
-                  {
-                    iso3code: feature.properties.ISO_3_CODE,
-                    errorMessage: err.message,
-                  }
-                )
-              );
-            }
+          try {
+            mapping.push({
+              id: feature.id,
+              centerlatitude: feature.properties.CENTER_LAT.toString(),
+              centerlongitude: feature.properties.CENTER_LON.toString(),
+              iso2code: feature.properties.ISO_2_CODE,
+              iso3code: feature.properties.ISO_3_CODE,
+              name: feature.properties.ADM0_VIZ_NAME,
+              // Reduction of the GeoJSON object into a simplified version
+              polygons: simplify(feature.geometry, {
+                tolerance: 0.1,
+                highQuality: true,
+                mutate: true,
+              }) as Polygon | MultiPolygon | Feature<Polygon | MultiPolygon>,
+            });
+          } catch (err: any) {
+            console.log(
+              this.translate.instant(
+                'components.widget.settings.map.tooltip.geographicExtent.admin0Error',
+                {
+                  iso3code: feature.properties.ISO_3_CODE,
+                  errorMessage: err.message,
+                }
+              )
+            );
           }
         }
         this.admin0s = mapping;

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "to-json-schema": "^0.2.5",
     "tslib": "^2.3.0",
     "uuid": "^8.3.1",
-    "wellknown": "^0.5.0",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
@@ -160,7 +159,6 @@
     "@types/proj4": "^2.5.2",
     "@types/to-json-schema": "^0.2.4",
     "@types/uuid": "^9.0.1",
-    "@types/wellknown": "^0.5.8",
     "@types/ws": "^7.4.1",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@tinymce/tinymce-angular": "^7.0.0",
     "@turf/boolean-point-in-polygon": "^6.5.0",
     "@turf/centroid": "^6.5.0",
+    "@turf/turf": "^6.5.0",
     "angular-gridster2": "^15.0.4",
     "angular-oauth2-oidc": "~13.0.1",
     "angular-resizable-element": "^7.0.2",
@@ -109,6 +110,7 @@
     "to-json-schema": "^0.2.5",
     "tslib": "^2.3.0",
     "uuid": "^8.3.1",
+    "wellknown": "^0.5.0",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
@@ -158,6 +160,7 @@
     "@types/proj4": "^2.5.2",
     "@types/to-json-schema": "^0.2.4",
     "@types/uuid": "^9.0.1",
+    "@types/wellknown": "^0.5.8",
     "@types/ws": "^7.4.1",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",


### PR DESCRIPTION
# Description
Updated the MapPolygonsService replacing the backend call with an endpoint call to fetch the admin0 polygons.
Added admin0PolygonsUrl as a new environment property to the sharedEnvironment.
Installed the package @turf/turf and  to do the reduction of the GeoJSON object into a simplified version that was done in the backend

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/92196

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
