### PR TITLE
Fix: Prevent Custom Template Mock Data Persistence & Incorrect DL List in Quick Send Preview

### DIFF
--- a/libs/shared/src/lib/components/email/email.component.ts
+++ b/libs/shared/src/lib/components/email/email.component.ts
@@ -1069,9 +1069,10 @@ export class EmailComponent extends UnsubscribeComponent implements OnInit {
    */
   createTemplate(): void {
     this.showTemplateCreationWizard = true;
-    !this.emailService.isCustomTemplateEdit
-      ? this.emailService.resetAllLayoutData()
-      : '';
+    if (!this.emailService.isCustomTemplateEdit) {
+      this.emailService.isNewCustomTemplate = true;
+      this.emailService.resetAllLayoutData();
+    }
   }
 
   /**
@@ -1179,6 +1180,7 @@ export class EmailComponent extends UnsubscribeComponent implements OnInit {
     this.emailService.datasetsForm?.get('emailLayout')?.reset();
     this.emailService.customTemplateId = '';
     this.emailService.isCustomTemplateEdit = false;
+    this.emailService.isNewCustomTemplate = false;
     this.emailService.allLayoutdata = {};
     this.emailService.emailLayout = {};
     this.emailService.customTemplateNames = this.customTemplates.map(

--- a/libs/shared/src/lib/components/email/email.service.ts
+++ b/libs/shared/src/lib/components/email/email.service.ts
@@ -176,6 +176,8 @@ export class EmailService {
   public cacheDistributionList: any = [];
   /** Final Email Preview */
   public finalEmailPreview: any = '';
+  /** Checks if custom template is new */
+  public isNewCustomTemplate = false;
   /** Checking the edit operation on custom template */
   public isCustomTemplateEdit = false;
   /** custom template ID */

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.html
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.html
@@ -425,8 +425,7 @@
             >
               <ui-select-option
                 *ngFor="
-                  let previewData of this.emailService.previewData?.datasets ??
-                    this.emailService.getAllPreviewData();
+                  let previewData of blockData;
                   let i = index
                 "
                 [value]="previewData?.tabName ?? previewData"

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -130,6 +130,8 @@ export class LayoutComponent
   readonly separatorKeysCodes: number[] = this.SEPARATOR_KEYS_CODE;
   /** flag for custom preview template  */
   @Input() isPreviewTemplate = false;
+  /** Block Data for Body  */
+  blockData: any = [];
 
   /**
    * Email layout page component.
@@ -157,7 +159,12 @@ export class LayoutComponent
   ngOnInit(): void {
     if (this.emailService.isQuickAction) {
       this.emailService.resetPreviewData();
-      this.emailService.previewData.datasets = ['Block 1'];
+      if (
+        !this.emailService.isCustomTemplateEdit &&
+        !this.emailService.isNewCustomTemplate
+      ) {
+        this.emailService.previewData.datasets = ['Block 1'];
+      }
       const layoutName = this.emailService?.emailLayout?.name || '';
       this.emailService.emailLayout = {};
       this.emailService.emailLayout.name = layoutName;
@@ -263,6 +270,23 @@ export class LayoutComponent
       this.layoutForm
         .get('bcc')
         ?.setValue(this.emailService.emailDistributionList.bcc);
+    }
+    this.getBlockData();
+  }
+
+  /**
+   * Block Data for Body
+   */
+  getBlockData() {
+    if (
+      this.emailService.datasetsForm.get('datasets')?.value?.[0]?.query?.fields
+        ?.length > 0
+    ) {
+      this.blockData =
+        this.emailService.previewData?.datasets ??
+        this.emailService.getAllPreviewData();
+    } else {
+      this.blockData = [];
     }
   }
 

--- a/libs/shared/src/lib/components/templates/components/preview-template-modal/preview-template-modal.component.ts
+++ b/libs/shared/src/lib/components/templates/components/preview-template-modal/preview-template-modal.component.ts
@@ -79,6 +79,7 @@ export class PreviewTemplateModalComponent {
     private dialogRef: DialogRef,
     @Inject('environment') environment: any
   ) {
+    this.emailService.setDatasetForm();
     this.environment = environment;
     this.emailService.isQuickAction = true;
     this.emailService.datasetsForm.get('emailDistributionList')?.reset();


### PR DESCRIPTION
# Description

109545: If no dataset is configured, Block 1 would still be available in the dropdown in the Layout configration.
109546: The Distribution List of the last mutated Email Notification was visible in Quick Send preview, instead of the Distribution List configured. 


## Useful links

https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/109545
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/109546

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
