### PR TITLE
AB#92824 Widget tooltips

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -2363,7 +2363,18 @@
 				"padding": "Use widget inner padding",
 				"searchable": "Allow search",
 				"sortable": "Allow sorting",
-				"title": "Widget display"
+				"title": "Widget display",
+				"tooltip": {
+					"content": "Tooltip content",
+					"display": {
+						"title": "Display tooltip",
+						"tooltip": "When configured, the tooltip will be displayed when hovering over the icon next to the widget title"
+					},
+					"title": {
+						"placeholder": "Enter a title (optional)",
+						"title": "Tooltip title"
+					}
+				}
 			},
 			"map": {
 				"defaultTitle": "Map Widget",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -2363,7 +2363,18 @@
 				"padding": "Utiliser la marge intérieure du widget",
 				"searchable": "Autoriser la recherche",
 				"sortable": "Autoriser le tri",
-				"title": "Affichage des widgets"
+				"title": "Affichage des widgets",
+				"tooltip": {
+					"content": "Contenu de l'infobulle",
+					"display": {
+						"title": "Afficher l'infobulle",
+						"tooltip": "Lorsqu'il est configuré, l'infobulle s'affiche lorsque vous survolez l'icône à côté du titre du widget"
+					},
+					"title": {
+						"placeholder": "Entrez un titre (facultatif)",
+						"title": "Titre de l'infobulle"
+					}
+				}
 			},
 			"map": {
 				"defaultTitle": "Widget Carte",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -2363,7 +2363,18 @@
 				"padding": "******",
 				"searchable": "******",
 				"sortable": "******",
-				"title": "******"
+				"title": "******",
+				"tooltip": {
+					"content": "******",
+					"display": {
+						"title": "******",
+						"tooltip": "******"
+					},
+					"title": {
+						"placeholder": "******",
+						"title": "******"
+					}
+				}
 			},
 			"map": {
 				"defaultTitle": "******",

--- a/libs/shared/src/lib/components/widget/widget.component.html
+++ b/libs/shared/src/lib/components/widget/widget.component.html
@@ -33,14 +33,16 @@
           '!border-b-gray-300': showBorder,
         }"
       >
-        <ng-container
-          *ngIf="headerLeftTemplate && !fullscreen"
-          [ngTemplateOutlet]="headerLeftTemplate"
-        ></ng-container>
-        <ng-container
-          *ngIf="widgetContentComponent?.headerTemplate"
-          [ngTemplateOutlet]="widgetContentComponent.headerTemplate"
-        ></ng-container>
+        <div class="flex gap-1">
+          <ng-container
+            *ngIf="headerLeftTemplate && !fullscreen"
+            [ngTemplateOutlet]="headerLeftTemplate"
+          ></ng-container>
+          <ng-container
+            *ngIf="widgetContentComponent?.headerTemplate"
+            [ngTemplateOutlet]="widgetContentComponent.headerTemplate"
+          ></ng-container>
+        </div>
         <ng-container
           *ngIf="headerRightTemplate && !fullscreen"
           [ngTemplateOutlet]="headerRightTemplate"

--- a/libs/shared/src/lib/components/widgets/chart/chart.component.html
+++ b/libs/shared/src/lib/components/widgets/chart/chart.component.html
@@ -104,9 +104,20 @@
   </p>
 </div>
 <ng-template #headerTemplate>
-  <span class="widget-title" [title]="settings.title">{{
-    settings.title
-  }}</span>
+  <span class="flex gap-2 items-center">
+    <span class="widget-title" [title]="settings.title">
+      {{ settings.title }}
+    </span>
+    <ui-icon
+      *ngIf="settings.widgetDisplay?.tooltip?.display"
+      class="cursor-help"
+      icon="help"
+      variant="primary"
+      [size]="24"
+      [uiTooltip]="settings.widgetDisplay.tooltip.content"
+      [uiTooltipTitle]="settings.widgetDisplay.tooltip.title"
+    ></ui-icon>
+  </span>
   <!-- Selection of predefined filter -->
   <ng-container *ngIf="predefinedFilters.length > 0">
     <ng-container *ngTemplateOutlet="filterTemplate"></ng-container>

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
@@ -30,9 +30,68 @@
           variant="grey"
           [size]="18"
           [uiTooltip]="'models.widget.tooltip.expandButton.help' | translate"
-        ></ui-icon
-      ></ng-container>
+        ></ui-icon>
+      </ng-container>
     </ui-toggle>
+    <ng-container formGroupName="tooltip">
+      <ui-toggle formControlName="display">
+        <ng-container ngProjectAs="label">
+          {{ 'models.widget.display.tooltip.display.title' | translate }}
+          <ui-icon
+            class="ml-1 cursor-help self-center"
+            icon="info_outline"
+            variant="grey"
+            [size]="18"
+            [uiTooltip]="
+              'models.widget.display.tooltip.display.tooltip' | translate
+            "
+          ></ui-icon>
+        </ng-container>
+        <ui-icon
+          class="ml-1 cursor-help self-center"
+          icon="info_outline"
+          variant="grey"
+          [size]="18"
+          [uiTooltip]="
+            'models.widget.display.tooltip.display.title.tooltip' | translate
+          "
+        ></ui-icon>
+      </ui-toggle>
+
+      <div
+        uiFormFieldDirective
+        *ngIf="formGroup.get('widgetDisplay.tooltip.display')?.value"
+        class="mb-0"
+      >
+        <label>
+          {{ 'models.widget.display.tooltip.title.title' | translate }}
+        </label>
+        <input
+          formControlName="title"
+          [placeholder]="
+            'models.widget.display.tooltip.title.placeholder' | translate
+          "
+        />
+      </div>
+      <div
+        uiFormFieldDirective
+        *ngIf="formGroup.get('widgetDisplay.tooltip.display')?.value"
+      >
+        <label>
+          {{ 'models.widget.display.tooltip.content' | translate }}
+        </label>
+        <ui-textarea
+          formControlName="content"
+          [placeholder]="
+            'components.application.update.placeholder.description' | translate
+          "
+          [minRows]="2"
+          [maxRows]="5"
+          name="textarea"
+        />
+      </div>
+    </ng-container>
+
     <ui-toggle formControlName="hideEmpty" *ngIf="showHideOption">
       <ng-container ngProjectAs="label"
         >{{ 'models.widget.display.hideEmpty' | translate }}

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.html
@@ -33,7 +33,10 @@
         ></ui-icon>
       </ng-container>
     </ui-toggle>
-    <ng-container formGroupName="tooltip">
+    <ng-container
+      formGroupName="tooltip"
+      *ngIf="formGroup.get('widgetDisplay.showHeader')?.value"
+    >
       <ui-toggle formControlName="display">
         <ng-container ngProjectAs="label">
           {{ 'models.widget.display.tooltip.display.title' | translate }}

--- a/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/display-settings.component.ts
@@ -2,7 +2,13 @@ import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { IconModule, ToggleModule, TooltipModule } from '@oort-front/ui';
+import {
+  FormWrapperModule,
+  IconModule,
+  TextareaModule,
+  ToggleModule,
+  TooltipModule,
+} from '@oort-front/ui';
 
 /** Component for selecting the widget display options */
 @Component({
@@ -16,6 +22,8 @@ import { IconModule, ToggleModule, TooltipModule } from '@oort-front/ui';
     TranslateModule,
     IconModule,
     TooltipModule,
+    FormWrapperModule,
+    TextareaModule,
   ],
   templateUrl: './display-settings.component.html',
   styleUrls: ['./display-settings.component.scss'],

--- a/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
@@ -1,9 +1,4 @@
-import {
-  AbstractControl,
-  FormControl,
-  FormGroup,
-  Validators,
-} from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
 import { get } from 'lodash';
 
 /**

--- a/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
@@ -11,6 +11,10 @@ import { get } from 'lodash';
  * @param settings.hideEmpty hide empty widget on preview, front-office and web-widgets apps
  * @param settings.style custom style of the widget
  * @param settings.expandable show expand button
+ * @param settings.tooltip tooltip settings
+ * @param settings.tooltip.display whether to display the tooltip
+ * @param settings.tooltip.title tooltip title, if any
+ * @param settings.tooltip.content tooltip content
  * @param specificControls specific controls to add to the form, on a widget basis
  * @returns form with the common fields
  */
@@ -24,6 +28,11 @@ export const extendWidgetForm = <
     showHeader?: boolean;
     hideEmpty?: boolean;
     expandable: boolean;
+    tooltip?: {
+      display: boolean;
+      title?: string;
+      content: string;
+    };
     style?: string;
   },
   specificControls?: T2
@@ -33,6 +42,11 @@ export const extendWidgetForm = <
     showHeader: new FormControl(get(settings, 'showHeader', true)),
     hideEmpty: new FormControl(get(settings, 'hideEmpty', false)),
     expandable: new FormControl(get(settings, 'expandable', false)),
+    tooltip: new FormGroup({
+      display: new FormControl(get(settings, 'tooltip.display', false)),
+      title: new FormControl(get(settings, 'tooltip.title', '')),
+      content: new FormControl(get(settings, 'tooltip.content', '')),
+    }),
     style: new FormControl(get(settings, 'style', '')),
   };
   Object.assign(controls, specificControls);
@@ -46,6 +60,11 @@ export const extendWidgetForm = <
           showHeader: FormControl<boolean>;
           hideEmpty: FormControl<boolean>;
           expandable: FormControl<boolean>;
+          tooltip: FormGroup<{
+            display: FormControl<boolean>;
+            title: FormControl<string>;
+            content: FormControl<string>;
+          }>;
           style: FormControl<string>;
         } & T2
       >;

--- a/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
@@ -1,4 +1,9 @@
-import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
 import { get } from 'lodash';
 
 /**
@@ -45,7 +50,10 @@ export const extendWidgetForm = <
     tooltip: new FormGroup({
       display: new FormControl(get(settings, 'tooltip.display', false)),
       title: new FormControl(get(settings, 'tooltip.title', '')),
-      content: new FormControl(get(settings, 'tooltip.content', '')),
+      content: new FormControl(
+        get(settings, 'tooltip.content', ''),
+        Validators.required
+      ),
     }),
     style: new FormControl(get(settings, 'style', '')),
   };

--- a/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
+++ b/libs/shared/src/lib/components/widgets/common/display-settings/extendWidgetForm.ts
@@ -50,10 +50,7 @@ export const extendWidgetForm = <
     tooltip: new FormGroup({
       display: new FormControl(get(settings, 'tooltip.display', false)),
       title: new FormControl(get(settings, 'tooltip.title', '')),
-      content: new FormControl(
-        get(settings, 'tooltip.content', ''),
-        Validators.required
-      ),
+      content: new FormControl(get(settings, 'tooltip.content', '')),
     }),
     style: new FormControl(get(settings, 'style', '')),
   };

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.html
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.html
@@ -17,9 +17,20 @@
   </div>
 </div>
 <ng-template #headerTemplate>
-  <span class="widget-title" [title]="settings.title">{{
-    settings.title
-  }}</span>
+  <span class="flex gap-2 items-center">
+    <span class="widget-title" [title]="settings.title">
+      {{ settings.title }}
+    </span>
+    <ui-icon
+      *ngIf="settings.widgetDisplay?.tooltip?.display"
+      class="cursor-help"
+      icon="help"
+      variant="primary"
+      [size]="24"
+      [uiTooltip]="settings.widgetDisplay.tooltip.content"
+      [uiTooltipTitle]="settings.widgetDisplay.tooltip.title"
+    ></ui-icon>
+  </span>
   <div class="flex">
     <!-- Data source button -->
     <ui-button

--- a/libs/shared/src/lib/components/widgets/editor/editor.module.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.module.ts
@@ -1,7 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { EditorComponent } from './editor.component';
-import { ButtonModule, SpinnerModule } from '@oort-front/ui';
+import {
+  ButtonModule,
+  IconModule,
+  SpinnerModule,
+  TooltipModule,
+} from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { HtmlWidgetContentModule } from '../common/html-widget-content/html-widget-content.module';
 
@@ -16,6 +21,8 @@ import { HtmlWidgetContentModule } from '../common/html-widget-content/html-widg
     TranslateModule,
     HtmlWidgetContentModule,
     SpinnerModule,
+    IconModule,
+    TooltipModule,
   ],
   exports: [EditorComponent],
 })

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.html
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.html
@@ -20,9 +20,20 @@
 
 <!-- Header -->
 <ng-template #headerTemplate>
-  <span class="widget-title" [title]="settings.title">{{
-    settings.title
-  }}</span>
+  <span class="flex gap-2 items-center">
+    <span class="widget-title" [title]="settings.title">
+      {{ settings.title }}
+    </span>
+    <ui-icon
+      *ngIf="settings.widgetDisplay?.tooltip?.display"
+      class="cursor-help"
+      icon="help"
+      variant="primary"
+      [size]="24"
+      [uiTooltip]="settings.widgetDisplay.tooltip.content"
+      [uiTooltipTitle]="settings.widgetDisplay.tooltip.title"
+    ></ui-icon>
+  </span>
   <!-- Sort selector -->
   <ng-container *ngIf="sortFields.length > 0">
     <ng-container *ngTemplateOutlet="sortTemplate"></ng-container>

--- a/libs/shared/src/lib/components/widgets/grid/grid.module.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.module.ts
@@ -7,7 +7,9 @@ import { AggregationGridModule } from '../../aggregation/aggregation-grid/aggreg
 import {
   ButtonModule,
   FormWrapperModule,
+  IconModule,
   SelectMenuModule,
+  TooltipModule,
 } from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { ReferenceDataGridModule } from '../../ui/reference-data-grid/reference-data-grid.module';
@@ -25,6 +27,8 @@ import { ReferenceDataGridModule } from '../../ui/reference-data-grid/reference-
     SelectMenuModule,
     TranslateModule,
     ReferenceDataGridModule,
+    IconModule,
+    TooltipModule,
   ],
   exports: [GridWidgetComponent],
 })

--- a/libs/shared/src/lib/components/widgets/map/map.component.html
+++ b/libs/shared/src/lib/components/widgets/map/map.component.html
@@ -1,7 +1,18 @@
 <shared-map class="flex-1" [mapSettings]="settings" />
 
 <ng-template #headerTemplate>
-  <span class="widget-title" [title]="settings ? settings.title : ''">{{
-    settings.title
-  }}</span>
+  <span class="flex gap-2 items-center">
+    <span class="widget-title" [title]="settings.title">
+      {{ settings.title }}
+    </span>
+    <ui-icon
+      *ngIf="settings.widgetDisplay?.tooltip?.display"
+      class="cursor-help"
+      icon="help"
+      variant="primary"
+      [size]="24"
+      [uiTooltip]="settings.widgetDisplay.tooltip.content"
+      [uiTooltipTitle]="settings.widgetDisplay.tooltip.title"
+    ></ui-icon>
+  </span>
 </ng-template>

--- a/libs/shared/src/lib/components/widgets/map/map.module.ts
+++ b/libs/shared/src/lib/components/widgets/map/map.module.ts
@@ -2,13 +2,14 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MapWidgetComponent } from './map.component';
 import { MapModule } from '../../ui/map/map.module';
+import { IconModule, TooltipModule } from '@oort-front/ui';
 
 /**
  * Map widget module
  */
 @NgModule({
   declarations: [MapWidgetComponent],
-  imports: [CommonModule, MapModule],
+  imports: [CommonModule, MapModule, TooltipModule, IconModule],
   exports: [MapWidgetComponent],
 })
 export class MapWidgetModule {}

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -101,9 +101,20 @@
 </ng-template>
 
 <ng-template #headerTemplate>
-  <span class="widget-title" [title]="settings.title">{{
-    settings.title
-  }}</span>
+  <span class="flex gap-2 items-center">
+    <span class="widget-title" [title]="settings.title">
+      {{ settings.title }}
+    </span>
+    <ui-icon
+      *ngIf="settings.widgetDisplay?.tooltip?.display"
+      class="cursor-help"
+      icon="help"
+      variant="primary"
+      [size]="24"
+      [uiTooltip]="settings.widgetDisplay?.tooltip?.content || ''"
+      [uiTooltipTitle]="settings.widgetDisplay?.tooltip?.title || ''"
+    ></ui-icon>
+  </span>
   <!-- Switch between grid and cards view -->
   <div class="flex">
     <!-- Searchbar -->

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.module.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.module.ts
@@ -12,6 +12,7 @@ import {
   SpinnerModule,
   SelectMenuModule,
   FormWrapperModule,
+  IconModule,
 } from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
 import { InputsModule } from '@progress/kendo-angular-inputs';
@@ -42,6 +43,7 @@ import { EmptyModule } from '../../ui/empty/empty.module';
     SelectMenuModule,
     FormWrapperModule,
     EmptyModule,
+    IconModule,
   ],
   exports: [SummaryCardComponent],
 })

--- a/libs/ui/src/lib/tooltip/tooltip.component.html
+++ b/libs/ui/src/lib/tooltip/tooltip.component.html
@@ -1,5 +1,9 @@
 <span
   #tooltip
   class="block transition-opacity delay-300 bg-gray-800 p-2 max-w-xs whitespace-pre-wrap text-xs text-gray-100 rounded-md z-[9999] break-words pointer-events-none"
-  >{{ uiTooltip }}</span
 >
+  <div *ngIf="uiTooltipTitle" class="mb-1">
+    <strong class="text-lg">{{ uiTooltipTitle }}</strong>
+  </div>
+  <span>{{ uiTooltip }}</span>
+</span>

--- a/libs/ui/src/lib/tooltip/tooltip.component.ts
+++ b/libs/ui/src/lib/tooltip/tooltip.component.ts
@@ -10,4 +10,6 @@ import { Component, Input } from '@angular/core';
 export class TooltipComponent {
   /** Tooltip text */
   @Input() uiTooltip!: string;
+  /** Tooltip title */
+  @Input() uiTooltipTitle = '';
 }

--- a/libs/ui/src/lib/tooltip/tooltip.directive.ts
+++ b/libs/ui/src/lib/tooltip/tooltip.directive.ts
@@ -27,6 +27,8 @@ import { TooltipPosition } from './types/tooltip-positions';
 export class TooltipDirective implements OnDestroy {
   /** Tooltip text */
   @Input() uiTooltip = '';
+  /** Tooltip title */
+  @Input() uiTooltipTitle = '';
   /** Is tooltip disabled */
   @Input() tooltipDisabled = false;
   /** preferred position for the tooltip */
@@ -149,6 +151,7 @@ export class TooltipDirective implements OnDestroy {
         this.overlayRef.attach(tooltipPortal);
       // Pass content to tooltip component instance
       tooltipRef.instance.uiTooltip = this.uiTooltip;
+      tooltipRef.instance.uiTooltipTitle = this.uiTooltipTitle;
     }
   }
 


### PR DESCRIPTION
# Description

Adds some new properties to the widget display, allowing the user to define a tooltip for each widget, that is displayed next to the title in the header. To make it look more like the mockup, I changed the tooltip directive to also accept a title as input, which is just more prominent than the rest of the text.

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/92824

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

See bellow, also tested on front-office

## Screenshots


https://github.com/ReliefApplications/ems-frontend/assets/102038450/7a330abf-ff6d-47fb-bd6c-fa488958a197



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
