### PR TITLE
AB#128603 - ABC - Custom label for form buttons

### DIFF
--- a/libs/shared/jest.config.ts
+++ b/libs/shared/jest.config.ts
@@ -32,5 +32,7 @@ export default {
     '<rootDir>/src/lib/services/html-parser/*.spec.ts',
     '<rootDir>/src/lib/pipes/asset/*.spec.ts',
     '<rootDir>/src/lib/pipes/gradient/*.spec.ts',
+    '<rootDir>/src/lib/survey/global-properties/*.spec.ts',
+    '<rootDir>/src/lib/utils/*.spec.ts',
   ],
 };

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.html
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.html
@@ -71,9 +71,9 @@
         {{ 'common.next' | translate }}
       </ui-button>
     </ng-container>
-    <!-- <ui-button [disabled]="disableSaveAsDraft" (click)="saveAsDraft()">{{
-      'components.form.draftRecords.save' | translate
-    }}</ui-button> -->
+    <ui-button [disabled]="disableSaveAsDraft" (click)="saveAsDraft()">{{
+      saveAsDraftButtonLabel || ('components.form.draftRecords.save' | translate)
+    }}</ui-button>
     <ui-button
       category="secondary"
       variant="primary"
@@ -81,7 +81,7 @@
       (click)="submit()"
       cdkFocusInitial
     >
-      {{ 'components.record.modal.update' | translate }}
+      {{ saveButtonLabel || ('components.record.modal.update' | translate) }}
     </ui-button>
   </ng-container>
 </ui-dialog>

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.html
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.html
@@ -72,7 +72,7 @@
       </ui-button>
     </ng-container>
     <ui-button [disabled]="disableSaveAsDraft" (click)="saveAsDraft()">{{
-      saveAsDraftButtonLabel || ('components.form.draftRecords.save' | translate)
+      modalSaveAsDraftButtonLabel || ('components.form.draftRecords.save' | translate)
     }}</ui-button>
     <ui-button
       category="secondary"
@@ -81,7 +81,7 @@
       (click)="submit()"
       cdkFocusInitial
     >
-      {{ saveButtonLabel || ('components.record.modal.update' | translate) }}
+      {{ modalSaveButtonLabel || ('components.record.modal.update' | translate) }}
     </ui-button>
   </ng-container>
 </ui-dialog>

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -46,6 +46,7 @@ import { RecordSummaryModule } from '../record-summary/record-summary.module';
 import { UnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component';
 import { ADD_RECORD, EDIT_RECORD, EDIT_RECORDS } from './graphql/mutations';
 import { GET_FORM_BY_ID, GET_RECORD_BY_ID } from './graphql/queries';
+import { getSurveyFormActionButtonLabels } from '../../utils/survey-form-action-labels.util';
 
 /**
  * Interface of Dialog data.
@@ -118,6 +119,10 @@ export class FormModalComponent
   public pages$ = this.pages.asObservable();
   /** Is multi edition of records enabled ( for grid actions ) */
   protected isMultiEdition = false;
+  /** Evaluated label for the save button (from form expression or default translation) */
+  public saveButtonLabel = '';
+  /** Evaluated label for the save as draft button */
+  public saveAsDraftButtonLabel = '';
   /** Temporary storage of files */
   protected temporaryFilesStorage: any = {};
   /** Stored cloned data */
@@ -297,9 +302,11 @@ export class FormModalComponent
       this.record
     );
 
+    this.updateButtonLabels();
     this.survey.onValueChanged.add(() => {
       // Allow user to save as draft
       this.disableSaveAsDraft = false;
+      this.updateButtonLabels();
     });
     this.survey.onComplete.add(this.onComplete);
 
@@ -317,7 +324,6 @@ export class FormModalComponent
       const resourceNames = new Set(resourcesFields.map((f) => f.name));
       // Omit nil values and resources questions from prefill data
       const cleanedData = omitBy(this.prefillClonedData, (value, key) => {
-        console.log({ key, value });
         return isNil(value) || resourceNames.has(key);
       });
       Object.keys(cleanedData).forEach((question) => {
@@ -349,7 +355,20 @@ export class FormModalComponent
       });
     }
 
+    // Bulk survey.data changes (e.g. multi-edition) do not fire onValueChanged
+    this.updateButtonLabels();
+
     this.loading = false;
+  }
+
+  /**
+   * Evaluates all action button label expressions from the survey settings.
+   * Falls back to an empty string (template will use the default translation key).
+   */
+  private updateButtonLabels(): void {
+    const labels = getSurveyFormActionButtonLabels(this.survey);
+    this.saveButtonLabel = labels.saveButtonLabel;
+    this.saveAsDraftButtonLabel = labels.saveAsDraftButtonLabel;
   }
 
   /**

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -119,10 +119,10 @@ export class FormModalComponent
   public pages$ = this.pages.asObservable();
   /** Is multi edition of records enabled ( for grid actions ) */
   protected isMultiEdition = false;
-  /** Evaluated label for the save button (from form expression or default translation) */
-  public saveButtonLabel = '';
-  /** Evaluated label for the save as draft button */
-  public saveAsDraftButtonLabel = '';
+  /** Evaluated label for the modal save button */
+  public modalSaveButtonLabel = '';
+  /** Evaluated label for the modal save as draft button */
+  public modalSaveAsDraftButtonLabel = '';
   /** Temporary storage of files */
   protected temporaryFilesStorage: any = {};
   /** Stored cloned data */
@@ -367,8 +367,8 @@ export class FormModalComponent
    */
   private updateButtonLabels(): void {
     const labels = getSurveyFormActionButtonLabels(this.survey);
-    this.saveButtonLabel = labels.saveButtonLabel;
-    this.saveAsDraftButtonLabel = labels.saveAsDraftButtonLabel;
+    this.modalSaveButtonLabel = labels.modalSaveButtonLabel;
+    this.modalSaveAsDraftButtonLabel = labels.modalSaveAsDraftButtonLabel;
   }
 
   /**

--- a/libs/shared/src/lib/components/form/form.component.html
+++ b/libs/shared/src/lib/components/form/form.component.html
@@ -55,11 +55,11 @@
           >{{ 'common.next' | translate }}</ui-button
         >
       </ng-container>
-      <!-- <ui-button [disabled]="disableSaveAsDraft" (click)="saveAsDraft()">{{
-        'components.form.draftRecords.save' | translate
-      }}</ui-button> -->
+      <ui-button [disabled]="disableSaveAsDraft" (click)="saveAsDraft()">{{
+        saveAsDraftButtonLabel || ('components.form.draftRecords.save' | translate)
+      }}</ui-button>
       <ui-button variant="primary" category="secondary" (click)="submit()">{{
-        'common.save' | translate
+        saveButtonLabel || ('common.save' | translate)
       }}</ui-button>
     </div>
   </ui-fixed-wrapper>

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -28,6 +28,7 @@ import { UnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component
 import { FormHelpersService } from '../../services/form-helper/form-helper.service';
 import { SnackbarService, UILayoutService } from '@oort-front/ui';
 import { isNil } from 'lodash';
+import { getSurveyFormActionButtonLabels } from '../../utils/survey-form-action-labels.util';
 
 /**
  * This component is used to display forms
@@ -76,6 +77,10 @@ export class FormComponent
   public lastDraftRecord?: string;
   /** Disables the save as draft button */
   public disableSaveAsDraft = false;
+  /** Evaluated label for the save button (from form expression or default translation) */
+  public saveButtonLabel = '';
+  /** Evaluated label for the save as draft button */
+  public saveAsDraftButtonLabel = '';
   /** Timeout for reset survey */
   private resetTimeoutListener!: NodeJS.Timeout;
   /** As we save the draft record in the db, the local storage is no longer used */
@@ -128,12 +133,14 @@ export class FormComponent
     );
 
     this.survey.showCompletedPage = false;
+    this.updateButtonLabels();
     if (!this.record && !this.form.canCreateRecords) {
       this.survey.mode = 'display';
     }
     this.survey.onValueChanged.add(() => {
       // Allow user to save as draft
       this.disableSaveAsDraft = false;
+      this.updateButtonLabels();
     });
     this.survey.onComplete.add(() => {
       this.onComplete();
@@ -182,6 +189,8 @@ export class FormComponent
       this.survey.data = this.record.data;
       this.modifiedAt = this.record.modifiedAt || null;
     }
+    // survey.data does not fire onValueChanged; refresh expression-based button labels
+    this.updateButtonLabels();
 
     // if (this.survey.getUsedLocales().length > 1) {
     //   this.survey.getUsedLocales().forEach((lang) => {
@@ -204,6 +213,16 @@ export class FormComponent
   }
 
   /**
+   * Evaluates all action button label expressions from the survey settings.
+   * Falls back to an empty string (template will use the default translation key).
+   */
+  private updateButtonLabels(): void {
+    const labels = getSurveyFormActionButtonLabels(this.survey);
+    this.saveButtonLabel = labels.saveButtonLabel;
+    this.saveAsDraftButtonLabel = labels.saveAsDraftButtonLabel;
+  }
+
+  /**
    * Reset the survey to empty
    */
   public reset(): void {
@@ -216,6 +235,7 @@ export class FormComponent
     /** Force reload of the survey so default value are being applied */
     this.survey.fromJSON(this.survey.toJSON());
     this.survey.showCompletedPage = false;
+    this.updateButtonLabels();
     this.save.emit({ completed: false });
     if (this.resetTimeoutListener) {
       clearTimeout(this.resetTimeoutListener);
@@ -386,6 +406,7 @@ export class FormComponent
     } else {
       this.survey.clear();
     }
+    this.updateButtonLabels();
     this.formHelpersService.clearTemporaryFilesStorage(
       this.temporaryFilesStorage
     );

--- a/libs/shared/src/lib/survey/global-properties/others.spec.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.spec.ts
@@ -1,0 +1,90 @@
+import { JsonObjectProperty, Serializer } from 'survey-core';
+import {
+  SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL,
+  SURVEY_PROP_MODAL_SAVE_AS_DRAFT_BUTTON_LABEL,
+} from '../../utils/survey-form-action-labels.util';
+import { init } from './others';
+
+type SurveyPropertyOwner = {
+  getPropertyValue: (propertyName: string) => string;
+  [key: string]: unknown;
+};
+
+/**
+ * Create a minimal survey-like object for serializer property visibility tests.
+ *
+ * @param propertyValues Survey-level property values
+ * @returns Object exposing getPropertyValue for SurveyJS property callbacks
+ */
+const createSurveyPropertyOwner = (
+  propertyValues: Partial<Record<string, string>> = {}
+): SurveyPropertyOwner =>
+  ({
+    getPropertyValue: (propertyName: string) =>
+      propertyValues[propertyName] || '',
+  } as SurveyPropertyOwner);
+
+describe('survey global navigation properties', () => {
+  let modalSaveButtonProperty: JsonObjectProperty;
+  let modalSaveAsDraftButtonProperty: JsonObjectProperty;
+  let modalLabelOverridesToggleProperty: JsonObjectProperty;
+
+  beforeAll(() => {
+    init({ apiUrl: '', csApiUrl: '' });
+    modalSaveButtonProperty = Serializer.getProperty(
+      'survey',
+      SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL
+    );
+    modalSaveAsDraftButtonProperty = Serializer.getProperty(
+      'survey',
+      SURVEY_PROP_MODAL_SAVE_AS_DRAFT_BUTTON_LABEL
+    );
+    modalLabelOverridesToggleProperty = Serializer.getProperty(
+      'survey',
+      'showAdvancedNavigationLabelOverrides'
+    );
+  });
+
+  it('registers modal navigation override properties in the navigation category', () => {
+    expect(modalLabelOverridesToggleProperty).toBeTruthy();
+    expect(modalLabelOverridesToggleProperty.category).toBe('navigation');
+    expect(modalLabelOverridesToggleProperty.isSerializable).toBe(false);
+
+    expect(modalSaveButtonProperty).toBeTruthy();
+    expect(modalSaveButtonProperty.category).toBe('navigation');
+
+    expect(modalSaveAsDraftButtonProperty).toBeTruthy();
+    expect(modalSaveAsDraftButtonProperty.category).toBe('navigation');
+  });
+
+  it('hides modal override properties by default', () => {
+    const survey = createSurveyPropertyOwner();
+
+    expect(modalSaveButtonProperty.visibleIf(survey)).toBe(false);
+    expect(modalSaveAsDraftButtonProperty.visibleIf(survey)).toBe(false);
+  });
+
+  it('shows modal override properties when the advanced toggle is enabled', () => {
+    const survey = createSurveyPropertyOwner();
+
+    modalLabelOverridesToggleProperty.onSetValue(
+      survey,
+      true,
+      undefined as any
+    );
+
+    expect(modalSaveButtonProperty.visibleIf(survey)).toBe(true);
+    expect(modalSaveAsDraftButtonProperty.visibleIf(survey)).toBe(true);
+  });
+
+  it('keeps modal override properties visible when override values already exist', () => {
+    const survey = createSurveyPropertyOwner({
+      [SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL]: 'Update record',
+      [SURVEY_PROP_MODAL_SAVE_AS_DRAFT_BUTTON_LABEL]: 'Update draft',
+    });
+
+    expect(modalLabelOverridesToggleProperty.onGetValue(survey)).toBe(true);
+    expect(modalSaveButtonProperty.visibleIf(survey)).toBe(true);
+    expect(modalSaveAsDraftButtonProperty.visibleIf(survey)).toBe(true);
+  });
+});

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -8,6 +8,10 @@ import {
 } from 'survey-core';
 import { registerCustomPropertyEditor } from '../components/utils/component-register';
 import { CustomPropertyGridComponentTypes } from '../components/utils/components.enum';
+import {
+  SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL,
+  SURVEY_PROP_SAVE_BUTTON_LABEL,
+} from '../../utils/survey-form-action-labels.util';
 import { Question } from '../types';
 
 /**
@@ -127,6 +131,24 @@ export const init = (environment: any): void => {
     visibleIndex: -1,
     category: 'logic',
     default: '',
+  });
+
+  // Add custom label expressions for the form action buttons
+  serializer.addProperty('survey', {
+    name: SURVEY_PROP_SAVE_BUTTON_LABEL,
+    type: 'expression',
+    category: 'navigation',
+    visibleIndex: 100,
+    default: '',
+    isLocalizable: false,
+  });
+  serializer.addProperty('survey', {
+    name: SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL,
+    type: 'expression',
+    category: 'navigation',
+    visibleIndex: 101,
+    default: '',
+    isLocalizable: false,
   });
 };
 

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -9,10 +9,52 @@ import {
 import { registerCustomPropertyEditor } from '../components/utils/component-register';
 import { CustomPropertyGridComponentTypes } from '../components/utils/components.enum';
 import {
+  SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL,
+  SURVEY_PROP_MODAL_SAVE_AS_DRAFT_BUTTON_LABEL,
   SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL,
   SURVEY_PROP_SAVE_BUTTON_LABEL,
 } from '../../utils/survey-form-action-labels.util';
 import { Question } from '../types';
+
+type SurveyPropertyOwner = {
+  getPropertyValue: (propertyName: string) => unknown;
+  [key: string]: unknown;
+};
+
+/** Property-grid toggle used to reveal modal-specific label overrides. */
+const ADVANCED_NAVIGATION_LABEL_OVERRIDES_PROPERTY =
+  'showAdvancedNavigationLabelOverrides';
+/** In-memory state key for the advanced navigation toggle. */
+const ADVANCED_NAVIGATION_LABEL_OVERRIDES_STATE =
+  '__showAdvancedNavigationLabelOverrides';
+
+/**
+ * Whether any modal-specific action label override is already configured.
+ *
+ * @param obj Survey property owner
+ * @returns True when at least one modal override has a value
+ */
+const hasModalActionButtonLabelOverrides = (
+  obj?: SurveyPropertyOwner
+): boolean =>
+  Boolean(
+    obj?.getPropertyValue(SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL) ||
+      obj?.getPropertyValue(SURVEY_PROP_MODAL_SAVE_AS_DRAFT_BUTTON_LABEL)
+  );
+
+/**
+ * Whether modal-specific navigation overrides should be visible in the property grid.
+ *
+ * @param obj Survey property owner
+ * @returns True when the advanced toggle is opened or override values already exist
+ */
+const shouldShowAdvancedNavigationLabelOverrides = (
+  obj?: SurveyPropertyOwner
+): boolean =>
+  Boolean(
+    obj?.[ADVANCED_NAVIGATION_LABEL_OVERRIDES_STATE] ||
+      hasModalActionButtonLabelOverrides(obj)
+  );
 
 /**
  * Add support for custom properties to the survey
@@ -149,6 +191,44 @@ export const init = (environment: any): void => {
     visibleIndex: 101,
     default: '',
     isLocalizable: false,
+  });
+  serializer.addProperty('survey', {
+    name: `${ADVANCED_NAVIGATION_LABEL_OVERRIDES_PROPERTY}:boolean`,
+    type: 'boolean',
+    category: 'navigation',
+    visibleIndex: 102,
+    displayName: 'Modal Label Overrides',
+    default: false,
+    isSerializable: false,
+    onGetValue: (obj: SurveyPropertyOwner) =>
+      shouldShowAdvancedNavigationLabelOverrides(obj),
+    onSetValue: (obj: SurveyPropertyOwner, value: boolean) => {
+      obj[ADVANCED_NAVIGATION_LABEL_OVERRIDES_STATE] = value;
+    },
+  });
+  serializer.addProperty('survey', {
+    name: SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL,
+    type: 'expression',
+    category: 'navigation',
+    visibleIndex: 103,
+    displayName: 'Modal save label override',
+    description:
+      'Only used when the form is opened in a modal. Falls back to the regular save label if empty.',
+    default: '',
+    isLocalizable: false,
+    visibleIf: shouldShowAdvancedNavigationLabelOverrides,
+  });
+  serializer.addProperty('survey', {
+    name: SURVEY_PROP_MODAL_SAVE_AS_DRAFT_BUTTON_LABEL,
+    type: 'expression',
+    category: 'navigation',
+    visibleIndex: 104,
+    displayName: 'Modal save as draft label override',
+    description:
+      'Only used when the form is opened in a modal. Falls back to the regular save as draft label if empty.',
+    default: '',
+    isLocalizable: false,
+    visibleIf: shouldShowAdvancedNavigationLabelOverrides,
   });
 };
 

--- a/libs/shared/src/lib/utils/survey-form-action-labels.util.spec.ts
+++ b/libs/shared/src/lib/utils/survey-form-action-labels.util.spec.ts
@@ -1,0 +1,157 @@
+import { SurveyModel } from 'survey-core';
+import {
+  evaluateSurveyActionButtonLabel,
+  getSurveyFormActionButtonLabels,
+  SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL,
+  SURVEY_PROP_MODAL_SAVE_AS_DRAFT_BUTTON_LABEL,
+  SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL,
+  SURVEY_PROP_SAVE_BUTTON_LABEL,
+} from './survey-form-action-labels.util';
+
+type SurveyProperties = Partial<Record<string, string>>;
+
+/**
+ * Create a minimal survey mock for action label evaluation tests.
+ *
+ * @param properties Survey-level properties returned by getPropertyValue
+ * @param runExpression Mocked survey expression evaluator
+ * @returns Survey model mock with the methods used by the utility
+ */
+const createSurveyMock = (
+  properties: SurveyProperties,
+  runExpression = jest.fn()
+): SurveyModel =>
+  ({
+    getPropertyValue: (propertyName: string) => properties[propertyName],
+    runExpression,
+  } as unknown as SurveyModel);
+
+describe('survey form action labels utility', () => {
+  describe('evaluateSurveyActionButtonLabel', () => {
+    it('returns an empty string when the property is not set', () => {
+      const survey = createSurveyMock({});
+
+      expect(
+        evaluateSurveyActionButtonLabel(survey, SURVEY_PROP_SAVE_BUTTON_LABEL)
+      ).toBe('');
+    });
+
+    it('returns a static label without evaluating it', () => {
+      const runExpression = jest.fn();
+      const survey = createSurveyMock(
+        {
+          [SURVEY_PROP_SAVE_BUTTON_LABEL]: 'Save changes',
+        },
+        runExpression
+      );
+
+      expect(
+        evaluateSurveyActionButtonLabel(survey, SURVEY_PROP_SAVE_BUTTON_LABEL)
+      ).toBe('Save changes');
+      expect(runExpression).not.toHaveBeenCalled();
+    });
+
+    it('evaluates expression-based labels', () => {
+      const runExpression = jest.fn().mockReturnValue('Continue editing');
+      const expression =
+        "iif({status} = 'draft', 'Continue editing', 'Save form')";
+      const survey = createSurveyMock(
+        {
+          [SURVEY_PROP_SAVE_BUTTON_LABEL]: expression,
+        },
+        runExpression
+      );
+
+      expect(
+        evaluateSurveyActionButtonLabel(survey, SURVEY_PROP_SAVE_BUTTON_LABEL)
+      ).toBe('Continue editing');
+      expect(runExpression).toHaveBeenCalledWith(expression);
+    });
+
+    it('falls back to the configured expression when evaluation throws', () => {
+      const expression =
+        "iif({status} = 'draft', 'Continue editing', 'Save form')";
+      const survey = createSurveyMock(
+        {
+          [SURVEY_PROP_SAVE_BUTTON_LABEL]: expression,
+        },
+        jest.fn(() => {
+          throw new Error('Expression error');
+        })
+      );
+
+      expect(
+        evaluateSurveyActionButtonLabel(survey, SURVEY_PROP_SAVE_BUTTON_LABEL)
+      ).toBe(expression);
+    });
+
+    it('falls back to the configured expression when evaluation is not a string', () => {
+      const expression =
+        "iif({status} = 'draft', 'Continue editing', 'Save form')";
+      const survey = createSurveyMock(
+        {
+          [SURVEY_PROP_SAVE_BUTTON_LABEL]: expression,
+        },
+        jest.fn().mockReturnValue(true)
+      );
+
+      expect(
+        evaluateSurveyActionButtonLabel(survey, SURVEY_PROP_SAVE_BUTTON_LABEL)
+      ).toBe(expression);
+    });
+  });
+
+  describe('getSurveyFormActionButtonLabels', () => {
+    it('falls back to the form save label when the modal label is empty', () => {
+      const saveExpression = "iif({status} = 'draft', 'Save draft', 'Save')";
+      const runExpression = jest.fn((expression: string) => {
+        if (expression === saveExpression) return 'Save draft';
+        return expression;
+      });
+      const survey = createSurveyMock(
+        {
+          [SURVEY_PROP_SAVE_BUTTON_LABEL]: saveExpression,
+          [SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL]: 'Save as draft',
+        },
+        runExpression
+      );
+
+      expect(getSurveyFormActionButtonLabels(survey)).toEqual({
+        saveButtonLabel: 'Save draft',
+        modalSaveButtonLabel: 'Save draft',
+        saveAsDraftButtonLabel: 'Save as draft',
+        modalSaveAsDraftButtonLabel: 'Save as draft',
+      });
+    });
+
+    it('uses dedicated modal labels when they are configured', () => {
+      const saveExpression = "iif({status} = 'draft', 'Save draft', 'Save')";
+      const modalExpression =
+        "iif({status} = 'draft', 'Update draft', 'Update record')";
+      const draftExpression =
+        "iif({status} = 'draft', 'Update saved draft', 'Save as draft')";
+      const runExpression = jest.fn((expression: string) => {
+        if (expression === saveExpression) return 'Save';
+        if (expression === modalExpression) return 'Update record';
+        if (expression === draftExpression) return 'Update saved draft';
+        return expression;
+      });
+      const survey = createSurveyMock(
+        {
+          [SURVEY_PROP_SAVE_BUTTON_LABEL]: saveExpression,
+          [SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL]: modalExpression,
+          [SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL]: 'Save as draft',
+          [SURVEY_PROP_MODAL_SAVE_AS_DRAFT_BUTTON_LABEL]: draftExpression,
+        },
+        runExpression
+      );
+
+      expect(getSurveyFormActionButtonLabels(survey)).toEqual({
+        saveButtonLabel: 'Save',
+        modalSaveButtonLabel: 'Update record',
+        saveAsDraftButtonLabel: 'Save as draft',
+        modalSaveAsDraftButtonLabel: 'Update saved draft',
+      });
+    });
+  });
+});

--- a/libs/shared/src/lib/utils/survey-form-action-labels.util.ts
+++ b/libs/shared/src/lib/utils/survey-form-action-labels.util.ts
@@ -3,8 +3,15 @@ import { SurveyModel } from 'survey-core';
 /** Serializer property: primary save action label expression. */
 export const SURVEY_PROP_SAVE_BUTTON_LABEL = 'saveButtonLabel';
 
+/** Serializer property: modal save action label expression. */
+export const SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL = 'modalSaveButtonLabel';
+
 /** Serializer property: save-as-draft action label expression. */
 export const SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL = 'saveAsDraftButtonLabel';
+
+/** Serializer property: modal save-as-draft action label expression. */
+export const SURVEY_PROP_MODAL_SAVE_AS_DRAFT_BUTTON_LABEL =
+  'modalSaveAsDraftButtonLabel';
 
 /**
  * Evaluates a single form action button label from survey-level expression settings.
@@ -38,16 +45,33 @@ export function evaluateSurveyActionButtonLabel(
  */
 export function getSurveyFormActionButtonLabels(survey: SurveyModel): {
   saveButtonLabel: string;
+  modalSaveButtonLabel: string;
   saveAsDraftButtonLabel: string;
+  modalSaveAsDraftButtonLabel: string;
 } {
+  const saveButtonLabel = evaluateSurveyActionButtonLabel(
+    survey,
+    SURVEY_PROP_SAVE_BUTTON_LABEL
+  );
+  const modalSaveButtonLabel =
+    evaluateSurveyActionButtonLabel(
+      survey,
+      SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL
+    ) || saveButtonLabel;
+  const saveAsDraftButtonLabel = evaluateSurveyActionButtonLabel(
+    survey,
+    SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL
+  );
+  const modalSaveAsDraftButtonLabel =
+    evaluateSurveyActionButtonLabel(
+      survey,
+      SURVEY_PROP_MODAL_SAVE_AS_DRAFT_BUTTON_LABEL
+    ) || saveAsDraftButtonLabel;
+
   return {
-    saveButtonLabel: evaluateSurveyActionButtonLabel(
-      survey,
-      SURVEY_PROP_SAVE_BUTTON_LABEL
-    ),
-    saveAsDraftButtonLabel: evaluateSurveyActionButtonLabel(
-      survey,
-      SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL
-    ),
+    saveButtonLabel,
+    modalSaveButtonLabel,
+    saveAsDraftButtonLabel,
+    modalSaveAsDraftButtonLabel,
   };
 }

--- a/libs/shared/src/lib/utils/survey-form-action-labels.util.ts
+++ b/libs/shared/src/lib/utils/survey-form-action-labels.util.ts
@@ -1,0 +1,53 @@
+import { SurveyModel } from 'survey-core';
+
+/** Serializer property: primary save action label expression. */
+export const SURVEY_PROP_SAVE_BUTTON_LABEL = 'saveButtonLabel';
+
+/** Serializer property: save-as-draft action label expression. */
+export const SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL = 'saveAsDraftButtonLabel';
+
+/**
+ * Evaluates a single form action button label from survey-level expression settings.
+ *
+ * @param survey Active survey model
+ * @param propertyName Serializer property name (e.g. saveButtonLabel)
+ * @returns Evaluated label, or empty string if unset (template uses default i18n)
+ */
+export function evaluateSurveyActionButtonLabel(
+  survey: SurveyModel,
+  propertyName: string
+): string {
+  const expression = survey.getPropertyValue(propertyName);
+  if (!expression) return '';
+  if (expression.includes('{')) {
+    try {
+      const result = survey.runExpression(expression);
+      return typeof result === 'string' && result ? result : expression;
+    } catch {
+      return expression;
+    }
+  }
+  return expression;
+}
+
+/**
+ * Evaluates save / save-as-draft button labels from the survey settings.
+ *
+ * @param survey Active survey model
+ * @returns Evaluated labels (empty strings fall back to default i18n in templates)
+ */
+export function getSurveyFormActionButtonLabels(survey: SurveyModel): {
+  saveButtonLabel: string;
+  saveAsDraftButtonLabel: string;
+} {
+  return {
+    saveButtonLabel: evaluateSurveyActionButtonLabel(
+      survey,
+      SURVEY_PROP_SAVE_BUTTON_LABEL
+    ),
+    saveAsDraftButtonLabel: evaluateSurveyActionButtonLabel(
+      survey,
+      SURVEY_PROP_SAVE_AS_DRAFT_BUTTON_LABEL
+    ),
+  };
+}


### PR DESCRIPTION
# Description

Forms were always using the same save and draft labels, including when the same form was opened inline or in a modal. Admins can now configure normal text or SurveyJS-style expressions for both actions in the Form Builder, with separate modal overrides available under Navigation > Advanced so labels like “Save and Send” or “Update draft” can change based on answers such as status, while still falling back to the existing translated defaults when no custom value is set.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# Screenshots

<img width="2555" height="1362" alt="image" src="https://github.com/user-attachments/assets/fc4263ae-8b31-4cf8-ad30-df4e8a436973" />

<img width="2167" height="1066" alt="image" src="https://github.com/user-attachments/assets/8f802b86-5fc2-46be-bcba-90aee6161559" />

To change a form's labels

<img width="2136" height="965" alt="image" src="https://github.com/user-attachments/assets/6b0409aa-572d-4e3d-84a6-3fdc75d0ce6f" />

<img width="2100" height="853" alt="image" src="https://github.com/user-attachments/assets/76f88c84-12fa-47ce-b9fe-157991ba5137" />

<img width="2187" height="1224" alt="image" src="https://github.com/user-attachments/assets/582d240d-9c6e-4a16-b953-dca9ef1190d6" />

To change a form's modal Labels

<img width="2104" height="1052" alt="image" src="https://github.com/user-attachments/assets/0a5a1f01-82b6-47ec-9e51-d1032f7734ec" />

<img width="2552" height="1341" alt="image" src="https://github.com/user-attachments/assets/d4a02bbe-7d82-4166-aa1d-9bc2db112a3b" />

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules