### PR TITLE
fix/AB#106122_ABC-resource-question-display-glitches

### DIFF
--- a/libs/shared/src/lib/components/controls/resource-select/resource-select.component.ts
+++ b/libs/shared/src/lib/components/controls/resource-select/resource-select.component.ts
@@ -80,17 +80,7 @@ export class ResourceSelectComponent extends GraphQLSelectComponent {
     this.valueField = 'id';
     this.textField = 'name';
     this.filterable = true;
-    this.searchChange.pipe(takeUntil(this.destroy$)).subscribe((value) => {
-      this.onSearchChange(value);
-    });
-  }
-
-  /**
-   * Override GraphQLSelectComponent onOpenSelect to only load query when
-   * select menu is open for the first time.
-   *
-   */
-  public override onOpenSelect(): void {
+    /** Initialize resource query with the component automatically*/
     if (!this.query) {
       this.query = this.apollo.watchQuery<ResourcesQueryResponse>({
         query: GET_RESOURCES,
@@ -107,7 +97,9 @@ export class ResourceSelectComponent extends GraphQLSelectComponent {
           this.updateValues(data, loading);
         });
     }
-    super.onOpenSelect();
+    this.searchChange.pipe(takeUntil(this.destroy$)).subscribe((value) => {
+      this.onSearchChange(value);
+    });
   }
 
   /**

--- a/libs/shared/src/lib/components/controls/resource-select/resource-select.component.ts
+++ b/libs/shared/src/lib/components/controls/resource-select/resource-select.component.ts
@@ -89,13 +89,6 @@ export class ResourceSelectComponent extends GraphQLSelectComponent {
           sortField: 'name',
         },
       });
-
-      this.query.valueChanges
-        .pipe(takeUntil(this.queryChange$), takeUntil(this.destroy$))
-        .subscribe(({ data, loading }) => {
-          this.queryName = Object.keys(data)[0];
-          this.updateValues(data, loading);
-        });
     }
     this.searchChange.pipe(takeUntil(this.destroy$)).subscribe((value) => {
       this.onSearchChange(value);

--- a/libs/shared/src/lib/survey/components/resource-dropdown/resource-dropdown.component.html
+++ b/libs/shared/src/lib/survey/components/resource-dropdown/resource-dropdown.component.html
@@ -3,7 +3,7 @@
   <shared-resource-select
     [isSurveyQuestion]="true"
     [formControl]="resourceControl"
-    [selectedElements]="[selectedResource]"
+    [selectedElements]="selectedResource"
   >
   </shared-resource-select>
 </div>

--- a/libs/shared/src/lib/survey/components/resource-dropdown/resource-dropdown.component.ts
+++ b/libs/shared/src/lib/survey/components/resource-dropdown/resource-dropdown.component.ts
@@ -6,15 +6,15 @@ import {
 } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { Apollo } from 'apollo-angular';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { QuestionAngular } from 'survey-angular-ui';
 import {
   Resource,
   ResourceQueryResponse,
 } from '../../../models/resource.model';
 import { GET_SHORT_RESOURCE_BY_ID } from './graphql/queries';
-import { takeUntil } from 'rxjs/operators';
-import { QuestionAngular } from 'survey-angular-ui';
 import { QuestionResourceDropdownModel } from './resource-dropdown.model';
-import { Subject } from 'rxjs';
 
 /**
  * This component is used to create a dropdown where the user can select a resource.
@@ -29,7 +29,7 @@ export class ResourceDropdownComponent
   implements OnInit
 {
   /** Selected resource */
-  public selectedResource?: Resource;
+  public selectedResource: Resource[] = [];
   /** Resource control */
   public resourceControl!: UntypedFormControl;
 
@@ -54,13 +54,6 @@ export class ResourceDropdownComponent
 
   override ngOnInit(): void {
     super.ngOnInit();
-    this.resourceControl = new UntypedFormControl(this.model.value ?? '');
-    this.resourceControl.valueChanges
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((value) => {
-        this.model.value = value;
-        this.model.obj.gridFieldsSettings = null;
-      });
     if (this.model.value) {
       this.apollo
         .query<ResourceQueryResponse>({
@@ -71,9 +64,17 @@ export class ResourceDropdownComponent
         })
         .subscribe(({ data }) => {
           if (data.resource) {
-            this.selectedResource = data.resource;
+            this.selectedResource = [data.resource];
+            this.changeDetectorRef.detectChanges();
           }
         });
     }
+    this.resourceControl = new UntypedFormControl(this.model.value ?? '');
+    this.resourceControl.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((value) => {
+        this.model.value = value;
+        this.model.obj.gridFieldsSettings = null;
+      });
   }
 }

--- a/libs/ui/src/lib/graphql-select/graphql-select.component.ts
+++ b/libs/ui/src/lib/graphql-select/graphql-select.component.ts
@@ -533,9 +533,10 @@ export class GraphQLSelectComponent
     const selectedElements = this.selectedElements.filter(
       (selectedElement) =>
         selectedElement &&
-        !elements.find(
-          (node) => node[this.valueField] === selectedElement[this.valueField]
-        )
+        (this.isSurveyQuestion ||
+          !elements.find(
+            (node) => node[this.valueField] === selectedElement[this.valueField]
+          ))
     );
     this.cachedElements = updateQueryUniqueValues(this.cachedElements, [
       ...selectedElements,


### PR DESCRIPTION
# Description

fix: initialize resource query on component mount, not on component open

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/106122)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

https://github.com/user-attachments/assets/f156a147-208a-41a4-8759-9ffadeeb64e7

We now initialize resource query on component mount, not on dropdown open

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
