### PR TITLE
Feat/comms module/reference data

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1006,6 +1006,13 @@
 				"noAttachment": "No attachments available.",
 				"subject": "Subject:"
 			},
+			"referenceData": {
+				"individualEmail": {
+					"addPath": "Add email path",
+					"helper": "Provide one or more JSONPath expressions to locate recipient emails in the reference data response. Example: $.email",
+					"jsonPathHint": "Use JSONPath syntax; paths are evaluated per row in the dataset."
+				}
+			},
 			"restrictSubscription": {
 				"description": "Restricts users being able to subscribe to this email notification",
 				"title": "Restrict user subscription"

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -84,6 +84,7 @@
 			"one": "Column"
 		},
 		"comma": "comma",
+		"configure": "Configure",
 		"copy": "Copy",
 		"copyright": {
 			"who": "Copyright © World Health Organization 2024."
@@ -922,6 +923,7 @@
 				"dlPreview": "All emails listed below will be used to create the distribution list.",
 				"individualEmailsInfo": "Select the email fields you would like to use to send record specific emails to",
 				"invalidFields": "The following fields are not available for selection: <strong>{{fields}}</strong> as they are of type <strong>{{types}}</strong> and cannot be properly displayed in the table for this form.",
+				"noReferenceSelected": "Please select a reference data source to continue",
 				"noResource": "Select a resource using the dropdown to display Distribution list filter wizard",
 				"noResourceFields": "Selected resource doesn't contain any fields",
 				"noSelectedFields": "Please select at least 1 field to save this dataset",
@@ -940,8 +942,17 @@
 					"label": "Block title",
 					"title": "Block"
 				},
+				"dataSource": "Data source",
 				"navigateToPage": {
 					"title": "Navigate to Page"
+				},
+				"reference": {
+					"inputConfiguration": "Input configuration",
+					"inputConfigured": "Inputs configured",
+					"inputs": "Variable inputs",
+					"mapping": "Variable mapping",
+					"noInputConfiguration": "Add an input configuration to capture values.",
+					"title": "Reference data"
 				}
 			},
 			"distributionList": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -84,6 +84,7 @@
 			"one": "Colonne"
 		},
 		"comma": "virgule",
+		"configure": "Configurer",
 		"copy": "Copier",
 		"copyright": {
 			"who": "Copyright © World Health Organization 2024."
@@ -922,6 +923,7 @@
 				"dlPreview": "Tous les e-mails répertoriés ci-dessous seront utilisés pour créer la liste de distribution.",
 				"individualEmailsInfo": "Sélectionnez les champs de courrier électronique que vous souhaitez utiliser pour envoyer des courriers électroniques spécifiques à un enregistrement.",
 				"invalidFields": "Les champs suivants ne peuvent pas être sélectionnés: <strong>{{fields}}</strong> car ils sont du type <strong>{{types}}</strong> et ne peut pas être correctement affiché dans le tableau de ce formulaire.",
+				"noReferenceSelected": "Veuillez sélectionner des données de référence pour continuer",
 				"noResource": "Sélectionnez une ressource à l'aide de la liste déroulante pour afficher l'assistant de filtrage de liste de distribution",
 				"noResourceFields": "La ressource sélectionnée ne contient aucun champ",
 				"noSelectedFields": "Veuillez sélectionner au moins 1 champ pour sauvegarder ce jeu de données",
@@ -940,8 +942,17 @@
 					"label": "Titre du Bloc",
 					"title": "Bloc"
 				},
+				"dataSource": "Source de données",
 				"navigateToPage": {
 					"title": "Aller à la page"
+				},
+				"reference": {
+					"inputConfiguration": "Configuration des entrées",
+					"inputConfigured": "Entrées configurées",
+					"inputs": "Valeurs des variables",
+					"mapping": "Correspondance des variables",
+					"noInputConfiguration": "Ajoutez une configuration d'entrée pour saisir les valeurs.",
+					"title": "Données de référence"
 				}
 			},
 			"distributionList": {

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1006,6 +1006,13 @@
 				"noAttachment": "Aucune pièce jointe disponible.",
 				"subject": "Sujet:"
 			},
+			"referenceData": {
+				"individualEmail": {
+					"addPath": "Ajouter un chemin e-mail",
+					"helper": "Fournissez une ou plusieurs expressions JSONPath pour trouver les e-mails des destinataires dans la réponse des données de référence. Exemple : $.email",
+					"jsonPathHint": "Utilisez la syntaxe JSONPath ; les chemins sont évalués par ligne dans l'ensemble de données."
+				}
+			},
 			"restrictSubscription": {
 				"description": "Limite la possibilité pour les utilisateurs de s'abonner à cette notification par e-mail",
 				"title": "Restreindre l'abonnement des utilisateurs"

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -955,6 +955,13 @@
 					"title": "******"
 				}
 			},
+			"referenceData": {
+				"individualEmail": {
+					"helper": "******",
+					"addPath": "******",
+					"jsonPathHint": "******"
+				}
+			},
 			"distributionList": {
 				"alert": {
 					"allSeparate": "******",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -84,6 +84,7 @@
 			"one": "******"
 		},
 		"comma": "******",
+		"configure": "******",
 		"copy": "******",
 		"copyright": {
 			"who": "******"
@@ -922,6 +923,7 @@
 				"dlPreview": "******",
 				"individualEmailsInfo": "******",
 				"invalidFields": "****** {{fields}} ****** {{types}} ******",
+				"noReferenceSelected": "******",
 				"noResource": "******",
 				"noResourceFields": "******",
 				"noSelectedFields": "******",
@@ -940,7 +942,16 @@
 					"label": "******",
 					"title": "******"
 				},
+				"dataSource": "******",
 				"navigateToPage": {
+					"title": "******"
+				},
+				"reference": {
+					"inputConfiguration": "******",
+					"inputConfigured": "******",
+					"inputs": "******",
+					"mapping": "******",
+					"noInputConfiguration": "******",
 					"title": "******"
 				}
 			},

--- a/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
+++ b/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
@@ -29,9 +29,27 @@
       </div>
     </div>
     <div class="w-2/3 flex flex-row gap-5">
-      <!-- select dataset dropdown -->
+      <div class="w-1/3">
+        <label
+          htmlFor="select__datasource"
+          class="block text-sm font-medium leading-6 text-gray-900"
+        >
+          {{ 'components.email.dataset.dataSource' | translate }}
+        </label>
+        <ui-select-menu
+          formControlName="dataType"
+          [placeholder]="'common.select' | translate"
+        >
+          <ui-select-option
+            *ngFor="let type of dataTypeList"
+            [value]="type"
+          >
+            {{ type }}
+          </ui-select-option>
+        </ui-select-menu>
+      </div>
 
-      <div class="w-1/2">
+      <div class="w-1/3" *ngIf="!isReferenceData">
         <label
           htmlFor="select__dataset"
           class="block text-sm font-medium leading-6 text-gray-900"
@@ -58,8 +76,35 @@
           ></ui-button>
         </div>
       </div>
+
+      <div class="w-1/3" *ngIf="isReferenceData">
+        <label
+          htmlFor="select__reference"
+          class="block text-sm font-medium leading-6 text-gray-900"
+        >
+          {{ 'components.email.dataset.reference.title' | translate }}
+        </label>
+
+        <div uiFormFieldDirective class="flex-1">
+          <shared-reference-data-select
+            [ngClass]="{ 'w-[80%]': this.query.get('reference').value }"
+            formControlName="reference"
+          ></shared-reference-data-select>
+          <ui-button
+            *ngIf="query?.value.reference"
+            uiSuffix
+            size="small"
+            [isIcon]="true"
+            (click)="clearFormField('reference', $event)"
+            icon="close"
+            variant="danger"
+            [uiTooltip]="'common.remove' | translate"
+          ></ui-button>
+        </div>
+      </div>
+
       <!-- For phase 2 -->
-      <div class="w-1/2 content-center text-center">
+      <div class="w-1/3 content-center text-center">
         <ui-checkbox
           formControlName="individualEmail"
           [(ngModel)]="separateEmail"
@@ -73,277 +118,341 @@
 
     <div class="w-1/3 flex loadingSign">
       <ui-spinner
-        *ngIf="loading || emailService.loading"
+        *ngIf="loading || emailService.loading || referenceDataLoading"
         style="position: relative"
       ></ui-spinner>
     </div>
   </div>
-  <ng-container
-    class="mt-5"
-    *ngTemplateOutlet="noFieldsInResourceAlertTmpl"
-  ></ng-container>
-  <div>
-    <ui-tabs
-      [selectedIndex]="currentTabIndex"
-      (selectedIndexChange)="onTabSelect($event, true)"
-      #datasetPreview
-      *ngIf="resource?.fields?.length && availableFields.length > 0"
-    >
-      <div class="mt-4 flex flex-row">
-        <!-- Fields Tab -->
-        <ui-tab title="Fields" [selected]="true">
+  <ng-container *ngIf="isReferenceData">
+    <div class="mt-5">
+      <ui-alert
+        variant="warning"
+        *ngIf="!query.value.reference"
+        class="mb-4"
+      >
+        {{ 'components.email.alert.noReferenceSelected' | translate }}
+      </ui-alert>
+      <ui-tabs>
+        <ui-tab title="Variable Mapping" [selected]="true">
           <ng-container ngProjectAs="label">
-            {{ 'components.queryBuilder.fields.title' | translate }}
+            {{ 'components.email.dataset.reference.mapping' | translate }}
           </ng-container>
           <ng-template uiTabContent>
-            <ng-container
-              class="mt-2"
-              *ngTemplateOutlet="invalidFieldsAlertTmpl"
-            ></ng-container>
-            <ng-container
-              class="mt-2"
-              *ngTemplateOutlet="noSelectedFieldsAlertTmpl"
-            ></ng-container>
-            <ng-container
-              class="mt-2"
-              *ngTemplateOutlet="ChildFieldAlertTmpl"
-            ></ng-container>
-            <div class="flex gap-4 mt-2" formGroupName="query">
-              <div class="mt-2 overflow-auto">
-                <!-- FIELDS -->
-                <shared-tab-fields
-                  *ngIf="availableFields.length > 0"
-                  [form]="getFieldsArray()"
-                  [fields]="availableFields"
-                  [showLimit]="false"
-                  [showColumnWidth]="false"
-                ></shared-tab-fields>
-              </div>
-            </div>
-
-            <ui-button
-              *ngIf="datasetFilterInfo.controls"
-              class="float-right mt-8"
-              category="secondary"
-              variant="primary"
-              (click)="getDataSet('fields')"
-            >
-              {{ 'components.queryBuilder.filter.applyField' | translate }}
-            </ui-button>
+            <ng-container *ngIf="referenceData && referenceMappingControl">
+              <shared-query-params-mapping
+                [referenceData]="referenceData"
+                [control]="referenceMappingControl"
+              ></shared-query-params-mapping>
+            </ng-container>
           </ng-template>
         </ui-tab>
-        <!-- Filter Tab -->
-        <ui-tab title="Filter">
+        <ui-tab title="Input Configuration">
           <ng-container ngProjectAs="label">
-            {{ 'components.queryBuilder.filter.title' | translate }}
+            {{ 'components.email.dataset.reference.inputConfiguration' | translate }}
           </ng-container>
           <ng-template uiTabContent>
-            <ng-container
-              class="mt-2"
-              *ngTemplateOutlet="invalidFieldsAlertTmpl"
-            ></ng-container>
-            <ng-container
-              *ngIf="resource?.fields?.length || availableFields.length > 0"
-            >
+            <div class="flex flex-col gap-3">
+              <ui-button
+                variant="primary"
+                category="secondary"
+                (click)="openReferenceInputBuilder()"
+              >
+                {{ 'common.configure' | translate }}
+              </ui-button>
+              <ui-alert
+                *ngIf="query.get('referenceDataInputConfig')?.value"
+                variant="primary"
+              >
+                {{ 'components.email.dataset.reference.inputConfigured' | translate }}
+              </ui-alert>
+            </div>
+          </ng-template>
+        </ui-tab>
+        <ui-tab
+          title="Variable Inputs"
+          [disabled]="!query.get('referenceDataInputConfig')?.value"
+        >
+          <ng-container ngProjectAs="label">
+            {{ 'components.email.dataset.reference.inputs' | translate }}
+          </ng-container>
+          <ng-template uiTabContent>
+            <div *ngIf="referenceInputsSurvey; else noInputConfig">
+              <survey [model]="referenceInputsSurvey"></survey>
+            </div>
+            <ng-template #noInputConfig>
+              <shared-empty
+                [title]="
+                  'components.email.dataset.reference.noInputConfiguration'
+                    | translate
+                "
+              ></shared-empty>
+            </ng-template>
+          </ng-template>
+        </ui-tab>
+      </ui-tabs>
+    </div>
+  </ng-container>
+  <ng-container
+    *ngIf="!isReferenceData"
+    [ngTemplateOutlet]="resourceConfig"
+  ></ng-container>
+  <ng-template #resourceConfig>
+    <ng-container
+      class="mt-5"
+      *ngTemplateOutlet="noFieldsInResourceAlertTmpl"
+    ></ng-container>
+    <div>
+      <ui-tabs
+        [selectedIndex]="currentTabIndex"
+        (selectedIndexChange)="onTabSelect($event, true)"
+        #datasetPreview
+        *ngIf="resourcePopulated"
+      >
+        <div class="mt-4 flex flex-row">
+          <!-- Fields Tab -->
+          <ui-tab title="Fields" [selected]="true">
+            <ng-container ngProjectAs="label">
+              {{ 'components.queryBuilder.fields.title' | translate }}
+            </ng-container>
+            <ng-template uiTabContent>
+              <ng-container
+                class="mt-2"
+                *ngTemplateOutlet="invalidFieldsAlertTmpl"
+              ></ng-container>
+              <ng-container
+                class="mt-2"
+                *ngTemplateOutlet="noSelectedFieldsAlertTmpl"
+              ></ng-container>
+              <ng-container
+                class="mt-2"
+                *ngTemplateOutlet="ChildFieldAlertTmpl"
+              ></ng-container>
+              <div class="flex gap-4 mt-2" formGroupName="query">
+                <div class="mt-2 overflow-auto">
+                  <!-- FIELDS -->
+                  <shared-tab-fields
+                    *ngIf="availableFields.length > 0"
+                    [form]="getFieldsArray()"
+                    [fields]="availableFields"
+                    [showLimit]="false"
+                    [showColumnWidth]="false"
+                  ></shared-tab-fields>
+                </div>
+              </div>
+
+              <ui-button
+                *ngIf="datasetFilterInfo.controls"
+                class="float-right mt-8"
+                category="secondary"
+                variant="primary"
+                (click)="getDataSet('fields')"
+              >
+                {{ 'components.queryBuilder.filter.applyField' | translate }}
+              </ui-button>
+            </ng-template>
+          </ui-tab>
+          <!-- Filter Tab -->
+          <ui-tab title="Filter">
+            <ng-container ngProjectAs="label">
+              {{ 'components.queryBuilder.filter.title' | translate }}
+            </ng-container>
+            <ng-template uiTabContent>
+              <ng-container
+                class="mt-2"
+                *ngTemplateOutlet="invalidFieldsAlertTmpl"
+              ></ng-container>
+              <ng-container
+                *ngIf="resource?.fields?.length || availableFields.length > 0"
+              >
+                <ng-container
+                  class="mt-2"
+                  *ngTemplateOutlet="tooManyRecordsAlertTmpl"
+                ></ng-container>
+                <div class="flex gap-4 mt-2" formGroupName="query">
+                  <div class="mt-2 w-full">
+                    <!-- NESTED FILTER GROUP -->
+                    <!-- <shared-filter [form]="query.get('filter')" [fields]="filterFields" [isEmailNotification]="true"></shared-filter> -->
+                    <shared-tab-filter
+                      [form]="$any(query.controls.query.get('filter'))"
+                      [query]="query.controls.query.getRawValue()"
+                    >
+                    </shared-tab-filter>
+                  </div>
+                </div>
+                <ui-button
+                  class="float-right mt-8"
+                  category="secondary"
+                  variant="primary"
+                  (click)="getDataSet('preview', true); showPreview = true"
+                  [disabled]="selectedFields.length === 0"
+                >
+                  {{ 'common.preview' | translate }}
+                </ui-button>
+              </ng-container>
+            </ng-template>
+          </ui-tab>
+
+          <!-- navigate to page Tab -->
+          <ui-tab title="Action">
+            <ng-container ngProjectAs="label">
+              {{ 'components.email.dataset.navigateToPage.title' | translate }}
+            </ng-container>
+            <ng-template uiTabContent>
+              <!-- Redirect to specific page action details -->
+              <div
+                formGroupName="navigateSettings"
+                class="flex flex-col ml-[55px]"
+              >
+                <div uiFormFieldDirective class="w-80">
+                  <label>{{
+                    'components.widget.settings.grid.actions.goTo.column.label'
+                      | translate
+                  }}</label>
+                  <input
+                    formControlName="title"
+                    [placeholder]="
+                      'components.widget.settings.grid.actions.goTo.column.placeholder'
+                        | translate
+                    "
+                  />
+                </div>
+                <div uiFormFieldDirective class="w-80">
+                  <label>
+                    {{
+                      'components.widget.settings.grid.actions.goTo.target.label'
+                        | translate
+                    }}
+                  </label>
+                  <ui-select-menu
+                    formControlName="pageUrl"
+                    [placeholder]="
+                      'components.widget.settings.grid.actions.goTo.target.placeholder'
+                        | translate
+                    "
+                  >
+                    <ui-select-option
+                      *ngFor="let page of pages"
+                      [value]="page.urlParams"
+                    >
+                      {{ page.name }}
+                    </ui-select-option>
+                  </ui-select-menu>
+                </div>
+                <div uiFormFieldDirective class="w-80">
+                  {{
+                    'components.widget.settings.grid.actions.goTo.field.label'
+                      | translate
+                  }}
+                  <ui-select-menu
+                    formControlName="field"
+                    [placeholder]="
+                      'components.widget.settings.grid.actions.goTo.field.placeholder'
+                        | translate
+                    "
+                  >
+                    <ng-container *ngFor="let field of availableFields">
+                      <ui-select-option
+                        *ngIf="!field.fields"
+                        [value]="field.name"
+                      >
+                        {{ field.text || field.name }}
+                      </ui-select-option>
+
+                      <ui-select-option *ngIf="field.fields" [isGroup]="true">
+                        {{ field.text || field.name }}
+                        <ui-select-option
+                          *ngFor="let subField of field.fields"
+                          [value]="field.name + '.' + subField.name"
+                        >
+                          {{
+                            field.name === '$attribute'
+                              ? subField.text || subField.name
+                              : field.name +
+                                ' - ' +
+                                (subField.text || subField.name)
+                          }}
+                        </ui-select-option>
+                      </ui-select-option>
+                    </ng-container>
+                  </ui-select-menu>
+                </div>
+              </div>
+            </ng-template>
+          </ui-tab>
+
+          <!-- Preview Tab -->
+          <ui-tab
+            [title]="'Preview'"
+            [disabled]="
+              showDatasetLimitWarning ||
+              this.query?.controls?.query?.get('fields')?.value.length === 0
+            "
+          >
+            <ng-container ngProjectAs="label">
+              {{ 'common.preview' | translate }}
+            </ng-container>
+            <ng-template uiTabContent>
+              <ng-container
+                class="mt-2"
+                *ngTemplateOutlet="ChildFieldAlertTmpl"
+              ></ng-container>
               <ng-container
                 class="mt-2"
                 *ngTemplateOutlet="tooManyRecordsAlertTmpl"
               ></ng-container>
+              <div
+                *ngIf="!showDatasetLimitWarning"
+                class="overflow-x-auto"
+                formGroupName="query"
+              >
+                <div id="tblPreview" [innerHTML]="previewHTML"></div>
+              </div>
+            </ng-template>
+          </ui-tab>
+
+          <!-- Send Separate Email Fields -->
+          <ui-tab
+            title="Send Separate Fields"
+            *ngIf="this.query.get('individualEmail').value"
+          >
+            <ng-container ngProjectAs="label">
+              {{ 'components.queryBuilder.sendSeparate.title' | translate }}
+            </ng-container>
+            <ng-template uiTabContent>
+              <ng-container
+                class="mt-2"
+                *ngTemplateOutlet="invalidFieldsAlertTmpl"
+              ></ng-container>
+              <ng-container
+                class="mt-2"
+                *ngTemplateOutlet="individualEmailsInfoMessageTmpl"
+              ></ng-container>
+              <ng-container
+                class="mt-2"
+                *ngTemplateOutlet="noSelectedFieldsForIndividualFieldsTmpl"
+              ></ng-container>
+              <ng-container
+                class="mt-2"
+                *ngTemplateOutlet="ChildFieldAlertTmpl_individualEmail"
+              ></ng-container>
               <div class="flex gap-4 mt-2" formGroupName="query">
-                <div class="mt-2 w-full">
-                  <!-- NESTED FILTER GROUP -->
-                  <!-- <shared-filter [form]="query.get('filter')" [fields]="filterFields" [isEmailNotification]="true"></shared-filter> -->
-                  <shared-tab-filter
-                    [form]="$any(query.controls.query.get('filter'))"
-                    [query]="query.controls.query.getRawValue()"
-                  >
-                  </shared-tab-filter>
+                <div class="mt-2 overflow-auto">
+                  <!-- FIELDS -->
+                  <shared-tab-fields
+                    *ngIf="availableFieldsIndividualEmail.length > 0"
+                    [form]="getIndividualEmailFieldsArray()"
+                    [fields]="availableFieldsIndividualEmail"
+                    [showLimit]="false"
+                    [showColumnWidth]="false"
+                  ></shared-tab-fields>
                 </div>
               </div>
-              <ui-button
-                class="float-right mt-8"
-                category="secondary"
-                variant="primary"
-                (click)="getDataSet('preview', true); showPreview = true"
-                [disabled]="selectedFields.length === 0"
-              >
-                {{ 'common.preview' | translate }}
-              </ui-button>
-            </ng-container>
-          </ng-template>
-        </ui-tab>
-
-        <!-- navigate to page Tab -->
-        <ui-tab title="Action">
-          <ng-container ngProjectAs="label">
-            {{ 'components.email.dataset.navigateToPage.title' | translate }}
-          </ng-container>
-          <ng-template uiTabContent>
-            <!-- Redirect to specific page action details -->
-            <div
-              formGroupName="navigateSettings"
-              class="flex flex-col ml-[55px]"
-            >
-              <div uiFormFieldDirective class="w-80">
-                <label>{{
-                  'components.widget.settings.grid.actions.goTo.column.label'
-                    | translate
-                }}</label>
-                <input
-                  formControlName="title"
-                  [placeholder]="
-                    'components.widget.settings.grid.actions.goTo.column.placeholder'
-                      | translate
-                  "
-                />
-              </div>
-              <div uiFormFieldDirective class="w-80">
-                <label>
-                  {{
-                    'components.widget.settings.grid.actions.goTo.target.label'
-                      | translate
-                  }}
-                </label>
-                <ui-select-menu
-                  formControlName="pageUrl"
-                  [placeholder]="
-                    'components.widget.settings.grid.actions.goTo.target.placeholder'
-                      | translate
-                  "
-                >
-                  <ui-select-option
-                    *ngFor="let page of pages"
-                    [value]="page.urlParams"
-                  >
-                    {{ page.name }}
-                  </ui-select-option>
-                </ui-select-menu>
-              </div>
-              <div uiFormFieldDirective class="w-80">
-                {{
-                  'components.widget.settings.grid.actions.goTo.field.label'
-                    | translate
-                }}
-                <ui-select-menu
-                  formControlName="field"
-                  [placeholder]="
-                    'components.widget.settings.grid.actions.goTo.field.placeholder'
-                      | translate
-                  "
-                >
-                  <ng-container *ngFor="let field of availableFields">
-                    <ui-select-option
-                      *ngIf="!field.fields"
-                      [value]="field.name"
-                    >
-                      {{ field.text || field.name }}
-                    </ui-select-option>
-
-                    <ui-select-option *ngIf="field.fields" [isGroup]="true">
-                      {{ field.text || field.name }}
-                      <ui-select-option
-                        *ngFor="let subField of field.fields"
-                        [value]="field.name + '.' + subField.name"
-                      >
-                        {{
-                          field.name === '$attribute'
-                            ? subField.text || subField.name
-                            : field.name +
-                              ' - ' +
-                              (subField.text || subField.name)
-                        }}
-                      </ui-select-option>
-                    </ui-select-option>
-                  </ng-container>
-                </ui-select-menu>
-              </div>
-            </div>
-          </ng-template>
-        </ui-tab>
-
-        <!-- Preview Tab -->
-        <ui-tab
-          [title]="'Preview'"
-          [disabled]="
-            showDatasetLimitWarning ||
-            this.query?.controls?.query?.get('fields')?.value.length === 0
-          "
-        >
-          <ng-container ngProjectAs="label">
-            {{ 'common.preview' | translate }}
-          </ng-container>
-          <ng-template uiTabContent>
-            <ng-container
-              class="mt-2"
-              *ngTemplateOutlet="ChildFieldAlertTmpl"
-            ></ng-container>
-            <ng-container
-              class="mt-2"
-              *ngTemplateOutlet="tooManyRecordsAlertTmpl"
-            ></ng-container>
-            <div
-              *ngIf="!showDatasetLimitWarning"
-              class="overflow-x-auto"
-              formGroupName="query"
-            >
-              <div id="tblPreview" [innerHTML]="previewHTML"></div>
-            </div>
-          </ng-template>
-        </ui-tab>
-
-        <!-- Send Separate Email Fields -->
-        <ui-tab
-          title="Send Separate Fields"
-          *ngIf="this.query.get('individualEmail').value"
-        >
-          <ng-container ngProjectAs="label">
-            {{ 'components.queryBuilder.sendSeparate.title' | translate }}
-          </ng-container>
-          <ng-template uiTabContent>
-            <ng-container
-              class="mt-2"
-              *ngTemplateOutlet="invalidFieldsAlertTmpl"
-            ></ng-container>
-            <ng-container
-              class="mt-2"
-              *ngTemplateOutlet="individualEmailsInfoMessageTmpl"
-            ></ng-container>
-            <ng-container
-              class="mt-2"
-              *ngTemplateOutlet="noSelectedFieldsForIndividualFieldsTmpl"
-            ></ng-container>
-            <ng-container
-              class="mt-2"
-              *ngTemplateOutlet="ChildFieldAlertTmpl_individualEmail"
-            ></ng-container>
-            <div class="flex gap-4 mt-2" formGroupName="query">
-              <div class="mt-2 overflow-auto">
-                <!-- FIELDS -->
-                <shared-tab-fields
-                  *ngIf="availableFieldsIndividualEmail.length > 0"
-                  [form]="getIndividualEmailFieldsArray()"
-                  [fields]="availableFieldsIndividualEmail"
-                  [showLimit]="false"
-                  [showColumnWidth]="false"
-                ></shared-tab-fields>
-              </div>
-            </div>
-          </ng-template>
-        </ui-tab>
-
-        <!-- Style Tab -->
-        <!-- <kendo-tabstrip-tab [disabled]="true">
-      <ng-template kendoTabTitle >
-        <div >
-          {{ 'components.queryBuilder.style.title' | translate }}
+            </ng-template>
+          </ui-tab>
         </div>
-      </ng-template>
-      <ng-template kendoTabContent>
-      </ng-template>
-    </kendo-tabstrip-tab> -->
-      </div>
-    </ui-tabs>
-  </div>
+      </ui-tabs>
+    </div>
+  </ng-template>
 </form>
 
 <!-- Too many records in dataset -->

--- a/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
+++ b/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
@@ -194,6 +194,58 @@
           </ng-template>
         </ui-tab>
         <ui-tab
+          *ngIf="this.query.get('individualEmail').value"
+          title="Send Separate Email Fields"
+        >
+          <ng-container ngProjectAs="label">
+            {{ 'components.queryBuilder.sendSeparate.title' | translate }}
+          </ng-container>
+          <ng-template uiTabContent>
+            <div class="space-y-2">
+              <p class="text-sm text-gray-700">
+                {{ 'components.email.referenceData.individualEmail.helper' | translate }}
+              </p>
+              <div formArrayName="individualEmailFields" class="space-y-2">
+                <div
+                  class="flex gap-2 items-center"
+                  *ngFor="
+                    let control of getIndividualEmailFieldsArray().controls;
+                    let idx = index
+                  "
+                >
+                  <input
+                    class="form-input flex-1 rounded-md"
+                    type="text"
+                    [formControlName]="idx"
+                    placeholder="$.email"
+                  />
+                  <ui-button
+                    variant="danger"
+                    icon="close"
+                    size="small"
+                    uiTooltip="common.actions.remove"
+                    (click)="removeReferenceEmailField(idx)"
+                    [disabled]="getIndividualEmailFieldsArray().length === 1"
+                  ></ui-button>
+                </div>
+              </div>
+              <div class="flex gap-2 items-center">
+                <ui-button
+                  variant="primary"
+                  size="small"
+                  icon="add"
+                  (click)="addReferenceEmailField()"
+                >
+                  {{ 'components.email.referenceData.individualEmail.addPath' | translate }}
+                </ui-button>
+                <span class="text-xs text-gray-500">
+                  {{ 'components.email.referenceData.individualEmail.jsonPathHint' | translate }}
+                </span>
+              </div>
+            </div>
+          </ng-template>
+        </ui-tab>
+        <ui-tab
           title="Preview"
           [disabled]="!query.value.reference"
         >
@@ -440,34 +492,83 @@
               {{ 'components.queryBuilder.sendSeparate.title' | translate }}
             </ng-container>
             <ng-template uiTabContent>
-              <ng-container
-                class="mt-2"
-                *ngTemplateOutlet="invalidFieldsAlertTmpl"
-              ></ng-container>
-              <ng-container
-                class="mt-2"
-                *ngTemplateOutlet="individualEmailsInfoMessageTmpl"
-              ></ng-container>
-              <ng-container
-                class="mt-2"
-                *ngTemplateOutlet="noSelectedFieldsForIndividualFieldsTmpl"
-              ></ng-container>
-              <ng-container
-                class="mt-2"
-                *ngTemplateOutlet="ChildFieldAlertTmpl_individualEmail"
-              ></ng-container>
-              <div class="flex gap-4 mt-2" formGroupName="query">
-                <div class="mt-2 overflow-auto">
-                  <!-- FIELDS -->
-                  <shared-tab-fields
-                    *ngIf="availableFieldsIndividualEmail.length > 0"
-                    [form]="getIndividualEmailFieldsArray()"
-                    [fields]="availableFieldsIndividualEmail"
-                    [showLimit]="false"
-                    [showColumnWidth]="false"
-                  ></shared-tab-fields>
+              <ng-container *ngIf="isReferenceData; else resourceSeparateEmail">
+                <div class="space-y-2">
+                  <p class="text-sm text-gray-700">
+                    {{ 'components.email.referenceData.individualEmail.helper' | translate }}
+                  </p>
+                  <div
+                    formArrayName="individualEmailFields"
+                    class="space-y-2"
+                  >
+                    <div
+                      class="flex gap-2 items-center"
+                      *ngFor="
+                        let control of getIndividualEmailFieldsArray().controls;
+                        let idx = index
+                      "
+                    >
+                      <input
+                        class="form-input flex-1 rounded-md"
+                        type="text"
+                        [formControlName]="idx"
+                        placeholder="$.data.*.email"
+                      />
+                      <ui-button
+                        variant="danger"
+                        icon="close"
+                        size="small"
+                        uiTooltip="common.actions.remove"
+                        (click)="removeReferenceEmailField(idx)"
+                        [disabled]="getIndividualEmailFieldsArray().length === 1"
+                      ></ui-button>
+                    </div>
+                  </div>
+                  <div class="flex gap-2 items-center">
+                    <ui-button
+                      variant="primary"
+                      size="small"
+                      icon="add"
+                      (click)="addReferenceEmailField()"
+                    >
+                      {{ 'components.email.referenceData.individualEmail.addPath' | translate }}
+                    </ui-button>
+                    <span class="text-xs text-gray-500">
+                      {{ 'components.email.referenceData.individualEmail.jsonPathHint' | translate }}
+                    </span>
+                  </div>
                 </div>
-              </div>
+              </ng-container>
+              <ng-template #resourceSeparateEmail>
+                <ng-container
+                  class="mt-2"
+                  *ngTemplateOutlet="invalidFieldsAlertTmpl"
+                ></ng-container>
+                <ng-container
+                  class="mt-2"
+                  *ngTemplateOutlet="individualEmailsInfoMessageTmpl"
+                ></ng-container>
+                <ng-container
+                  class="mt-2"
+                  *ngTemplateOutlet="noSelectedFieldsForIndividualFieldsTmpl"
+                ></ng-container>
+                <ng-container
+                  class="mt-2"
+                  *ngTemplateOutlet="ChildFieldAlertTmpl_individualEmail"
+                ></ng-container>
+                <div class="flex gap-4 mt-2" formGroupName="query">
+                  <div class="mt-2 overflow-auto">
+                    <!-- FIELDS -->
+                    <shared-tab-fields
+                      *ngIf="availableFieldsIndividualEmail.length > 0"
+                      [form]="getIndividualEmailFieldsArray()"
+                      [fields]="availableFieldsIndividualEmail"
+                      [showLimit]="false"
+                      [showColumnWidth]="false"
+                    ></shared-tab-fields>
+                  </div>
+                </div>
+              </ng-template>
             </ng-template>
           </ui-tab>
         </div>

--- a/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
+++ b/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
@@ -132,7 +132,10 @@
       >
         {{ 'components.email.alert.noReferenceSelected' | translate }}
       </ui-alert>
-      <ui-tabs>
+      <ui-tabs
+        [selectedIndex]="currentTabIndex"
+        (selectedIndexChange)="onTabSelect($event, true)"
+      >
         <ui-tab title="Variable Mapping" [selected]="true">
           <ng-container ngProjectAs="label">
             {{ 'components.email.dataset.reference.mapping' | translate }}
@@ -187,6 +190,23 @@
                 "
               ></shared-empty>
             </ng-template>
+          </ng-template>
+        </ui-tab>
+        <ui-tab
+          title="Preview"
+          [disabled]="!query.value.reference"
+        >
+          <ng-container ngProjectAs="label">
+            {{ 'common.preview' | translate }}
+          </ng-container>
+          <ng-template uiTabContent>
+            <div
+              *ngIf="!showDatasetLimitWarning"
+              class="overflow-x-auto"
+              formGroupName="query"
+            >
+              <div id="tblPreview" [innerHTML]="previewHTML"></div>
+            </div>
           </ng-template>
         </ui-tab>
       </ui-tabs>

--- a/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
+++ b/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.html
@@ -89,6 +89,7 @@
           <shared-reference-data-select
             [ngClass]="{ 'w-[80%]': this.query.get('reference').value }"
             formControlName="reference"
+            [selectedElements]="referenceData ? [referenceData] : []"
           ></shared-reference-data-select>
           <ui-button
             *ngIf="query?.value.reference"

--- a/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.ts
+++ b/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.ts
@@ -410,6 +410,19 @@ export class DatasetFilterComponent
     const newIndex = event;
     const previewTabIndex = 3;
 
+    if (this.isReferenceData) {
+      this.showDatasetLimitWarning = false;
+      this.currentTabIndex = newIndex;
+      if (
+        fromHTML &&
+        newIndex === previewTabIndex &&
+        this.query.value.reference
+      ) {
+        this.getDataSet('preview');
+      }
+      return;
+    }
+
     const isSeparateEmailValid =
       (this.query.get('individualEmail').value === true &&
         this.selectedFieldsIndividualEmail.length > 0) ||
@@ -659,15 +672,52 @@ export class DatasetFilterComponent
    * @param validCheck - Check if data needs validation
    */
   getDataSet(tabName?: any, validCheck?: boolean): void {
-    if (this.isReferenceData) {
-      this.emailService.disableSaveAndProceed.next(false);
-      this.emailService.disableSaveAsDraft.next(false);
-      return;
-    }
     if (
       this.query.controls['name'].value !== null &&
       this.query.controls['name'].value !== ''
     ) {
+      if (this.isReferenceData) {
+        if (tabName === 'preview' && this.query.value.reference) {
+          this.loading = true;
+          const objPreview: any = {
+            resource: '',
+            reference: this.query.get('reference')?.value || '',
+            name: this.query.get('name')?.value,
+            query: this.query.get('query')?.value,
+            referenceDataVariableMapping: this.query.get(
+              'referenceDataVariableMapping'
+            )?.value,
+            referenceDataInputConfig: this.query.get('referenceDataInputConfig')
+              ?.value,
+            referenceDataInputs: this.query.get('referenceDataInputs')?.value,
+            navigateSettings: this.query.value.navigateSettings,
+            navigateToPage: this.query.value.navigateToPage,
+          };
+
+          this.http
+            .post(
+              `${this.restService.apiUrl}/notification/preview-dataset`,
+              objPreview
+            )
+            .subscribe(
+              (response: any) => {
+                const previewRes = window.atob(response.tableHtml);
+                setTimeout(() => {
+                  this.previewHTML =
+                    this.sanitizer.bypassSecurityTrustHtml(previewRes);
+                }, 100);
+                this.loading = false;
+              },
+              (error: string) => {
+                console.error('Error:', error);
+                this.loading = false;
+              }
+            );
+        }
+        this.emailService.disableSaveAndProceed.next(false);
+        this.emailService.disableSaveAsDraft.next(false);
+        return;
+      }
       if (tabName == 'fields') {
         this.onTabSelect(1, false);
         if (this.selectedFields.length) {

--- a/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.ts
+++ b/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.ts
@@ -706,6 +706,16 @@ export class DatasetFilterComponent
                   this.previewHTML =
                     this.sanitizer.bypassSecurityTrustHtml(previewRes);
                 }, 100);
+
+                const datasetEntry = {
+                  dataList: response,
+                  datasetFields:
+                    this.referenceData?.fields?.map((f: any) => f.name) || [],
+                  tabIndex: this.activeTab?.index,
+                  tabName: this.activeTab?.title,
+                };
+                this.emailService.setAllPreviewData([datasetEntry]);
+
                 this.loading = false;
               },
               (error: string) => {

--- a/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.ts
+++ b/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.ts
@@ -31,6 +31,11 @@ import {
   ContentType,
   Page,
 } from '../../../../../index';
+import { ReferenceData } from '../../../../models/reference-data.model';
+import { ReferenceDataService } from '../../../../services/reference-data/reference-data.service';
+import { FormBuilderService } from '../../../../services/form-builder/form-builder.service';
+import { Dialog } from '@angular/cdk/dialog';
+import { Model } from 'survey-core';
 /**
  * Component for filtering, selecting fields and styling block data sets.
  */
@@ -58,13 +63,13 @@ export class DatasetFilterComponent
   /** GraphQL query reference for fetching resources. */
   public resourcesQuery!: QueryRef<ResourcesQueryResponse>;
   /** Selected resource. */
-  public resource!: Resource;
+  public resource: Resource | null = null;
   /** Response of the data set. */
   public datasetResponse: any;
   /** Fields of the data set. */
   public datasetFields!: any[];
   /** Selected resource ID. */
-  public selectedResourceId!: string;
+  public selectedResourceId: string | null = null;
   /** List of data. */
   public dataList!: { [key: string]: any }[];
   /** Selected search field. */
@@ -129,10 +134,27 @@ export class DatasetFilterComponent
   public isReferenceData = false;
   /** List of data types */
   public dataTypeList: any = ['Resource', 'Reference Data'];
+  /** Currently selected reference data */
+  public referenceData: ReferenceData | null = null;
+  /** Survey model for variable inputs */
+  public referenceInputsSurvey: Model | null = null;
+  /** Reference data loading flag */
+  public referenceDataLoading = false;
   /** Available pages from the application */
   public pages: any[] = [];
   /** Flag to show the Child fields limit warning. */
   public showFieldsWarning_SSE = false;
+
+  /**
+   * Reference variable mapping control helper
+   *
+   * @returns reference data mapping control if available
+   */
+  get referenceMappingControl(): FormControl | null {
+    return (
+      (this.query?.get('referenceDataVariableMapping') as FormControl) || null
+    );
+  }
 
   /**
    * To use helper functions, Apollo serve
@@ -145,6 +167,9 @@ export class DatasetFilterComponent
    * @param restService rest service
    * @param sanitizer html sanitizer
    * @param applicationService application service
+   * @param referenceDataService reference data service
+   * @param formBuilderService form builder service
+   * @param dialog dialog service
    */
   constructor(
     public emailService: EmailService,
@@ -154,7 +179,10 @@ export class DatasetFilterComponent
     private http: HttpClient,
     private restService: RestService,
     private sanitizer: DomSanitizer,
-    public applicationService: ApplicationService
+    public applicationService: ApplicationService,
+    private referenceDataService: ReferenceDataService,
+    private formBuilderService: FormBuilderService,
+    private dialog: Dialog
   ) {
     super();
   }
@@ -162,13 +190,65 @@ export class DatasetFilterComponent
   ngOnInit(): void {
     const application = this.applicationService.application.getValue();
     this.pages = this.getPages(application);
-    if (this.query.controls.resource.value && !this.resource) {
+    const dataTypeControl = this.query.get('dataType');
+    const selectedDataType = dataTypeControl?.value ?? this.dataTypeList[0];
+    if (!dataTypeControl?.value) {
+      dataTypeControl?.setValue(selectedDataType, { emitEvent: false });
+    }
+    this.isReferenceData = selectedDataType === this.dataTypeList[1];
+
+    dataTypeControl?.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((value: string) => {
+        this.isReferenceData = value === this.dataTypeList[1];
+        if (this.isReferenceData) {
+          this.query.get('resource')?.setValue(null, { emitEvent: false });
+          this.resource = null;
+          this.availableFields = [];
+          this.selectedFields = [];
+          this.selectedFieldsIndividualEmail = [];
+          this.referenceInputsSurvey = null;
+          this.resetQuery(this.query.get('query'));
+          if (!this.query.get('referenceDataVariableMapping')?.value) {
+            this.query.get('referenceDataVariableMapping')?.setValue('{}');
+          }
+          const referenceId = this.query.get('reference')?.value;
+          if (referenceId) {
+            this.loadReferenceData(referenceId as string);
+          }
+          this.emailService.disableSaveAndProceed.next(true);
+        } else {
+          this.query.get('reference')?.setValue(null, { emitEvent: false });
+          this.referenceData = null;
+          this.referenceInputsSurvey = null;
+          this.query
+            .get('referenceDataVariableMapping')
+            ?.setValue(null, { emitEvent: false });
+          this.query
+            .get('referenceDataInputConfig')
+            ?.setValue(null, { emitEvent: false });
+          this.query
+            .get('referenceDataInputs')
+            ?.setValue(null, { emitEvent: false });
+          if (this.query.controls.resource.value) {
+            this.selectedResourceId = this.query.controls.resource.value;
+            this.getResourceData(false);
+          }
+        }
+      });
+
+    if (
+      this.query.controls.resource.value &&
+      !this.resource &&
+      !this.isReferenceData
+    ) {
       this.selectedResourceId = this.query.controls.resource.value;
       this.getResourceData(false);
     }
     this.query.controls.resource.valueChanges
       .pipe(takeUntil(this.destroy$))
       .subscribe((value: any) => {
+        if (this.isReferenceData) return;
         if (
           value !== undefined &&
           value !== null &&
@@ -185,6 +265,19 @@ export class DatasetFilterComponent
           if (this.resource?.fields) {
             this.resource.fields = [];
           }
+        }
+      });
+    const referenceControl = this.query.get('reference');
+    referenceControl?.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((value: any) => {
+        if (!this.isReferenceData) return;
+        if (value) {
+          this.loadReferenceData(value);
+        } else {
+          this.referenceData = null;
+          this.referenceInputsSurvey = null;
+          this.updateReferenceDataValidity();
         }
       });
     this.query.controls.name.valueChanges
@@ -211,18 +304,25 @@ export class DatasetFilterComponent
     this.separateEmail = this.emailService.updateSeparateEmail(
       this.activeTab.index
     );
-    if (this.query.value.name == null) {
+    if (!this.query.value.name) {
       const name = 'Block ' + this.activeTab.blockHeaderCount;
       this.query.controls['name'].setValue(name);
     }
 
-    if (this.query?.value?.resource) {
+    if (this.query?.value?.resource && !this.isReferenceData) {
       this.selectedResourceId = this.query?.value?.resource;
       this.getResourceData(false);
     }
 
+    if (this.isReferenceData && this.query?.value?.reference) {
+      this.loadReferenceData(this.query.value.reference);
+    }
+
     this.filteredFields = this.resource?.fields;
-    if (this.query.controls.query.get('cacheData')?.value) {
+    if (
+      !this.isReferenceData &&
+      this.query.controls.query.get('cacheData')?.value
+    ) {
       const {
         dataList,
         resource,
@@ -252,6 +352,7 @@ export class DatasetFilterComponent
     this.query.controls.individualEmail.valueChanges
       .pipe(takeUntil(this.destroy$))
       .subscribe((value: any) => {
+        if (this.isReferenceData) return;
         if (
           value === true &&
           this.selectedFieldsIndividualEmail?.length === 0 &&
@@ -372,6 +473,8 @@ export class DatasetFilterComponent
       this.resetQuery(this.query.get('query'));
     }
     if (this.selectedResourceId) {
+      // Show tabs while loading to avoid empty UI
+      this.resourcePopulated = true;
       this.emailService
         .fetchResourceData(this.selectedResourceId)
         .pipe(takeUntil(this.destroy$))
@@ -382,9 +485,9 @@ export class DatasetFilterComponent
             this.query.controls.query.addControl('name', new FormControl(''));
           }
           this.query.controls.query.get('name').setValue(queryTemp.queryName);
-          this.availableFields = newData;
-          this.availableFieldsIndividualEmail = cloneDeep(newData);
-          this.filterFields = cloneDeep(newData);
+          this.availableFields = newData || [];
+          this.availableFieldsIndividualEmail = cloneDeep(newData || []);
+          this.filterFields = cloneDeep(newData || []);
           this.loading = false;
           this.resourcePopulated = true;
           this.resource = data.resource;
@@ -409,6 +512,96 @@ export class DatasetFilterComponent
     filters.push(this.emailService.getNewFilterFields);
 
     query.get('name')?.setValue('');
+  }
+
+  /**
+   * Loads reference data metadata and builds survey for inputs.
+   *
+   * @param referenceId Reference data id
+   */
+  async loadReferenceData(referenceId: string) {
+    this.referenceDataLoading = true;
+    try {
+      this.referenceData = await this.referenceDataService.loadReferenceData(
+        referenceId
+      );
+      this.buildReferenceInputsSurvey(
+        this.query.get('referenceDataInputConfig')?.value
+      );
+    } catch (err) {
+      console.error(err);
+      this.referenceData = null;
+    } finally {
+      this.referenceDataLoading = false;
+      this.updateReferenceDataValidity();
+    }
+  }
+
+  /**
+   * Opens Survey builder to configure variable inputs.
+   */
+  openReferenceInputBuilder(): void {
+    import(
+      '../../../dashboard-filter/filter-builder-modal/filter-builder-modal.component'
+    ).then(({ FilterBuilderModalComponent }) => {
+      const dialogRef = this.dialog.open(FilterBuilderModalComponent, {
+        data: {
+          surveyStructure: this.query.get('referenceDataInputConfig')?.value,
+        },
+        autoFocus: false,
+      });
+      dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value) => {
+        if (value) {
+          this.query.get('referenceDataInputConfig')?.setValue(value);
+          this.buildReferenceInputsSurvey(value);
+        }
+      });
+    });
+  }
+
+  /**
+   * Build survey instance for variable inputs.
+   *
+   * @param structure Survey JSON definition
+   */
+  buildReferenceInputsSurvey(structure?: any): void {
+    if (!structure) {
+      this.referenceInputsSurvey = null;
+      this.updateReferenceDataValidity();
+      return;
+    }
+    try {
+      const surveyStructure =
+        typeof structure === 'string' ? structure : JSON.stringify(structure);
+      const survey = this.formBuilderService.createSurvey(surveyStructure);
+      const currentInputs = this.query.get('referenceDataInputs')?.value;
+      if (currentInputs) {
+        survey.data = currentInputs;
+      }
+      survey.onValueChanged.add(() => {
+        this.query
+          .get('referenceDataInputs')
+          ?.setValue({ ...(survey.data as any) });
+        this.updateReferenceDataValidity();
+      });
+      this.referenceInputsSurvey = survey;
+      this.updateReferenceDataValidity();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  /**
+   * Update save/proceed availability for reference data datasets.
+   */
+  updateReferenceDataValidity(): void {
+    if (!this.isReferenceData) return;
+    const hasReference = !!this.query.get('reference')?.value;
+    const mappingControl = this.query.get('referenceDataVariableMapping');
+    const mappingValid = mappingControl ? mappingControl.valid : true;
+    const isValid = hasReference && mappingValid;
+    this.emailService.disableSaveAndProceed.next(!isValid);
+    this.emailService.disableSaveAsDraft.next(false);
   }
 
   /**
@@ -466,6 +659,11 @@ export class DatasetFilterComponent
    * @param validCheck - Check if data needs validation
    */
   getDataSet(tabName?: any, validCheck?: boolean): void {
+    if (this.isReferenceData) {
+      this.emailService.disableSaveAndProceed.next(false);
+      this.emailService.disableSaveAsDraft.next(false);
+      return;
+    }
     if (
       this.query.controls['name'].value !== null &&
       this.query.controls['name'].value !== ''
@@ -779,13 +977,26 @@ export class DatasetFilterComponent
    * @param event click event
    */
   clearFormField(formField: string, event: Event) {
-    if (this.query.controls[formField]?.value) {
-      this.query.controls[formField].setValue(null);
-      this.query.controls.resource.value = null;
+    const control = this.query.get(formField);
+    if (control?.value) {
+      control.setValue(null);
     }
-    this.resetQuery(this.query.get('query'));
-    this.resource.fields = [];
-    this.selectedResourceId = '';
+    if (formField === 'resource') {
+      this.query.controls.resource.value = null;
+      this.resetQuery(this.query.get('query'));
+      if (this.resource) {
+        this.resource.fields = [];
+      }
+      this.selectedResourceId = '';
+    }
+    if (formField === 'reference') {
+      this.referenceData = null;
+      this.referenceInputsSurvey = null;
+      this.query.get('referenceDataVariableMapping')?.setValue('{}');
+      this.query.get('referenceDataInputConfig')?.setValue(null);
+      this.query.get('referenceDataInputs')?.setValue(null);
+      this.updateReferenceDataValidity();
+    }
     event.stopPropagation();
   }
 

--- a/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.ts
+++ b/libs/shared/src/lib/components/email/components/dataset-filter/dataset-filter.component.ts
@@ -8,7 +8,13 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import { FormArray, FormControl, FormGroup } from '@angular/forms';
+import {
+  AbstractControl,
+  FormArray,
+  FormControl,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
 import { QueryRef } from 'apollo-angular';
 import { cloneDeep } from 'lodash';
 import {
@@ -347,12 +353,24 @@ export class DatasetFilterComponent
     }
 
     this.setFieldsValidity();
+    if (this.isReferenceData) {
+      this.updateReferenceEmailValidation();
+    }
 
     // Check for individual email checkbox value
     this.query.controls.individualEmail.valueChanges
       .pipe(takeUntil(this.destroy$))
       .subscribe((value: any) => {
-        if (this.isReferenceData) return;
+        if (this.isReferenceData) {
+          if (
+            value === true &&
+            (this.query.get('individualEmailFields') as FormArray).length === 0
+          ) {
+            this.addReferenceEmailField();
+          }
+          this.updateReferenceEmailValidation();
+          return;
+        }
         if (
           value === true &&
           this.selectedFieldsIndividualEmail?.length === 0 &&
@@ -408,7 +426,8 @@ export class DatasetFilterComponent
    */
   onTabSelect(event: any, fromHTML: boolean): void {
     const newIndex = event;
-    const previewTabIndex = 3;
+    const previewTabIndex =
+      this.isReferenceData && this.query.get('individualEmail')?.value ? 4 : 3;
 
     if (this.isReferenceData) {
       this.showDatasetLimitWarning = false;
@@ -938,6 +957,13 @@ export class DatasetFilterComponent
    * @returns FormArray of fields
    */
   getIndividualEmailFieldsArray() {
+    if (this.isReferenceData) {
+      const formArray = this.query.get('individualEmailFields') as FormArray;
+      this.selectedFieldsIndividualEmail = formArray?.value || [];
+      this.updateReferenceEmailValidation();
+      return formArray;
+    }
+
     const formArray = this.query.get('individualEmailFields') as FormArray;
     formArray.controls.forEach((field: any) => {
       if (!field.value.name) {
@@ -981,6 +1007,50 @@ export class DatasetFilterComponent
     }
 
     return formArray;
+  }
+
+  /**
+   * Adds a reference data email path input.
+   */
+  addReferenceEmailField(): void {
+    const formArray = this.query.get('individualEmailFields') as FormArray;
+    formArray.push(new FormControl('', Validators.required));
+    this.updateReferenceEmailValidation();
+  }
+
+  /**
+   * Removes a reference data email path input.
+   *
+   * @param index Control index to remove
+   */
+  removeReferenceEmailField(index: number): void {
+    const formArray = this.query.get('individualEmailFields') as FormArray;
+    if (index >= 0 && index < formArray.length) {
+      formArray.removeAt(index);
+    }
+    this.updateReferenceEmailValidation();
+  }
+
+  /**
+   * Validates reference data separate email configuration.
+   */
+  updateReferenceEmailValidation(): void {
+    if (!this.isReferenceData) return;
+    const formArray = this.query.get('individualEmailFields') as FormArray;
+    const isSeparate = this.query.get('individualEmail').value === true;
+    const hasPath =
+      formArray?.controls?.some(
+        (ctrl: AbstractControl) =>
+          ctrl.value !== null && ctrl.value?.toString().trim().length > 0
+      ) || false;
+
+    if (isSeparate && !hasPath) {
+      this.emailService.disableSaveAndProceed.next(true);
+      this.emailService.disableSaveAsDraft.next(false);
+    } else if (isSeparate) {
+      this.emailService.disableSaveAndProceed.next(false);
+      this.emailService.disableSaveAsDraft.next(false);
+    }
   }
 
   /**

--- a/libs/shared/src/lib/components/email/email.component.ts
+++ b/libs/shared/src/lib/components/email/email.component.ts
@@ -888,6 +888,11 @@ export class EmailComponent extends UnsubscribeComponent implements OnInit {
       resource: new FormControl(ele.resource),
       reference: new FormControl(ele.reference),
       dataType: new FormControl(ele.resource ? 'Resource' : 'Reference Data'),
+      referenceDataVariableMapping: new FormControl(
+        ele.referenceDataVariableMapping
+      ),
+      referenceDataInputConfig: new FormControl(ele.referenceDataInputConfig),
+      referenceDataInputs: new FormControl(ele.referenceDataInputs),
       pageSize: new FormControl(ele.pageSize),
       blockType: new FormControl('table'),
       tableStyle: new FormControl(this.emailService.getTableStyles()),

--- a/libs/shared/src/lib/components/email/email.module.ts
+++ b/libs/shared/src/lib/components/email/email.module.ts
@@ -50,10 +50,13 @@ import { EmsTemplateComponent } from './components/ems-template/ems-template.com
 import { EmptyModule } from '../ui/empty/empty.module';
 import { FilterModule } from '../filter/filter.module';
 import { ResourceSelectComponent } from '../controls/public-api';
+import { ReferenceDataSelectComponent } from '../controls/reference-data-select/reference-data-select.component';
+import { QueryParamsMappingComponent } from '../widgets/common/query-params-mapping/query-params-mapping.component';
 import { CustomTemplateComponent } from './components/custom-templates/custom-template.component';
 import { EmailAttachmentComponent } from './components/email-attachment/email-attachment.component';
 import { CreateDistributionComponent } from './components/create-distribution/create-distribution.component';
 import { PreviewDistributionComponent } from './components/preview-distribution/preview-distribution.component';
+import { SurveyModule } from 'survey-angular-ui';
 
 /**
  * Email module.
@@ -115,8 +118,11 @@ import { PreviewDistributionComponent } from './components/preview-distribution/
     ErrorMessageModule,
     FilterModule,
     ResourceSelectComponent,
+    ReferenceDataSelectComponent,
+    QueryParamsMappingComponent,
     ExpansionPanelModule,
     DialogModule,
+    SurveyModule,
   ],
   schemas: [NO_ERRORS_SCHEMA],
   exports: [

--- a/libs/shared/src/lib/components/email/email.service.ts
+++ b/libs/shared/src/lib/components/email/email.service.ts
@@ -1002,10 +1002,17 @@ export class EmailService {
           datasets.push(dataset.name);
         }
       });
-      const fields: string[] = [];
-      datasetsValues[0].query.fields.forEach((field: any) => {
-        this.appendFields(field, field.name, fields);
-      });
+
+      let fields: string[] = [];
+      const previewEntries = this.getAllPreviewData();
+      const firstPreview = previewEntries?.[0];
+      if (firstPreview?.datasetFields?.length) {
+        fields = firstPreview.datasetFields;
+      } else if (datasetsValues[0]?.query?.fields?.length) {
+        datasetsValues[0].query.fields.forEach((field: any) => {
+          this.appendFields(field, field.name, fields);
+        });
+      }
       this.previewData = {
         datasets: datasets,
         fields: fields,

--- a/libs/shared/src/lib/components/email/email.service.ts
+++ b/libs/shared/src/lib/components/email/email.service.ts
@@ -254,6 +254,11 @@ export class EmailService {
       name: null,
       query: this.createQuerygroup(),
       resource: null,
+      reference: null,
+      dataType: 'Resource',
+      referenceDataVariableMapping: null,
+      referenceDataInputConfig: null,
+      referenceDataInputs: null,
       pageSize: 10,
       tableStyle: this.defaultTableStyle,
       blockType: 'table', // Either Table or Text
@@ -264,8 +269,6 @@ export class EmailService {
       sendAsAttachment: false,
       individualEmail: false,
       individualEmailFields: this.formBuilder.array([]),
-      dataType: null,
-      reference: null,
       navigateToPage: false,
       navigateSettings: this.formBuilder.group({
         title: get('', 'actions.navigateSettings.title', 'Details view'),

--- a/libs/shared/src/lib/components/email/email.service.ts
+++ b/libs/shared/src/lib/components/email/email.service.ts
@@ -991,12 +991,15 @@ export class EmailService {
       const datasetsValues = this.datasetsForm?.get('datasets')?.getRawValue();
       const datasets: string[] = [];
       datasetsValues.forEach((dataset: any) => {
-        if (dataset.query.name && dataset.resource) {
+        const hasResource =
+          dataset.resource && dataset.query && dataset.query.name;
+        const hasReference =
+          dataset.reference &&
+          (dataset.referenceDataVariableMapping ||
+            dataset.referenceDataInputConfig ||
+            dataset.referenceDataInputs);
+        if (hasResource || hasReference) {
           datasets.push(dataset.name);
-        } else {
-          dataset.query.name && dataset.reference
-            ? datasets.push(dataset.name)
-            : '';
         }
       });
       const fields: string[] = [];

--- a/libs/shared/src/lib/components/email/graphql/queries.ts
+++ b/libs/shared/src/lib/components/email/graphql/queries.ts
@@ -218,8 +218,12 @@ export const GET_EMAIL_NOTIFICATIONS = gql`
               filter
               fields
             }
+            dataType
             resource
             reference
+            referenceDataVariableMapping
+            referenceDataInputConfig
+            referenceDataInputs
             tableStyle
             blockType
             textStyle
@@ -259,8 +263,12 @@ export const ADD_EMAIL_NOTIFICATION = gql`
           filter
           fields
         }
+        dataType
         resource
         reference
+        referenceDataVariableMapping
+        referenceDataInputConfig
+        referenceDataInputs
         tableStyle
         blockType
         textStyle
@@ -311,8 +319,12 @@ export const GET_AND_UPDATE_EMAIL_NOTIFICATION = gql`
           filter
           fields
         }
+        dataType
         resource
         reference
+        referenceDataVariableMapping
+        referenceDataInputConfig
+        referenceDataInputs
         tableStyle
         blockType
         textStyle

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -405,13 +405,23 @@ export class LayoutComponent
    * Block Data for Body
    */
   getBlockData() {
-    if (
-      this.emailService.datasetsForm.get('datasets')?.value?.[0]?.query?.fields
-        ?.length > 0
-    ) {
+    const datasets =
+      this.emailService.datasetsForm.get('datasets')?.value || [];
+    const hasConfiguredDataset = datasets.some(
+      (ds: any) =>
+        (ds.resource && ds.query?.fields?.length > 0) ||
+        (ds.reference &&
+          (ds.referenceDataVariableMapping ||
+            ds.referenceDataInputConfig ||
+            ds.referenceDataInputs))
+    );
+
+    if (hasConfiguredDataset) {
       this.blockData =
-        this.emailService.previewData?.datasets ??
-        this.emailService.getAllPreviewData();
+        this.emailService.previewData?.datasets &&
+        this.emailService.previewData.datasets.length
+          ? this.emailService.previewData.datasets
+          : this.emailService.getAllPreviewData();
     } else {
       this.blockData = [];
     }

--- a/libs/ui/src/lib/graphql-select/graphql-select.component.ts
+++ b/libs/ui/src/lib/graphql-select/graphql-select.component.ts
@@ -435,7 +435,11 @@ export class GraphQLSelectComponent
     // focus on search input, if filterable
     if (this.filterable) this.searchInput?.nativeElement.focus();
     const panel =
+      (this.elementRef.nativeElement.querySelector(
+        '#optionList'
+      ) as HTMLElement) ||
       this.shadowDomService.currentHost.getElementById('optionList');
+    if (!panel) return;
     if (this.scrollListener) {
       this.scrollListener();
     }


### PR DESCRIPTION
# Description

This PR allows Reference Data to be used in Email Notifications. The flow for configuring a reference data dataset follows the same process used in dashboards, with variable mapping used to pass query variables. This includes reusing the existing dashboard filters configuration. The values entered into the form inputs created in the dashboard filters configuration are saved and loaded for Email Notification edition. 

An additional change to support this implementation is dynamic date filters for Reference Data. The tokens `{{today}}`, `{{today±n}}`, `{{now}}`, and `{{timeLastExecuted}}` are replaced in the email function app with their corresponding values before querying. This enables scenarios provided by the client that are dependent on the scheduler and reference data.  

## Useful links

- Please insert link to ticket
- Please insert link to back-end branch if any
- Please insert any useful link ( documentation you used for example )

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

These changes have been tested by our internal QA team following scenarios provided by the client. 

## Screenshots

<img width="1175" height="520" alt="image" src="https://github.com/user-attachments/assets/41f9d0ac-1157-4ff4-9415-d6d7450bb6d8" />

- Reference Data selection and variable mapping in dataset configuration

<img width="1881" height="705" alt="image" src="https://github.com/user-attachments/assets/6fccf764-e739-4f64-a25f-c2f065990ca0" />

- Existing dashboard filters configuration used in dataset configuration to configure form inputs for variable mapping.

<img width="1167" height="490" alt="image" src="https://github.com/user-attachments/assets/17ad47c7-10ba-48eb-93bb-d0d608e28a12" />

- Form inputs from dashboard filter in dataset configuration (which persist and load values across Email Notification editions and triggers)

<img width="1217" height="242" alt="image" src="https://github.com/user-attachments/assets/3a976f25-18f8-410d-8819-533ec5e3ff26" />

- Send separate email field configuration for Reference Data using JSONPath expression. 

# Dependencies

- The function app now requires `ENCRYPTION_KEY` added to its environment variables, this is the same key used on the backend to encrypt API configuration settings. 

# Checklist:

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
