### PR TITLE
AB#124987 - Make it possible to mimic history in resource

### DIFF
--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -318,6 +318,7 @@ export class FormModalComponent
         Object.keys(notNullValues).forEach((question) => {
           this.survey.setValue(question, notNullValues[question]);
         });
+        this.formBuilderService.normalizeHistoryPanels(this.survey);
       }
       addCustomFunctions(this.authService);
       this.survey.showCompletedPage = false;

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -178,9 +178,11 @@ export class FormComponent
     if (this.form.uniqueRecord && this.form.uniqueRecord.data) {
       this.survey.data = this.form.uniqueRecord.data;
       this.modifiedAt = this.form.uniqueRecord.modifiedAt || null;
+      this.formBuilderService.normalizeHistoryPanels(this.survey);
     } else if (this.record && this.record.data) {
       this.survey.data = this.record.data;
       this.modifiedAt = this.record.modifiedAt || null;
+      this.formBuilderService.normalizeHistoryPanels(this.survey);
     }
 
     // if (this.survey.getUsedLocales().length > 1) {

--- a/libs/shared/src/lib/components/record-modal/record-modal.component.ts
+++ b/libs/shared/src/lib/components/record-modal/record-modal.component.ts
@@ -193,6 +193,7 @@ export class RecordModalComponent
       {}
     );
     this.survey.data = this.record.data;
+    this.formBuilderService.normalizeHistoryPanels(this.survey);
 
     if (this.data.compareTo) {
       this.surveyNext = this.formBuilderService.createSurvey(
@@ -208,6 +209,7 @@ export class RecordModalComponent
         {}
       );
       this.surveyNext.data = this.data.compareTo.data;
+      this.formBuilderService.normalizeHistoryPanels(this.surveyNext);
 
       // Set list of updated questions
       const updatedQuestions: string[] = [];

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -3,7 +3,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { renderGlobalProperties } from '../../survey/render-global-properties';
 import { SnackbarService } from '@oort-front/ui';
 import { Apollo } from 'apollo-angular';
-import { isNil } from 'lodash';
+import { isEqual, isNil } from 'lodash';
 import get from 'lodash/get';
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import {
@@ -116,6 +116,7 @@ export class FormBuilderService {
           }
         }
       }
+      this.appendDynamicPanelHistoryEntriesOnSave(survey);
     });
     if (fields.length > 0) {
       for (const f of fields.filter((x) => !x.automated)) {
@@ -161,6 +162,207 @@ export class FormBuilderService {
     // Add record to survey properties
     survey.setPropertyValue('record', record);
     return survey;
+  }
+
+  /**
+   * Make the panel be normalized to render saved entries.
+   *
+   * @param survey Survey instance
+   */
+  public normalizeHistoryPanels(survey: SurveyModel): void {
+    const normalizeArray = (value: unknown): any[] => {
+      if (Array.isArray(value)) return value;
+      if (typeof value === 'string') {
+        try {
+          const parsed = JSON.parse(value);
+          if (Array.isArray(parsed)) return parsed;
+          if (parsed && typeof parsed === 'object') return [parsed];
+        } catch {
+          return [];
+        }
+      }
+      if (value && typeof value === 'object') return [value];
+      return [];
+    };
+
+    survey
+      .getAllQuestions()
+      .filter((q) => q.getType() === 'paneldynamic')
+      .forEach((q: any) => {
+        if (!q.getPropertyValue('appendOnSave')) return;
+        const key = q.valueName || q.name;
+        const raw = survey.getValue(key);
+        const entries = normalizeArray(raw);
+        survey.setValue(key, entries);
+        q.value = entries;
+        if (
+          typeof q.panelCount === 'number' &&
+          q.panelCount !== entries.length
+        ) {
+          q.panelCount = entries.length;
+        }
+      });
+  }
+
+  /**
+   * Append dynamic panel history entries on save.
+   *
+   * @param survey Survey instance
+   */
+  private appendDynamicPanelHistoryEntriesOnSave(survey: SurveyModel): void {
+    const normalizeArray = (value: unknown): any[] => {
+      if (Array.isArray(value)) {
+        if (value.every((v) => typeof v === 'string')) {
+          const parsed = (value as string[])
+            .map((v) => {
+              try {
+                return JSON.parse(v);
+              } catch {
+                return null;
+              }
+            })
+            .filter((v) => v && typeof v === 'object');
+          return parsed.length ? (parsed as any[]) : [];
+        }
+        return value;
+      }
+      if (typeof value === 'string') {
+        try {
+          const parsed = JSON.parse(value);
+          if (Array.isArray(parsed)) return parsed;
+          if (parsed && typeof parsed === 'object') return [parsed];
+        } catch {
+          return [];
+        }
+      }
+      if (value && typeof value === 'object') return [value];
+      return [];
+    };
+
+    const isEmpty = (value: any): boolean => {
+      if (isNil(value) || value === '') return true;
+      if (Array.isArray(value) && value.length === 0) return true;
+      return false;
+    };
+
+    const normalizeKey = (value: any): string =>
+      String(value || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '');
+
+    const resolveTemplateKey = (panelQuestion: any, logicalName: string) => {
+      const templateElements: any[] =
+        panelQuestion?.template?.elements ||
+        panelQuestion?.template?.questions ||
+        panelQuestion?.templateElements ||
+        [];
+
+      const wanted = normalizeKey(logicalName);
+
+      const match = (q: any) => {
+        const name = normalizeKey(q?.name);
+        const valueName = normalizeKey(q?.valueName);
+        const title = normalizeKey(q?.title);
+        const placeholder = normalizeKey(q?.placeholder);
+        return (
+          name === wanted ||
+          valueName === wanted ||
+          title === wanted ||
+          placeholder === wanted
+        );
+      };
+
+      const found = templateElements.find(match);
+      return found?.valueName || found?.name;
+    };
+
+    survey
+      .getAllQuestions()
+      .filter((q) => q.getType() === 'paneldynamic')
+      .forEach((question: any) => {
+        if (!question.getPropertyValue('appendOnSave')) {
+          return;
+        }
+
+        const fromField = question.getPropertyValue('fromField');
+        const toField = question.getPropertyValue('toField');
+        const subjectField = question.getPropertyValue('subjectField');
+        const sentOnField = question.getPropertyValue('sentOnField');
+        const bodyField = question.getPropertyValue('bodyField');
+        const commentField = question.getPropertyValue('commentField');
+        const clearCommentFieldOnSave = !!question.getPropertyValue(
+          'clearCommentFieldOnSave'
+        );
+
+        const fromKey = resolveTemplateKey(question, 'from') || 'from';
+        const toKey = resolveTemplateKey(question, 'to') || 'to';
+        const subjectKey = resolveTemplateKey(question, 'subject') || 'subject';
+        const sentOnKey = resolveTemplateKey(question, 'sentOn') || 'sentOn';
+        const bodyKey = resolveTemplateKey(question, 'body') || 'body';
+        const commentKey = resolveTemplateKey(question, 'comment') || 'comment';
+
+        const entry: Record<string, any> = {};
+        entry[fromKey] = fromField ? survey.getValue(fromField) : undefined;
+        entry[toKey] = toField ? survey.getValue(toField) : undefined;
+        entry[subjectKey] = subjectField
+          ? survey.getValue(subjectField)
+          : undefined;
+        entry[sentOnKey] = sentOnField
+          ? survey.getValue(sentOnField)
+          : undefined;
+        entry[bodyKey] = bodyField ? survey.getValue(bodyField) : undefined;
+        entry[commentKey] = commentField
+          ? survey.getValue(commentField)
+          : undefined;
+
+        if (
+          Object.values(entry).every((value) => isEmpty(value)) ||
+          (!fromField &&
+            !toField &&
+            !subjectField &&
+            !sentOnField &&
+            !bodyField &&
+            !commentField)
+        ) {
+          return;
+        }
+
+        const existing = normalizeArray(question.value);
+        const newestFirst = !!question.getPropertyValue('newestFirst');
+        const allowDuplicates = !!question.getPropertyValue('allowDuplicates');
+
+        if (!allowDuplicates && existing.length > 0) {
+          const last = newestFirst
+            ? existing[0]
+            : existing[existing.length - 1];
+          if (isEqual(last, entry)) {
+            return;
+          }
+        }
+
+        let updated = newestFirst ? [entry, ...existing] : [...existing, entry];
+
+        const maxEntries = Number(question.getPropertyValue('maxEntries') || 0);
+        if (maxEntries > 0 && updated.length > maxEntries) {
+          updated = newestFirst
+            ? updated.slice(0, maxEntries)
+            : updated.slice(updated.length - maxEntries);
+        }
+
+        const key = question.valueName || question.name;
+        survey.setValue(key, updated);
+        question.value = updated;
+        if (
+          typeof question.panelCount === 'number' &&
+          question.panelCount !== updated.length
+        ) {
+          question.panelCount = updated.length;
+        }
+
+        if (commentField && clearCommentFieldOnSave) {
+          survey.setValue(commentField, null);
+        }
+      });
   }
 
   /**

--- a/libs/shared/src/lib/survey/components/editor.ts
+++ b/libs/shared/src/lib/survey/components/editor.ts
@@ -67,9 +67,6 @@ export const init = (
         if (!value) {
           return;
         }
-        if (!question.value && question.defaultValueExpression) {
-          question.value = question.defaultValueExpression;
-        }
         if (question.value) {
           instance.editor.editor.writeValue(question.value);
         }

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -83,6 +83,88 @@ export const init = (environment: any): void => {
     isSerializable: false,
   });
 
+  // === Communication history (email chain) ===
+  // Allows forms to append a snapshot entry into a paneldynamic question only on save.
+  serializer.addProperty('paneldynamic', {
+    name: 'appendOnSave:boolean',
+    category: 'Custom Questions',
+    displayName: 'Append entry on save',
+    default: false,
+    visibleIndex: 1,
+  });
+  serializer.addProperty('paneldynamic', {
+    name: 'allowDuplicates:boolean',
+    category: 'Custom Questions',
+    displayName: 'Allow duplicate entries',
+    default: false,
+    visibleIndex: 2,
+  });
+  serializer.addProperty('paneldynamic', {
+    name: 'newestFirst:boolean',
+    category: 'Custom Questions',
+    displayName: 'Newest first',
+    default: false,
+    visibleIndex: 3,
+  });
+  serializer.addProperty('paneldynamic', {
+    name: 'maxEntries:number',
+    category: 'Custom Questions',
+    displayName: 'Maximum entries (0 = unlimited)',
+    default: 0,
+    visibleIndex: 4,
+  });
+
+  serializer.addProperty('paneldynamic', {
+    name: 'fromField',
+    category: 'Custom Questions',
+    displayName: 'From field',
+    description: 'Question name to snapshot into history.from',
+    visibleIndex: 10,
+  });
+  serializer.addProperty('paneldynamic', {
+    name: 'toField',
+    category: 'Custom Questions',
+    displayName: 'To field',
+    description: 'Question name to snapshot into history.to',
+    visibleIndex: 11,
+  });
+  serializer.addProperty('paneldynamic', {
+    name: 'subjectField',
+    category: 'Custom Questions',
+    displayName: 'Subject field',
+    description: 'Question name to snapshot into history.subject',
+    visibleIndex: 12,
+  });
+  serializer.addProperty('paneldynamic', {
+    name: 'sentOnField',
+    category: 'Custom Questions',
+    displayName: 'Sent on field',
+    description: 'Question name to snapshot into history.sentOn',
+    visibleIndex: 13,
+  });
+  serializer.addProperty('paneldynamic', {
+    name: 'bodyField',
+    category: 'Custom Questions',
+    displayName: 'Body field',
+    description: 'Question name to snapshot into history.body',
+    visibleIndex: 14,
+  });
+  serializer.addProperty('paneldynamic', {
+    name: 'commentField',
+    category: 'Custom Questions',
+    displayName: 'Comment field (optional)',
+    description:
+      'Question name containing an optional comment attached to the entry (history.comment)',
+    visibleIndex: 15,
+  });
+  serializer.addProperty('paneldynamic', {
+    name: 'clearCommentFieldOnSave:boolean',
+    category: 'logic',
+    displayName: 'Clear comment field on save',
+    default: true,
+    visibleIndex: 16,
+  });
+
   /** Readonly default accepted types, will use the acceptedTypesValues component */
   serializer.getProperty('file', 'acceptedTypes').readOnly = true;
   /** Size per file is mandatory */
@@ -130,5 +212,13 @@ export const render = (question: Question): void => {
   // define the default max size for files
   if (question.getType() === 'file' && !question.getPropertyValue('maxSize')) {
     (question as QuestionFileModel).maxSize = 7340032;
+  }
+
+  // Ensure dynamic panels that store a history thread render all saved entries.
+  if (
+    question.getType() === 'paneldynamic' &&
+    !question.getPropertyValue('appendOnSave')
+  ) {
+    // No-op: panel count is handled during append; avoid extra hooks to keep behavior simple.
   }
 };


### PR DESCRIPTION
# Description

Added an append-on-save “email thread” history: on each record save, EMS snapshots the current From/To/Subject/Sent on/Body fields (which are configurable) into a read-only paneldynamic history panel (configured via new paneldynamic properties).

There is still an on going issue where, when we reload the record with some saved entries on its history, they are not being displayed.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules