### PR TITLE
fix/AB#92208_search_in_question_type_resources_opening_incorrect_modal

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -46,6 +46,7 @@
       [placeholder]="'common.placeholder.search' | translate"
       [formControl]="search"
       [clearButton]="true"
+      (keydown.enter)="$event.preventDefault()"
     >
     </kendo-textbox>
     <!-- Column Chooser -->


### PR DESCRIPTION
# Description

Fix: Search in question of type Resources is opening incorrect modal.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/92208)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

As the attached video.
observation: press enter after search.

## Screenshots

![Peek 22-05-2024 12-08](https://github.com/ReliefApplications/ems-frontend/assets/56398308/9ae57882-5707-4a97-9e81-5babd8f40947)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
