### PR TITLE
AB#122462 - Display only resources questions

### DIFF
--- a/libs/shared/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/shared/src/lib/components/form-builder/form-builder.component.ts
@@ -590,14 +590,33 @@ export class FormBuilderComponent
       });
     }
     if (['resource', 'resources'].includes(question.getType())) {
-      if (question.relatedName) {
-        question.relatedName = this.formHelpersService.toSnakeCase(
-          question.relatedName
-        );
-        if (this.relatedNames.includes(question.relatedName)) {
+      if (!question.displayOnly) {
+        if (question.relatedName) {
+          question.relatedName = this.formHelpersService.toSnakeCase(
+            question.relatedName
+          );
+          if (this.relatedNames.includes(question.relatedName)) {
+            this.snackBar.openSnackBar(
+              this.translate.instant(
+                'components.formBuilder.errors.duplicatedRelatedName',
+                {
+                  question: question.name,
+                  page: page.name,
+                }
+              ),
+              {
+                error: true,
+                duration: 15000,
+              }
+            );
+            return false;
+          } else {
+            this.relatedNames.push(question.relatedName);
+          }
+        } else {
           this.snackBar.openSnackBar(
             this.translate.instant(
-              'components.formBuilder.errors.duplicatedRelatedName',
+              'components.formBuilder.errors.missingRelatedName',
               {
                 question: question.name,
                 page: page.name,
@@ -609,24 +628,7 @@ export class FormBuilderComponent
             }
           );
           return false;
-        } else {
-          this.relatedNames.push(question.relatedName);
         }
-      } else {
-        this.snackBar.openSnackBar(
-          this.translate.instant(
-            'components.formBuilder.errors.missingRelatedName',
-            {
-              question: question.name,
-              page: page.name,
-            }
-          ),
-          {
-            error: true,
-            duration: 15000,
-          }
-        );
-        return false;
       }
       if (question.addRecord && !question.addTemplate) {
         this.snackBar.openSnackBar(

--- a/libs/shared/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/shared/src/lib/components/form-builder/form-builder.component.ts
@@ -590,6 +590,7 @@ export class FormBuilderComponent
       });
     }
     if (['resource', 'resources'].includes(question.getType())) {
+      // Check that relatedName is set and not duplicated
       if (!question.displayOnly) {
         if (question.relatedName) {
           question.relatedName = this.formHelpersService.toSnakeCase(
@@ -630,6 +631,8 @@ export class FormBuilderComponent
           return false;
         }
       }
+
+      // Error if the user selected Add Record without adding a template.
       if (question.addRecord && !question.addTemplate) {
         this.snackBar.openSnackBar(
           this.translate.instant(

--- a/libs/shared/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/shared/src/lib/components/form-builder/form-builder.component.ts
@@ -592,6 +592,7 @@ export class FormBuilderComponent
     if (['resource', 'resources'].includes(question.getType())) {
       // Check that relatedName is set and not duplicated
       if (!question.displayOnly) {
+        // Skip check if display only
         if (question.relatedName) {
           question.relatedName = this.formHelpersService.toSnakeCase(
             question.relatedName

--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -6,7 +6,7 @@ import {
   FilterDescriptor,
 } from '@progress/kendo-data-query';
 import { Apollo } from 'apollo-angular';
-import { isNil } from 'lodash';
+import { isEqual, isNil } from 'lodash';
 import get from 'lodash/get';
 import {
   ComponentCollection,
@@ -705,9 +705,6 @@ export const init = (
    * @param question survey question.
    */
   const setGridInputs = async (instance: CoreGridComponent, question: any) => {
-    if (question.displayOnly) {
-      question.readOnly = true;
-    }
     instance.multiSelect = !question.displayOnly;
     instance.selectable = !question.displayOnly;
     const promises: any[] = [];
@@ -735,37 +732,26 @@ export const init = (
       temporaryRecordsForm.setValue(settings.query.temporaryRecords);
     }
     if (question.displayOnly) {
-      const filtersToMerge: any[] = [];
-      const dynamicFilter = question.filters;
-      const preBuiltFilter = question.gridFieldsSettings?.filter;
+      const filters: any[] = [];
 
-      if (dynamicFilter) {
-        if (dynamicFilter.filters) {
-          filtersToMerge.push(dynamicFilter);
-        } else if (Array.isArray(dynamicFilter)) {
-          filtersToMerge.push(...dynamicFilter);
-        } else {
-          filtersToMerge.push(dynamicFilter);
-        }
+      if (question.filters) {
+        filters.push(question.filters);
+      }
+      if (question.gridFieldsSettings?.filter) {
+        filters.push(question.gridFieldsSettings.filter);
       }
 
-      if (preBuiltFilter) {
-        if (preBuiltFilter.filters) {
-          filtersToMerge.push(preBuiltFilter);
-        } else if (Array.isArray(preBuiltFilter)) {
-          filtersToMerge.push(...preBuiltFilter);
-        } else {
-          filtersToMerge.push(preBuiltFilter);
-        }
-      }
-
-      settings.query.filter = filtersToMerge.length
-        ? { logic: 'and', filters: filtersToMerge }
-        : { logic: 'and', filters: [] };
+      settings.query.filter = {
+        logic: 'and',
+        filters: filters,
+      };
     }
-    instance.settings = settings;
     Promise.allSettled(promises).then(() => {
-      instance.configureGrid();
+      // Only update grid if needed
+      if (!isEqual(instance.settings, settings)) {
+        instance.settings = settings;
+        instance.configureGrid();
+      }
     });
   };
 };

--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -455,39 +455,11 @@ export const init = (
           }
         });
         if (question.customFilter && question.customFilter.trim().length > 0) {
-          /**
-           * Get question filters value
-           *
-           * @param question Current question
-           */
-          const getQuestionFilters = (question: any) => {
-            const surveyData = question.survey?.data;
-
-            const customFilter = JSON.parse(question.customFilter);
-            if (Array.isArray(customFilter)) {
-              question.filters = {
-                logic: 'and',
-                filters: customFilter
-                  .map((x) => updateFilter(surveyData, x))
-                  .filter((x) => !isNil(x)),
-              };
-            } else {
-              question.filters = updateFilter(surveyData, customFilter);
-            }
-
-            // Load question choices
-            if (!question.displayAsGrid) {
-              this.populateChoices(question);
-            }
-          };
-
           // Subscribe to survey value changes
           question.survey?.onValueChanged.add(() => {
-            getQuestionFilters(question);
+            console.log('Survey data changed');
+            this.getQuestionFilters(question);
           });
-
-          // Initial load
-          getQuestionFilters(question);
         } else {
           // Load question choices
           if (!question.displayAsGrid) {
@@ -502,6 +474,7 @@ export const init = (
      * @param question Current question
      */
     populateChoices: (question: any): void => {
+      console.log('populate choices called');
       getResourceRecordsById(question).subscribe(({ data }) => {
         const choices = mapQuestionChoices(data, question);
         question.contentQuestion.choices = choices;
@@ -522,7 +495,39 @@ export const init = (
         question.prefillWithCurrentRecord = false;
       }
     },
-    onAfterRender: (question: QuestionResource, el: any): void => {
+    /**
+     * Get question filters
+     *
+     * @param question Current question
+     */
+    getQuestionFilters(question: QuestionResource): void {
+      const surveyData = (question.survey as SurveyModel).data;
+      const customFilter = JSON.parse(question.customFilter);
+      if (Array.isArray(customFilter)) {
+        question.filters = {
+          logic: 'and',
+          filters: customFilter
+            .map((x) => updateFilter(surveyData, x))
+            .filter((x) => !isNil(x)),
+        };
+      } else {
+        question.filters = updateFilter(surveyData, customFilter);
+      }
+
+      // Load question choices
+      if (!question.displayAsGrid) {
+        console.log('should populate choices');
+        // (this as any).populateChoices(question);
+        this.populateChoices(question);
+      }
+    },
+    /**
+     * On After render callback
+     *
+     * @param question Current question
+     * @param el Element
+     */
+    onAfterRender(question: QuestionResource, el: any): void {
       const parentElement = el.querySelector('.sd-question__content');
       // Display the add button | grid for resources question
       const actionsButtons = setUpActionsButtonWrapper();
@@ -536,6 +541,13 @@ export const init = (
           }
         }
       }, 500);
+
+      if (question.resource) {
+        if (question.customFilter && question.customFilter.trim().length > 0) {
+          // Initial load
+          this.getQuestionFilters(question);
+        }
+      }
 
       const searchBtn = buildSearchButton(
         question,
@@ -740,6 +752,8 @@ export const init = (
       if (question.gridFieldsSettings?.filter) {
         filters.push(question.gridFieldsSettings.filter);
       }
+
+      console.log(filters);
 
       settings.query.filter = {
         logic: 'and',

--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -14,6 +14,7 @@ import {
   Serializer,
   SurveyModel,
   SvgRegistry,
+  surveyLocalization,
 } from 'survey-core';
 import { CoreGridComponent } from '../../components/ui/core-grid/core-grid.component';
 import { ResourceQueryResponse } from '../../models/resource.model';
@@ -179,6 +180,13 @@ export const init = (
     resourceFieldsName: [] as any[],
     onInit: (): void => {
       Serializer.addProperty('resources', {
+        name: 'displayOnly:boolean',
+        category: 'general',
+        displayName: surveyLocalization.getString('oort:displayOnly'),
+        visibleIndex: 7,
+        default: false,
+      });
+      Serializer.addProperty('resources', {
         name: 'resource',
         category: 'Custom Questions',
         type: CustomPropertyGridComponentTypes.resourcesDropdown,
@@ -218,7 +226,7 @@ export const init = (
         dependsOn: 'resource',
         required: true,
         description: 'unique name for this resource question',
-        visibleIf: visibleIfResource,
+        visibleIf: (obj: any) => visibleIfResource(obj) && !obj.displayOnly,
         visibleIndex: 4,
       });
 
@@ -540,14 +548,17 @@ export const init = (
       );
       searchBtn.style.display = 'none';
       if (question.resource) {
-        searchBtn.style.display = 'block';
+        searchBtn.style.display = question.displayOnly ? 'none' : 'block';
+        if (question.displayOnly) {
+          question.canSearch = false;
+        }
         if (parentElement) {
           if (question.displayAsGrid) {
             gridComponentRef = buildGridDisplay(question, parentElement);
           }
 
           if ((question.survey as SurveyModel).mode !== 'display') {
-            searchBtn.style.display = 'block';
+            searchBtn.style.display = question.displayOnly ? 'none' : 'block';
             const addBtn = buildAddButton(
               question,
               true,
@@ -579,7 +590,7 @@ export const init = (
       actionsButtons.appendChild(searchBtn);
       parentElement.insertBefore(actionsButtons, parentElement.firstChild);
       question.registerFunctionOnPropertyValueChanged('resource', () => {
-        if (question.resource && question.canSearch) {
+        if (question.resource && question.canSearch && !question.displayOnly) {
           searchBtn.style.display = 'block';
         }
       });
@@ -587,7 +598,8 @@ export const init = (
         if (question.displayAsGrid) {
           setGridInputs(gridComponentRef.instance, question);
         } else {
-          searchBtn.style.display = question.canSearch ? 'block' : 'none';
+          searchBtn.style.display =
+            question.canSearch && !question.displayOnly ? 'block' : 'none';
         }
       });
       question.registerFunctionOnPropertyValueChanged(
@@ -614,7 +626,7 @@ export const init = (
           if (element) {
             element.style.display = 'block';
           }
-          if (question.canSearch) {
+          if (question.canSearch && !question.displayOnly) {
             searchBtn.style.display = 'block';
           }
         }
@@ -679,7 +691,7 @@ export const init = (
     );
     setGridInputs(grid.instance, question);
     question.survey?.onValueChanged.add((_: any, options: any) => {
-      if (options.name === question.name) {
+      if (question.displayOnly || options.name === question.name) {
         setGridInputs(grid.instance, question);
       }
     });
@@ -693,7 +705,11 @@ export const init = (
    * @param question survey question.
    */
   const setGridInputs = async (instance: CoreGridComponent, question: any) => {
-    instance.multiSelect = true;
+    if (question.displayOnly) {
+      question.readOnly = true;
+    }
+    instance.multiSelect = !question.displayOnly;
+    instance.selectable = !question.displayOnly;
     const promises: any[] = [];
     const settings = await processNewCreatedRecords(question, true, promises);
     if (
@@ -717,6 +733,35 @@ export const init = (
     // If search button exists, updates grid displayed records
     if (question.canSearch) {
       temporaryRecordsForm.setValue(settings.query.temporaryRecords);
+    }
+    if (question.displayOnly) {
+      const filtersToMerge: any[] = [];
+      const dynamicFilter = question.filters;
+      const preBuiltFilter = question.gridFieldsSettings?.filter;
+
+      if (dynamicFilter) {
+        if (dynamicFilter.filters) {
+          filtersToMerge.push(dynamicFilter);
+        } else if (Array.isArray(dynamicFilter)) {
+          filtersToMerge.push(...dynamicFilter);
+        } else {
+          filtersToMerge.push(dynamicFilter);
+        }
+      }
+
+      if (preBuiltFilter) {
+        if (preBuiltFilter.filters) {
+          filtersToMerge.push(preBuiltFilter);
+        } else if (Array.isArray(preBuiltFilter)) {
+          filtersToMerge.push(...preBuiltFilter);
+        } else {
+          filtersToMerge.push(preBuiltFilter);
+        }
+      }
+
+      settings.query.filter = filtersToMerge.length
+        ? { logic: 'and', filters: filtersToMerge }
+        : { logic: 'and', filters: [] };
     }
     instance.settings = settings;
     Promise.allSettled(promises).then(() => {

--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -746,8 +746,6 @@ export const init = (
         filters.push(question.gridFieldsSettings.filter);
       }
 
-      console.log(filters);
-
       settings.query.filter = {
         logic: 'and',
         filters: filters,

--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -457,7 +457,6 @@ export const init = (
         if (question.customFilter && question.customFilter.trim().length > 0) {
           // Subscribe to survey value changes
           question.survey?.onValueChanged.add(() => {
-            console.log('Survey data changed');
             this.getQuestionFilters(question);
           });
         } else {
@@ -474,7 +473,6 @@ export const init = (
      * @param question Current question
      */
     populateChoices: (question: any): void => {
-      console.log('populate choices called');
       getResourceRecordsById(question).subscribe(({ data }) => {
         const choices = mapQuestionChoices(data, question);
         question.contentQuestion.choices = choices;
@@ -516,8 +514,6 @@ export const init = (
 
       // Load question choices
       if (!question.displayAsGrid) {
-        console.log('should populate choices');
-        // (this as any).populateChoices(question);
         this.populateChoices(question);
       }
     },
@@ -561,9 +557,6 @@ export const init = (
       searchBtn.style.display = 'none';
       if (question.resource) {
         searchBtn.style.display = question.displayOnly ? 'none' : 'block';
-        if (question.displayOnly) {
-          question.canSearch = false;
-        }
         if (parentElement) {
           if (question.displayAsGrid) {
             gridComponentRef = buildGridDisplay(question, parentElement);

--- a/libs/shared/src/lib/survey/localization.ts
+++ b/libs/shared/src/lib/survey/localization.ts
@@ -10,6 +10,13 @@ const SURVEY_LOCALIZABLE_STRINGS = [
     },
   },
   {
+    key: 'displayOnly',
+    locales: {
+      en: 'Display only',
+      fr: 'Affichage seul',
+    },
+  },
+  {
     key: 'fileLimitations',
     locales: {
       en: (question: any) => {

--- a/libs/shared/src/lib/survey/types.ts
+++ b/libs/shared/src/lib/survey/types.ts
@@ -82,6 +82,7 @@ export interface QuestionResource
   staticValue: string;
   customFilter: string;
   displayAsGrid: boolean;
+  displayOnly?: boolean;
   remove?: boolean;
   template?: string;
   draftData?: any;


### PR DESCRIPTION
# Description

Added a new "display-only" option to the “resources” question that shows a read-only grid of records without saving any. Removed the need for a "Related name" in that mode, and also hid the field. When "display-only" is enabled, the grid loads all records, applies dynamic and additional admin filters, hides the Search button, and disables row selection and actions.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
