### PR TITLE
Ab#92198 add loading indicators

### DIFF
--- a/apps/back-office/src/app/components/custom-style/custom-style.component.html
+++ b/apps/back-office/src/app/components/custom-style/custom-style.component.html
@@ -40,11 +40,11 @@
   <ui-spinner class="my-2" *ngIf="loading"></ui-spinner>
   <!-- Style editor -->
   <div class="grow overflow-y-auto overflow-x-hidden">
-    <ngx-monaco-editor
+    <shared-monaco-editor
       class="!h-full"
-      (onInit)="initEditor($event)"
+      (editorLoaded)="initEditor($event)"
       [options]="editorOptions"
-      [formControl]="formControl"
-    ></ngx-monaco-editor>
+      [control]="formControl"
+    ></shared-monaco-editor>
   </div>
 </div>

--- a/apps/back-office/src/app/components/custom-style/custom-style.component.ts
+++ b/apps/back-office/src/app/components/custom-style/custom-style.component.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import {
   Application,
   ApplicationService,
@@ -17,6 +16,7 @@ import {
   RestService,
   BlobType,
   DownloadService,
+  MonacoEditorComponent,
 } from '@oort-front/shared';
 import { takeUntil } from 'rxjs/operators';
 import { Apollo } from 'apollo-angular';
@@ -43,12 +43,12 @@ const DEFAULT_STYLE = '';
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    MonacoEditorModule,
     TranslateModule,
     ButtonModule,
     SpinnerModule,
     TooltipModule,
     ResizableModule,
+    MonacoEditorComponent,
   ],
   templateUrl: './custom-style.component.html',
   styleUrls: ['./custom-style.component.scss'],

--- a/apps/back-office/src/app/dashboard/pages/pull-jobs/components/edit-pull-job-modal/edit-pull-job-modal.component.html
+++ b/apps/back-office/src/app/dashboard/pages/pull-jobs/components/edit-pull-job-modal/edit-pull-job-modal.component.html
@@ -168,11 +168,11 @@
             <!-- Raw edition mode (json) -->
             <ng-container *ngIf="openRawJSON">
               <div class="grow h-[300px]">
-                <ngx-monaco-editor
+                <shared-monaco-editor
                   class="!h-full"
-                  formControlName="rawMapping"
+                  [control]="formGroup.get('rawMapping')"
                   [options]="editorOptions"
-                ></ngx-monaco-editor>
+                ></shared-monaco-editor>
               </div>
               <!-- <div uiFormFieldDirective>
                 <label>{{ 'common.input.rawJson' | translate }}</label>

--- a/apps/back-office/src/app/dashboard/pages/pull-jobs/components/edit-pull-job-modal/edit-pull-job-modal.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/pull-jobs/components/edit-pull-job-modal/edit-pull-job-modal.component.ts
@@ -17,6 +17,7 @@ import {
   StatusOptionsComponent,
   getCachedValues,
   updateQueryUniqueValues,
+  MonacoEditorComponent,
 } from '@oort-front/shared';
 import { Apollo, QueryRef } from 'apollo-angular';
 import {
@@ -51,7 +52,6 @@ import {
   IconModule,
 } from '@oort-front/ui';
 import { DialogModule } from '@oort-front/ui';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 
 /** Items per page for pagination */
 const ITEMS_PER_PAGE = 10;
@@ -79,7 +79,7 @@ const DEFAULT_FIELDS = ['createdBy'];
     SelectMenuModule,
     FormWrapperModule,
     StatusOptionsComponent,
-    MonacoEditorModule,
+    MonacoEditorComponent,
   ],
   selector: 'app-edit-pull-job-modal',
   templateUrl: './edit-pull-job-modal.component.html',

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.component.html
@@ -67,12 +67,12 @@
             >{{ 'pages.referenceData.queryName' | translate }} *</label
           >
           <!-- Graphql query editor -->
-          <ngx-monaco-editor
-            (onInit)="initEditor($event)"
+          <shared-monaco-editor
+            (editorLoaded)="initEditor($event)"
             [options]="editorOptions"
-            [formControl]="queryControl"
+            [control]="queryControl"
             class="!h-full !w-full"
-          ></ngx-monaco-editor>
+          ></shared-monaco-editor>
           <!-- Resize handle -->
           <div
             class="cursor-row-resize absolute w-full h-2 bottom-0"

--- a/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.module.ts
+++ b/apps/back-office/src/app/dashboard/pages/reference-data/reference-data.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReferenceDataRoutingModule } from './reference-data-routing.module';
 import { ReferenceDataComponent } from './reference-data.component';
-import { AccessModule } from '@oort-front/shared';
+import { AccessModule, MonacoEditorComponent } from '@oort-front/shared';
 import {
   AlertModule,
   GraphQLSelectModule,
@@ -23,7 +23,6 @@ import {
   FixedWrapperModule,
   DialogModule,
 } from '@oort-front/ui';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { InputsModule } from '@progress/kendo-angular-inputs';
 import { DropDownsModule } from '@progress/kendo-angular-dropdowns';
 import { ResizableModule } from 'angular-resizable-element';
@@ -49,7 +48,6 @@ import { ResizableModule } from 'angular-resizable-element';
     UiButtonModule,
     SelectMenuModule,
     FormWrapperModule,
-    MonacoEditorModule,
     FixedWrapperModule,
     FormsModule,
     DialogModule,
@@ -58,6 +56,7 @@ import { ResizableModule } from 'angular-resizable-element';
     DropDownsModule,
     ToggleModule,
     ResizableModule,
+    MonacoEditorComponent,
   ],
 })
 export class ReferenceDataModule {}

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -97,6 +97,7 @@ export * from './lib/components/users/public-api';
 export * from './lib/components/payload-modal/payload-modal.component';
 export * from './lib/components/widgets/map/public-api';
 export * from './lib/components/dashboard/public-api';
+export * from './lib/components/widgets/common/monaco-editor/monaco-editor.component';
 
 // Export of controls
 export * from './lib/components/controls/public-api';

--- a/libs/shared/src/lib/components/controls/editor-control/editor-control.component.html
+++ b/libs/shared/src/lib/components/controls/editor-control/editor-control.component.html
@@ -4,3 +4,4 @@
   [(ngModel)]="editorContent"
   (ngModelChange)="onEditorContentChange()"
 ></editor>
+<ui-spinner *ngIf="editorLoading"></ui-spinner>

--- a/libs/shared/src/lib/components/controls/editor-control/editor-control.component.html
+++ b/libs/shared/src/lib/components/controls/editor-control/editor-control.component.html
@@ -1,5 +1,6 @@
 <editor
   #editor
+  (onInit)="editorLoading = false"
   [init]="editorConfig"
   [(ngModel)]="editorContent"
   (ngModelChange)="onEditorContentChange()"

--- a/libs/shared/src/lib/components/controls/editor-control/editor-control.component.ts
+++ b/libs/shared/src/lib/components/controls/editor-control/editor-control.component.ts
@@ -23,14 +23,14 @@ import {
 } from '@tinymce/tinymce-angular';
 import { EditorService } from '../../../services/editor/editor.service';
 import { RawEditorSettings } from 'tinymce';
-import { FormControlComponent } from '@oort-front/ui';
+import { FormControlComponent, SpinnerModule } from '@oort-front/ui';
 import { DOCUMENT } from '@angular/common';
 
 /** Component for using TinyMCE editor with formControl */
 @Component({
   selector: 'shared-editor-control',
   standalone: true,
-  imports: [CommonModule, EditorModule, FormsModule],
+  imports: [CommonModule, EditorModule, FormsModule, SpinnerModule],
   templateUrl: './editor-control.component.html',
   styleUrls: ['./editor-control.component.scss'],
   providers: [
@@ -52,6 +52,8 @@ export class EditorControlComponent
   @ViewChild('editor') editor!: EditorComponent;
   /** Editor content */
   public editorContent = '';
+  /** Editor loading */
+  public editorLoading = true;
 
   /** Tinymce editor configuration */
   @Input() editorConfig!: RawEditorSettings;
@@ -211,6 +213,7 @@ export class EditorControlComponent
   }
 
   ngAfterViewInit(): void {
+    this.editorService.listenToLoader(this.editor, this);
     this.editor.onFocusIn.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.onFocusIn();
     });

--- a/libs/shared/src/lib/components/controls/editor-control/editor-control.component.ts
+++ b/libs/shared/src/lib/components/controls/editor-control/editor-control.component.ts
@@ -213,7 +213,6 @@ export class EditorControlComponent
   }
 
   ngAfterViewInit(): void {
-    this.editorService.listenToLoader(this.editor, this);
     this.editor.onFocusIn.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.onFocusIn();
     });
@@ -243,7 +242,6 @@ export class EditorControlComponent
         }
       }
     });
-    // this.editor.onInit.subscribe(() => {});
   }
 
   /** onTouched function shell */

--- a/libs/shared/src/lib/components/custom-widget-style/custom-widget-style.component.html
+++ b/libs/shared/src/lib/components/custom-widget-style/custom-widget-style.component.html
@@ -39,11 +39,11 @@
   </div>
   <!-- Style editor -->
   <div class="grow overflow-y-auto overflow-x-hidden">
-    <ngx-monaco-editor
+    <shared-monaco-editor
       class="!h-full !w-full"
-      (onInit)="initEditor($event)"
+      (editorLoaded)="initEditor($event)"
       [options]="editorOptions"
-      [formControl]="formControl"
-    ></ngx-monaco-editor>
+      [control]="formControl"
+    ></shared-monaco-editor>
   </div>
 </div>

--- a/libs/shared/src/lib/components/custom-widget-style/custom-widget-style.component.ts
+++ b/libs/shared/src/lib/components/custom-widget-style/custom-widget-style.component.ts
@@ -21,6 +21,7 @@ import { UnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component
 import { DOCUMENT } from '@angular/common';
 import { ResizeEvent } from 'angular-resizable-element';
 import { ResizableModule } from 'angular-resizable-element';
+import { MonacoEditorComponent } from '../widgets/common/monaco-editor/monaco-editor.component';
 
 /** Default css style example to initialize the form and editor */
 const DEFAULT_STYLE = '';
@@ -38,6 +39,7 @@ const DEFAULT_STYLE = '';
     ButtonModule,
     TooltipModule,
     ResizableModule,
+    MonacoEditorComponent,
   ],
   templateUrl: './custom-widget-style.component.html',
   styleUrls: ['./custom-widget-style.component.scss'],

--- a/libs/shared/src/lib/components/email-preview-modal/email-preview-modal.component.html
+++ b/libs/shared/src/lib/components/email-preview-modal/email-preview-modal.component.html
@@ -10,7 +10,9 @@
         [uiErrorMessage]="
           'components.emailPreview.errors.missingSubject' | translate
         "
-        [uiErrorMessageIf]="this.emailForm.controls.subject.hasError('required')"
+        [uiErrorMessageIf]="
+          this.emailForm.controls.subject.hasError('required')
+        "
         uiFormFieldDirective
       >
         <label>{{ 'components.emailPreview.subject' | translate }}</label>
@@ -53,7 +55,11 @@
         formControlName="files"
         [restrictions]="fileRestrictions"
       ></kendo-fileselect>
-      <editor [init]="editor" formControlName="html"></editor>
+      <editor
+        (onInit)="editorLoading = false"
+        [init]="editor"
+        formControlName="html"
+      ></editor>
       <ui-spinner *ngIf="editorLoading"></ui-spinner>
     </form>
   </ng-container>

--- a/libs/shared/src/lib/components/email-preview-modal/email-preview-modal.component.html
+++ b/libs/shared/src/lib/components/email-preview-modal/email-preview-modal.component.html
@@ -54,6 +54,7 @@
         [restrictions]="fileRestrictions"
       ></kendo-fileselect>
       <editor [init]="editor" formControlName="html"></editor>
+      <ui-spinner *ngIf="editorLoading"></ui-spinner>
     </form>
   </ng-container>
   <ng-container ngProjectAs="actions">

--- a/libs/shared/src/lib/components/email-preview-modal/email-preview-modal.component.ts
+++ b/libs/shared/src/lib/components/email-preview-modal/email-preview-modal.component.ts
@@ -22,6 +22,7 @@ import {
   DialogModule,
   ErrorMessageModule,
   FormWrapperModule,
+  SpinnerModule,
 } from '@oort-front/ui';
 import {
   FileRestrictions,
@@ -66,6 +67,7 @@ const SEPARATOR_KEYS_CODE = [ENTER, COMMA, TAB, SPACE];
     ButtonModule,
     ChipModule,
     ErrorMessageModule,
+    SpinnerModule,
   ],
   providers: [
     { provide: TINYMCE_SCRIPT_SRC, useValue: 'tinymce/tinymce.min.js' },
@@ -90,6 +92,8 @@ export class EmailPreviewModalComponent implements OnDestroy {
   public fileRestrictions: FileRestrictions = {
     maxFileSize: 7 * 1024 * 1024, // should represent 7MB
   };
+  /** boolean whether editor loading */
+  public editorLoading = true;
 
   /** Timeout */
   private timeoutListener!: NodeJS.Timeout;
@@ -133,6 +137,7 @@ export class EmailPreviewModalComponent implements OnDestroy {
     this.editor.base_url = editorService.url;
     // Set the editor language
     this.editor.language = editorService.language;
+    this.editorService.listenToLoader(this.editor, this);
   }
 
   ngOnDestroy(): void {

--- a/libs/shared/src/lib/components/email-preview-modal/email-preview-modal.component.ts
+++ b/libs/shared/src/lib/components/email-preview-modal/email-preview-modal.component.ts
@@ -137,7 +137,6 @@ export class EmailPreviewModalComponent implements OnDestroy {
     this.editor.base_url = editorService.url;
     // Set the editor language
     this.editor.language = editorService.language;
-    this.editorService.listenToLoader(this.editor, this);
   }
 
   ngOnDestroy(): void {

--- a/libs/shared/src/lib/components/form-builder/custom-json-editor/custom-json-editor.component.html
+++ b/libs/shared/src/lib/components/form-builder/custom-json-editor/custom-json-editor.component.html
@@ -1,5 +1,5 @@
-<ngx-monaco-editor
+<shared-monaco-editor
   class="!h-full"
   [options]="editorOptions"
-  [formControl]="formControl"
-></ngx-monaco-editor>
+  [control]="formControl"
+></shared-monaco-editor>

--- a/libs/shared/src/lib/components/form-builder/custom-json-editor/custom-json-editor.component.ts
+++ b/libs/shared/src/lib/components/form-builder/custom-json-editor/custom-json-editor.component.ts
@@ -5,7 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { SnackbarService } from '@oort-front/ui';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
+import { MonacoEditorComponent } from '../../widgets/common/monaco-editor/monaco-editor.component';
 
 // Documentation:
 // https://surveyjs.io/survey-creator/examples/modify-tab-bar/angular#
@@ -46,7 +46,12 @@ export class SurveyCustomJSONEditorPlugin implements ICreatorPlugin {
   selector: 'svc-tab-customJSONEditor',
   templateUrl: './custom-json-editor.component.html',
   styleUrls: ['./custom-json-editor.component.scss'],
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, MonacoEditorModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MonacoEditorComponent,
+  ],
   standalone: true,
 })
 export class CustomJSONEditorComponent

--- a/libs/shared/src/lib/components/payload-modal/payload-modal.component.html
+++ b/libs/shared/src/lib/components/payload-modal/payload-modal.component.html
@@ -11,12 +11,12 @@
   <ng-container ngProjectAs="content">
     <!-- Style editor -->
     <div class="h-[400px]">
-      <ngx-monaco-editor
+      <shared-monaco-editor
         class="!h-full"
         [options]="editorOptions"
-        [formControl]="formControl"
-        (onInit)="initEditor($event)"
-      ></ngx-monaco-editor>
+        [control]="formControl"
+        (editorLoaded)="initEditor($event)"
+      ></shared-monaco-editor>
     </div>
   </ng-container>
   <ng-container ngProjectAs="actions">

--- a/libs/shared/src/lib/components/payload-modal/payload-modal.component.ts
+++ b/libs/shared/src/lib/components/payload-modal/payload-modal.component.ts
@@ -1,10 +1,10 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { DialogModule } from '@oort-front/ui';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { CommonModule } from '@angular/common';
 import { FormsModule, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ButtonModule } from '@oort-front/ui';
+import { MonacoEditorComponent } from '../widgets/common/monaco-editor/monaco-editor.component';
 
 /** Interface of data passed to dialog */
 interface DialogData {
@@ -20,7 +20,7 @@ interface DialogData {
   standalone: true,
   imports: [
     DialogModule,
-    MonacoEditorModule,
+    MonacoEditorComponent,
     FormsModule,
     ReactiveFormsModule,
     CommonModule,

--- a/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.html
+++ b/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.html
@@ -40,6 +40,7 @@
         ></ui-icon>
       </div>
       <editor [init]="bodyEditor" formControlName="body"></editor>
+      <ui-spinner *ngIf="editorLoading"></ui-spinner>
     </form>
   </ng-container>
   <ng-container ngProjectAs="actions">

--- a/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.html
+++ b/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.html
@@ -39,7 +39,11 @@
           [uiTooltip]="'common.tooltip.editor.insert' | translate"
         ></ui-icon>
       </div>
-      <editor [init]="bodyEditor" formControlName="body"></editor>
+      <editor
+        (onInit)="editorLoading = false"
+        [init]="bodyEditor"
+        formControlName="body"
+      ></editor>
       <ui-spinner *ngIf="editorLoading"></ui-spinner>
     </form>
   </ng-container>

--- a/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.ts
+++ b/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.ts
@@ -100,7 +100,6 @@ export class EditTemplateModalComponent implements OnInit {
 
   /** Build the form. */
   ngOnInit(): void {
-    this.editorService.listenToLoader(this.bodyEditor, this);
     this.editorService.addCalcAndKeysAutoCompleter(
       this.bodyEditor,
       BODY_EDITOR_AUTOCOMPLETE_KEYS.map((key) => ({ value: key, text: key }))

--- a/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.ts
+++ b/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.ts
@@ -17,6 +17,7 @@ import {
   ButtonModule,
   IconModule,
   SelectMenuModule,
+  SpinnerModule,
   TooltipModule,
 } from '@oort-front/ui';
 import { DialogModule, FormWrapperModule } from '@oort-front/ui';
@@ -49,6 +50,7 @@ const SUBJECT_EDITOR_AUTOCOMPLETE_KEYS = ['{{now}}', '{{today}}'];
     SelectMenuModule,
     IconModule,
     TooltipModule,
+    SpinnerModule,
   ],
   selector: 'shared-edit-template',
   templateUrl: './edit-template-modal.component.html',
@@ -66,6 +68,8 @@ export class EditTemplateModalComponent implements OnInit {
 
   /** tinymce body editor */
   public bodyEditor: RawEditorSettings = EMAIL_EDITOR_CONFIG;
+  /** boolean whether editor loading */
+  public editorLoading = true;
 
   /** tinymce subject editor */
   public subjectEditor: RawEditorSettings = INLINE_EDITOR_CONFIG;
@@ -96,6 +100,7 @@ export class EditTemplateModalComponent implements OnInit {
 
   /** Build the form. */
   ngOnInit(): void {
+    this.editorService.listenToLoader(this.bodyEditor, this);
     this.editorService.addCalcAndKeysAutoCompleter(
       this.bodyEditor,
       BODY_EDITOR_AUTOCOMPLETE_KEYS.map((key) => ({ value: key, text: key }))

--- a/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.html
+++ b/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.html
@@ -1,4 +1,8 @@
-<div [formGroup]="formGroup" class="flex flex-col last:mb-0">
+<div
+  [formGroup]="formGroup"
+  class="flex flex-col last:mb-0"
+  *ngIf="!loading; else loadingTmpl"
+>
   <h2>{{ 'common.general' | translate }}</h2>
   <div uiFormFieldDirective>
     <label>{{ 'common.title' | translate }}</label>
@@ -128,3 +132,10 @@
     </ng-container>
   </ng-container>
 </div>
+
+<!-- Loading indicator -->
+<ng-template #loadingTmpl>
+  <div class="h-full w-full flex">
+    <ui-spinner class="m-auto block"></ui-spinner>
+  </div>
+</ng-template>

--- a/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.ts
+++ b/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.component.ts
@@ -42,6 +42,8 @@ export class TabMainComponent extends UnsubscribeComponent implements OnInit {
   public aggregation?: Aggregation;
   /** Available fields */
   public availableSeriesFields: any[] = [];
+  /** Loading */
+  public loading = false;
 
   /**
    * Get the selected chart type object
@@ -110,6 +112,7 @@ export class TabMainComponent extends UnsubscribeComponent implements OnInit {
    * @param id resource id
    */
   private getResource(id: string): void {
+    this.loading = true;
     const aggregationId = this.formGroup.get('chart.aggregationId')?.value;
     this.apollo
       .query<ResourceQueryResponse>({
@@ -131,6 +134,7 @@ export class TabMainComponent extends UnsubscribeComponent implements OnInit {
         } else {
           this.availableSeriesFields = [];
         }
+        this.loading = false;
       });
   }
 
@@ -140,6 +144,7 @@ export class TabMainComponent extends UnsubscribeComponent implements OnInit {
    * @param id reference data id
    */
   private getReferenceData(id: string): void {
+    this.loading = true;
     const aggregationId = this.formGroup.get('chart.aggregationId')?.value;
     this.apollo
       .query<ReferenceDataQueryResponse>({
@@ -151,6 +156,7 @@ export class TabMainComponent extends UnsubscribeComponent implements OnInit {
       })
       .pipe(takeUntil(this.destroy$))
       .subscribe(({ data }) => {
+        this.loading = false;
         this.referenceData = data.referenceData;
         if (aggregationId && this.referenceData.aggregations?.edges[0]) {
           this.aggregation = this.referenceData.aggregations.edges[0].node;

--- a/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.module.ts
+++ b/libs/shared/src/lib/components/widgets/chart-settings/tab-main/tab-main.module.ts
@@ -7,6 +7,7 @@ import {
   DividerModule,
   ExpansionPanelModule,
   SelectMenuModule,
+  SpinnerModule,
 } from '@oort-front/ui';
 import { IconModule } from '@oort-front/ui';
 import { TabsModule } from '@oort-front/ui';
@@ -52,6 +53,7 @@ import { GraphqlVariablesMappingComponent } from '../../common/graphql-variables
     ReferenceDataSelectComponent,
     DividerModule,
     GraphqlVariablesMappingComponent,
+    SpinnerModule,
   ],
   exports: [TabMainComponent],
 })

--- a/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.html
@@ -30,12 +30,12 @@
       ></ui-icon>
     </h2>
     <div class="grow overflow-y-auto overflow-x-hidden w-full">
-      <ngx-monaco-editor
+      <shared-monaco-editor
         class="!h-full min-h-[450px]"
         (onInit)="initEditor($event)"
         [options]="editorOptions"
-        [formControl]="$any(form.get('contextFilters'))"
-      ></ngx-monaco-editor>
+        [control]="form.get('contextFilters')"
+      ></shared-monaco-editor>
     </div>
   </div>
 </div>

--- a/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/contextual-filters-settings/contextual-filters-settings.component.ts
@@ -1,9 +1,9 @@
 import { Component, Input, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { FormWrapperModule, IconModule, TooltipModule } from '@oort-front/ui';
+import { MonacoEditorComponent } from '../monaco-editor/monaco-editor.component';
 
 /** Component to define the contextual filters of a widget or a map layer */
 @Component({
@@ -11,7 +11,7 @@ import { FormWrapperModule, IconModule, TooltipModule } from '@oort-front/ui';
   standalone: true,
   imports: [
     CommonModule,
-    MonacoEditorModule,
+    MonacoEditorComponent,
     FormsModule,
     ReactiveFormsModule,
     TranslateModule,

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
@@ -45,7 +45,7 @@
     <!-- JSON editor -->
     <shared-monaco-editor
       class="!h-full !w-full min-w-[200px]"
-      [formControl]="control"
+      [control]="control"
       [options]="editorOptions"
     ></shared-monaco-editor>
     <!-- Resize handle -->

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.html
@@ -43,11 +43,11 @@
     [validateResize]="validate.bind(this)"
   >
     <!-- JSON editor -->
-    <ngx-monaco-editor
+    <shared-monaco-editor
       class="!h-full !w-full min-w-[200px]"
       [formControl]="control"
       [options]="editorOptions"
-    ></ngx-monaco-editor>
+    ></shared-monaco-editor>
     <!-- Resize handle -->
     <div
       class="cursor-row-resize absolute w-full h-2 bottom-0"

--- a/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/graphql-variables-mapping/graphql-variables-mapping.component.ts
@@ -14,13 +14,13 @@ import {
   AlertModule,
 } from '@oort-front/ui';
 import { EmptyModule } from '../../../ui/empty/empty.module';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { ReferenceData } from '../../../../models/reference-data.model';
 import { gql } from '@apollo/client';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ResizableModule, ResizeEvent } from 'angular-resizable-element';
 import isEqual from 'lodash/isEqual';
 import { JSONValidator } from '../../../../utils/validators/json.validator';
+import { MonacoEditorComponent } from '../monaco-editor/monaco-editor.component';
 
 /**
  * Graphql variables mapping, for widgets using graphql reference data.
@@ -34,7 +34,7 @@ import { JSONValidator } from '../../../../utils/validators/json.validator';
     IconModule,
     TooltipModule,
     EmptyModule,
-    MonacoEditorModule,
+    MonacoEditorComponent,
     FormsModule,
     ReactiveFormsModule,
     ButtonModule,

--- a/libs/shared/src/lib/components/widgets/common/monaco-editor/monaco-editor.component.html
+++ b/libs/shared/src/lib/components/widgets/common/monaco-editor/monaco-editor.component.html
@@ -1,0 +1,15 @@
+<!-- Loading indicator -->
+<div class="h-full w-full flex" *ngIf="loading">
+  <ui-spinner class="m-auto block"></ui-spinner>
+</div>
+
+<ngx-monaco-editor
+  [class]="parentClass"
+  [ngClass]="{
+    hidden: loading
+  }"
+  [options]="options"
+  (onInit)="onEditorInit($event)"
+  [formControl]="control"
+>
+</ngx-monaco-editor>

--- a/libs/shared/src/lib/components/widgets/common/monaco-editor/monaco-editor.component.html
+++ b/libs/shared/src/lib/components/widgets/common/monaco-editor/monaco-editor.component.html
@@ -4,7 +4,7 @@
 </div>
 
 <ngx-monaco-editor
-  [class]="parentClass"
+  [class]="elementRef.nativeElement.className"
   [ngClass]="{
     hidden: loading
   }"

--- a/libs/shared/src/lib/components/widgets/common/monaco-editor/monaco-editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/monaco-editor/monaco-editor.component.ts
@@ -1,0 +1,74 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+} from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SpinnerModule } from '@oort-front/ui';
+import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
+
+/**
+ * Edition of card template.
+ */
+@Component({
+  selector: 'shared-monaco-editor',
+  templateUrl: './monaco-editor.component.html',
+  standalone: true,
+  imports: [
+    CommonModule,
+    SpinnerModule,
+    MonacoEditorModule,
+    ReactiveFormsModule,
+    FormsModule,
+  ],
+})
+export class MonacoEditorComponent implements OnInit {
+  /** Editor options */
+  @Input() options:
+    | {
+        automaticLayout?: boolean;
+        theme?: string;
+        language?: string;
+        fixedOverflowWidgets?: boolean;
+      }
+    | undefined = {};
+  /** form control */
+  @Input() control: any = new FormControl();
+  /** parent class */
+  public parentClass = '';
+  /** Emit when oninit done */
+  @Output() editorLoaded = new EventEmitter();
+  /** editor loading */
+  public loading = true;
+
+  /**
+   * Shared monaco editor component
+   *
+   * @param elementRef reference to the parent element
+   * @param changeDetectorRef Change detector ref
+   */
+  constructor(
+    private elementRef: ElementRef,
+    private changeDetectorRef: ChangeDetectorRef
+  ) {}
+
+  ngOnInit() {
+    this.parentClass = this.elementRef.nativeElement.className;
+  }
+
+  /**
+   * Sets the loading to false upon ending of loading
+   *
+   * @param event event fired by the monaco editor onInit
+   */
+  onEditorInit(event: Event) {
+    this.loading = false;
+    this.changeDetectorRef.detectChanges();
+    this.editorLoaded.emit(event);
+  }
+}

--- a/libs/shared/src/lib/components/widgets/common/monaco-editor/monaco-editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/monaco-editor/monaco-editor.component.ts
@@ -5,10 +5,9 @@ import {
   ElementRef,
   EventEmitter,
   Input,
-  OnInit,
   Output,
 } from '@angular/core';
-import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SpinnerModule } from '@oort-front/ui';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 
@@ -27,7 +26,7 @@ import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
     FormsModule,
   ],
 })
-export class MonacoEditorComponent implements OnInit {
+export class MonacoEditorComponent {
   /** Editor options */
   @Input() options:
     | {
@@ -36,11 +35,9 @@ export class MonacoEditorComponent implements OnInit {
         language?: string;
         fixedOverflowWidgets?: boolean;
       }
-    | undefined = {};
+    | undefined;
   /** form control */
-  @Input() control: any = new FormControl();
-  /** parent class */
-  public parentClass = '';
+  @Input() control: any;
   /** Emit when oninit done */
   @Output() editorLoaded = new EventEmitter();
   /** editor loading */
@@ -53,13 +50,9 @@ export class MonacoEditorComponent implements OnInit {
    * @param changeDetectorRef Change detector ref
    */
   constructor(
-    private elementRef: ElementRef,
+    public elementRef: ElementRef,
     private changeDetectorRef: ChangeDetectorRef
   ) {}
-
-  ngOnInit() {
-    this.parentClass = this.elementRef.nativeElement.className;
-  }
 
   /**
    * Sets the loading to false upon ending of loading

--- a/libs/shared/src/lib/components/widgets/common/widget-automation/edit-automation-component/edit-automation-component.component.html
+++ b/libs/shared/src/lib/components/widgets/common/widget-automation/edit-automation-component/edit-automation-component.component.html
@@ -41,11 +41,11 @@
           <!-- JSON -->
           <ng-container *ngSwitchCase="'json'">
             <div class="h-[300px]">
-              <ngx-monaco-editor
+              <shared-monaco-editor
                 class="!h-full !w-full min-w-[200px]"
-                [formControlName]="property.name"
+                [control]="formGroup.controls[property.name]"
                 [options]="property.options"
-              ></ngx-monaco-editor>
+              ></shared-monaco-editor>
             </div>
           </ng-container>
         </ng-container>

--- a/libs/shared/src/lib/components/widgets/common/widget-automation/edit-automation-component/edit-automation-component.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/widget-automation/edit-automation-component/edit-automation-component.component.ts
@@ -15,11 +15,11 @@ import { UnsubscribeComponent } from '../../../../utils/unsubscribe/unsubscribe.
 import { BehaviorSubject, isObservable, map, takeUntil } from 'rxjs';
 import { MapLayersService } from '../../../../../services/map/map-layers.service';
 import { get, isArray, isNil } from 'lodash';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import {
   ActionType,
   ActionWithProperties,
 } from '../../../../../models/automation.model';
+import { MonacoEditorComponent } from '../../monaco-editor/monaco-editor.component';
 
 /**
  * Edition of automation component.
@@ -35,7 +35,7 @@ import {
     ReactiveFormsModule,
     FormWrapperModule,
     SelectMenuModule,
-    MonacoEditorModule,
+    MonacoEditorComponent,
   ],
   templateUrl: './edit-automation-component.component.html',
   styleUrls: ['./edit-automation-component.component.scss'],
@@ -45,7 +45,7 @@ export class EditAutomationComponentComponent
   implements OnInit
 {
   /** Automation component form */
-  public formGroup!: ReturnType<typeof createAutomationComponentForm>;
+  public formGroup: any;
   /** Available widgets */
   public widgets = new BehaviorSubject<any[]>([]);
   /** Current editor */

--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.html
@@ -20,10 +20,11 @@
           </div>
           <editor
             *ngIf="!loading"
+            (onInit)="editorLoading = false"
             [init]="editor"
             formControlName="text"
           ></editor>
-          <ui-spinner *ngIf="loading || editorLoading"></ui-spinner>
+          <ui-spinner *ngIf="editorLoading"></ui-spinner>
         </form>
       </ng-template>
     </ui-tab>

--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.html
@@ -23,7 +23,7 @@
             [init]="editor"
             formControlName="text"
           ></editor>
-          <ui-spinner *ngIf="loading"></ui-spinner>
+          <ui-spinner *ngIf="loading || editorLoading"></ui-spinner>
         </form>
       </ng-template>
     </ui-tab>

--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.ts
@@ -27,6 +27,7 @@ import {
 import { createEditorForm } from './editor-settings.forms';
 import { WidgetSettings } from '../../../models/dashboard.model';
 import { WidgetService } from '../../../services/widget/widget.service';
+import { RawEditorSettings } from 'tinymce';
 
 // export type EditorFormType = ReturnType<typeof createEditorForm>;
 
@@ -54,7 +55,7 @@ export class EditorSettingsComponent
   @Output() formChange: EventEmitter<ReturnType<typeof createEditorForm>> =
     new EventEmitter();
   /** tinymce editor configuration */
-  public editor: any = WIDGET_EDITOR_CONFIG;
+  public editor: RawEditorSettings = WIDGET_EDITOR_CONFIG;
   /** Current resource */
   public resource: Resource | null = null;
   /** Current reference data */
@@ -63,6 +64,8 @@ export class EditorSettingsComponent
   public layout: Layout | null = null;
   /** Loading indicator */
   public loading = true;
+  /** whether tinymce is done loading */
+  public editorLoading = true;
   /** Html element containing widget custom style */
   private customStyle?: HTMLStyleElement;
 
@@ -86,6 +89,8 @@ export class EditorSettingsComponent
     // Set the editor language
     this.editor.language = editorService.language;
     this.dataTemplateService.setEditorLinkList(this.editor);
+    console.log(this.editor);
+    this.editorService.listenToLoader(this.editor, this);
   }
 
   ngOnInit(): void {

--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.ts
@@ -89,7 +89,6 @@ export class EditorSettingsComponent
     // Set the editor language
     this.editor.language = editorService.language;
     this.dataTemplateService.setEditorLinkList(this.editor);
-    console.log(this.editor);
     this.editorService.listenToLoader(this.editor, this);
   }
 

--- a/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor-settings/editor-settings.component.ts
@@ -89,7 +89,6 @@ export class EditorSettingsComponent
     // Set the editor language
     this.editor.language = editorService.language;
     this.dataTemplateService.setEditorLinkList(this.editor);
-    this.editorService.listenToLoader(this.editor, this);
   }
 
   ngOnInit(): void {

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.html
@@ -18,6 +18,7 @@
         [formGroup]="widgetFormGroup"
         [resource]="resource"
         [templates]="templates"
+        [loading]="loading"
       ></shared-tab-main>
     </ng-template>
   </ui-tab>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -75,6 +75,8 @@ export class GridSettingsComponent
   public templates: Form[] = [];
   /** Resource */
   public resource: Resource | null = null;
+  /** Loading */
+  public loading = false;
 
   /** Stores the selected tab */
   public selectedTab = 0;
@@ -302,6 +304,7 @@ export class GridSettingsComponent
    */
   private getQueryMetaData(): void {
     if (this.widgetFormGroup.get('resource')?.value) {
+      this.loading = true;
       const layoutIds: string[] | undefined =
         this.widgetFormGroup?.get('layouts')?.value;
       const aggregationIds: string[] | undefined =
@@ -337,6 +340,7 @@ export class GridSettingsComponent
             this.resource = null;
             this.fields = [];
           }
+          this.loading = false;
         });
     } else {
       this.relatedForms = [];

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.html
@@ -1,4 +1,8 @@
-<div [formGroup]="formGroup" class="flex flex-col">
+<div
+  [formGroup]="formGroup"
+  class="flex flex-col"
+  *ngIf="!loading; else loadingTmpl"
+>
   <h2>{{ 'common.general' | translate }}</h2>
   <!-- Widget title -->
   <div uiFormFieldDirective>
@@ -77,3 +81,10 @@
     ></shared-layout-table>
   </div>
 </div>
+
+<!-- Loading indicator -->
+<ng-template #loadingTmpl>
+  <div class="h-full w-full flex">
+    <ui-spinner class="m-auto block"></ui-spinner>
+  </div>
+</ng-template>

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.component.ts
@@ -18,6 +18,8 @@ export class TabMainComponent {
   @Input() resource: Resource | null = null;
   /** Available resource templates */
   @Input() templates: Form[] = [];
+  /** loading boolean */
+  @Input() loading = false;
 
   /**
    * Reset given form field value if there is a value previously to avoid triggering

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.module.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-main/tab-main.module.ts
@@ -11,6 +11,7 @@ import {
   SelectMenuModule,
   IconModule,
   ButtonModule,
+  SpinnerModule,
 } from '@oort-front/ui';
 import { AggregationTableModule } from '../../../aggregation/aggregation-table/aggregation-table.module';
 import { ResourceSelectComponent } from '../../../controls/public-api';
@@ -34,6 +35,7 @@ import { ResourceSelectComponent } from '../../../controls/public-api';
     SelectMenuModule,
     ResourceSelectComponent,
     ButtonModule,
+    SpinnerModule,
   ],
   exports: [TabMainComponent],
 })

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.html
@@ -56,6 +56,7 @@
           [fields$]="fields$"
           (fields)="fields.next($event)"
           [mapPortal]="mapPortal"
+          [loading]="loading"
         ></shared-layer-datasource>
       </ui-tab>
       <!-- Sublayers -->

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
@@ -133,6 +133,8 @@ export class EditLayerModalComponent
   public isDatasourceValid = false;
   /** Map dom portal */
   public mapPortal?: DomPortal;
+  /** Loading */
+  public loading = false;
   /**
    * This property would handle the form change side effects to be triggered once all
    * layer related updates are done in order to avoid multiple mismatches and duplications between
@@ -513,6 +515,7 @@ export class EditLayerModalComponent
    * Get resource from graphql
    */
   getResource(): void {
+    this.loading = true;
     this.fields.next([]);
     const formValue = this.form.getRawValue();
     const resourceID = get(formValue, 'datasource.resource');
@@ -552,6 +555,7 @@ export class EditLayerModalComponent
               );
             }
           }
+          this.loading = false;
         });
     }
   }

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.html
@@ -1,6 +1,10 @@
 <div class="flex flex-wrap gap-4 flex-col lg:flex-row lg:h-full">
   <!-- Datasource form -->
-  <form [formGroup]="formGroup" class="flex-1 lg:max-w-[50%]">
+  <form
+    [formGroup]="formGroup"
+    class="flex-1 lg:max-w-[50%]"
+    *ngIf="!loading; else loadingTmpl"
+  >
     <div class="flex flex-col gap-3 w-full">
       <div class="flex-1 flex-col">
         <!-- Reference data selection  -->
@@ -95,9 +99,7 @@
       <shared-graphql-variables-mapping
         *ngIf="referenceData && referenceData.type === 'graphql'"
         [referenceData]="referenceData"
-        [control]="
-          $any(formGroup.get('referenceDataVariableMapping'))
-        "
+        [control]="$any(formGroup.get('referenceDataVariableMapping'))"
       ></shared-graphql-variables-mapping>
 
       <!-- Selected layout -->
@@ -300,6 +302,13 @@
       </div>
     </ng-template>
   </form>
+  <!-- Loading indicator -->
+  <ng-template #loadingTmpl>
+    <div class="h-full w-full flex">
+      <ui-spinner class="m-auto block"></ui-spinner>
+    </div>
+  </ng-template>
+
   <!-- Map -->
   <div
     class="lg:flex-1 max-lg:min-w-full h-80 lg:h-[400px] flex-shrink-0 rounded overflow-hidden"

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.component.ts
@@ -59,6 +59,8 @@ export class LayerDatasourceComponent extends UnsubscribeComponent {
   @Input() fields$!: Observable<Fields[]>;
   /** Map dom portal */
   @Input() mapPortal?: DomPortal;
+  /** Loading */
+  @Input() loading = false;
   /** Emit new fields */
   @Output() fields: EventEmitter<Fields[]> = new EventEmitter<Fields[]>();
   /** Admin fields */

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.module.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-datasource/layer-datasource.module.ts
@@ -12,6 +12,7 @@ import {
   SelectMenuModule,
   DividerModule,
   TooltipModule,
+  SpinnerModule,
 } from '@oort-front/ui';
 import { PortalModule } from '@angular/cdk/portal';
 import {
@@ -42,6 +43,7 @@ import { GraphqlVariablesMappingComponent } from '../../../common/graphql-variab
     ResourceSelectComponent,
     ReferenceDataSelectComponent,
     GraphqlVariablesMappingComponent,
+    SpinnerModule,
   ],
   exports: [LayerDatasourceComponent],
 })

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.html
@@ -1,4 +1,8 @@
 <ng-container [formGroup]="formGroup">
-  <editor [init]="editor" formControlName="text"></editor>
+  <editor
+    (onInit)="editorLoading = false"
+    [init]="editor"
+    formControlName="text"
+  ></editor>
 </ng-container>
 <ui-spinner *ngIf="editorLoading"></ui-spinner>

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.html
@@ -1,3 +1,4 @@
 <ng-container [formGroup]="formGroup">
   <editor [init]="editor" formControlName="text"></editor>
 </ng-container>
+<ui-spinner *ngIf="editorLoading"></ui-spinner>

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.ts
@@ -7,6 +7,7 @@ import { EditorModule, TINYMCE_SCRIPT_SRC } from '@tinymce/tinymce-angular';
 import { Fields } from '../../../../../../models/layer.model';
 import { Observable, takeUntil } from 'rxjs';
 import { UnsubscribeComponent } from '../../../../../utils/unsubscribe/unsubscribe.component';
+import { SpinnerModule } from '@oort-front/ui';
 
 /**
  * Popup text element component.
@@ -14,7 +15,13 @@ import { UnsubscribeComponent } from '../../../../../utils/unsubscribe/unsubscri
 @Component({
   selector: 'shared-text-element',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, EditorModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    EditorModule,
+    SpinnerModule,
+  ],
   templateUrl: './text-element.component.html',
   styleUrls: ['./text-element.component.scss'],
   providers: [
@@ -31,6 +38,8 @@ export class TextElementComponent
   @Input() fields$!: Observable<Fields[]>;
   /** Tinymce editor configuration */
   public editor: any = POPUP_EDITOR_CONFIG;
+  /** loading boolean for editor */
+  public editorLoading = true;
 
   /**
    * Popup text element component.
@@ -53,6 +62,7 @@ export class TextElementComponent
         text: `{{${field.name}}}`,
       }));
       this.editorService.addCalcAndKeysAutoCompleter(this.editor, keys);
+      this.editorService.listenToLoader(this.editor, this);
     });
   }
 }

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.ts
@@ -62,7 +62,6 @@ export class TextElementComponent
         text: `{{${field.name}}}`,
       }));
       this.editorService.addCalcAndKeysAutoCompleter(this.editor, keys);
-      this.editorService.listenToLoader(this.editor, this);
     });
   }
 }

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.html
@@ -1,4 +1,8 @@
-<form [formGroup]="formGroup" class="flex flex-col gap-3">
+<form
+  [formGroup]="formGroup"
+  class="flex flex-col gap-3"
+  *ngIf="!loading; else loadingTmpl"
+>
   <div uiFormFieldDirective>
     <label>{{ 'common.title' | translate }}</label>
     <input formControlName="title" type="string" />
@@ -228,3 +232,10 @@
     </ng-container>
   </ng-container>
 </form>
+
+<!-- Loading indicator -->
+<ng-template #loadingTmpl>
+  <div class="h-full w-full flex">
+    <ui-spinner class="m-auto block"></ui-spinner>
+  </div>
+</ng-template>

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-general/summary-card-general.component.ts
@@ -22,6 +22,7 @@ import {
   RadioModule,
   SelectMenuModule,
   SelectOptionModule,
+  SpinnerModule,
   TooltipModule,
 } from '@oort-front/ui';
 import { Dialog } from '@angular/cdk/dialog';
@@ -56,6 +57,7 @@ import { GraphqlVariablesMappingComponent } from '../../common/graphql-variables
     ReferenceDataSelectComponent,
     DividerModule,
     GraphqlVariablesMappingComponent,
+    SpinnerModule,
   ],
   templateUrl: './summary-card-general.component.html',
   styleUrls: ['./summary-card-general.component.scss'],
@@ -71,6 +73,8 @@ export class SummaryCardGeneralComponent extends UnsubscribeComponent {
   @Input() layout: Layout | null = null;
   /** Selected aggregation */
   @Input() aggregation: Aggregation | null = null;
+  /** loading boolean */
+  @Input() loading = false;
 
   /**
    * Component for the general summary cards tab

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.html
@@ -21,6 +21,7 @@
           [resource]="resource"
           [layout]="layout"
           [aggregation]="aggregation"
+          [loading]="loading"
         ></shared-summary-card-general>
       </ng-template>
     </ui-tab>

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -77,6 +77,8 @@ export class SummaryCardSettingsComponent
   private previousTabsLength = 0;
   /** Current active settings tab index */
   public activeSettingsTab = 0;
+  /** Loading boolean */
+  public loading = false;
 
   /** @returns a FormControl for the searchable field */
   get searchableControl(): FormControl {
@@ -285,6 +287,7 @@ export class SummaryCardSettingsComponent
    * @param id resource id
    */
   private getResource(id: string): void {
+    this.loading = true;
     const formValue = this.widgetFormGroup.getRawValue();
     const layoutID = get(formValue, 'card.layout');
     const aggregationID = get(formValue, 'card.aggregation');
@@ -328,6 +331,7 @@ export class SummaryCardSettingsComponent
             this.getCustomAggregation();
           }
         }
+        this.loading = false;
       });
   }
 
@@ -337,6 +341,7 @@ export class SummaryCardSettingsComponent
    * @param id reference data id
    */
   private getReferenceData(id: string): void {
+    this.loading = true;
     this.apollo
       .query<ReferenceDataQueryResponse>({
         query: GET_REFERENCE_DATA,
@@ -360,6 +365,7 @@ export class SummaryCardSettingsComponent
               };
             });
         }
+        this.loading = false;
       });
   }
 

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.html
@@ -8,6 +8,7 @@
       }}
     </ui-alert>
     <!-- Template editor -->
-    <editor [init]="editor" formControlName="html"></editor>
+    <editor [init]="editor" formControlName="html"></editor
+    ><ui-spinner *ngIf="editorLoading"></ui-spinner>
   </ng-container>
 </form>

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.html
@@ -8,7 +8,11 @@
       }}
     </ui-alert>
     <!-- Template editor -->
-    <editor [init]="editor" formControlName="html"></editor
+    <editor
+      (onInit)="editorLoading = false"
+      [init]="editor"
+      formControlName="html"
+    ></editor
     ><ui-spinner *ngIf="editorLoading"></ui-spinner>
   </ng-container>
 </form>

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.ts
@@ -37,7 +37,6 @@ export class TextEditorTabComponent implements OnChanges {
     // Set the editor language
     this.editor.language = editorService.language;
     this.dataTemplateService.setEditorLinkList(this.editor);
-    this.editorService.listenToLoader(this.editor, this);
   }
 
   ngOnChanges(): void {

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component.ts
@@ -19,6 +19,8 @@ export class TextEditorTabComponent implements OnChanges {
   @Input() fields: any[] = [];
   /** Tinymce editor configuration */
   public editor = WIDGET_EDITOR_CONFIG;
+  /** editor loading */
+  public editorLoading = true;
 
   /**
    * Edition of card template.
@@ -35,6 +37,7 @@ export class TextEditorTabComponent implements OnChanges {
     // Set the editor language
     this.editor.language = editorService.language;
     this.dataTemplateService.setEditorLinkList(this.editor);
+    this.editorService.listenToLoader(this.editor, this);
   }
 
   ngOnChanges(): void {

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor.module.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/text-editor-tab/text-editor.module.ts
@@ -4,7 +4,7 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { EditorModule, TINYMCE_SCRIPT_SRC } from '@tinymce/tinymce-angular';
 import { TextEditorTabComponent } from './text-editor-tab.component';
-import { AlertModule, IconModule } from '@oort-front/ui';
+import { AlertModule, IconModule, SpinnerModule } from '@oort-front/ui';
 
 /** Text editor tab Module for summary cards edition */
 @NgModule({
@@ -17,6 +17,7 @@ import { AlertModule, IconModule } from '@oort-front/ui';
     FormsModule,
     AlertModule,
     IconModule,
+    SpinnerModule,
   ],
   exports: [TextEditorTabComponent],
   providers: [

--- a/libs/shared/src/lib/const/tinymce.const.ts
+++ b/libs/shared/src/lib/const/tinymce.const.ts
@@ -329,6 +329,9 @@ export const EMAIL_EDITOR_CONFIG: RawEditorSettings = {
     'keyboardnav', // the default keyboard navigation tab
   ],
   convert_urls: false,
+  init_instance_callback: (editor) => {
+    editor.fire('loaded');
+  },
 };
 
 /** Field Editor tinymce configuration. */
@@ -346,6 +349,9 @@ export const FIELD_EDITOR_CONFIG: RawEditorSettings = {
     'shortcuts', // the default shortcuts tab
     'keyboardnav', // the default keyboard navigation tab
   ],
+  init_instance_callback: (editor) => {
+    editor.fire('loaded');
+  },
 };
 
 /** Popup Editor tinymce configuration. */
@@ -373,6 +379,9 @@ export const POPUP_EDITOR_CONFIG: RawEditorSettings = {
     'shortcuts', // the default shortcuts tab
     'keyboardnav', // the default keyboard navigation tab
   ],
+  init_instance_callback: (editor) => {
+    editor.fire('loaded');
+  },
 };
 
 /** Inline Editor tinymce configuration. */
@@ -383,4 +392,7 @@ export const INLINE_EDITOR_CONFIG: RawEditorSettings = {
   plugins: '',
   height: 50,
   content_style: 'p { margin: 0 !important; }',
+  init_instance_callback: (editor) => {
+    editor.fire('loaded');
+  },
 };

--- a/libs/shared/src/lib/const/tinymce.const.ts
+++ b/libs/shared/src/lib/const/tinymce.const.ts
@@ -298,9 +298,6 @@ export const WIDGET_EDITOR_CONFIG: RawEditorSettings = {
       items: 'contextFilter resetFilters',
     });
   },
-  init_instance_callback: (editor) => {
-    editor.fire('loaded');
-  },
 };
 
 /** Email Editor tinymce configuration. */
@@ -329,9 +326,6 @@ export const EMAIL_EDITOR_CONFIG: RawEditorSettings = {
     'keyboardnav', // the default keyboard navigation tab
   ],
   convert_urls: false,
-  init_instance_callback: (editor) => {
-    editor.fire('loaded');
-  },
 };
 
 /** Field Editor tinymce configuration. */
@@ -349,9 +343,6 @@ export const FIELD_EDITOR_CONFIG: RawEditorSettings = {
     'shortcuts', // the default shortcuts tab
     'keyboardnav', // the default keyboard navigation tab
   ],
-  init_instance_callback: (editor) => {
-    editor.fire('loaded');
-  },
 };
 
 /** Popup Editor tinymce configuration. */
@@ -379,9 +370,6 @@ export const POPUP_EDITOR_CONFIG: RawEditorSettings = {
     'shortcuts', // the default shortcuts tab
     'keyboardnav', // the default keyboard navigation tab
   ],
-  init_instance_callback: (editor) => {
-    editor.fire('loaded');
-  },
 };
 
 /** Inline Editor tinymce configuration. */
@@ -392,7 +380,4 @@ export const INLINE_EDITOR_CONFIG: RawEditorSettings = {
   plugins: '',
   height: 50,
   content_style: 'p { margin: 0 !important; }',
-  init_instance_callback: (editor) => {
-    editor.fire('loaded');
-  },
 };

--- a/libs/shared/src/lib/const/tinymce.const.ts
+++ b/libs/shared/src/lib/const/tinymce.const.ts
@@ -298,6 +298,9 @@ export const WIDGET_EDITOR_CONFIG: RawEditorSettings = {
       items: 'contextFilter resetFilters',
     });
   },
+  init_instance_callback: (editor) => {
+    editor.fire('loaded');
+  },
 };
 
 /** Email Editor tinymce configuration. */

--- a/libs/shared/src/lib/services/editor/editor.service.ts
+++ b/libs/shared/src/lib/services/editor/editor.service.ts
@@ -3,6 +3,12 @@ import { EDITOR_LANGUAGE_PAIRS } from '../../const/tinymce.const';
 import { TranslateService } from '@ngx-translate/core';
 import { Editor, RawEditorSettings } from 'tinymce';
 import { DOCUMENT } from '@angular/common';
+import { EditorControlComponent } from '../../components/controls/public-api';
+import { EditorSettingsComponent } from '../../components/widgets/editor-settings/editor-settings.component';
+import { TextEditorTabComponent } from '../../components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component';
+import { TextElementComponent } from '../../components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component';
+import { EditTemplateModalComponent } from '../../components/templates/components/edit-template-modal/edit-template-modal.component';
+import { EmailPreviewModalComponent } from '../../components/email-preview-modal/email-preview-modal.component';
 
 /**
  * Shared editor service
@@ -121,7 +127,16 @@ export class EditorService {
    * @param editor current editor
    * @param componentInstance component instance
    */
-  listenToLoader(editor: RawEditorSettings, componentInstance: any) {
+  listenToLoader(
+    editor: RawEditorSettings,
+    componentInstance:
+      | EditorControlComponent
+      | EditorSettingsComponent
+      | TextEditorTabComponent
+      | TextElementComponent
+      | EditTemplateModalComponent
+      | EmailPreviewModalComponent
+  ) {
     const defaultSetup = editor.setup;
     editor.setup = (e) => {
       if (defaultSetup && typeof defaultSetup === 'function') {

--- a/libs/shared/src/lib/services/editor/editor.service.ts
+++ b/libs/shared/src/lib/services/editor/editor.service.ts
@@ -3,12 +3,6 @@ import { EDITOR_LANGUAGE_PAIRS } from '../../const/tinymce.const';
 import { TranslateService } from '@ngx-translate/core';
 import { Editor, RawEditorSettings } from 'tinymce';
 import { DOCUMENT } from '@angular/common';
-import { EditorControlComponent } from '../../components/controls/public-api';
-import { EditorSettingsComponent } from '../../components/widgets/editor-settings/editor-settings.component';
-import { TextEditorTabComponent } from '../../components/widgets/summary-card-settings/text-editor-tab/text-editor-tab.component';
-import { TextElementComponent } from '../../components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component';
-import { EditTemplateModalComponent } from '../../components/templates/components/edit-template-modal/edit-template-modal.component';
-import { EmailPreviewModalComponent } from '../../components/email-preview-modal/email-preview-modal.component';
 
 /**
  * Shared editor service
@@ -117,34 +111,6 @@ export class EditorService {
             (key.value || key.text).includes(pattern)
           );
         },
-      });
-    };
-  }
-
-  /**
-   * listens to the loading event
-   *
-   * @param editor current editor
-   * @param componentInstance component instance
-   */
-  listenToLoader(
-    editor: RawEditorSettings,
-    componentInstance:
-      | EditorControlComponent
-      | EditorSettingsComponent
-      | TextEditorTabComponent
-      | TextElementComponent
-      | EditTemplateModalComponent
-      | EmailPreviewModalComponent
-  ) {
-    const defaultSetup = editor.setup;
-    editor.setup = (e) => {
-      if (defaultSetup && typeof defaultSetup === 'function') {
-        defaultSetup(e);
-      }
-      e.on('loaded', () => {
-        componentInstance.editorLoading = false;
-        return false;
       });
     };
   }

--- a/libs/shared/src/lib/services/editor/editor.service.ts
+++ b/libs/shared/src/lib/services/editor/editor.service.ts
@@ -28,6 +28,7 @@ export class EditorService {
    * @returns the base url
    */
   get url(): string {
+    return 'https://whoemssafedsta03.blob.core.windows.net/shared/dev/tinymce';
     if (this.environment.tinymceBaseUrl) {
       return this.environment.tinymceBaseUrl;
     } else {
@@ -82,7 +83,9 @@ export class EditorService {
   ) {
     const defaultSetup = editor.setup;
     editor.setup = (e: Editor) => {
-      if (defaultSetup && typeof defaultSetup === 'function') defaultSetup(e);
+      if (defaultSetup && typeof defaultSetup === 'function') {
+        defaultSetup(e);
+      }
       e.ui.registry.addAutocompleter('keys_data_and_calc', {
         ch: '{',
         minChars: 0,
@@ -109,6 +112,25 @@ export class EditorService {
             (key.value || key.text).includes(pattern)
           );
         },
+      });
+    };
+  }
+
+  /**
+   * listens to the loading event
+   *
+   * @param editor current editor
+   * @param componentInstance component instance
+   */
+  listenToLoader(editor: RawEditorSettings, componentInstance: any) {
+    const defaultSetup = editor.setup;
+    editor.setup = (e) => {
+      if (defaultSetup && typeof defaultSetup === 'function') {
+        defaultSetup(e);
+      }
+      e.on('loaded', () => {
+        componentInstance.editorLoading = false;
+        return false;
       });
     };
   }

--- a/libs/shared/src/lib/services/editor/editor.service.ts
+++ b/libs/shared/src/lib/services/editor/editor.service.ts
@@ -28,7 +28,6 @@ export class EditorService {
    * @returns the base url
    */
   get url(): string {
-    return 'https://whoemssafedsta03.blob.core.windows.net/shared/dev/tinymce';
     if (this.environment.tinymceBaseUrl) {
       return this.environment.tinymceBaseUrl;
     } else {

--- a/libs/shared/src/lib/shared.module.ts
+++ b/libs/shared/src/lib/shared.module.ts
@@ -45,10 +45,12 @@ import { ListFilterComponent } from './components/list-filter/list-filter.compon
 import { StatusOptionsComponent } from './components/status-options/status-options.component';
 import { DashboardFilterIconComponent } from './components/dashboard-filter-icon/dashboard-filter-icon.component';
 import { PayloadModalComponent } from './components/payload-modal/payload-modal.component';
+import { MonacoEditorComponent } from './components/widgets/common/monaco-editor/monaco-editor.component';
 
 /** Main module for the shared project */
 @NgModule({
   exports: [
+    MonacoEditorComponent,
     PayloadModalComponent,
     LayoutModule,
     AccessModule,
@@ -106,6 +108,7 @@ import { PayloadModalComponent } from './components/payload-modal/payload-modal.
     StatusOptionsComponent,
     DashboardFilterIconComponent,
     PayloadModalComponent,
+    MonacoEditorComponent,
   ],
 })
 export class Module {}

--- a/libs/shared/src/lib/survey/components/json-editor/json-editor.component.html
+++ b/libs/shared/src/lib/survey/components/json-editor/json-editor.component.html
@@ -1,6 +1,6 @@
 <!-- JSON editor -->
-<ngx-monaco-editor
+<shared-monaco-editor
   class="h-[200px] !w-full min-w-[200px]"
-  [formControl]="control"
+  [control]="control"
   [options]="editorOptions"
-></ngx-monaco-editor>
+></shared-monaco-editor>

--- a/libs/shared/src/lib/survey/components/json-editor/json-editor.component.ts
+++ b/libs/shared/src/lib/survey/components/json-editor/json-editor.component.ts
@@ -7,10 +7,10 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { QuestionAngular } from 'survey-angular-ui';
 import { JSONEditorModel } from './json-editor.model';
 import { Subject, takeUntil } from 'rxjs';
+import { MonacoEditorComponent } from '../../../components/widgets/common/monaco-editor/monaco-editor.component';
 
 /**
  * JSON editor component for Form Builder.
@@ -19,7 +19,12 @@ import { Subject, takeUntil } from 'rxjs';
 @Component({
   selector: 'shared-json-editor',
   standalone: true,
-  imports: [CommonModule, MonacoEditorModule, FormsModule, ReactiveFormsModule],
+  imports: [
+    CommonModule,
+    MonacoEditorComponent,
+    FormsModule,
+    ReactiveFormsModule,
+  ],
   templateUrl: './json-editor.component.html',
   styleUrls: ['./json-editor.component.scss'],
 })

--- a/libs/shared/src/lib/survey/components/query-editor/query-editor.component.html
+++ b/libs/shared/src/lib/survey/components/query-editor/query-editor.component.html
@@ -1,6 +1,6 @@
 <!-- Query editor -->
-<ngx-monaco-editor
+<shared-monaco-editor
   class="h-[200px] !w-full min-w-[200px]"
-  [formControl]="control"
+  [control]="control"
   [options]="editorOptions"
-></ngx-monaco-editor>
+></shared-monaco-editor>

--- a/libs/shared/src/lib/survey/components/query-editor/query-editor.component.ts
+++ b/libs/shared/src/lib/survey/components/query-editor/query-editor.component.ts
@@ -6,11 +6,11 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { QueryEditorModel } from './query-editor.model';
 import { QuestionAngular } from 'survey-angular-ui';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Subject, takeUntil } from 'rxjs';
+import { MonacoEditorComponent } from '../../../components/widgets/common/monaco-editor/monaco-editor.component';
 
 /**
  * Query editor component for Form Builder.
@@ -20,7 +20,12 @@ import { Subject, takeUntil } from 'rxjs';
 @Component({
   selector: 'shared-query-editor',
   standalone: true,
-  imports: [CommonModule, MonacoEditorModule, FormsModule, ReactiveFormsModule],
+  imports: [
+    CommonModule,
+    MonacoEditorComponent,
+    FormsModule,
+    ReactiveFormsModule,
+  ],
   templateUrl: './query-editor.component.html',
   styleUrls: ['./query-editor.component.scss'],
 })


### PR DESCRIPTION
# Description

- add loading indicators when resource/reference data is loading from widgets settings
- add loading indicator when tinymce is loading
- add loading indicator when monaco editor loading

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/92198)

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Went in diverse components and checked that a loader appeared.

## Screenshots

![loadingEverywhere](https://github.com/ReliefApplications/ems-frontend/assets/59645813/0b94af90-6197-4a9a-9a97-9045b3792615)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
