### PR TITLE
AB#105659_Allow-context-to-be-used-in-linked-generated-in-action-buttons

### DIFF
--- a/libs/shared/src/lib/components/action-button/action-button.component.ts
+++ b/libs/shared/src/lib/components/action-button/action-button.component.ts
@@ -150,14 +150,9 @@ export class ActionButtonComponent
     // Navigation to url
     if (this.actionButton.href) {
       // If contextId is present, replace context in href else remove context placeholder
-      const href = this.contextId
-        ? this.contextService.replaceContext(
-            this.dataTemplateService.renderLink(this.actionButton.href)
-          )
-        : this.contextService.removeContext(
-            this.dataTemplateService.renderLink(this.actionButton.href)
-          );
-
+      const href = this.contextService.replaceContext(
+        this.dataTemplateService.renderLink(this.actionButton.href)
+      );
       if (this.actionButton.openInNewTab) {
         window.open(href, '_blank');
       } else {

--- a/libs/shared/src/lib/components/action-button/action-button.component.ts
+++ b/libs/shared/src/lib/components/action-button/action-button.component.ts
@@ -149,7 +149,15 @@ export class ActionButtonComponent
   public async onClick() {
     // Navigation to url
     if (this.actionButton.href) {
-      const href = this.dataTemplateService.renderLink(this.actionButton.href);
+      // If contextId is present, replace context in href else remove context placeholder
+      const href = this.contextId
+        ? this.contextService.replaceContext(
+            this.dataTemplateService.renderLink(this.actionButton.href)
+          )
+        : this.contextService.removeContext(
+            this.dataTemplateService.renderLink(this.actionButton.href)
+          );
+
       if (this.actionButton.openInNewTab) {
         window.open(href, '_blank');
       } else {

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -28,6 +28,7 @@ import { UnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component
 import { FormHelpersService } from '../../services/form-helper/form-helper.service';
 import { SnackbarService, UILayoutService } from '@oort-front/ui';
 import { isNil } from 'lodash';
+import { ContextService } from '../../services/context/context.service';
 
 /**
  * This component is used to display forms
@@ -95,6 +96,7 @@ export class FormComponent
    * @param formBuilderService This is the service that will be used to build forms.
    * @param formHelpersService This is the service that will handle forms.
    * @param translate This is the service used to translate text
+   * @param contextService This is the service that will handle the context of the application.
    */
   constructor(
     public dialog: Dialog,
@@ -104,7 +106,8 @@ export class FormComponent
     private layoutService: UILayoutService,
     private formBuilderService: FormBuilderService,
     public formHelpersService: FormHelpersService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private contextService: ContextService
   ) {
     super();
   }
@@ -331,6 +334,7 @@ export class FormComponent
         } else {
           this.survey.showCompletedPage = true;
         }
+        this.contextService.setNewRecordContext(data.addRecord);
         this.save.emit({
           completed: true,
           hideNewRecord: data.addRecord && data.addRecord.form.uniqueRecord,

--- a/libs/shared/src/lib/services/context/context.service.ts
+++ b/libs/shared/src/lib/services/context/context.service.ts
@@ -253,6 +253,27 @@ export class ContextService {
   }
 
   /**
+   * Remove {{context}} placeholders in object
+   *
+   * @param obj object to clean
+   * @returns object without placeholders
+   */
+  public removeContext = (obj: any): any => {
+    if (typeof obj === 'string') {
+      return obj.replace(new RegExp(this.contextRegex, 'g'), '');
+    } else if (Array.isArray(obj)) {
+      return obj.map((item) => this.removeContext(item));
+    } else if (obj && typeof obj === 'object') {
+      const newObj = { ...obj };
+      for (const key in newObj) {
+        newObj[key] = this.removeContext(newObj[key]);
+      }
+      return newObj;
+    }
+    return obj;
+  };
+
+  /**
    * Parse JSON values of object.
    *
    * @param obj object to transform


### PR DESCRIPTION
# Description

This update improves the handling of "navigate to" buttons by dynamically replacing placeholders with the appropriate context ID. If no context is available, placeholders are automatically removed, ensuring clean navigation behavior.

To maintain a smooth user experience during new record creation, a temporary newRecordContext is introduced. This approach preserves the existing context structure, preventing any unintended impact on the current context.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/105659)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

https://github.com/user-attachments/assets/6b86526f-a471-41b5-ab85-fc6e28b53734

### With no context
https://github.com/user-attachments/assets/7fc35c59-8d3d-49b3-8b60-e7649fc3ba75



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
