### PR TITLE
AB#83348 ABC - On some layout loadings, the scroll is by default not all on the left

### DIFF
--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -504,6 +504,15 @@ export class CoreGridComponent
                   defaultLayoutFields,
                   ''
                 );
+                // Scroll to left
+                if (this.grid) {
+                  (
+                    this.grid as any
+                  ).gridRef.nativeElement.children[1].children[1].children[0].scrollTo(
+                    0,
+                    0
+                  );
+                }
               }
             }
             this.getRecords();
@@ -816,15 +825,6 @@ export class CoreGridComponent
                 // if (!this.readOnly) {
                 //   this.initSelectedRows();
                 // }
-                // We reset the scroll position
-                if (this.hasLayoutChanges && this.grid) {
-                  (
-                    this.grid as any
-                  ).gridRef.nativeElement.children[1].children[1].children[0].scrollTo(
-                    0,
-                    0
-                  );
-                }
               }
             } catch (error) {
               console.error(error);

--- a/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/core-grid.component.ts
@@ -816,6 +816,15 @@ export class CoreGridComponent
                 // if (!this.readOnly) {
                 //   this.initSelectedRows();
                 // }
+                // We reset the scroll position
+                if (this.hasLayoutChanges && this.grid) {
+                  (
+                    this.grid as any
+                  ).gridRef.nativeElement.children[1].children[1].children[0].scrollTo(
+                    0,
+                    0
+                  );
+                }
               }
             } catch (error) {
               console.error(error);


### PR DESCRIPTION
# Description

The core grid component was (in some) loading the layout without the scroll starting from the start, a forced reset of the scroll position has been coded in the component. so after the layout has changed and loaded the position is reset.

## Useful links

- [83348 ABC - On some layout loadings, the scroll is by default not all on the left](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83348/)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Change layout to one which was causing the issue and make sure it doesn't happen anymore.
- [x] Check other layouts and make sure no regressions happened.

## Screenshots

https://github.com/ReliefApplications/ems-frontend/assets/94831019/2ed14077-de3d-4585-84b2-aeba03a38114


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x]  * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
