### PR TITLE
Bug/ab#83434 Using disabled with formcontrol on ui-select-menu

### DIFF
--- a/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.html
+++ b/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.html
@@ -14,7 +14,7 @@
       <div class="flex gap-2">
         <div uiFormFieldDirective class="flex-1">
           <label>{{ 'components.templates.type.title' | translate }}</label>
-          <ui-select-menu formControlName="type" [disabled]="true">
+          <ui-select-menu formControlName="type">
             <ui-select-option value="email">{{
               'components.templates.type.email' | translate
             }}</ui-select-option>

--- a/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.ts
+++ b/libs/shared/src/lib/components/templates/components/edit-template-modal/edit-template-modal.component.ts
@@ -60,7 +60,10 @@ export class EditTemplateModalComponent implements OnInit {
   /** Reactive form for the template */
   public form = this.fb.group({
     name: [get(this.data, 'name', null), Validators.required],
-    type: [get(this.data, 'type', 'email'), Validators.required],
+    type: [
+      { value: get(this.data, 'type', 'email'), disabled: true },
+      Validators.required,
+    ],
     subject: [get(this.data, 'content.subject', null), Validators.required],
     body: [get(this.data, 'content.body', ''), Validators.required],
   });

--- a/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-properties/map-properties.component.html
@@ -213,7 +213,7 @@
                     'components.widget.settings.map.properties.geographicExtent'
                       | translate
                   }}</label>
-                  <ui-select-menu formControlName="extent" [disabled]="true">
+                  <ui-select-menu formControlName="extent">
                     <ui-select-option
                       *ngFor="let extent of extents"
                       [value]="extent"

--- a/libs/ui/src/lib/select-menu/select-menu.module.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.module.ts
@@ -16,7 +16,9 @@ import { TooltipModule } from '../tooltip/tooltip.module';
   declarations: [SelectMenuComponent],
   imports: [
     CommonModule,
-    ReactiveFormsModule,
+    ReactiveFormsModule.withConfig({
+      callSetDisabledState: 'whenDisabledForLegacyCode',
+    }),
     SelectOptionModule,
     TranslateModule,
     IconModule,

--- a/libs/ui/src/lib/select-menu/select-menu.module.ts
+++ b/libs/ui/src/lib/select-menu/select-menu.module.ts
@@ -16,9 +16,7 @@ import { TooltipModule } from '../tooltip/tooltip.module';
   declarations: [SelectMenuComponent],
   imports: [
     CommonModule,
-    ReactiveFormsModule.withConfig({
-      callSetDisabledState: 'whenDisabledForLegacyCode',
-    }),
+    ReactiveFormsModule,
     SelectOptionModule,
     TranslateModule,
     IconModule,


### PR DESCRIPTION
# Description

When using reactive forms, the disabled state should be set on the model, not the template. This caused elements like this:
`<ui-select-menu formControlName="type" [disabled]="true">`
to not be disabled and never calling setDIsabledState.
This is an implementation of a workaround to this issue.

## Useful links

- Angular warning regarding this implementation:
![image](https://github.com/ReliefApplications/ems-frontend/assets/39497117/ea472244-2069-44e6-8b0d-ef22376c4ff0)

- Full explanation: https://github.com/angular/angular/issues/48350#issuecomment-1405900515

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on the example provided in the ticket

## Screenshots

![image](https://github.com/ReliefApplications/ems-frontend/assets/39497117/e6153e1c-a6e8-4fdf-81cc-e14854d4bd43)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
