### PR TITLE
Ab#106123 Email Notifications - Warning message if the records are more than 50 in Step 2 issue resolved

### DIFF
--- a/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
+++ b/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
@@ -160,7 +160,7 @@
                 class="float-right mt-8"
                 category="secondary"
                 variant="primary"
-                (click)="getDataSet('preview'); showPreview = true"
+                (click)="getDataSet('preview', true); showPreview = true"
                 [disabled]="selectedFields.length === 0"
               >
                 {{ 'common.preview' | translate }}

--- a/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
+++ b/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
@@ -277,7 +277,11 @@
               class="mt-2"
               *ngTemplateOutlet="tooManyRecordsAlertTmpl"
             ></ng-container>
-            <div class="overflow-x-auto" formGroupName="query">
+            <div
+              *ngIf="!showDatasetLimitWarning"
+              class="overflow-x-auto"
+              formGroupName="query"
+            >
               <div id="tblPreview" [innerHTML]="previewHTML"></div>
             </div>
           </ng-template>

--- a/libs/shared/src/lib/components/email/components/email-template/email-template.component.html
+++ b/libs/shared/src/lib/components/email/components/email-template/email-template.component.html
@@ -383,6 +383,7 @@
               *ngTemplateOutlet="showDLPreview"
             ></ng-container>
             <div
+             *ngIf="!showDatasetLimitWarning"
               id="tblPreview"
               class="overflow-scroll"
               #tblPreview


### PR DESCRIPTION
# Description

System not throwing Warning message if the records are more than 50 in Step 2 -- Resolved

## Useful links
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/106124

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Manual test - 
Step taken:
1. Create a new email Notification
2. Enter the title Step 1
3. In Step 2 select the resources which has more than 50 records in it
4. Select the fields
5. Skip the filters
6. Click on Preview 
7. Click on next in Preview section

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
