### PR TITLE
AB#128626 - ABC - prevent read-only grids in froms to display any data if filter is empty

### DIFF
--- a/libs/shared/jest.config.ts
+++ b/libs/shared/jest.config.ts
@@ -32,5 +32,6 @@ export default {
     '<rootDir>/src/lib/services/html-parser/*.spec.ts',
     '<rootDir>/src/lib/pipes/asset/*.spec.ts',
     '<rootDir>/src/lib/pipes/gradient/*.spec.ts',
+    '<rootDir>/src/lib/survey/components/resources.spec.ts',
   ],
 };

--- a/libs/shared/src/lib/survey/components/resources.spec.ts
+++ b/libs/shared/src/lib/survey/components/resources.spec.ts
@@ -1,0 +1,153 @@
+import { Dialog } from '@angular/cdk/dialog';
+import { Injector, NgZone } from '@angular/core';
+import { Apollo } from 'apollo-angular';
+import { Subject } from 'rxjs';
+import { DomService } from '../../services/dom/dom.service';
+import { init } from './resources';
+import { processNewCreatedRecords } from './utils';
+
+/** Flushes pending microtasks and the next queued timer. */
+const flushAsyncTasks = async () => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+jest.mock('./utils', () => ({
+  buildAddButton: jest.fn(() => document.createElement('button')),
+  buildSearchButton: jest.fn(() => document.createElement('button')),
+  processNewCreatedRecords: jest.fn(),
+  setUpActionsButtonWrapper: jest.fn(() => document.createElement('div')),
+}));
+
+jest.mock('./utils/component-register', () => ({
+  registerCustomPropertyEditor: jest.fn(),
+}));
+
+jest.mock('../../components/ui/core-grid/core-grid.component', () => ({
+  CoreGridComponent: jest.fn(),
+}));
+
+jest.mock('survey-core', () => {
+  const actual = jest.requireActual('survey-core');
+
+  return {
+    ...actual,
+    ConditionRunner: jest.fn().mockImplementation(() => ({
+      run: jest.fn(() => true),
+    })),
+  };
+});
+
+describe('resources question', () => {
+  const mockedProcessNewCreatedRecords =
+    processNewCreatedRecords as jest.MockedFunction<
+      typeof processNewCreatedRecords
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+    mockedProcessNewCreatedRecords.mockResolvedValue({
+      query: {
+        temporaryRecords: [],
+      },
+    } as any);
+  });
+
+  it('should force an empty filter when clearIf matches on a display-only grid', async () => {
+    const componentCollection = {
+      add: jest.fn(),
+    };
+
+    const gridInstance = {
+      configureGrid: jest.fn(),
+      removeRowIds: new Subject<string[]>(),
+      selectionChange: new Subject<unknown>(),
+      settings: {} as {
+        query?: {
+          filter?: unknown;
+        };
+      },
+    };
+
+    const domService = {
+      appendComponentToBody: jest.fn(() => ({
+        instance: gridInstance,
+      })),
+      removeComponentFromBody: jest.fn(),
+    };
+
+    const injector = {
+      get: jest.fn((token: unknown) => {
+        if (token === DomService) {
+          return domService;
+        }
+
+        if (token === Apollo || token === Dialog) {
+          return {};
+        }
+
+        return null;
+      }),
+    } as unknown as Injector;
+
+    init(injector, componentCollection as any, {} as NgZone, document);
+
+    const component = componentCollection.add.mock.calls[0][0];
+    const content = document.createElement('div');
+    content.className = 'sd-question__content';
+    content.appendChild(document.createElement('div'));
+
+    const element = document.createElement('div');
+    element.appendChild(content);
+    document.body.appendChild(element);
+
+    const question = {
+      canSearch: false,
+      customFilter: '',
+      displayAsGrid: true,
+      displayOnly: true,
+      getPropertyValue: jest.fn((property: string) =>
+        property === 'clearIf' ? '{dependentQuestion} empty' : ''
+      ),
+      gridFieldsSettings: undefined,
+      onSelect: '',
+      readOnly: false,
+      registerFunctionOnPropertiesValueChanged: jest.fn(),
+      registerFunctionOnPropertyValueChanged: jest.fn(),
+      resource: 'resource-id',
+      survey: {
+        mode: 'display',
+        getFilteredProperties: jest.fn(() => []),
+        getFilteredValues: jest.fn(() => ({ dependentQuestion: null })),
+        onValueChanged: {
+          add: jest.fn(),
+        },
+      },
+      value: [],
+    };
+
+    component.onAfterRender(question as any, element);
+    await flushAsyncTasks();
+    await flushAsyncTasks();
+
+    const settings = gridInstance.settings as unknown as {
+      query: {
+        filter: unknown;
+      };
+    };
+
+    expect(domService.appendComponentToBody).toHaveBeenCalled();
+    expect(settings.query.filter).toEqual({
+      logic: 'and',
+      filters: [
+        {
+          field: 'ids',
+          operator: 'eq',
+          value: [],
+        },
+      ],
+    });
+    expect(gridInstance.configureGrid).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -804,10 +804,7 @@ export const init = (
       if (clearIfExpression) {
         const survey = question.survey as SurveyModel;
         const conditionRunner = new ConditionRunner(clearIfExpression);
-        const shouldClear = conditionRunner.run(
-          survey.getFilteredValues(),
-          survey.getFilteredProperties()
-        );
+        const shouldClear = conditionRunner.run(survey.data);
         if (shouldClear) {
           // Force an empty result
           settings.query.filter = {

--- a/libs/shared/src/lib/survey/components/resources.ts
+++ b/libs/shared/src/lib/survey/components/resources.ts
@@ -10,6 +10,7 @@ import { isEqual, isNil } from 'lodash';
 import get from 'lodash/get';
 import {
   ComponentCollection,
+  ConditionRunner,
   ExpressionRunner,
   JsonObject,
   Serializer,
@@ -797,6 +798,38 @@ export const init = (
       temporaryRecordsForm.setValue(settings.query.temporaryRecords);
     }
     if (question.displayOnly) {
+      // Evaluate the "clear if" expression to determine whether the grid
+      // should fetch data. Skip the query and show an empty grid if true.
+      const clearIfExpression = question.getPropertyValue('clearIf');
+      if (clearIfExpression) {
+        const survey = question.survey as SurveyModel;
+        const conditionRunner = new ConditionRunner(clearIfExpression);
+        const shouldClear = conditionRunner.run(
+          survey.getFilteredValues(),
+          survey.getFilteredProperties()
+        );
+        if (shouldClear) {
+          // Force an empty result
+          settings.query.filter = {
+            logic: 'and',
+            filters: [
+              {
+                field: 'ids',
+                operator: 'eq',
+                value: [],
+              },
+            ],
+          };
+          Promise.allSettled(promises).then(() => {
+            if (!isEqual(instance.settings, settings)) {
+              instance.settings = settings;
+              instance.configureGrid();
+            }
+          });
+          return;
+        }
+      }
+
       const filters: any[] = [];
 
       if (question.filters) {


### PR DESCRIPTION
# Description

Display-only grid questions would fetch and display all records with empty filters. Added a ConditionRunner check at the start of the display-only grid data loading path: if clearIf evaluates to true, the query is short-circuited and an empty ids filter is injected instead, resulting in an empty grid without hitting the backend for real data.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

## Screenshots

<img width="2184" height="891" alt="image" src="https://github.com/user-attachments/assets/76ef52a1-057c-4a12-80bb-9871b2008a61" />

<img width="2163" height="1150" alt="image" src="https://github.com/user-attachments/assets/933a2c07-f4e4-4609-862b-e58ca7ee3ffd" />

<img width="2144" height="989" alt="image" src="https://github.com/user-attachments/assets/ef1609aa-1e60-40b5-b21b-402d387ecaba" />

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules