### PR TITLE
Ab#105504

### DIFF
--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -29,6 +29,7 @@ import { GradientPipe } from '../../../pipes/gradient/gradient.pipe';
 import { MapLayersService } from '../../../services/map/map-layers.service';
 import { BehaviorSubject } from 'rxjs';
 import centroid from '@turf/centroid';
+import { coordEach } from '@turf/meta';
 import { Injector, Renderer2, Inject } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import {
@@ -915,7 +916,23 @@ export class Layer implements LayerModel {
                 clusterGroup.addLayer(clusterLayer);
                 return this.updateLayerContextInformation(clusterGroup);
               default:
-                const layer = L.geoJSON(data, geoJSONopts);
+                const leftData = JSON.parse(JSON.stringify(data));
+                coordEach(leftData, (coord) => {
+                  coord[0] += -360;
+                });
+
+                const rightData = JSON.parse(JSON.stringify(data));
+                coordEach(rightData, (coord) => {
+                  coord[0] += 360;
+                });
+
+                const layer = L.geoJSON(
+                  {
+                    type: 'FeatureCollection',
+                    features: [leftData, data, rightData],
+                  } as any,
+                  geoJSONopts
+                );
 
                 layer.onAdd = (map: L.Map) => {
                   this.updateMapPanesStatus(map);

--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -632,7 +632,7 @@ export class Layer implements LayerModel {
     };
 
     switch (this.type) {
-      case 'GroupLayer':
+      case 'GroupLayer': {
         const childrenIds = this.getChildren();
         const layerPromises = childrenIds.map((layer) => {
           return this.layerService.createLayersFromId(
@@ -668,12 +668,14 @@ export class Layer implements LayerModel {
           return l;
         };
         return this.updateLayerContextInformation(layer);
-
-      default:
+      }
+      // Single layer
+      default: {
         switch (
           get(this.layerDefinition, 'drawingInfo.renderer.type', 'simple')
         ) {
-          case 'heatmap':
+          // Heatmap
+          case 'heatmap': {
             // check data type
             if (data.type !== 'FeatureCollection') {
               throw new Error(
@@ -697,9 +699,13 @@ export class Layer implements LayerModel {
                   const long = parseFloat(get(feature, 'coordinates[0]'));
                   if (!isNaN(lat) && !isNaN(long)) {
                     if (valueField) {
+                      heatArray.push([lat, long - 360, intensity(feature)]);
                       heatArray.push([lat, long, intensity(feature)]);
+                      heatArray.push([lat, long + 360, intensity(feature)]);
                     } else {
+                      heatArray.push([lat, long - 360]);
                       heatArray.push([lat, long]);
+                      heatArray.push([lat, long + 360]);
                     }
                   }
                   break;
@@ -713,9 +719,13 @@ export class Layer implements LayerModel {
                   );
                   if (!isNaN(lat) && !isNaN(long)) {
                     if (valueField) {
+                      heatArray.push([lat, long - 360, intensity(feature)]);
                       heatArray.push([lat, long, intensity(feature)]);
+                      heatArray.push([lat, long + 360, intensity(feature)]);
                     } else {
+                      heatArray.push([lat, long - 360]);
                       heatArray.push([lat, long]);
+                      heatArray.push([lat, long + 360]);
                     }
                   }
                   break;
@@ -826,9 +836,12 @@ export class Layer implements LayerModel {
               return l;
             };
             return this.updateLayerContextInformation(layer);
-          default:
+          }
+          // Cluster & everything else
+          default: {
             switch (get(this.layerDefinition, 'featureReduction.type')) {
-              case 'cluster':
+              // Cluster
+              case 'cluster': {
                 const clusterSymbol: LayerSymbol = get(
                   this.layerDefinition,
                   'featureReduction.drawingInfo.renderer.symbol',
@@ -900,7 +913,23 @@ export class Layer implements LayerModel {
                   );
                 });
 
-                const clusterLayer = L.geoJSON(data, geoJSONopts);
+                const leftData = JSON.parse(JSON.stringify(data));
+                coordEach(leftData, (coord) => {
+                  coord[0] += -360;
+                });
+
+                const rightData = JSON.parse(JSON.stringify(data));
+                coordEach(rightData, (coord) => {
+                  coord[0] += 360;
+                });
+
+                const clusterLayer = L.geoJSON(
+                  {
+                    type: 'FeatureCollection',
+                    features: [leftData, data, rightData],
+                  } as any,
+                  geoJSONopts
+                );
 
                 clusterLayer.onAdd = (map: L.Map) => {
                   this.updateMapPanesStatus(map);
@@ -909,13 +938,18 @@ export class Layer implements LayerModel {
                   return l;
                 };
                 clusterLayer.onRemove = (map: L.Map) => {
-                  const l = L.GeoJSON.prototype.onRemove.call(layer, map);
+                  const l = L.GeoJSON.prototype.onRemove.call(
+                    clusterLayer,
+                    map
+                  );
                   this.onRemoveLayer(map, clusterLayer);
                   return l;
                 };
                 clusterGroup.addLayer(clusterLayer);
                 return this.updateLayerContextInformation(clusterGroup);
-              default:
+              }
+              // Everything else
+              default: {
                 const leftData = JSON.parse(JSON.stringify(data));
                 coordEach(leftData, (coord) => {
                   coord[0] += -360;
@@ -946,8 +980,11 @@ export class Layer implements LayerModel {
                   return l;
                 };
                 return this.updateLayerContextInformation(layer);
+              }
             }
+          }
         }
+      }
     }
   }
 

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -435,7 +435,7 @@ export class MapComponent
   private drawMap(initMap = true): void {
     const {
       initialState,
-      maxBounds,
+      // maxBounds,
       basemap,
       maxZoom,
       minZoom,
@@ -460,12 +460,12 @@ export class MapComponent
           : this.mapId,
         {
           zoomControl,
-          maxBounds: maxBounds
-            ? L.latLngBounds(
-                L.latLng(maxBounds[0][0], maxBounds[0][1]),
-                L.latLng(maxBounds[1][0], maxBounds[1][1])
-              )
-            : undefined,
+          // maxBounds: maxBounds
+          //   ? L.latLngBounds(
+          //       L.latLng(maxBounds[0][0], maxBounds[0][1]),
+          //       L.latLng(maxBounds[1][0], maxBounds[1][1])
+          //     )
+          //   : undefined,
           minZoom,
           maxZoom,
           worldCopyJump,
@@ -496,9 +496,9 @@ export class MapComponent
       if (this.map.getMinZoom() !== minZoom) {
         this.map.setMinZoom(minZoom as number);
       }
-      if (maxBounds) {
-        this.map.setMaxBounds(maxBounds as L.LatLngBoundsExpression);
-      }
+      // if (maxBounds) {
+      //   this.map.setMaxBounds(maxBounds as L.LatLngBoundsExpression);
+      // }
       if (this.map.getZoom() !== initialState.viewpoint.zoom) {
         this.map.setZoom(initialState.viewpoint.zoom);
       }


### PR DESCRIPTION
# Description

- Avoid the map to automatically jump to next instance when crossing borders on left & right of the default mercator view
- Duplicate data on left & right of the default mercator view, so users can use the map around the Pacific Ocean

## Useful links

- [Ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/105504)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
