### PR TITLE
Bug/ab#95183 - Sidenav collapsing on form builder firefox

### DIFF
--- a/libs/shared/src/lib/components/navbar/navbar.component.html
+++ b/libs/shared/src/lib/components/navbar/navbar.component.html
@@ -4,7 +4,7 @@
     'border-b': !vertical,
     'pt-2 flex-col gap-y-7': vertical
   }"
-  class="flex overflow-y-auto"
+  class="flex"
 >
   <ng-container *ngFor="let group of navGroups; let i = index" class="h-full">
     <!-- Vertical navigation -->

--- a/libs/shared/src/lib/components/navbar/navbar.component.html
+++ b/libs/shared/src/lib/components/navbar/navbar.component.html
@@ -4,7 +4,7 @@
     'border-b': !vertical,
     'pt-2 flex-col gap-y-7': vertical
   }"
-  class="flex"
+  class="flex overflow-y-auto"
 >
   <ng-container *ngFor="let group of navGroups; let i = index" class="h-full">
     <!-- Vertical navigation -->

--- a/libs/ui/src/lib/sidenav/sidenav-container.component.html
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.html
@@ -6,7 +6,7 @@
     <!-- ngStyle prevent the left sidenav to have a fixed height -->
     <div
       #sidenav
-      class="will-change-transform overflow-y-auto bg-white translate-x-0"
+      class="will-change-transform bg-white translate-x-0"
       [attr.data-sidenav-show]="showSidenav[i]"
       [ngClass]="resolveSidenavClasses(i)"
       [ngStyle]="(i > 0 && { height: height }) || null"

--- a/libs/ui/src/lib/sidenav/sidenav-container.component.html
+++ b/libs/ui/src/lib/sidenav/sidenav-container.component.html
@@ -6,7 +6,7 @@
     <!-- ngStyle prevent the left sidenav to have a fixed height -->
     <div
       #sidenav
-      class="will-change-transform bg-white translate-x-0"
+      class="will-change-transform overflow-y-auto bg-white translate-x-0"
       [attr.data-sidenav-show]="showSidenav[i]"
       [ngClass]="resolveSidenavClasses(i)"
       [ngStyle]="(i > 0 && { height: height }) || null"
@@ -15,7 +15,7 @@
     </div>
   </ng-container>
   <!-- CONTENT -->
-  <div class="flex-1 overflow-clip" #contentContainer>
+  <div class="flex-1 overflow-hidden" #contentContainer>
     <div
       [ngClass]="{
         'visible bg-black opacity-50': showSidenav[0] && mode[0] === 'over',


### PR DESCRIPTION
# Description

Sometimes when resizing some elements in the DOM, specially inside a form builder, the sidenav would shrink until its no longer visible, even when it is set to visible. This issue occurs only on Firefox and can be reproduced by entering a form builder with a resource type question whose grid layout has a lot of fields, which causes the survey builder's width to increase and shrinks the sidenav.
Taking the overflow-y-auto out of the sidenav overflow class vector fixes this issue, but causes the overflow-y of one of its children (`<section>`) to bug out when the sidenav is collapsed, so setting the section's overflow-y to auto fixes this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on all viewports, zoomed in an out, inside and outside of a form builder, on Chrome and Firefox.

## Screenshots

Before:
![2big4u (1)](https://github.com/ReliefApplications/ems-frontend/assets/39497117/beb394b2-4428-4f20-baa5-6ea834ed2b8c)
After:
[screen-recorder-wed-jun-05-2024-15-03-28.webm](https://github.com/ReliefApplications/ems-frontend/assets/39497117/7501198b-a892-4e93-8c7c-ce9ec8fd581f)


# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
