### PR TITLE
feat/AB#106027_EIS-improve-front-end-qa

### DIFF
--- a/libs/shared/.storybook/storybook-translate.module.ts
+++ b/libs/shared/.storybook/storybook-translate.module.ts
@@ -1,0 +1,45 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { NgModule } from '@angular/core';
+import {
+  TranslateModule,
+  TranslateService,
+  TranslateLoader,
+} from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+
+/**
+ * Sets up translator.
+ *
+ * @param http http client
+ * @returns Translator.
+ */
+export const httpTranslateLoader = (http: HttpClient) =>
+  new TranslateHttpLoader(http);
+/**
+ * A utility module adding I18N support for Storybook stories
+ */
+@NgModule({
+  imports: [
+    HttpClientModule,
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: httpTranslateLoader,
+        deps: [HttpClient],
+      },
+    }),
+    TranslateModule,
+  ],
+})
+export class StorybookTranslateModule {
+  /**
+   * The constructor function is a special function that is called when a new instance of the class is
+   * created
+   *
+   * @param translateService The translate service that will be used to translate the text.
+   */
+  constructor(translateService: TranslateService) {
+    translateService.setDefaultLang('en');
+    translateService.use('en');
+  }
+}

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -134,6 +134,7 @@ export * from './lib/views/public-api';
 // === MODULE ===
 export * from './lib/components/widget-choice/widget-choice.module';
 export * from './lib/shared.module';
+export * from '../.storybook/storybook-translate.module';
 
 // === PIPES ===
 export * from './lib/pipes/cron-parser/public-api';

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -76,7 +76,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
   public formattedHtml: SafeHtml = '';
   /** Formatted style */
   public formattedStyle?: string;
-  /** Result of aggregations */
+  /** Result of aggregations, for html rendering */
   public aggregationsData: any = {};
   /** Loading indicator */
   public loading = true;
@@ -84,8 +84,6 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
   private cancelRefresh$ = new Subject<void>();
   /** Timeout to init active filter */
   private timeoutListener!: NodeJS.Timeout;
-  /** Aggregation data for render html data */
-  private aggregationData = {};
 
   /** @returns does the card use reference data */
   get useReferenceData() {
@@ -276,7 +274,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
    * Set widget html.
    */
   private setHtml() {
-    this.aggregationData = {};
+    this.aggregationsData = {};
     const callback = () => {
       if (this.timeoutListener) {
         clearTimeout(this.timeoutListener);
@@ -335,7 +333,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
             this.settings.text,
             {
               data: this.fieldsValue,
-              aggregation: this.aggregationData,
+              aggregation: this.aggregationsData,
               fields: this.fields,
               styles: this.styles,
             }
@@ -382,7 +380,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
             this.settings.text,
             {
               data: this.fieldsValue,
-              aggregation: this.aggregationData,
+              aggregation: this.aggregationsData,
               fields: this.fields,
             }
           );
@@ -397,7 +395,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
             this.settings.text,
             {
               data: this.fieldsValue,
-              aggregation: this.aggregationData,
+              aggregation: this.aggregationsData,
               fields: this.fields,
             }
           );
@@ -439,13 +437,13 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
           .then(({ data }) => {
             if (aggregation.resource) {
               set(
-                this.aggregationData,
+                this.aggregationsData,
                 aggregation.id,
                 (data as any).recordsAggregation
               );
             } else {
               set(
-                this.aggregationData,
+                this.aggregationsData,
                 aggregation.id,
                 (data as any).referenceDataAggregation
               );
@@ -486,7 +484,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
                             ),
                         })
                         .then((data) => {
-                          set(this.aggregationData, aggregation.id, data);
+                          set(this.aggregationsData, aggregation.id, data);
                         })
                         .finally(() => resolve());
                     })
@@ -539,7 +537,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
                 this.settings.text,
                 {
                   data: this.fieldsValue,
-                  aggregation: this.aggregationData,
+                  aggregation: this.aggregationsData,
                   fields: this.fields,
                   styles: this.styles,
                 }

--- a/libs/shared/src/lib/components/widgets/editor/editor.component.ts
+++ b/libs/shared/src/lib/components/widgets/editor/editor.component.ts
@@ -84,6 +84,8 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
   private cancelRefresh$ = new Subject<void>();
   /** Timeout to init active filter */
   private timeoutListener!: NodeJS.Timeout;
+  /** Aggregation data for render html data */
+  private aggregationData = {};
 
   /** @returns does the card use reference data */
   get useReferenceData() {
@@ -274,6 +276,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
    * Set widget html.
    */
   private setHtml() {
+    this.aggregationData = {};
     const callback = () => {
       if (this.timeoutListener) {
         clearTimeout(this.timeoutListener);
@@ -332,7 +335,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
             this.settings.text,
             {
               data: this.fieldsValue,
-              aggregation: this.aggregations,
+              aggregation: this.aggregationData,
               fields: this.fields,
               styles: this.styles,
             }
@@ -379,7 +382,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
             this.settings.text,
             {
               data: this.fieldsValue,
-              aggregation: this.aggregations,
+              aggregation: this.aggregationData,
               fields: this.fields,
             }
           );
@@ -394,7 +397,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
             this.settings.text,
             {
               data: this.fieldsValue,
-              aggregation: this.aggregations,
+              aggregation: this.aggregationData,
               fields: this.fields,
             }
           );
@@ -436,13 +439,13 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
           .then(({ data }) => {
             if (aggregation.resource) {
               set(
-                this.aggregations,
+                this.aggregationData,
                 aggregation.id,
                 (data as any).recordsAggregation
               );
             } else {
               set(
-                this.aggregations,
+                this.aggregationData,
                 aggregation.id,
                 (data as any).referenceDataAggregation
               );
@@ -483,7 +486,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
                             ),
                         })
                         .then((data) => {
-                          set(this.aggregations, aggregation.id, data);
+                          set(this.aggregationData, aggregation.id, data);
                         })
                         .finally(() => resolve());
                     })
@@ -536,7 +539,7 @@ export class EditorComponent extends BaseWidgetComponent implements OnInit {
                 this.settings.text,
                 {
                   data: this.fieldsValue,
-                  aggregation: this.aggregations,
+                  aggregation: this.aggregationData,
                   fields: this.fields,
                   styles: this.styles,
                 }

--- a/libs/shared/src/lib/pipes/strip-html/strip-html.stories.ts
+++ b/libs/shared/src/lib/pipes/strip-html/strip-html.stories.ts
@@ -102,7 +102,7 @@ export const ComplexHTML: Story = {
     `,
   },
 };
-
+/** all inline tags html story */
 export const allInlineTags: Story = {
   args: {
     htmlValue: `

--- a/libs/shared/src/lib/pipes/strip-html/strip-html.stories.ts
+++ b/libs/shared/src/lib/pipes/strip-html/strip-html.stories.ts
@@ -102,7 +102,7 @@ export const ComplexHTML: Story = {
     `,
   },
 };
-/** all inline tags html story */
+/** All inline tags html story */
 export const allInlineTags: Story = {
   args: {
     htmlValue: `

--- a/libs/shared/src/lib/services/context/context-test-values.ts
+++ b/libs/shared/src/lib/services/context/context-test-values.ts
@@ -1,0 +1,36 @@
+/**
+ * Html with context
+ *
+ * Results removes all \n as they'll be added from tailwind
+ */
+export const contextFormatElement = {
+  before: `
+<p>{{context.id}}</p>
+<p>{{context.status}}</p>
+<p>{{context.title}}</p>
+<p>{{context.description}}</p>
+<p>{{context.check_box}}</p>
+<p>{{context.createdAt}}</p>
+<p>{{context.modifiedAt}}</p>
+ `,
+  after: `
+<p>66fa9502760ab688bf8508e9s</p>
+<p>Published</p>
+<p>I can't believe this is a title</p>
+<p>Super duper dubi dat gua trikili dup description</p>
+<p>true</p>
+<p>2024-09-28T12:21:21.498Z</p>
+<p>2024-09-30T12:21:21.498Z</p>
+ `,
+};
+/** Context data */
+export const optionsContext = {
+  __typename: 'TestsMockData',
+  id: '66fa9502760ab688bf8508e9s',
+  status: 'Published',
+  title: "I can't believe this is a title",
+  description: 'Super duper dubi dat gua trikili dup description',
+  check_box: true,
+  modifiedAt: '2024-09-30T12:21:21.498Z',
+  createdAt: '2024-09-28T12:21:21.498Z',
+};

--- a/libs/shared/src/lib/services/context/context.service.spec.ts
+++ b/libs/shared/src/lib/services/context/context.service.spec.ts
@@ -1,44 +1,53 @@
+import { DialogModule } from '@angular/cdk/dialog';
+import { HttpClientModule } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
-import { ContextService } from './context.service';
-import { ApolloTestingModule } from 'apollo-angular/testing';
-import {
-  TranslateFakeLoader,
-  TranslateLoader,
-  TranslateModule,
-  TranslateService,
-} from '@ngx-translate/core';
+import { FormBuilder, FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { ShadowDomService, SnackbarService } from '@oort-front/ui';
 import {
   DateTimeProvider,
   OAuthLogger,
   OAuthService,
   UrlHelperService,
 } from 'angular-oauth2-oidc';
-import { HttpClientModule } from '@angular/common/http';
+import { ApolloTestingModule } from 'apollo-angular/testing';
+import { StorybookTranslateModule } from '../../../../.storybook/storybook-translate.module';
+import { ApplicationService } from '../application/application.service';
 import { AppAbility } from '../auth/auth.service';
+import { contextFormatElement, optionsContext } from './context-test-values';
+import { ContextService } from './context.service';
 
 describe('ContextService', () => {
   let service: ContextService;
-
-  beforeEach(() => {
+  beforeAll(() => {
     TestBed.configureTestingModule({
       providers: [
-        { provide: 'environment', useValue: {} },
         TranslateService,
+        {
+          provide: 'environment',
+          useValue: {
+            availableLanguages: [],
+            theme: {},
+          },
+        },
         OAuthService,
         OAuthLogger,
+        SnackbarService,
+        ApplicationService,
+        ShadowDomService,
+        FormBuilder,
         DateTimeProvider,
         AppAbility,
         UrlHelperService,
       ],
       imports: [
         ApolloTestingModule,
-        TranslateModule.forRoot({
-          loader: {
-            provide: TranslateLoader,
-            useClass: TranslateFakeLoader,
-          },
-        }),
+        StorybookTranslateModule,
         HttpClientModule,
+        DialogModule,
+        FormsModule,
+        RouterModule,
       ],
     });
     service = TestBed.inject(ContextService);
@@ -46,5 +55,33 @@ describe('ContextService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+  describe('Parse HTML with context data', () => {
+    let replaceContext!: any;
+    beforeAll(() => {
+      replaceContext = jest.spyOn(service, 'replaceContext');
+    });
+    it('executes replaceContext function', () => {
+      service.updateSettingsContextContent(
+        { text: contextFormatElement.before },
+        { contextData: optionsContext }
+      );
+      expect(replaceContext).toHaveBeenCalled();
+    });
+    it('executes html element parse with injected context correctly', () => {
+      service.context = optionsContext;
+      const result = service.updateSettingsContextContent(
+        { text: contextFormatElement.before },
+        { contextData: optionsContext }
+      );
+      expect(result.settings.text).toEqual(contextFormatElement.after);
+    });
+    it('executes html element parse with injected context correctly if no context set', () => {
+      const result = service.updateSettingsContextContent(
+        { text: contextFormatElement.before },
+        { contextData: null as any }
+      );
+      expect(result.settings.text).toEqual(contextFormatElement.before);
+    });
   });
 });

--- a/libs/shared/src/lib/services/html-parser/html-parser-helper.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser-helper.ts
@@ -103,7 +103,7 @@ export const applyTableStyle = (formattedHtml: string) => {
  * @param pages array of pages
  * @returns formatted html
  */
-export const replacePages = (html: string, pages: any[]): string => {
+export const replacePages = (html: string, pages?: any[]): string => {
   let formattedHtml = html;
   if (pages) {
     for (const page of pages) {

--- a/libs/shared/src/lib/services/html-parser/html-parser-test-values.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser-test-values.ts
@@ -1,0 +1,375 @@
+/** Not number value examples */
+export const notNumberValueExamples = [
+  'a',
+  '?',
+  '/',
+  '%%',
+  '#',
+  '&(',
+  ')',
+  '|\\',
+  '.',
+  ',',
+  ';',
+];
+
+/**
+ * Hardcoded values for round func test cases
+ * - [initial value, expected value, precision level]
+ */
+export const roundValues = {
+  regular: [
+    ['1.49', '1'],
+    ['1.49', '1.5', '1'],
+  ],
+  up: [
+    ['1.49', '2'],
+    ['1.511', '1.52', '2'],
+  ],
+  down: [
+    ['1.49', '1'],
+    ['1.555', '1.55', '2'],
+  ],
+};
+/**
+ * Hardcoded values for percentage func test cases
+ * - [initial value, total value, expected value, precision level]
+ */
+export const percentageValues = [
+  ['50.04', '100', '50.04%'],
+  ['5', '1', '500%', '0'],
+  ['50.6', '100', '51%', '0'],
+];
+/**
+ * Hardcoded values for max/min func test cases
+ * - [expected value, ...values]
+ */
+export const maxMinValues = {
+  max: [
+    ['1.501', '1', '1.01', '1.500', '1.501'],
+    ['1.49', '1.48', '1.0', '1', '0.54'],
+  ],
+  min: [
+    ['1', '1', '1.01', '1.500', '1.501'],
+    ['0.54', '1.48', '1.0', '1', '0.54'],
+  ],
+};
+/** Custom date formats */
+export const customDateFormats = [
+  { format: 'yyyy-MM-dd', result: `2024-11-26` }, // 2024-11-26: ISO 8601 format date
+  { format: 'dd/MM/yyyy', result: `26/11/2024` }, // 26/11/2024: Day-first numeric format
+  { format: 'MM/dd/yyyy', result: `11/26/2024` }, // 11/26/2024: Month-first numeric format
+  {
+    format: 'EEEE, MMMM d, yyyy',
+    result: `Tuesday, November 26, 2024`,
+  }, // Tuesday, November 26, 2024: Full day name, month name, day, year
+  {
+    format: 'MMM d, y, h:mm a',
+    result: `Nov 26, 2024, 1:00 PM`,
+  }, // Nov 26, 2024, 1:00 PM: Short month name, day, year, 12-hour time
+  {
+    format: "MMMM d, y 'at' h:mm a",
+    result: `November 26, 2024 at 1:00 PM`,
+  }, // November 26, 2024 at 1:00 PM: Full month, day, year with literal text
+  {
+    format: 'yyyy/MM/dd HH:mm:ss Z',
+    result: `2024/11/26 13:00:00 +0100`,
+  }, // 2024/11/26 1:00:00 +0000: ISO-like with timezone offset
+  {
+    format: 'yyyy-MM-ddTHH:mm:ss',
+    result: `2024-11-26T13:00:00`,
+  }, // 2024-11-26T1:00:00: ISO 8601 with "T" separator for time
+  { format: 'hh:mm a', result: `01:00 PM` }, // 1:00 PM: 12-hour time with AM/PM
+  { format: 'HH:mm:ss', result: `13:00:00` }, // 1:00:00: 24-hour time with seconds
+  { format: 'MMMM d', result: `November 26` }, // November 26: Full month name and day (no year)
+  { format: 'E, MMM dd yyyy', result: `Tue, Nov 26 2024` }, // Tue, Nov 26 2024: Short day name, short month, day, year
+  { format: 'yyyy MMMM dd', result: `2024 November 26` }, // 2024 November 26: Year, full month name, day
+  {
+    format: 'yyyy-MM-dd HH:mm',
+    result: `2024-11-26 13:00`,
+  }, // 2024-11-26 1:00: ISO-like date with hours and minutes
+  { format: 'dd-MMM-yyyy', result: `26-Nov-2024` }, // 26-Nov-2024: Day, short month name, year
+  { format: 'MM/yyyy', result: `11/2024` }, // 11/2024: Month and year only
+  {
+    format: 'HH:mm:ss.SSS',
+    result: `13:00:00.000`,
+  }, // 1:00:00.000: 24-hour time with milliseconds
+  {
+    format: 'EEE, d MMM yyyy HH:mm:ss Z',
+    result: `Tue, 26 Nov 2024 13:00:00 +0100`,
+  }, // Tue, 26 Nov 2024 1:00:00 +0000: RFC 2822 format (emails)
+  {
+    format: 'yyyy-MM-dd HH:mm:ss zzzz',
+    result: `2024-11-26 13:00:00 GMT+01:00`,
+  }, // 2024-11-26 1:00:00 GMT+01:00: Full timezone name
+  {
+    format: 'h:mm:ss a z',
+    result: `1:00:00 PM GMT+1`,
+  }, // 12:00:00 PM GMT: 12-hour time with seconds and timezone abbreviation
+  { format: 'G yyyy-MM-dd', result: 'AD 2024-11-26' }, // AD 2024-11-26: Era designator (AD/BC), year, month, day
+];
+/** Predefined formats */
+export const predefinedDateFormats = [
+  {
+    format: 'short',
+    result: `11/26/24, 1:00 PM`,
+  }, // Example: 11/26/24, 1:00 PM
+  {
+    format: 'medium',
+    result: `Nov 26, 2024, 1:00:00 PM`,
+  }, // Example: Nov 26, 2024, 1:00:00 PM
+  {
+    format: 'long',
+    result: `November 26, 2024 at 1:00:00 PM GMT+1`,
+  }, // Example: November 26, 2024 at 1:00:00 PM GMT+1
+  {
+    format: 'full',
+    result: `Tuesday, November 26, 2024 at 1:00:00 PM GMT+01:00`,
+  }, // Example: Tuesday, November 26, 2024 at 1:00:00 PM GMT+01:00
+  { format: 'shortDate', result: '11/26/24' }, // Example: 11/26/24
+  { format: 'mediumDate', result: 'Nov 26, 2024' }, // Example: Nov 26, 2024
+  { format: 'longDate', result: 'November 26, 2024' }, // Example: November 26, 2024
+  {
+    format: 'fullDate',
+    result: 'Tuesday, November 26, 2024',
+  }, // Example: Tuesday, November 26, 2024
+  { format: 'shortTime', result: `1:00 PM` }, // Example: 1:00 PM
+  {
+    format: 'mediumTime',
+    result: `1:00:00 PM`,
+  }, // Example: 1:00:00 PM
+  {
+    format: 'longTime',
+    result: `1:00:00 PM GMT+1`,
+  }, // Example: 1:00:00 PM GMT
+  {
+    format: 'fullTime',
+    result: `1:00:00 PM GMT+01:00`,
+  }, // Example: 1:00:00 PM GMT+00:00
+];
+/** Html with calc functions */
+export const calcFormatElement = {
+  before: `
+  <p>{{calc.round( 9.5 ; 1 )}}</p>
+  <p>{{calc.roundup( 9.5 ; 1 )}}</p>
+  <p>{{calc.rounddown( 9.5 ; 1 )}}</p>
+  <p>{{calc.percentage( 5 ; 10 ; 0 )}}</p>
+  <p>{{calc.min( 1 ; 2 ; 3 )}}</p>
+  <p>{{calc.max( 3 ; 2 ; 1 )}}</p>
+  <p>{{calc.date( Tuesday, November 26, 2024 ; shortDate )}}</p>
+  `,
+  after: `
+  <p>9.5</p>
+  <p>9.5</p>
+  <p>9.5</p>
+  <p>50%</p>
+  <p>1</p>
+  <p>3</p>
+  <p>11/26/24</p>
+  `,
+};
+/** Aggregations data for testing */
+export const optionsAggregation = {
+  '59ac6544-6bee-4099-84f6-7d0c6324cb46': {
+    items: [
+      {
+        count: 1,
+        property_to_check: 'societal',
+        property_to_also_check: 'Published',
+      },
+      {
+        count: 2,
+        property_to_check: 'product',
+        property_to_also_check: 'Published',
+      },
+      {
+        count: 302,
+        property_to_check: 'infectious',
+        property_to_also_check: 'Published',
+      },
+      {
+        count: 1,
+        property_to_check: 'chemical',
+        property_to_also_check: 'Published',
+      },
+      {
+        count: 3,
+        property_to_check: 'animal',
+        property_to_also_check: 'Published',
+      },
+      {
+        count: 20,
+        property_to_check: 'zoonosis',
+        property_to_also_check: 'Published',
+      },
+      {
+        count: 3,
+        property_to_check: 'disaster',
+        property_to_also_check: 'Published',
+      },
+      {
+        count: 6,
+        property_to_check: 'undetermined',
+        property_to_also_check: 'Published',
+      },
+      {
+        count: 1,
+        property_to_check: 'food safety',
+        property_to_also_check: 'Published',
+      },
+    ],
+    totalCount: 9,
+  },
+  '2fa51225-02c9-4ef8-9bc2-0ef5df3638b1': {
+    items: [
+      {
+        count: 1,
+        property_to_check: 'societal_income',
+        property_to_also_check: 'Pending',
+      },
+      {
+        count: 2,
+        property_to_check: 'product_income',
+        property_to_also_check: 'Pending',
+      },
+      {
+        count: 102,
+        property_to_check: 'infectious_income',
+        property_to_also_check: 'Pending',
+      },
+      {
+        count: 1,
+        property_to_check: 'chemical_income',
+        property_to_also_check: 'Pending',
+      },
+      {
+        count: 3,
+        property_to_check: 'animal_income',
+        property_to_also_check: 'Pending',
+      },
+      {
+        count: 20,
+        property_to_check: 'zoonosis_income',
+        property_to_also_check: 'Pending',
+      },
+      {
+        count: 3,
+        property_to_check: 'disaster_income',
+        property_to_also_check: 'Pending',
+      },
+      {
+        count: 6,
+        property_to_check: 'undetermined_income',
+        property_to_also_check: 'Pending',
+      },
+      {
+        count: 1,
+        property_to_check: 'food safety_income',
+        property_to_also_check: 'Pending',
+      },
+    ],
+    totalCount: 19,
+  },
+};
+
+/**
+ * Html with aggregations
+ *
+ * Results removes all \n as they'll be added from tailwind
+ */
+export const aggregationFormatElement = {
+  before: `
+<div>Infectious count 1</div>
+<div>{{calc.max({{aggregation.59ac6544-6bee-4099-84f6-7d0c6324cb46.$.items[?(@.property_to_check=="infectious")].count}};0)}}</div>
+<div>Infectious count 2</div>
+<div>{{calc.max({{aggregation.2fa51225-02c9-4ef8-9bc2-0ef5df3638b1.$.items[?(@.property_to_check=="infectious_income")].count}};0)}}</div>
+<div>Total count 1</div>
+<div>{{aggregation.59ac6544-6bee-4099-84f6-7d0c6324cb46.$.totalCount}}</div>
+<div>Total count 2</div>
+<div>{{aggregation.2fa51225-02c9-4ef8-9bc2-0ef5df3638b1.$.totalCount}}</div>
+  `,
+  after: `<div>Infectious count 1</div><div>302</div><div>Infectious count 2</div><div>102</div><div>Total count 1</div><div>9</div><div>Total count 2</div><div>19</div>  `,
+};
+
+/**
+ * Html with data
+ *
+ * Results removes all \n as they'll be added from tailwind
+ */
+export const dataFormatElement = {
+  before: `
+<p>{{data.id}}</p>
+<p>{{data.status}}</p>
+<p>{{data.title}}</p>
+<p>{{data.description}}</p>
+<p>{{data.check_box}}</p>
+<p>{{data.createdAt}}</p>
+<p>{{data.modifiedAt}}</p>
+ `,
+  after: `<p>66fa9502760ab688bf8508e9s</p><p>Published</p><p>I can't believe this is a title</p><p>Super duper dubi dat gua trikili dup description</p><p><input type="checkbox" style="margin: 0; height: 16px; width: 16px;" checked disabled></input></p><p><span style=''>9/28/2024, 2:21 PM</span></p><p><span style=''>9/30/2024</span></p> `,
+};
+/** Record data */
+export const optionsData = {
+  __typename: 'TestsMockData',
+  id: '66fa9502760ab688bf8508e9s',
+  status: 'Published',
+  title: "I can't believe this is a title",
+  description: 'Super duper dubi dat gua trikili dup description',
+  check_box: true,
+  modifiedAt: '2024-09-30T12:21:21.498Z',
+  createdAt: '2024-09-28T12:21:21.498Z',
+};
+/** Option data fields metadata to inject */
+export const optionFields = [
+  {
+    name: 'modifiedAt',
+    type: 'date',
+    kind: 'SCALAR',
+    label: 'Modified At',
+    width: null,
+    format: null,
+    __typename: 'FieldMetaData',
+  },
+  {
+    name: 'createdAt',
+    type: 'datetime',
+    __typename: 'FieldMetaData',
+  },
+  {
+    name: 'description',
+    type: 'text',
+    kind: 'SCALAR',
+    label: 'Description',
+    width: null,
+    format: null,
+    __typename: 'FieldMetaData',
+  },
+  {
+    name: 'status',
+    type: 'dropdown',
+    kind: 'SCALAR',
+    label: 'Status',
+    width: null,
+    format: null,
+    __typename: 'FieldMetaData',
+  },
+  {
+    name: 'title',
+    type: 'text',
+    __typename: 'FieldMetaData',
+  },
+  {
+    name: 'id',
+    type: 'text',
+    kind: 'SCALAR',
+    label: 'Id',
+    width: null,
+    format: null,
+    __typename: 'FieldMetaData',
+  },
+  {
+    name: 'check_box',
+    type: 'boolean',
+    __typename: 'FieldMetaData',
+  },
+];

--- a/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
@@ -288,7 +288,9 @@ describe('HtmlParserService', () => {
       replaceAggregationData = jest.spyOn(service, 'replaceAggregationData');
     });
     it('executes replaceAggregationData function', () => {
-      service.parseHtml(aggregationFormatElement.before, {});
+      service.parseHtml(aggregationFormatElement.before, {
+        aggregation: optionsAggregation,
+      });
       expect(replaceAggregationData).toHaveBeenCalled();
     });
     it('executes html element parse with aggregation data correctly', () => {

--- a/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
@@ -1,15 +1,318 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import get from 'lodash/get';
+import { StorybookTranslateModule } from '../../../../.storybook/storybook-translate.module';
+import { DatePipe } from '../../pipes/date/date.pipe';
 import { HtmlParserService } from './html-parser.service';
+
+/** Not number value examples */
+const notNumberValueExamples = [
+  'a',
+  '?',
+  '/',
+  '%%',
+  '#',
+  '&(',
+  ')',
+  '|\\',
+  '.',
+  ',',
+  ';',
+];
+
+/**
+ * Hardcoded values for round func test cases
+ * - [initial value, expected value, precision level]
+ */
+const roundValues = {
+  regular: [
+    ['1.49', '1'],
+    ['1.49', '1.5', '1'],
+  ],
+  up: [
+    ['1.49', '2'],
+    ['1.511', '1.52', '2'],
+  ],
+  down: [
+    ['1.49', '1'],
+    ['1.555', '1.55', '2'],
+  ],
+};
+/**
+ * Hardcoded values for percentage func test cases
+ * - [initial value, total value, expected value, precision level]
+ */
+const percentageValues = [
+  ['50.04', '100', '50.04%'],
+  ['5', '1', '500%', '0'],
+  ['50.6', '100', '51%', '0'],
+];
+/**
+ * Hardcoded values for max/min func test cases
+ * - [expected value, ...values]
+ */
+const maxMinValues = {
+  max: [
+    ['1.501', '1', '1.01', '1.500', '1.501'],
+    ['1.49', '1.48', '1.0', '1', '0.54'],
+  ],
+  min: [
+    ['1', '1', '1.01', '1.500', '1.501'],
+    ['0.54', '1.48', '1.0', '1', '0.54'],
+  ],
+};
+/** Custom date formats */
+const customDateFormats = [
+  { format: 'yyyy-MM-dd', result: '2024-11-26' }, // 2024-11-26: ISO 8601 format date
+  { format: 'dd/MM/yyyy', result: '26/11/2024' }, // 26/11/2024: Day-first numeric format
+  { format: 'MM/dd/yyyy', result: '11/26/2024' }, // 11/26/2024: Month-first numeric format
+  { format: 'EEEE, MMMM d, yyyy', result: 'Tuesday, November 26, 2024' }, // Tuesday, November 26, 2024: Full day name, month name, day, year
+  { format: 'MMM d, y, h:mm a', result: 'Nov 26, 2024, 12:00 PM' }, // Nov 26, 2024, 12:00 PM: Short month name, day, year, 12-hour time
+  { format: "MMMM d, y 'at' h:mm a", result: 'November 26, 2024 at 12:00 PM' }, // November 26, 2024 at 12:00 PM: Full month, day, year with literal text
+  { format: 'yyyy/MM/dd HH:mm:ss Z', result: '2024/11/26 12:00:00 +0000' }, // 2024/11/26 12:00:00 +0000: ISO-like with timezone offset
+  { format: 'yyyy-MM-ddTHH:mm:ss', result: '2024-11-26T12:00:00' }, // 2024-11-26T12:00:00: ISO 8601 with "T" separator for time
+  { format: 'hh:mm a', result: '12:00 PM' }, // 12:00 PM: 12-hour time with AM/PM
+  { format: 'HH:mm:ss', result: '12:00:00' }, // 12:00:00: 24-hour time with seconds
+  { format: 'MMMM d', result: 'November 26' }, // November 26: Full month name and day (no year)
+  { format: 'E, MMM dd yyyy', result: 'Tue, Nov 26 2024' }, // Tue, Nov 26 2024: Short day name, short month, day, year
+  { format: 'yyyy MMMM dd', result: '2024 November 26' }, // 2024 November 26: Year, full month name, day
+  { format: 'yyyy-MM-dd HH:mm', result: '2024-11-26 12:00' }, // 2024-11-26 12:00: ISO-like date with hours and minutes
+  { format: 'dd-MMM-yyyy', result: '26-Nov-2024' }, // 26-Nov-2024: Day, short month name, year
+  { format: 'MM/yyyy', result: '11/2024' }, // 11/2024: Month and year only
+  { format: 'HH:mm:ss.SSS', result: '12:00:00.000' }, // 12:00:00.000: 24-hour time with milliseconds
+  {
+    format: 'EEE, d MMM yyyy HH:mm:ss Z',
+    result: 'Tue, 26 Nov 2024 12:00:00 +0000',
+  }, // Tue, 26 Nov 2024 12:00:00 +0000: RFC 2822 format (emails)
+  {
+    format: 'yyyy-MM-dd HH:mm:ss zzzz',
+    result: '2024-11-26 12:00:00 GMT+00:00',
+  }, // 2024-11-26 12:00:00 GMT+00:00: Full timezone name
+  { format: 'h:mm:ss a z', result: '12:00:00 PM GMT' }, // 12:00:00 PM GMT: 12-hour time with seconds and timezone abbreviation
+  { format: 'G yyyy-MM-dd', result: 'AD 2024-11-26' }, // AD 2024-11-26: Era designator (AD/BC), year, month, day
+];
+/** Predefined formats */
+const predefinedDateFormats = [
+  { format: 'short', result: '11/26/24, 12:00 PM' }, // Example: 11/26/24, 12:00 PM
+  { format: 'medium', result: 'Nov 26, 2024, 12:00:00 PM' }, // Example: Nov 26, 2024, 12:00:00 PM
+  { format: 'long', result: 'November 26, 2024 at 12:00:00 PM GMT+0' }, // Example: November 26, 2024 at 12:00:00 PM GMT+0
+  {
+    format: 'full',
+    result: 'Tuesday, November 26, 2024 at 12:00:00 PM GMT+00:00',
+  }, // Example: Tuesday, November 26, 2024 at 12:00:00 PM GMT+00:00
+  { format: 'shortDate', result: '11/26/24' }, // Example: 11/26/24
+  { format: 'mediumDate', result: 'Nov 26, 2024' }, // Example: Nov 26, 2024
+  { format: 'longDate', result: 'November 26, 2024' }, // Example: November 26, 2024
+  { format: 'fullDate', result: 'Tuesday, November 26, 2024' }, // Example: Tuesday, November 26, 2024
+  { format: 'shortTime', result: '12:00 PM' }, // Example: 12:00 PM
+  { format: 'mediumTime', result: '12:00:00 PM' }, // Example: 12:00:00 PM
+  { format: 'longTime', result: '12:00:00 PM GMT+0' }, // Example: 12:00:00 PM GMT+0
+  { format: 'fullTime', result: '12:00:00 PM GMT+00:00' }, // Example: 12:00:00 PM GMT+00:00
+];
 
 describe('HtmlParserService', () => {
   let service: HtmlParserService;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
+  // let roundFunc!: any;
+  beforeAll(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, StorybookTranslateModule],
+      providers: [DatePipe],
+    });
     service = TestBed.inject(HtmlParserService);
   });
-
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+  describe('Calculations with hardcoded data', () => {
+    let roundFunc!: any;
+    let roundUpFunc!: any;
+    let roundDownFunc!: any;
+    let percentageFunc!: any;
+    let minFunc!: any;
+    let maxFunc!: any;
+    let dateFunc!: any;
+    beforeAll(() => {
+      roundFunc = get(service.calcFunctions, 'round');
+      roundUpFunc = get(service.calcFunctions, 'roundup');
+      roundDownFunc = get(service.calcFunctions, 'rounddown');
+      percentageFunc = get(service.calcFunctions, 'percentage');
+      minFunc = get(service.calcFunctions, 'min');
+      maxFunc = get(service.calcFunctions, 'max');
+      dateFunc = get(service.calcFunctions, 'date');
+    });
+    /** Round functions */
+    describe('executes round calculations correctly', () => {
+      let currentRoundFunction!: any;
+      Object.keys(roundValues).forEach((key) => {
+        describe(`executes ${key} round calculations correctly`, () => {
+          beforeEach(() => {
+            switch (key) {
+              case 'up':
+                currentRoundFunction = roundUpFunc;
+                break;
+              case 'down':
+                currentRoundFunction = roundDownFunc;
+                break;
+              default:
+                currentRoundFunction = roundFunc;
+                break;
+            }
+          });
+          roundValues[key as keyof typeof roundValues].forEach((testCases) => {
+            it(`and rounds ${testCases[0]} to ${testCases[1]} if precision level is ${testCases[2]}`, () => {
+              const result = currentRoundFunction.call(
+                testCases[0],
+                testCases[2]
+              );
+              expect(result).toBe(testCases[1]);
+            });
+          });
+        });
+      });
+    });
+    describe('handles round calculation errors gracefully', () => {
+      let currentRoundFunction!: any;
+      Object.keys(roundValues).forEach((key) => {
+        describe(`handles ${key} round calculation errors gracefully`, () => {
+          beforeEach(() => {
+            switch (key) {
+              case 'up':
+                currentRoundFunction = roundUpFunc;
+                break;
+              case 'down':
+                currentRoundFunction = roundDownFunc;
+                break;
+              default:
+                currentRoundFunction = roundFunc;
+                break;
+            }
+          });
+          const noNumberValue =
+            notNumberValueExamples[
+              Math.floor(notNumberValueExamples.length * Math.random())
+            ];
+          it(`and rounds not number value ${noNumberValue} to '0'`, () => {
+            const result = currentRoundFunction.call(noNumberValue);
+            expect(result).toBe('0');
+          });
+          it(`and rounds no value to '0'`, () => {
+            const result = currentRoundFunction.call();
+            expect(result).toBe('0');
+          });
+        });
+      });
+    });
+    /** Percentage function */
+    describe('executes percentage calculation correctly', () => {
+      percentageValues.forEach((testCases) => {
+        it(`sets percentage of ${testCases[0]} against ${testCases[1]} is ${testCases[2]} if precision level is ${testCases[3]}`, () => {
+          const result = percentageFunc.call(
+            testCases[0],
+            testCases[1],
+            testCases[3]
+          );
+          expect(result).toBe(testCases[2]);
+        });
+      });
+    });
+    describe('handles percentage calculation errors gracefully', () => {
+      const noNumberValue =
+        notNumberValueExamples[
+          Math.floor(notNumberValueExamples.length * Math.random())
+        ];
+      it(`and sets percentage of not number value ${noNumberValue} to '0'`, () => {
+        const result = percentageFunc.call(noNumberValue);
+        expect(result).toBe('0');
+      });
+      it(`and sets percentage of no value to '0'`, () => {
+        const result = percentageFunc.call();
+        expect(result).toBe('0');
+      });
+    });
+    /** Max/Min functions */
+    describe('executes max/min calculations correctly', () => {
+      let currentFunction!: any;
+      Object.keys(maxMinValues).forEach((key) => {
+        describe(`executes ${key} value calculations correctly`, () => {
+          beforeEach(() => {
+            switch (key) {
+              case 'max':
+                currentFunction = maxFunc;
+                break;
+              case 'min':
+                currentFunction = minFunc;
+                break;
+              default:
+                break;
+            }
+          });
+          maxMinValues[key as keyof typeof maxMinValues].forEach(
+            (testCases) => {
+              it(`and ${key} value from ${testCases.join(', ')} is ${
+                testCases[0]
+              }`, () => {
+                const result = currentFunction.call(testCases[0], ...testCases);
+                expect(result).toBe(testCases[0]);
+              });
+            }
+          );
+        });
+      });
+    });
+    describe('handles max/min calculation errors gracefully', () => {
+      let currentFunction!: any;
+      Object.keys(maxMinValues).forEach((key) => {
+        describe(`handles ${key} value calculation errors gracefully`, () => {
+          beforeEach(() => {
+            switch (key) {
+              case 'max':
+                currentFunction = maxFunc;
+                break;
+              case 'min':
+                currentFunction = minFunc;
+                break;
+              default:
+                break;
+            }
+          });
+          it(`and sets ${key} value from not number values ${notNumberValueExamples.join(
+            ', '
+          )} to an empty string`, () => {
+            const result = currentFunction.call(...notNumberValueExamples);
+            expect(result).toBe('');
+          });
+          it(`and sets ${key} value from no value to be an empty string`, () => {
+            const result = currentFunction.call();
+            expect(result).toBe('');
+          });
+        });
+      });
+    });
+    /** Date function */
+    describe('executes date calculation correctly', () => {
+      const fixedDate = new Date(
+        Date.UTC(2024, 10, 26, 12, 0, 0)
+      ).toISOString();
+      [...customDateFormats, ...predefinedDateFormats].forEach((testCase) => {
+        it(`sets given ${fixedDate} date with format ${testCase.format} to ${testCase.result}`, () => {
+          const result = dateFunc.call(fixedDate, testCase.format);
+          expect(result).toBe(testCase.result);
+        });
+      });
+    });
+    // describe('handles date calculation errors gracefully', () => {
+    //   const noNumberValue =
+    //     notNumberValueExamples[
+    //       Math.floor(notNumberValueExamples.length * Math.random())
+    //     ];
+    //   it(`and sets percentage of not number value ${noNumberValue} to '0'`, () => {
+    //     const result = percentageFunc.call(noNumberValue);
+    //     expect(result).toBe('0');
+    //   });
+    //   it(`and sets percentage of no value to '0'`, () => {
+    //     const result = percentageFunc.call();
+    //     expect(result).toBe('0');
+    //   });
+    // });
   });
 });

--- a/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
@@ -63,56 +63,121 @@ const maxMinValues = {
 };
 /** Custom date formats */
 const customDateFormats = [
-  { format: 'yyyy-MM-dd', result: '2024-11-26' }, // 2024-11-26: ISO 8601 format date
-  { format: 'dd/MM/yyyy', result: '26/11/2024' }, // 26/11/2024: Day-first numeric format
-  { format: 'MM/dd/yyyy', result: '11/26/2024' }, // 11/26/2024: Month-first numeric format
-  { format: 'EEEE, MMMM d, yyyy', result: 'Tuesday, November 26, 2024' }, // Tuesday, November 26, 2024: Full day name, month name, day, year
-  { format: 'MMM d, y, h:mm a', result: 'Nov 26, 2024, 12:00 PM' }, // Nov 26, 2024, 12:00 PM: Short month name, day, year, 12-hour time
-  { format: "MMMM d, y 'at' h:mm a", result: 'November 26, 2024 at 12:00 PM' }, // November 26, 2024 at 12:00 PM: Full month, day, year with literal text
-  { format: 'yyyy/MM/dd HH:mm:ss Z', result: '2024/11/26 12:00:00 +0000' }, // 2024/11/26 12:00:00 +0000: ISO-like with timezone offset
-  { format: 'yyyy-MM-ddTHH:mm:ss', result: '2024-11-26T12:00:00' }, // 2024-11-26T12:00:00: ISO 8601 with "T" separator for time
-  { format: 'hh:mm a', result: '12:00 PM' }, // 12:00 PM: 12-hour time with AM/PM
-  { format: 'HH:mm:ss', result: '12:00:00' }, // 12:00:00: 24-hour time with seconds
-  { format: 'MMMM d', result: 'November 26' }, // November 26: Full month name and day (no year)
-  { format: 'E, MMM dd yyyy', result: 'Tue, Nov 26 2024' }, // Tue, Nov 26 2024: Short day name, short month, day, year
-  { format: 'yyyy MMMM dd', result: '2024 November 26' }, // 2024 November 26: Year, full month name, day
-  { format: 'yyyy-MM-dd HH:mm', result: '2024-11-26 12:00' }, // 2024-11-26 12:00: ISO-like date with hours and minutes
-  { format: 'dd-MMM-yyyy', result: '26-Nov-2024' }, // 26-Nov-2024: Day, short month name, year
-  { format: 'MM/yyyy', result: '11/2024' }, // 11/2024: Month and year only
-  { format: 'HH:mm:ss.SSS', result: '12:00:00.000' }, // 12:00:00.000: 24-hour time with milliseconds
+  { format: 'yyyy-MM-dd', result: `2024-11-26` }, // 2024-11-26: ISO 8601 format date
+  { format: 'dd/MM/yyyy', result: `26/11/2024` }, // 26/11/2024: Day-first numeric format
+  { format: 'MM/dd/yyyy', result: `11/26/2024` }, // 11/26/2024: Month-first numeric format
+  {
+    format: 'EEEE, MMMM d, yyyy',
+    result: `Tuesday, November 26, 2024`,
+  }, // Tuesday, November 26, 2024: Full day name, month name, day, year
+  {
+    format: 'MMM d, y, h:mm a',
+    result: `Nov 26, 2024, 1:00 PM`,
+  }, // Nov 26, 2024, 1:00 PM: Short month name, day, year, 12-hour time
+  {
+    format: "MMMM d, y 'at' h:mm a",
+    result: `November 26, 2024 at 1:00 PM`,
+  }, // November 26, 2024 at 1:00 PM: Full month, day, year with literal text
+  {
+    format: 'yyyy/MM/dd HH:mm:ss Z',
+    result: `2024/11/26 13:00:00 +0100`,
+  }, // 2024/11/26 1:00:00 +0000: ISO-like with timezone offset
+  {
+    format: 'yyyy-MM-ddTHH:mm:ss',
+    result: `2024-11-26T13:00:00`,
+  }, // 2024-11-26T1:00:00: ISO 8601 with "T" separator for time
+  { format: 'hh:mm a', result: `01:00 PM` }, // 1:00 PM: 12-hour time with AM/PM
+  { format: 'HH:mm:ss', result: `13:00:00` }, // 1:00:00: 24-hour time with seconds
+  { format: 'MMMM d', result: `November 26` }, // November 26: Full month name and day (no year)
+  { format: 'E, MMM dd yyyy', result: `Tue, Nov 26 2024` }, // Tue, Nov 26 2024: Short day name, short month, day, year
+  { format: 'yyyy MMMM dd', result: `2024 November 26` }, // 2024 November 26: Year, full month name, day
+  {
+    format: 'yyyy-MM-dd HH:mm',
+    result: `2024-11-26 13:00`,
+  }, // 2024-11-26 1:00: ISO-like date with hours and minutes
+  { format: 'dd-MMM-yyyy', result: `26-Nov-2024` }, // 26-Nov-2024: Day, short month name, year
+  { format: 'MM/yyyy', result: `11/2024` }, // 11/2024: Month and year only
+  {
+    format: 'HH:mm:ss.SSS',
+    result: `13:00:00.000`,
+  }, // 1:00:00.000: 24-hour time with milliseconds
   {
     format: 'EEE, d MMM yyyy HH:mm:ss Z',
-    result: 'Tue, 26 Nov 2024 12:00:00 +0000',
-  }, // Tue, 26 Nov 2024 12:00:00 +0000: RFC 2822 format (emails)
+    result: `Tue, 26 Nov 2024 13:00:00 +0100`,
+  }, // Tue, 26 Nov 2024 1:00:00 +0000: RFC 2822 format (emails)
   {
     format: 'yyyy-MM-dd HH:mm:ss zzzz',
-    result: '2024-11-26 12:00:00 GMT+00:00',
-  }, // 2024-11-26 12:00:00 GMT+00:00: Full timezone name
-  { format: 'h:mm:ss a z', result: '12:00:00 PM GMT' }, // 12:00:00 PM GMT: 12-hour time with seconds and timezone abbreviation
+    result: `2024-11-26 13:00:00 GMT+01:00`,
+  }, // 2024-11-26 1:00:00 GMT+01:00: Full timezone name
+  {
+    format: 'h:mm:ss a z',
+    result: `1:00:00 PM GMT+1`,
+  }, // 12:00:00 PM GMT: 12-hour time with seconds and timezone abbreviation
   { format: 'G yyyy-MM-dd', result: 'AD 2024-11-26' }, // AD 2024-11-26: Era designator (AD/BC), year, month, day
 ];
 /** Predefined formats */
 const predefinedDateFormats = [
-  { format: 'short', result: '11/26/24, 12:00 PM' }, // Example: 11/26/24, 12:00 PM
-  { format: 'medium', result: 'Nov 26, 2024, 12:00:00 PM' }, // Example: Nov 26, 2024, 12:00:00 PM
-  { format: 'long', result: 'November 26, 2024 at 12:00:00 PM GMT+0' }, // Example: November 26, 2024 at 12:00:00 PM GMT+0
+  {
+    format: 'short',
+    result: `11/26/24, 1:00 PM`,
+  }, // Example: 11/26/24, 1:00 PM
+  {
+    format: 'medium',
+    result: `Nov 26, 2024, 1:00:00 PM`,
+  }, // Example: Nov 26, 2024, 1:00:00 PM
+  {
+    format: 'long',
+    result: `November 26, 2024 at 1:00:00 PM GMT+1`,
+  }, // Example: November 26, 2024 at 1:00:00 PM GMT+1
   {
     format: 'full',
-    result: 'Tuesday, November 26, 2024 at 12:00:00 PM GMT+00:00',
-  }, // Example: Tuesday, November 26, 2024 at 12:00:00 PM GMT+00:00
+    result: `Tuesday, November 26, 2024 at 1:00:00 PM GMT+01:00`,
+  }, // Example: Tuesday, November 26, 2024 at 1:00:00 PM GMT+01:00
   { format: 'shortDate', result: '11/26/24' }, // Example: 11/26/24
   { format: 'mediumDate', result: 'Nov 26, 2024' }, // Example: Nov 26, 2024
   { format: 'longDate', result: 'November 26, 2024' }, // Example: November 26, 2024
-  { format: 'fullDate', result: 'Tuesday, November 26, 2024' }, // Example: Tuesday, November 26, 2024
-  { format: 'shortTime', result: '12:00 PM' }, // Example: 12:00 PM
-  { format: 'mediumTime', result: '12:00:00 PM' }, // Example: 12:00:00 PM
-  { format: 'longTime', result: '12:00:00 PM GMT+0' }, // Example: 12:00:00 PM GMT+0
-  { format: 'fullTime', result: '12:00:00 PM GMT+00:00' }, // Example: 12:00:00 PM GMT+00:00
+  {
+    format: 'fullDate',
+    result: 'Tuesday, November 26, 2024',
+  }, // Example: Tuesday, November 26, 2024
+  { format: 'shortTime', result: `1:00 PM` }, // Example: 1:00 PM
+  {
+    format: 'mediumTime',
+    result: `1:00:00 PM`,
+  }, // Example: 1:00:00 PM
+  {
+    format: 'longTime',
+    result: `1:00:00 PM GMT+1`,
+  }, // Example: 1:00:00 PM GMT
+  {
+    format: 'fullTime',
+    result: `1:00:00 PM GMT+01:00`,
+  }, // Example: 1:00:00 PM GMT+00:00
 ];
+
+const calcFormatElement = {
+  before: `
+<p>{{calc.round( 9.5 ; 1 )}}</p>
+<p>{{calc.roundup( 9.5 ; 1 )}}</p>
+<p>{{calc.rounddown( 9.5 ; 1 )}}</p>
+<p>{{calc.percentage( 5 ; 10 ; 0 )}}</p>
+<p>{{calc.min( 1 ; 2 ; 3 )}}</p>
+<p>{{calc.max( 3 ; 2 ; 1 )}}</p>
+<p>{{calc.date( Tuesday, November 26, 2024 ; shortDate )}}</p>
+`,
+  after: `
+<p>9.5</p>
+<p>9.5</p>
+<p>9.5</p>
+<p>50%</p>
+<p>1</p>
+<p>3</p>
+<p>11/26/24</p>
+`,
+};
 
 describe('HtmlParserService', () => {
   let service: HtmlParserService;
-  // let roundFunc!: any;
   beforeAll(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, StorybookTranslateModule],
@@ -300,19 +365,78 @@ describe('HtmlParserService', () => {
         });
       });
     });
-    // describe('handles date calculation errors gracefully', () => {
-    //   const noNumberValue =
-    //     notNumberValueExamples[
-    //       Math.floor(notNumberValueExamples.length * Math.random())
-    //     ];
-    //   it(`and sets percentage of not number value ${noNumberValue} to '0'`, () => {
-    //     const result = percentageFunc.call(noNumberValue);
-    //     expect(result).toBe('0');
-    //   });
-    //   it(`and sets percentage of no value to '0'`, () => {
-    //     const result = percentageFunc.call();
-    //     expect(result).toBe('0');
-    //   });
-    // });
+    describe('handles date calculation errors gracefully', () => {
+      const noNumberValue =
+        notNumberValueExamples[
+          Math.floor(notNumberValueExamples.length * Math.random())
+        ];
+      const fixedDate = new Date(
+        Date.UTC(2024, 10, 26, 12, 0, 0)
+      ).toISOString();
+      it(`and sets given not date format ${noNumberValue} to same ${noNumberValue}`, () => {
+        const result = dateFunc.call(fixedDate, noNumberValue);
+        expect(result).toBe(noNumberValue);
+      });
+      it(`and sets no value to ''`, () => {
+        const result = dateFunc.call();
+        expect(result).toBe('');
+      });
+    });
+  });
+  describe('Parse HTML with calculations data', () => {
+    let roundFunc!: any;
+    let roundUpFunc!: any;
+    let roundDownFunc!: any;
+    let percentageFunc!: any;
+    let minFunc!: any;
+    let maxFunc!: any;
+    let dateFunc!: any;
+    beforeAll(() => {
+      roundFunc = jest.spyOn(get(service.calcFunctions, 'round'), 'call');
+      roundUpFunc = jest.spyOn(get(service.calcFunctions, 'roundup'), 'call');
+      roundDownFunc = jest.spyOn(
+        get(service.calcFunctions, 'rounddown'),
+        'call'
+      );
+      percentageFunc = jest.spyOn(
+        get(service.calcFunctions, 'percentage'),
+        'call'
+      );
+      minFunc = jest.spyOn(get(service.calcFunctions, 'min'), 'call');
+      maxFunc = jest.spyOn(get(service.calcFunctions, 'max'), 'call');
+      dateFunc = jest.spyOn(get(service.calcFunctions, 'date'), 'call');
+    });
+    it('executes calc function for round', () => {
+      service.parseHtml(calcFormatElement.before, {});
+      expect(roundFunc).toHaveBeenCalled();
+    });
+    it('executes calc function for roundup', () => {
+      service.parseHtml(calcFormatElement.before, {});
+      expect(roundUpFunc).toHaveBeenCalled();
+    });
+    it('executes calc function for rounddown', () => {
+      service.parseHtml(calcFormatElement.before, {});
+      expect(roundDownFunc).toHaveBeenCalled();
+    });
+    it('executes calc function for percentage', () => {
+      service.parseHtml(calcFormatElement.before, {});
+      expect(percentageFunc).toHaveBeenCalled();
+    });
+    it('executes calc function for max', () => {
+      service.parseHtml(calcFormatElement.before, {});
+      expect(maxFunc).toHaveBeenCalled();
+    });
+    it('executes calc function for min', () => {
+      service.parseHtml(calcFormatElement.before, {});
+      expect(minFunc).toHaveBeenCalled();
+    });
+    it('executes calc function for date', () => {
+      service.parseHtml(calcFormatElement.before, {});
+      expect(dateFunc).toHaveBeenCalled();
+    });
+    it('executes html element parse with calcs correctly', () => {
+      const result = service.parseHtml(calcFormatElement.before, {});
+      expect(result).toEqual(calcFormatElement.after);
+    });
   });
 });

--- a/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
@@ -4,177 +4,20 @@ import get from 'lodash/get';
 import { StorybookTranslateModule } from '../../../../.storybook/storybook-translate.module';
 import { DatePipe } from '../../pipes/date/date.pipe';
 import { HtmlParserService } from './html-parser.service';
-
-/** Not number value examples */
-const notNumberValueExamples = [
-  'a',
-  '?',
-  '/',
-  '%%',
-  '#',
-  '&(',
-  ')',
-  '|\\',
-  '.',
-  ',',
-  ';',
-];
-
-/**
- * Hardcoded values for round func test cases
- * - [initial value, expected value, precision level]
- */
-const roundValues = {
-  regular: [
-    ['1.49', '1'],
-    ['1.49', '1.5', '1'],
-  ],
-  up: [
-    ['1.49', '2'],
-    ['1.511', '1.52', '2'],
-  ],
-  down: [
-    ['1.49', '1'],
-    ['1.555', '1.55', '2'],
-  ],
-};
-/**
- * Hardcoded values for percentage func test cases
- * - [initial value, total value, expected value, precision level]
- */
-const percentageValues = [
-  ['50.04', '100', '50.04%'],
-  ['5', '1', '500%', '0'],
-  ['50.6', '100', '51%', '0'],
-];
-/**
- * Hardcoded values for max/min func test cases
- * - [expected value, ...values]
- */
-const maxMinValues = {
-  max: [
-    ['1.501', '1', '1.01', '1.500', '1.501'],
-    ['1.49', '1.48', '1.0', '1', '0.54'],
-  ],
-  min: [
-    ['1', '1', '1.01', '1.500', '1.501'],
-    ['0.54', '1.48', '1.0', '1', '0.54'],
-  ],
-};
-/** Custom date formats */
-const customDateFormats = [
-  { format: 'yyyy-MM-dd', result: `2024-11-26` }, // 2024-11-26: ISO 8601 format date
-  { format: 'dd/MM/yyyy', result: `26/11/2024` }, // 26/11/2024: Day-first numeric format
-  { format: 'MM/dd/yyyy', result: `11/26/2024` }, // 11/26/2024: Month-first numeric format
-  {
-    format: 'EEEE, MMMM d, yyyy',
-    result: `Tuesday, November 26, 2024`,
-  }, // Tuesday, November 26, 2024: Full day name, month name, day, year
-  {
-    format: 'MMM d, y, h:mm a',
-    result: `Nov 26, 2024, 1:00 PM`,
-  }, // Nov 26, 2024, 1:00 PM: Short month name, day, year, 12-hour time
-  {
-    format: "MMMM d, y 'at' h:mm a",
-    result: `November 26, 2024 at 1:00 PM`,
-  }, // November 26, 2024 at 1:00 PM: Full month, day, year with literal text
-  {
-    format: 'yyyy/MM/dd HH:mm:ss Z',
-    result: `2024/11/26 13:00:00 +0100`,
-  }, // 2024/11/26 1:00:00 +0000: ISO-like with timezone offset
-  {
-    format: 'yyyy-MM-ddTHH:mm:ss',
-    result: `2024-11-26T13:00:00`,
-  }, // 2024-11-26T1:00:00: ISO 8601 with "T" separator for time
-  { format: 'hh:mm a', result: `01:00 PM` }, // 1:00 PM: 12-hour time with AM/PM
-  { format: 'HH:mm:ss', result: `13:00:00` }, // 1:00:00: 24-hour time with seconds
-  { format: 'MMMM d', result: `November 26` }, // November 26: Full month name and day (no year)
-  { format: 'E, MMM dd yyyy', result: `Tue, Nov 26 2024` }, // Tue, Nov 26 2024: Short day name, short month, day, year
-  { format: 'yyyy MMMM dd', result: `2024 November 26` }, // 2024 November 26: Year, full month name, day
-  {
-    format: 'yyyy-MM-dd HH:mm',
-    result: `2024-11-26 13:00`,
-  }, // 2024-11-26 1:00: ISO-like date with hours and minutes
-  { format: 'dd-MMM-yyyy', result: `26-Nov-2024` }, // 26-Nov-2024: Day, short month name, year
-  { format: 'MM/yyyy', result: `11/2024` }, // 11/2024: Month and year only
-  {
-    format: 'HH:mm:ss.SSS',
-    result: `13:00:00.000`,
-  }, // 1:00:00.000: 24-hour time with milliseconds
-  {
-    format: 'EEE, d MMM yyyy HH:mm:ss Z',
-    result: `Tue, 26 Nov 2024 13:00:00 +0100`,
-  }, // Tue, 26 Nov 2024 1:00:00 +0000: RFC 2822 format (emails)
-  {
-    format: 'yyyy-MM-dd HH:mm:ss zzzz',
-    result: `2024-11-26 13:00:00 GMT+01:00`,
-  }, // 2024-11-26 1:00:00 GMT+01:00: Full timezone name
-  {
-    format: 'h:mm:ss a z',
-    result: `1:00:00 PM GMT+1`,
-  }, // 12:00:00 PM GMT: 12-hour time with seconds and timezone abbreviation
-  { format: 'G yyyy-MM-dd', result: 'AD 2024-11-26' }, // AD 2024-11-26: Era designator (AD/BC), year, month, day
-];
-/** Predefined formats */
-const predefinedDateFormats = [
-  {
-    format: 'short',
-    result: `11/26/24, 1:00 PM`,
-  }, // Example: 11/26/24, 1:00 PM
-  {
-    format: 'medium',
-    result: `Nov 26, 2024, 1:00:00 PM`,
-  }, // Example: Nov 26, 2024, 1:00:00 PM
-  {
-    format: 'long',
-    result: `November 26, 2024 at 1:00:00 PM GMT+1`,
-  }, // Example: November 26, 2024 at 1:00:00 PM GMT+1
-  {
-    format: 'full',
-    result: `Tuesday, November 26, 2024 at 1:00:00 PM GMT+01:00`,
-  }, // Example: Tuesday, November 26, 2024 at 1:00:00 PM GMT+01:00
-  { format: 'shortDate', result: '11/26/24' }, // Example: 11/26/24
-  { format: 'mediumDate', result: 'Nov 26, 2024' }, // Example: Nov 26, 2024
-  { format: 'longDate', result: 'November 26, 2024' }, // Example: November 26, 2024
-  {
-    format: 'fullDate',
-    result: 'Tuesday, November 26, 2024',
-  }, // Example: Tuesday, November 26, 2024
-  { format: 'shortTime', result: `1:00 PM` }, // Example: 1:00 PM
-  {
-    format: 'mediumTime',
-    result: `1:00:00 PM`,
-  }, // Example: 1:00:00 PM
-  {
-    format: 'longTime',
-    result: `1:00:00 PM GMT+1`,
-  }, // Example: 1:00:00 PM GMT
-  {
-    format: 'fullTime',
-    result: `1:00:00 PM GMT+01:00`,
-  }, // Example: 1:00:00 PM GMT+00:00
-];
-/** Html with calc functions */
-const calcFormatElement = {
-  before: `
-<p>{{calc.round( 9.5 ; 1 )}}</p>
-<p>{{calc.roundup( 9.5 ; 1 )}}</p>
-<p>{{calc.rounddown( 9.5 ; 1 )}}</p>
-<p>{{calc.percentage( 5 ; 10 ; 0 )}}</p>
-<p>{{calc.min( 1 ; 2 ; 3 )}}</p>
-<p>{{calc.max( 3 ; 2 ; 1 )}}</p>
-<p>{{calc.date( Tuesday, November 26, 2024 ; shortDate )}}</p>
-`,
-  after: `
-<p>9.5</p>
-<p>9.5</p>
-<p>9.5</p>
-<p>50%</p>
-<p>1</p>
-<p>3</p>
-<p>11/26/24</p>
-`,
-};
+import {
+  aggregationFormatElement,
+  calcFormatElement,
+  customDateFormats,
+  dataFormatElement,
+  maxMinValues,
+  notNumberValueExamples,
+  optionFields,
+  optionsAggregation,
+  optionsData,
+  percentageValues,
+  predefinedDateFormats,
+  roundValues,
+} from './html-parser-test-values';
 
 describe('HtmlParserService', () => {
   let service: HtmlParserService;
@@ -437,6 +280,88 @@ describe('HtmlParserService', () => {
     it('executes html element parse with calcs correctly', () => {
       const result = service.parseHtml(calcFormatElement.before, {});
       expect(result).toEqual(calcFormatElement.after);
+    });
+  });
+  describe('Parse HTML with aggregation data', () => {
+    let replaceAggregationData!: any;
+    beforeAll(() => {
+      replaceAggregationData = jest.spyOn(service, 'replaceAggregationData');
+    });
+    it('executes replaceAggregationData function', () => {
+      service.parseHtml(aggregationFormatElement.before, {});
+      expect(replaceAggregationData).toHaveBeenCalled();
+    });
+    it('executes html element parse with aggregation data correctly', () => {
+      const result = service.parseHtml(aggregationFormatElement.before, {
+        aggregation: optionsAggregation,
+      });
+      expect(result).toEqual(aggregationFormatElement.after);
+    });
+    it('executes html element parse with aggregation data correctly if html does not have any aggregation set', () => {
+      const result = service.parseHtml(calcFormatElement.before, {
+        aggregation: optionsAggregation,
+      });
+      expect(result).toEqual(
+        calcFormatElement.after.replace(new RegExp('\\n', 'g'), '')
+      );
+    });
+  });
+  describe('Parse HTML with injected data', () => {
+    let replaceRecordFields!: any;
+    beforeAll(() => {
+      replaceRecordFields = jest.spyOn(service, 'replaceRecordFields');
+    });
+    it('executes replaceRecordFields function', () => {
+      service.parseHtml(dataFormatElement.before, {
+        data: optionsData,
+        fields: optionFields,
+      });
+      expect(replaceRecordFields).toHaveBeenCalled();
+    });
+    it('executes html element parse with injected data correctly', () => {
+      const result = service.parseHtml(dataFormatElement.before, {
+        data: optionsData,
+        fields: optionFields,
+      });
+      expect(result).toEqual(dataFormatElement.after);
+    });
+    it('executes html element parse with injected data correctly if html does not have any data set', () => {
+      const result = service.parseHtml(calcFormatElement.before, {
+        data: optionsData,
+        fields: optionFields,
+      });
+      expect(result).toEqual(
+        calcFormatElement.after.replace(new RegExp('\\n', 'g'), '')
+      );
+    });
+  });
+  describe('Parse HTML with context data', () => {
+    let replaceRecordFields!: any;
+    beforeAll(() => {
+      replaceRecordFields = jest.spyOn(service, 'replaceRecordFields');
+    });
+    it('executes replaceRecordFields function', () => {
+      service.parseHtml(dataFormatElement.before, {
+        data: optionsData,
+        fields: optionFields,
+      });
+      expect(replaceRecordFields).toHaveBeenCalled();
+    });
+    it('executes html element parse with injected data correctly', () => {
+      const result = service.parseHtml(dataFormatElement.before, {
+        data: optionsData,
+        fields: optionFields,
+      });
+      expect(result).toEqual(dataFormatElement.after);
+    });
+    it('executes html element parse with injected data correctly if html does not have any data set', () => {
+      const result = service.parseHtml(calcFormatElement.before, {
+        data: optionsData,
+        fields: optionFields,
+      });
+      expect(result).toEqual(
+        calcFormatElement.after.replace(new RegExp('\\n', 'g'), '')
+      );
     });
   });
 });

--- a/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
@@ -154,7 +154,7 @@ const predefinedDateFormats = [
     result: `1:00:00 PM GMT+01:00`,
   }, // Example: 1:00:00 PM GMT+00:00
 ];
-
+/** Html with calc functions */
 const calcFormatElement = {
   before: `
 <p>{{calc.round( 9.5 ; 1 )}}</p>

--- a/libs/shared/src/lib/services/html-parser/html-parser.service.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser.service.ts
@@ -115,6 +115,8 @@ const createAvatarGroup = (
 export class HtmlParserService {
   /** Date pipe used for transforming date calc values */
   private datePipe = inject(DatePipe);
+  /** Function for replacing aggregation data in html */
+  replaceAggregationData = replaceAggregationData;
 
   /**
    * Definition of all supported functions for calculations inside the text of a
@@ -307,7 +309,7 @@ export class HtmlParserService {
    * @param styles Array of layout styles.
    * @returns formatted html.
    */
-  private replaceRecordFields(
+  replaceRecordFields(
     html: string,
     fieldsValue: any,
     fields: any,
@@ -663,8 +665,8 @@ export class HtmlParserService {
     }
   ) {
     let formattedHtml = replacePages(html, options.pages);
-    if (options.aggregation) {
-      formattedHtml = replaceAggregationData(
+    if (Object.keys(options.aggregation || {})?.length) {
+      formattedHtml = this.replaceAggregationData(
         formattedHtml,
         options.aggregation
       );

--- a/libs/shared/src/lib/services/html-parser/html-parser.service.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser.service.ts
@@ -658,7 +658,7 @@ export class HtmlParserService {
       data?: any;
       aggregation?: any;
       fields?: any;
-      pages: any[];
+      pages?: any[];
       styles?: any[];
     }
   ) {

--- a/libs/shared/src/lib/services/html-parser/html-parser.service.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser.service.ts
@@ -215,7 +215,7 @@ export class HtmlParserService {
        */
       call: (...values) => {
         // Ensure that the values are treated as numbers
-        return min(values.map((x) => Number(x)))?.toString() || '';
+        return min(values?.map((x) => Number(x)))?.toString() || '';
       },
     },
     max: {
@@ -228,7 +228,7 @@ export class HtmlParserService {
        */
       call: (...values) => {
         // Ensure that the values are treated as numbers
-        return max(values.map((x) => Number(x)))?.toString() || '';
+        return max(values?.map((x) => Number(x)))?.toString() || '';
       },
     },
     date: {


### PR DESCRIPTION
# Description

feat: add default tests for all calc functions with hard coded data 
feat: add story book translate module as shared module to load translation features 
feat: fix html parser calc for max min when no value is send

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/106027)
- Please insert link to back-end branch if any
- Please insert any useful link ( documentation you used for example )

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
