### PR TITLE
AB#112755 - Overlap text fix while exporting dashboards

### DIFF
--- a/libs/shared/src/lib/components/widgets/common/html-widget-content/html-widget-content.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/html-widget-content/html-widget-content.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Input } from '@angular/core';
 import { SafeHtml } from '@angular/platform-browser';
 
 /**
@@ -13,7 +13,7 @@ import { SafeHtml } from '@angular/platform-browser';
   // todo: enable
   // encapsulation: ViewEncapsulation.ShadowDom,
 })
-export class HtmlWidgetContentComponent {
+export class HtmlWidgetContentComponent implements AfterViewInit {
   /**
    * HTML to render
    */
@@ -29,4 +29,25 @@ export class HtmlWidgetContentComponent {
    * @param {ElementRef} el Element reference
    */
   constructor(public el: ElementRef) {}
+
+  /**
+   * Script to fix bulletin and announcement text overlapping issue
+   */
+  ngAfterViewInit(): void {
+    // Find the element with the class "text-overlapping-fix"
+    const overlappedElement: HTMLElement | null =
+      this.el.nativeElement.querySelector('.text-overlapping-fix');
+
+    // If the element exists, remove all inline styles from its children
+    if (overlappedElement) {
+      // Find all elements with the "style" attribute
+      const elementsWithStyle: NodeListOf<HTMLElement> =
+        overlappedElement.querySelectorAll<HTMLElement>('[style]');
+
+      // Iterate over the elements and remove the "style" attribute
+      elementsWithStyle.forEach((element: HTMLElement) => {
+        element.removeAttribute('style');
+      });
+    }
+  }
 }

--- a/libs/shared/src/lib/const/tinymce.const.ts
+++ b/libs/shared/src/lib/const/tinymce.const.ts
@@ -337,8 +337,6 @@ export const FIELD_EDITOR_CONFIG: RawEditorSettings = {
   menubar: 'edit view insert format tools table help',
   toolbar:
     'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist | forecolor backcolor removeformat | charmap emoticons | fullscreen  preview save | insertfile image media link avatar recordeditor',
-  paste_retain_style_properties: 'color font-size',
-  paste_webkit_styles: 'color font-size',
   toolbar_sticky: true,
   paste_retain_style_properties: 'color font-size',
   paste_webkit_styles: 'color font-size',

--- a/libs/shared/src/lib/const/tinymce.const.ts
+++ b/libs/shared/src/lib/const/tinymce.const.ts
@@ -337,6 +337,8 @@ export const FIELD_EDITOR_CONFIG: RawEditorSettings = {
   menubar: 'edit view insert format tools table help',
   toolbar:
     'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist | forecolor backcolor removeformat | charmap emoticons | fullscreen  preview save | insertfile image media link avatar recordeditor',
+  paste_retain_style_properties: 'color font-size',
+  paste_webkit_styles: 'color font-size',
   toolbar_sticky: true,
   image_advtab: true,
   importcss_append: true,


### PR DESCRIPTION
# Description

Applied fix for overlapping text and spaces between pasted html text.

## Useful links

Link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/112755

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested with all special characters from international languages (latin based, other european, middle eastern, african, asian and native american languages.)
- [x] Tested with the original broken text and other examples

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/fc533146-5a55-48cc-97be-4e4f561daca7)


After:
![image](https://github.com/user-attachments/assets/1ef8c394-0b0f-42e5-9c6c-b77865f4c7c7)
![image](https://github.com/user-attachments/assets/5304dfd9-a339-4707-9ef1-e265b2a613a8)



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings


# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
