### PR TITLE
bug/AB#95015 - Browser freezes on dropdowns with too much options

### DIFF
--- a/libs/shared/src/lib/components/filter/filter-row/filter-row.component.html
+++ b/libs/shared/src/lib/components/filter/filter-row/filter-row.component.html
@@ -138,13 +138,19 @@
         <ui-select-option>{{
           'common.input.none' | translate
         }}</ui-select-option>
-        <ui-select-option
-          *ngFor="let option of field.options"
-          [value]="option.value"
+        <cdk-virtual-scroll-viewport
+          itemSize="30"
+          class="virtual-scroll-viewport"
         >
-          {{ option.text }}
-        </ui-select-option>
+          <ui-select-option
+            *cdkVirtualFor="let option of field.options"
+            [value]="option.value"
+          >
+            {{ option.text }}
+          </ui-select-option>
+        </cdk-virtual-scroll-viewport>
       </ui-select-menu>
+
       <ui-select-menu
         [filterable]="true"
         *ngIf="field.multiSelect"
@@ -154,12 +160,17 @@
         <ui-select-option>{{
           'common.input.none' | translate
         }}</ui-select-option>
-        <ui-select-option
-          *ngFor="let option of field.options"
-          [value]="option.value"
+        <cdk-virtual-scroll-viewport
+          itemSize="30"
+          class="virtual-scroll-viewport"
         >
-          {{ option.text }}
-        </ui-select-option>
+          <ui-select-option
+            *cdkVirtualFor="let option of field.options"
+            [value]="option.value"
+          >
+            {{ option.text }}
+          </ui-select-option>
+        </cdk-virtual-scroll-viewport>
       </ui-select-menu>
     </div>
   </ng-template>

--- a/libs/shared/src/lib/components/filter/filter-row/filter-row.component.scss
+++ b/libs/shared/src/lib/components/filter/filter-row/filter-row.component.scss
@@ -5,3 +5,9 @@
     gap: 8px;
   }
 }
+
+.virtual-scroll-viewport {
+  height: 200px; /* Adjust height as needed */
+  overflow: hidden;
+  display: block;
+}

--- a/libs/shared/src/lib/components/filter/filter.module.ts
+++ b/libs/shared/src/lib/components/filter/filter.module.ts
@@ -12,6 +12,7 @@ import {
   DateModule,
   TooltipModule,
 } from '@oort-front/ui';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 /**
  * Composite Filter module.
@@ -29,6 +30,7 @@ import {
     DateModule,
     FormWrapperModule,
     TooltipModule,
+    ScrollingModule,
   ],
   exports: [FilterComponent],
 })


### PR DESCRIPTION
# Description

Started trying to implement cdk virtual scrolling on some large dropdowns in layout configurations -> filters. Main issue is that only a few items load and I can't get the dropdown to load more.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories/?workitem=95015
- https://material.angular.io/cdk/scrolling/overview

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
