### PR TITLE
Ab#89558 do not resize when toggling filter

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -227,6 +227,8 @@ export class GridComponent
   public hasEnabledActions = false;
   /** Reference to the column chooser element */
   private columnChooserRef: PopupRef | null = null;
+  /** Prevent next column reset */
+  private preventColumnResize = false;
 
   /** @returns show border of grid */
   get showBorder(): boolean {
@@ -385,7 +387,9 @@ export class GridComponent
           this.updateColumnShowFullScreenButton((column as any).field);
         });
       }, 0);
-      this.setColumnsWidth();
+      this.preventColumnResize
+        ? (this.preventColumnResize = false)
+        : this.setColumnsWidth();
     }
   }
 
@@ -442,6 +446,7 @@ export class GridComponent
         logic: 'and',
         filters: this.showFilter ? [] : this.filter.filters,
       });
+      this.preventColumnResize = true;
     }
   }
 


### PR DESCRIPTION
# Description

Prevent emitting the filter when toggling showFilter.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/89558/)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Tried toggling the show filter, and navigating between both filters, quick and complete. The code I removed is 2 years old, and it seems to work fine without (checked Maximo's commit).

## Screenshots

![Peek 2024-05-15 14-21](https://github.com/ReliefApplications/ems-frontend/assets/59645813/9541fce0-b87c-4b45-968e-2e8171555557)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
