### PR TITLE
AB #91351 ABC - History feature allow user to visualize fields they shouldn't have access to

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/form-records/form-records.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/form-records/form-records.component.ts
@@ -415,6 +415,7 @@ export class FormRecordsComponent
           id: item.id,
           revert: (version: any) => this.confirmRevertDialog(item, version),
           resizable: true,
+          availableFields: this.form.metadata?.filter((el: any) => el.canSee),
         },
       });
     });

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -371,6 +371,7 @@ export class FormComponent
           revert: (version: any) =>
             this.confirmRevertDialog(this.record, version),
           resizable: true,
+          availableFields: this.form.metadata?.filter((el) => el.canSee),
         },
       });
     }

--- a/libs/shared/src/lib/components/record-history-modal/record-history-modal.component.html
+++ b/libs/shared/src/lib/components/record-history-modal/record-history-modal.component.html
@@ -10,6 +10,7 @@
       [revert]="data.revert"
       [template]="data.template"
       [refresh$]="data.refresh$"
+      [availableFields]="data.availableFields"
       [showHeader]="false"
     ></shared-record-history>
   </ng-container>

--- a/libs/shared/src/lib/components/record-history-modal/record-history-modal.component.ts
+++ b/libs/shared/src/lib/components/record-history-modal/record-history-modal.component.ts
@@ -15,7 +15,7 @@ interface DialogData {
   revert: any;
   template?: string;
   refresh$?: Subject<boolean>;
-  availableFields: Field[]
+  availableFields: Field[];
 }
 
 /**

--- a/libs/shared/src/lib/components/record-history-modal/record-history-modal.component.ts
+++ b/libs/shared/src/lib/components/record-history-modal/record-history-modal.component.ts
@@ -5,6 +5,7 @@ import { Dialog, DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { ButtonModule, DialogModule } from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { Subject } from 'rxjs';
+import { Field } from '../../services/query-builder/query-builder.service';
 
 /**
  * This interface describes the structure of the data that will be displayed in the dialog modal
@@ -14,6 +15,7 @@ interface DialogData {
   revert: any;
   template?: string;
   refresh$?: Subject<boolean>;
+  availableFields: Field[]
 }
 
 /**

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -196,10 +196,15 @@ export class RecordHistoryComponent
             this.cancel.emit(true);
           } else {
             // console.log(data.recordHistory);
-            const availableHistory = data.recordHistory.map(item => {
-              item.changes = item.changes.filter(change => this.availableFields.findIndex(availableField => availableField.name === change.field) !== -1)
+            const availableHistory = data.recordHistory.map((item) => {
+              item.changes = item.changes.filter(
+                (change) =>
+                  this.availableFields.findIndex(
+                    (availableField) => availableField.name === change.field
+                  ) !== -1
+              );
               return item;
-            })
+            });
             console.log(availableHistory);
             this.history = data.recordHistory.filter(
               (item) => item.changes.length
@@ -519,7 +524,11 @@ export class RecordHistoryComponent
     if (this.record?.resource) {
       // Take the fields from the form
       this.record.resource.fields?.map((field: any) => {
-        if (this.availableFields.findIndex(availableField => availableField.name === field.name) !== -1) {
+        if (
+          this.availableFields.findIndex(
+            (availableField) => availableField.name === field.name
+          ) !== -1
+        ) {
           fields.push(Object.assign({}, field));
         }
       });

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -78,7 +78,7 @@ export class RecordHistoryComponent
   /** Boolean indicating whether the dialog is resizable. */
   @Input() resizable = false;
   /** Available fields for the user */
-  @Input() availableFields: Field[] = [];
+  @Input() availableFields?: Field[];
   /** Event emitter for cancel event */
   @Output() cancel = new EventEmitter();
 
@@ -195,17 +195,16 @@ export class RecordHistoryComponent
             );
             this.cancel.emit(true);
           } else {
-            // console.log(data.recordHistory);
-            const availableHistory = data.recordHistory.map((item) => {
+            data.recordHistory.map((item) => {
               item.changes = item.changes.filter(
                 (change) =>
+                  !this.availableFields ||
                   this.availableFields.findIndex(
                     (availableField) => availableField.name === change.field
                   ) !== -1
               );
               return item;
             });
-            console.log(availableHistory);
             this.history = data.recordHistory.filter(
               (item) => item.changes.length
             );
@@ -525,6 +524,7 @@ export class RecordHistoryComponent
       // Take the fields from the form
       this.record.resource.fields?.map((field: any) => {
         if (
+          !this.availableFields ||
           this.availableFields.findIndex(
             (availableField) => availableField.name === field.name
           ) !== -1

--- a/libs/shared/src/lib/components/record-history/record-history.component.ts
+++ b/libs/shared/src/lib/components/record-history/record-history.component.ts
@@ -30,6 +30,7 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { startCase, isNil } from 'lodash';
 import { ResizeEvent } from 'angular-resizable-element';
 import { DOCUMENT } from '@angular/common';
+import { Field } from '../../services/query-builder/query-builder.service';
 
 /**
  * Return the type of the old value if existing, else the type of the new value.
@@ -76,6 +77,8 @@ export class RecordHistoryComponent
   @Input() refresh$?: Subject<boolean> = new Subject<boolean>();
   /** Boolean indicating whether the dialog is resizable. */
   @Input() resizable = false;
+  /** Available fields for the user */
+  @Input() availableFields: Field[] = [];
   /** Event emitter for cancel event */
   @Output() cancel = new EventEmitter();
 
@@ -192,6 +195,12 @@ export class RecordHistoryComponent
             );
             this.cancel.emit(true);
           } else {
+            // console.log(data.recordHistory);
+            const availableHistory = data.recordHistory.map(item => {
+              item.changes = item.changes.filter(change => this.availableFields.findIndex(availableField => availableField.name === change.field) !== -1)
+              return item;
+            })
+            console.log(availableHistory);
             this.history = data.recordHistory.filter(
               (item) => item.changes.length
             );
@@ -510,7 +519,9 @@ export class RecordHistoryComponent
     if (this.record?.resource) {
       // Take the fields from the form
       this.record.resource.fields?.map((field: any) => {
-        fields.push(Object.assign({}, field));
+        if (this.availableFields.findIndex(availableField => availableField.name === field.name) !== -1) {
+          fields.push(Object.assign({}, field));
+        }
       });
       if (this.record.form && this.record.form.structure) {
         const structure = JSON.parse(this.record.form.structure);

--- a/libs/shared/src/lib/components/record-modal/record-modal.component.ts
+++ b/libs/shared/src/lib/components/record-modal/record-modal.component.ts
@@ -273,6 +273,7 @@ export class RecordModalComponent
     this.dialog.open(RecordHistoryModalComponent, {
       data: {
         id: this.record.id,
+        availableFields: this.form?.metadata?.filter((el) => el.canSee),
         revert: (version: any) =>
           this.confirmRevertDialog(this.record, version),
       },

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -1285,7 +1285,7 @@ export class CoreGridComponent
               revert: (version: any) => this.confirmRevertDialog(item, version),
               template: this.settings.template || null,
               refresh$: this.refresh$,
-              availableFields: this.fields
+              availableFields: this.fields,
             },
             autoFocus: false,
           });
@@ -1303,7 +1303,7 @@ export class CoreGridComponent
               template: this.settings.template || null,
               refresh$: this.refresh$,
               resizable: true,
-              availableFields: this.fields
+              availableFields: this.fields,
             },
           });
         }

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -1285,6 +1285,7 @@ export class CoreGridComponent
               revert: (version: any) => this.confirmRevertDialog(item, version),
               template: this.settings.template || null,
               refresh$: this.refresh$,
+              availableFields: this.fields
             },
             autoFocus: false,
           });
@@ -1302,6 +1303,7 @@ export class CoreGridComponent
               template: this.settings.template || null,
               refresh$: this.refresh$,
               resizable: true,
+              availableFields: this.fields
             },
           });
         }


### PR DESCRIPTION
# Description

History for records didn't take into account the metadata for fields, so a user with permission to just see some of the fields was able to see everything in the history, instead of just seeing only entries with their relevant fields.
A new input has been added to the RecordHistoryComponent so you can use it to pass the available fields for the user.
The download is still returning every field, which requires some backwork.

## Useful links

- [AB#91351](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/91351)

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Accessed to the record history from all components featuring it with an account with limited view of the fields, making sure it only show the available fields.
- [x] Accessed to the record history from all components featuring it with an account full view, making sure it shows all available fields.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/94831019/239cb4c2-d0ac-4d4a-ba65-1c744f62cb01
Another field exists on the resource, month. Month field is not visible for that user.

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
