### PR TITLE
109540 Hide clone button if the user doesn't have sufficient permissions

### DIFF
--- a/libs/shared/src/lib/components/email/email.component.html
+++ b/libs/shared/src/lib/components/email/email.component.html
@@ -163,18 +163,19 @@
                           [uiTooltip]="'common.edit' | translate"
                         >
                         </ui-button>
-
-                        <ui-button
-                          variant="grey"
-                          class="hide-icons hover:text-primary-600"
-                          [isIcon]="true"
-                          size="large"
-                          (click)="cloneEmailNotification(element)"
-                          [icon]="'content_copy'"
-                          [uiTooltip]="'common.clone' | translate"
-                          *ngIf="!element.isDraft"
-                        >
-                        </ui-button>
+                        <ng-container *ngIf="this.ability.can('create', 'EmailNotification')">
+                          <ui-button
+                            variant="grey"
+                            class="hide-icons hover:text-primary-600"
+                            [isIcon]="true"
+                            size="large"
+                            (click)="cloneEmailNotification(element)"
+                            [icon]="'content_copy'"
+                            [uiTooltip]="'common.clone' | translate"
+                            *ngIf="!element.isDraft"
+                          >
+                          </ui-button>
+                        </ng-container>
 
                         <ui-button
                           variant="danger"


### PR DESCRIPTION
# Description

Hide the clone button on Email Notifications if the user doesn't have permission to create an Email Notification. 

## Useful links

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/109540/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)