### PR TITLE
AB#128605 Add vars for incrementalid, id and displayField

### DIFF
--- a/libs/shared/src/lib/services/reference-data/reference-data.service.ts
+++ b/libs/shared/src/lib/services/reference-data/reference-data.service.ts
@@ -107,6 +107,36 @@ export class ReferenceDataService {
   }
 
   /**
+   * Asynchronously fetch choices from ReferenceData and return them in the right format for a selectable questions.
+   * Return the choice corresponding to the referenceDataValue passed.
+   *
+   * @param referenceDataValue ReferenceData specific value to obtain.
+   * @param referenceDataID ReferenceData ID.
+   * @param displayField Field used for display in the question.
+   * @param storePrimitiveValue Whether to store the whole item or only the primitive value given the displayField
+   * @param graphQLVariables optional graphql variables, built from form value
+   * @returns Promised choice.
+   */
+  async getChoice(
+    referenceDataValue: string,
+    referenceDataID: string,
+    displayField: string,
+    storePrimitiveValue = true,
+    graphQLVariables?: any
+  ) {
+    // Implementation for fetching a single choice
+    return await this.getChoices(
+      referenceDataID,
+      displayField,
+      storePrimitiveValue,
+      graphQLVariables
+    ).then((choices) => {
+      const choice = choices.find((c) => c.value === referenceDataValue);
+      return choice || null;
+    });
+  }
+
+  /**
    * Get the items and the value field of a reference data
    *
    * @param referenceData The reference data id or the reference data object

--- a/libs/shared/src/lib/survey/components/resource.ts
+++ b/libs/shared/src/lib/survey/components/resource.ts
@@ -63,10 +63,10 @@ const addRecordToSurveyContext = (question: Question, recordID: string) => {
   survey.setVariable(`${question.name}.id`, record.id);
   survey.setVariable(`${question.name}.incrementalId`, record.incrementalId);
 
-  // set record display field as survey variable
+  // set record display value as survey variable
   const displayField = question.displayField;
   survey.setVariable(
-    `${question.name}.displayField`,
+    `${question.name}.displayValue`,
     displayField ? record?.data[displayField] : record.id
   );
 

--- a/libs/shared/src/lib/survey/components/resource.ts
+++ b/libs/shared/src/lib/survey/components/resource.ts
@@ -59,7 +59,18 @@ const addRecordToSurveyContext = (question: Question, recordID: string) => {
   const record = loadedRecords.get(recordID);
   if (!record) return;
 
-  const data = record?.data || {};
+  // set record id and incremental id as survey variables
+  survey.setVariable(`${question.name}.id`, record.id);
+  survey.setVariable(`${question.name}.incrementalId`, record.incrementalId);
+
+  // set record display field as survey variable
+  const displayField = question.displayField;
+  survey.setVariable(
+    `${question.name}.displayField`,
+    displayField ? record?.data[displayField] : record.id
+  );
+
+  const data = record.data || {};
   for (const field in data) {
     // create survey expression in the format {[questionName].[fieldName]} = [value]
     survey.setVariable(`${question.name}.${field}`, data[field]);

--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -172,8 +172,8 @@ export const render = (questionElement: Question, injector: Injector): void => {
   if (isSelectQuestion(questionElement)) {
     const question = questionElement as QuestionSelectBase;
 
-    // set display field as survey variable
-    const updateDisplayField = async () => {
+    // set display value as survey variable
+    const updateDisplayValue = async () => {
       if (question.referenceData && question.referenceDataDisplayField) {
         const survey = question.survey as SurveyModel;
         const choice = await referenceDataService.getChoice(
@@ -183,7 +183,7 @@ export const render = (questionElement: Question, injector: Injector): void => {
           question.isPrimitiveValue,
           graphQLVariables(question, 'referenceDataVariableMapping')
         );
-        survey.setVariable(`${question.name}.displayField`, choice?.text);
+        survey.setVariable(`${question.name}.displayValue`, choice?.text);
       }
     };
 
@@ -287,14 +287,14 @@ export const render = (questionElement: Question, injector: Injector): void => {
             )
             .then(() => {
               updateChoices();
-              updateDisplayField();
+              updateDisplayValue();
             });
         });
       question.referenceDataChoicesLoaded = true;
     }
 
-    // Set the display field when question value changes
-    question.valueChangedCallback = updateDisplayField;
+    // Set the display value variable when question value changes
+    question.valueChangedCallback = updateDisplayValue;
     // Prevent selected choices to be removed when sending the value
     question.clearIncorrectValuesCallback = () => {
       // console.log(question.visibleChoices);

--- a/libs/shared/src/lib/survey/global-properties/reference-data.ts
+++ b/libs/shared/src/lib/survey/global-properties/reference-data.ts
@@ -172,6 +172,21 @@ export const render = (questionElement: Question, injector: Injector): void => {
   if (isSelectQuestion(questionElement)) {
     const question = questionElement as QuestionSelectBase;
 
+    // set display field as survey variable
+    const updateDisplayField = async () => {
+      if (question.referenceData && question.referenceDataDisplayField) {
+        const survey = question.survey as SurveyModel;
+        const choice = await referenceDataService.getChoice(
+          question.value,
+          question.referenceData,
+          question.referenceDataDisplayField,
+          question.isPrimitiveValue,
+          graphQLVariables(question, 'referenceDataVariableMapping')
+        );
+        survey.setVariable(`${question.name}.displayField`, choice?.text);
+      }
+    };
+
     const updateChoices = async () => {
       if (question.referenceData && question.referenceDataDisplayField) {
         const choices = await referenceDataService.getChoices(
@@ -270,10 +285,16 @@ export const render = (questionElement: Question, injector: Injector): void => {
               referenceData,
               graphQLVariables(question, 'referenceDataVariableMapping')
             )
-            .then(() => updateChoices());
+            .then(() => {
+              updateChoices();
+              updateDisplayField();
+            });
         });
       question.referenceDataChoicesLoaded = true;
     }
+
+    // Set the display field when question value changes
+    question.valueChangedCallback = updateDisplayField;
     // Prevent selected choices to be removed when sending the value
     question.clearIncorrectValuesCallback = () => {
       // console.log(question.visibleChoices);

--- a/libs/shared/src/lib/survey/graphql/queries.ts
+++ b/libs/shared/src/lib/survey/graphql/queries.ts
@@ -24,6 +24,7 @@ export const GET_RESOURCE_BY_ID = gql`
         edges {
           node {
             id
+            incrementalId
             data(display: $display)
           }
           cursor


### PR DESCRIPTION
# Description

New variables have been added for the expressions in a form. The variables are:
- <question>.id: Only for Resources, shows the resource id.
- <question>.incrementalId: Only for Resources, shows the resource Incremental id.
- <question>.displayValue: For Resources and Reference data, shows the displayField value selected for the question.

The ticket also required support for static strings, this is already possible be using '<static-string>', which will render the written string.

## Useful links

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.


- [x] On an expression question, define a static string like: `'Test'`, make sure 'Test' is rendered on the survey preview, survey record creation and edition and on the records table.
- [x] On an expression question, reference a resource question with variable `<resource>.incrementalId`, make sure the resource incremental id is rendered on the survey preview, survey record creation and edition and on the records table.
- [x] On an expression question, reference a resource question with variable `<resource>.displayValue`, make sure the value displayed on the resource selection is rendered on the survey preview, survey record creation and edition and on the records table.
- [x] On an expression question, reference a reference data question with variable `<refData>.displayValue`, make sure the value displayed on the resource selection is rendered on the survey preview, survey record creation and edition and on the records table.

## Screenshots

<img width="839" height="709" alt="Screenshot 2026-04-01 at 10 24 51" src="https://github.com/user-attachments/assets/c7f8012f-55bf-4af0-8570-0b8aed8c6c20" />

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
