### PR TITLE
AB#93799 ABC - Add close button below modal to see attached records on a grid

### DIFF
--- a/libs/shared/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.html
+++ b/libs/shared/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.html
@@ -20,8 +20,11 @@
     </shared-core-grid>
   </ng-container>
   <ng-container ngProjectAs="actions">
-    <ui-button [uiDialogClose] variant="danger">{{
-      'common.close' | translate
+    <ui-button [uiDialogClose] variant="default" *ngIf="!selectable">
+      {{ 'common.close' | translate }}
+    </ui-button>
+    <ui-button [uiDialogClose] variant="danger" *ngIf="selectable">{{
+      'common.cancel' | translate
     }}</ui-button>
     <ui-button
       category="secondary"

--- a/libs/shared/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.html
+++ b/libs/shared/src/lib/components/search-resource-grid-modal/search-resource-grid-modal.component.html
@@ -19,10 +19,10 @@
     >
     </shared-core-grid>
   </ng-container>
-  <ng-container ngProjectAs="actions" *ngIf="selectable">
-    <ui-button [uiDialogClose] variant="default">
-      {{ 'common.cancel' | translate }}
-    </ui-button>
+  <ng-container ngProjectAs="actions">
+    <ui-button [uiDialogClose] variant="danger">{{
+      'common.close' | translate
+    }}</ui-button>
     <ui-button
       category="secondary"
       variant="primary"


### PR DESCRIPTION
# Description

Modal for record details on the grid has been updated so it features a close button.
The close button was already coded, but it was being hidden by a ngif.
Button has been updated to use 'close' instead of 'cancel' and it now uses the danger style so its text is displayed in red.

## Useful links

- [AB#2393799 ABC - Add close button below modal to see attached records on a grid](https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories?text=93799&workitem=93799)

## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Open the record details modal and make sure the new button is available

## Screenshots

![Screenshot 2024-05-23 113438](https://github.com/ReliefApplications/ems-frontend/assets/94831019/aa1da985-4047-42f5-ab4e-1e1799946d7a)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
