### PR TITLE
AB#134014 translate more fields from widgets

### DIFF
--- a/apps/back-office/src/app/components/edit-action-button-modal/edit-action-button-modal.component.html
+++ b/apps/back-office/src/app/components/edit-action-button-modal/edit-action-button-modal.component.html
@@ -33,7 +33,7 @@
                 <label>{{
                   'models.dashboard.actionButtons.text' | translate
                 }}</label>
-                <input formControlName="buttonText" type="string" />
+                <shared-localized-input formControlName="buttonText"></shared-localized-input>
               </div>
 
               <!-- Use role restriction -->

--- a/apps/back-office/src/app/components/edit-action-button-modal/edit-action-button-modal.component.html
+++ b/apps/back-office/src/app/components/edit-action-button-modal/edit-action-button-modal.component.html
@@ -33,7 +33,9 @@
                 <label>{{
                   'models.dashboard.actionButtons.text' | translate
                 }}</label>
-                <shared-localized-input formControlName="buttonText"></shared-localized-input>
+                <shared-localized-input
+                  formControlName="buttonText"
+                ></shared-localized-input>
               </div>
 
               <!-- Use role restriction -->

--- a/apps/back-office/src/app/components/edit-action-button-modal/edit-action-button-modal.component.ts
+++ b/apps/back-office/src/app/components/edit-action-button-modal/edit-action-button-modal.component.ts
@@ -26,6 +26,8 @@ import {
   Form,
   Application,
   ContentType,
+  LocalizedInputComponent,
+  localizedRequired,
   Page,
   INLINE_EDITOR_CONFIG,
   QueryBuilderModule,
@@ -81,6 +83,7 @@ interface DialogData {
     ToggleModule,
     EditorModule,
     EditorControlComponent,
+    LocalizedInputComponent,
     DividerModule,
     TabsModule,
     IconModule,
@@ -268,7 +271,7 @@ export class EditActionButtonModalComponent
     };
     const form = this.fb.group({
       general: this.fb.group({
-        buttonText: [get(data, 'text', ''), Validators.required],
+        buttonText: [get(data, 'text', ''), localizedRequired],
         hasRoleRestriction: [
           get(data, 'hasRoleRestriction', false),
           Validators.required,

--- a/apps/back-office/src/app/components/edit-action-buttons-modal/edit-action-buttons-modal.component.html
+++ b/apps/back-office/src/app/components/edit-action-buttons-modal/edit-action-buttons-modal.component.html
@@ -58,7 +58,7 @@
                 *cdkCellDef="let element"
                 class="!text-gray-900 !font-medium max-w-[30vw]"
               >
-                {{ element.text }}
+                {{ element.text | sharedLocalize }}
               </td>
             </ng-container>
 

--- a/apps/back-office/src/app/components/edit-action-buttons-modal/edit-action-buttons-modal.component.ts
+++ b/apps/back-office/src/app/components/edit-action-buttons-modal/edit-action-buttons-modal.component.ts
@@ -9,7 +9,9 @@ import {
   ApplicationService,
   Dashboard,
   EmptyModule,
+  LocalizePipe,
   Page,
+  resolveLocalizedString,
   Role,
   Step,
   UnsubscribeComponent,
@@ -45,6 +47,7 @@ import { BehaviorSubject, takeUntil } from 'rxjs';
     IconModule,
     DragDropModule,
     EmptyModule,
+    LocalizePipe,
   ],
   templateUrl: './edit-action-buttons-modal.component.html',
   styleUrls: ['./edit-action-buttons-modal.component.scss'],
@@ -204,9 +207,26 @@ export class EditActionButtonsModalComponent
    */
   public async onDuplicateActionButton(actionButton: ActionButton) {
     const newActionButton = structuredClone(actionButton);
-    newActionButton.text = `${newActionButton.text} (${this.translate.instant(
-      'common.copy'
-    )})`;
+    if (typeof newActionButton.text === 'object' && newActionButton.text) {
+      for (const locale of Object.keys(newActionButton.text)) {
+        console.log('locale', locale);
+        const copySuffix = this.translate.instant('common.copy');
+        const val = (newActionButton.text as Record<string, string>)[locale];
+        if (val)
+          (newActionButton.text as Record<string, string>)[
+            locale
+          ] = `${val} (${copySuffix})`;
+      }
+    } else {
+      const resolvedText =
+        resolveLocalizedString(
+          newActionButton.text,
+          this.translate.currentLang
+        ) ?? '';
+      newActionButton.text = `${resolvedText} (${this.translate.instant(
+        'common.copy'
+      )})`;
+    }
     this.actionButtons.push(newActionButton);
     this.searchTerm = '';
     this.updateTable();
@@ -253,7 +273,10 @@ export class EditActionButtonsModalComponent
 
     if (this.searchTerm !== '') {
       actionButtons = this.actionButtons.filter((action) =>
-        action.text.toLowerCase().includes(this.searchTerm.toLowerCase())
+        resolveLocalizedString(
+          action.text,
+          this.translate.currentLang
+        )?.includes(this.searchTerm.toLowerCase())
       );
     } else {
       actionButtons = this.actionButtons;

--- a/libs/shared/src/lib/components/action-button/action-button.component.html
+++ b/libs/shared/src/lib/components/action-button/action-button.component.html
@@ -4,5 +4,5 @@
   [category]="actionButton.category"
   (click)="onClick()"
 >
-  {{ actionButton.text }}
+  {{ actionButton.text | sharedLocalize }}
 </ui-button>

--- a/libs/shared/src/lib/components/action-button/action-button.component.ts
+++ b/libs/shared/src/lib/components/action-button/action-button.component.ts
@@ -11,6 +11,7 @@ import { CommonModule, Location } from '@angular/common';
 import { ActionButton } from './action-button.type';
 import { ButtonModule, TooltipModule } from '@oort-front/ui';
 import { TranslateModule } from '@ngx-translate/core';
+import { LocalizePipe } from '../../pipes/localize/localize.pipe';
 import { Dialog } from '@angular/cdk/dialog';
 import { DataTemplateService } from '../../services/data-template/data-template.service';
 import { Router } from '@angular/router';
@@ -44,7 +45,13 @@ import { EmailNotification } from '../../models/email-notifications.model';
 @Component({
   selector: 'shared-action-button',
   standalone: true,
-  imports: [CommonModule, ButtonModule, TooltipModule, TranslateModule],
+  imports: [
+    CommonModule,
+    ButtonModule,
+    TooltipModule,
+    TranslateModule,
+    LocalizePipe,
+  ],
   templateUrl: './action-button.component.html',
   styleUrls: ['./action-button.component.scss'],
 })

--- a/libs/shared/src/lib/components/action-button/action-button.type.ts
+++ b/libs/shared/src/lib/components/action-button/action-button.type.ts
@@ -1,4 +1,5 @@
 import { Category, Variant } from '@oort-front/ui';
+import { LocalizedString } from '../../models/localized-string.model';
 
 /** Field interface for sendNotification action */
 interface Field {
@@ -18,7 +19,7 @@ interface Field {
  * Action button Type
  */
 export type ActionButton = {
-  text: string;
+  text: LocalizedString;
   // Display
   variant: Variant;
   category: Category;

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.ts
@@ -52,6 +52,7 @@ import {
   SELECTABLE_SETTINGS,
 } from './grid.constants';
 import { ActionButton } from '../../../widgets/grid/action-button.type';
+import { resolveLocalizedString } from '../../../../models/localized-string.model';
 import { File, FileService } from '../../../../services/file/file.service';
 
 /** Minimum column width */
@@ -368,6 +369,8 @@ export class GridComponent
         });
         this.data = { ...this.data };
       }
+      this.buildCustomRowActionGroups();
+      this.updateCustomActionColumnWidths();
     });
   }
 
@@ -391,19 +394,7 @@ export class GridComponent
     // cache snapshots the column list once and never re-includes columns
     // added later, which makes multiple action groups overlap.
     if (changes['widget']) {
-      const customRowActions: ActionButton[] = get(
-        this.widget,
-        'settings.customRowActions',
-        []
-      );
-      this.customRowActionGroups = map(
-        groupBy(customRowActions, 'columnLabel'),
-        (actions, label) => ({
-          label,
-          actions,
-          width: 0,
-        })
-      );
+      this.buildCustomRowActionGroups();
     }
     if (
       (changes['data']?.currentValue?.data.length || this.data.data.length) &&
@@ -468,6 +459,28 @@ export class GridComponent
   }
 
   /**
+   * Build customRowActionGroups from widget settings, resolving LocalizedString column labels.
+   * Called on widget changes and on language change so column titles stay in sync.
+   */
+  private buildCustomRowActionGroups(): void {
+    const customRowActions: ActionButton[] = get(
+      this.widget,
+      'settings.customRowActions',
+      []
+    );
+    this.customRowActionGroups = map(
+      groupBy(customRowActions, (action) =>
+        resolveLocalizedString(action.columnLabel, this.translate.currentLang)
+      ),
+      (actions, label) => ({
+        label,
+        actions,
+        width: 0,
+      })
+    );
+  }
+
+  /**
    * Get the custom row actions to display in a given group column for a given row.
    * Filters the full set of actions in the group using the per-row actions
    * populated by the backend on `dataItem.actions` (grouped by columnLabel).
@@ -482,22 +495,30 @@ export class GridComponent
     dataItem: any,
     group: { label: string; actions: ActionButton[] }
   ): ActionButton[] {
-    const rowGroups: { label: string; actions: ActionButton[] }[] =
-      dataItem?.actions ?? [];
-    if (!rowGroups.length) {
-      // return group.actions;
+    // Backend returns a flat ActionButton[] of the actions visible for this row.
+    const visibleActions: ActionButton[] = dataItem?._meta?.actions ?? [];
+    if (!visibleActions.length) {
       return [];
     }
-    const rowGroup = rowGroups.find((g) => g.label === group.label);
-    if (!rowGroup) {
-      return [];
-    }
-    // Intersect by text + columnLabel to preserve widget config order.
+    const lang = this.translate.currentLang;
+    // Build a key set from all visible actions so we can intersect with group.actions
+    // (which is already scoped to this column's columnLabel).
     const visibleKeys = new Set(
-      rowGroup.actions.map((a) => `${a.columnLabel}::${a.text}`)
+      visibleActions.map(
+        (a) =>
+          `${resolveLocalizedString(
+            a.columnLabel,
+            lang
+          )}::${resolveLocalizedString(a.text, lang)}`
+      )
     );
     return group.actions.filter((a) =>
-      visibleKeys.has(`${a.columnLabel}::${a.text}`)
+      visibleKeys.has(
+        `${resolveLocalizedString(
+          a.columnLabel,
+          lang
+        )}::${resolveLocalizedString(a.text, lang)}`
+      )
     );
   }
 
@@ -538,7 +559,10 @@ export class GridComponent
             (sum, action) =>
               sum +
               Math.max(
-                (action.text?.length ?? 0) * charWidth + buttonPadding,
+                resolveLocalizedString(action.text, this.translate.currentLang)
+                  .length *
+                  charWidth +
+                  buttonPadding,
                 minButtonWidth
               ),
             0
@@ -556,7 +580,10 @@ export class GridComponent
         (sum, action) =>
           sum +
           Math.max(
-            (action.text?.length ?? 0) * charWidth + buttonPadding,
+            resolveLocalizedString(action.text, this.translate.currentLang)
+              .length *
+              charWidth +
+              buttonPadding,
             minButtonWidth
           ),
         0

--- a/libs/shared/src/lib/components/ui/map/interfaces/layer-settings.type.ts
+++ b/libs/shared/src/lib/components/ui/map/interfaces/layer-settings.type.ts
@@ -5,6 +5,7 @@ import {
   PopupElement,
 } from '../../../../models/layer.model';
 import { FaIconName } from '@oort-front/ui';
+import { LocalizedString } from '../../../../models/localized-string.model';
 
 export type GeoJSON =
   | Geometry
@@ -20,7 +21,7 @@ export type GeometryType = 'Point' | 'Polygon';
 /** Layer documents interface declaration */
 export interface LayerFormData {
   id?: string;
-  name: string;
+  name: LocalizedString;
   type: string;
   visibility: boolean;
   opacity: number;
@@ -44,8 +45,8 @@ export interface LayerFormData {
     };
   };
   popupInfo: {
-    title: string;
-    description: string;
+    title: LocalizedString;
+    description: LocalizedString;
     popupElements: PopupElement[];
     fieldsInfo?: Fields[];
   };

--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -23,6 +23,10 @@ import {
   LayerSymbol,
   PopupInfo,
 } from '../../../models/layer.model';
+import {
+  LocalizedString,
+  resolveLocalizedString,
+} from '../../../models/localized-string.model';
 import { MapPopupService } from './map-popup/map-popup.service';
 import { haversineDistance } from './utils/haversine';
 import { GradientPipe } from '../../../pipes/gradient/gradient.pipe';
@@ -43,6 +47,7 @@ import { QueryBuilderService } from '../../../services/query-builder/query-build
 import { Apollo } from 'apollo-angular';
 import { ResourceQueryResponse } from '../../../models/resource.model';
 import { GET_LAYOUT } from './graphql/queries';
+import { TranslateService } from '@ngx-translate/core';
 
 type FieldTypes = 'string' | 'number' | 'boolean' | 'date' | 'any';
 
@@ -168,7 +173,9 @@ export class Layer implements LayerModel {
   /** Layer id */
   public id!: string;
   /** Layer name */
-  public name!: string;
+  public name!: LocalizedString;
+  /** Translate service for resolving localized strings */
+  private translateService!: TranslateService;
   /** Layer type */
   public type!: LayerType;
 
@@ -296,6 +303,7 @@ export class Layer implements LayerModel {
       this.gridService = injector.get(GridService);
       this.queryBuilder = injector.get(QueryBuilderService);
       this.apollo = injector.get(Apollo);
+      this.translateService = injector.get(TranslateService);
       // If no dashboard automation service is provided(it's optional, map settings does not use it), cannot recognize the token and breaks
       try {
         this.dashboardAutomationService = injector.get(
@@ -1315,7 +1323,11 @@ export class Layer implements LayerModel {
       }
     }
     if (html) {
-      html = `<div class="font-bold">${this.name}</div>` + html;
+      html =
+        `<div class="font-bold">${resolveLocalizedString(
+          this.name,
+          this.translateService.currentLang
+        )}</div>` + html;
     }
     return html;
   }

--- a/libs/shared/src/lib/components/ui/map/map-popup/map-popup.service.ts
+++ b/libs/shared/src/lib/components/ui/map/map-popup/map-popup.service.ts
@@ -411,10 +411,11 @@ export class MapPopupService {
 
         template += `${elementHeader}${containerStartTemplate}${contentGridTemplate}${containerEndTemplate}${imageElement}</div>`;
       } else if (element.type === 'text') {
-        if (element.text) {
+        const resolvedText = resolveLocalizedString(element.text, lang);
+        if (resolvedText) {
           const scriptRegex = /<script>(.*?)<\/script>/g;
           // remove all script tags
-          const sanitizedHtml = element.text?.replace(scriptRegex, '') ?? '';
+          const sanitizedHtml = resolvedText.replace(scriptRegex, '') ?? '';
           template =
             template +
             `<div class="m-2 break-all rounded-md border-gray-200 border shadow-md px-1">${sanitizedHtml}</div>`;

--- a/libs/shared/src/lib/components/ui/map/map-popup/map-popup.service.ts
+++ b/libs/shared/src/lib/components/ui/map/map-popup/map-popup.service.ts
@@ -8,6 +8,8 @@ import { DomService } from '../../../../services/dom/dom.service';
 import { MapPopupComponent } from './map-popup.component';
 import { PopupInfo } from '../../../../models/layer.model';
 import { DOCUMENT } from '@angular/common';
+import { TranslateService } from '@ngx-translate/core';
+import { resolveLocalizedString } from '../../../../models/localized-string.model';
 /**
  * Shared map control service.
  */
@@ -39,11 +41,13 @@ export class MapPopupService {
    * @param domService DomService
    * @param renderer Angular renderer
    * @param document document
+   * @param translate TranslateService
    */
   constructor(
     private domService: DomService,
     private renderer: Renderer2,
-    @Inject(DOCUMENT) private document: Document
+    @Inject(DOCUMENT) private document: Document,
+    private translate: TranslateService
   ) {}
 
   /**
@@ -341,6 +345,8 @@ export class MapPopupService {
    * @returns Popup content template
    */
   private generatePopupContentTemplate(popupInfo: PopupInfo): string {
+    const lang = this.translate.currentLang;
+
     const title = (title: string, popupTitle?: boolean) =>
       popupTitle
         ? `<h3 class="break-words !m-0 font-bold text-xl">${title}</h3>`
@@ -363,13 +369,17 @@ export class MapPopupService {
       '<div class="shared-popup-content px-2 my-4">';
     const containerEndTemplate = '</div>';
 
+    const resolvedPopupTitle = resolveLocalizedString(popupInfo.title, lang);
+    const resolvedPopupDesc = resolveLocalizedString(
+      popupInfo.description,
+      lang
+    );
+
     let template =
-      popupInfo.description || popupInfo.description
+      resolvedPopupTitle || resolvedPopupDesc
         ? `<div class="w-full flex flex-col px-2 py-1" >${
-            popupInfo.title && title(popupInfo.title, true)
-          }${
-            popupInfo.description && description(popupInfo.description, true)
-          }</div>`
+            resolvedPopupTitle && title(resolvedPopupTitle, true)
+          }${resolvedPopupDesc && description(resolvedPopupDesc, true)}</div>`
         : '';
 
     // We have a template per popup element
@@ -379,9 +389,11 @@ export class MapPopupService {
         let contentGridTemplate = '';
         for (const field of element.fields || []) {
           const dataField = popupInfo.fieldsInfo?.find((x) => x.name === field);
+          const labelStr =
+            resolveLocalizedString(dataField?.label, lang) || field;
           if (!field.toLowerCase().includes('img')) {
             contentGridTemplate = `${contentGridTemplate} ${propertyNameTemplate(
-              dataField?.label || field
+              labelStr
             )} ${propertyValueTemplate(field)}`;
           } else {
             imageElement = imageTemplate(field);
@@ -391,9 +403,11 @@ export class MapPopupService {
           template +
           '<div class="m-2 rounded-md border-gray-200 border shadow-md py-2 px-1">';
 
+        const elemTitle = resolveLocalizedString(element.title, lang);
+        const elemDesc = resolveLocalizedString(element.description, lang);
         const elementHeader = `<div class="w-full flex flex-col ml-2" >${
-          element.title && title(element.title)
-        }${element.description && description(element.description)}</div>`;
+          elemTitle && title(elemTitle)
+        }${elemDesc && description(elemDesc)}</div>`;
 
         template += `${elementHeader}${containerStartTemplate}${contentGridTemplate}${containerEndTemplate}${imageElement}</div>`;
       } else if (element.type === 'text') {

--- a/libs/shared/src/lib/components/ui/map/map.component.ts
+++ b/libs/shared/src/lib/components/ui/map/map.component.ts
@@ -75,6 +75,7 @@ import { ShadowDomService } from '@oort-front/ui';
 import { DashboardAutomationService } from '../../../services/dashboard-automation/dashboard-automation.service';
 import { ActionComponent, ActionType } from '../../../models/automation.model';
 import { DashboardExportService } from '../../../services/dashboard-export/dashboard-export.service';
+import { resolveLocalizedString } from '../../../models/localized-string.model';
 
 /** Component for the map widget */
 @Component({
@@ -798,7 +799,7 @@ export class MapComponent
 
         // It is a group, it should not have any layer but it should be able to check/uncheck its children
         return {
-          label: layer.name,
+          label: resolveLocalizedString(layer.name, this.translate.currentLang),
           selectAllCheckbox: true,
           children:
             children.length > 0
@@ -818,7 +819,7 @@ export class MapComponent
         }
         // It is a node, it does not have any children but it displays a layer
         return {
-          label: layer.name,
+          label: resolveLocalizedString(layer.name, this.translate.currentLang),
           layer: featureLayer,
         };
       }

--- a/libs/shared/src/lib/components/widgets/common/sorting-settings/sorting-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/sorting-settings/sorting-settings.component.html
@@ -80,7 +80,9 @@
         [formGroupName]="rowIndex"
       >
         <div uiFormFieldDirective class="!m-0">
-          <shared-localized-input formControlName="label"></shared-localized-input>
+          <shared-localized-input
+            formControlName="label"
+          ></shared-localized-input>
         </div>
       </td>
     </ng-container>

--- a/libs/shared/src/lib/components/widgets/common/sorting-settings/sorting-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/common/sorting-settings/sorting-settings.component.html
@@ -80,7 +80,7 @@
         [formGroupName]="rowIndex"
       >
         <div uiFormFieldDirective class="!m-0">
-          <input formControlName="label" />
+          <shared-localized-input formControlName="label"></shared-localized-input>
         </div>
       </td>
     </ng-container>

--- a/libs/shared/src/lib/components/widgets/common/sorting-settings/sorting-settings.module.ts
+++ b/libs/shared/src/lib/components/widgets/common/sorting-settings/sorting-settings.module.ts
@@ -4,6 +4,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 import { TranslateModule } from '@ngx-translate/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SortingSettingsComponent } from './sorting-settings.component';
+import { LocalizedInputComponent } from '../../../controls/localized-input/localized-input.component';
 import {
   ButtonModule,
   FormWrapperModule,
@@ -37,6 +38,7 @@ import { EmptyModule } from '../../../ui/empty/empty.module';
     FormWrapperModule,
     SelectMenuModule,
     EmptyModule,
+    LocalizedInputComponent,
   ],
   exports: [SortingSettingsComponent],
 })

--- a/libs/shared/src/lib/components/widgets/common/widget-automation/edit-automation-component/edit-automation-component.component.ts
+++ b/libs/shared/src/lib/components/widgets/common/widget-automation/edit-automation-component/edit-automation-component.component.ts
@@ -15,6 +15,8 @@ import { UnsubscribeComponent } from '../../../../utils/unsubscribe/unsubscribe.
 import { BehaviorSubject, isObservable, map, takeUntil } from 'rxjs';
 import { MapLayersService } from '../../../../../services/map/map-layers.service';
 import { get, isArray, isNil } from 'lodash';
+import { TranslateService } from '@ngx-translate/core';
+import { resolveLocalizedString } from '../../../../../models/localized-string.model';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import {
   ActionType,
@@ -276,11 +278,13 @@ export class EditAutomationComponentComponent
    *
    * @param dashboardService Dashboard service
    * @param mapLayersService Map layers service
+   * @param translate
    * @param data Dialog data, automation component to edit
    */
   constructor(
     private dashboardService: DashboardService,
     private mapLayersService: MapLayersService,
+    private translate: TranslateService,
     @Inject(DIALOG_DATA) public data: any
   ) {
     super();
@@ -341,7 +345,10 @@ export class EditAutomationComponentComponent
             .subscribe((layers) => {
               property.choices = layers.map((layer) => ({
                 value: layer.id,
-                text: layer.name,
+                text: resolveLocalizedString(
+                  layer.name,
+                  this.translate.currentLang
+                ),
               }));
             });
           break;

--- a/libs/shared/src/lib/components/widgets/grid-settings/custom-row-actions/custom-row-actions.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/custom-row-actions/custom-row-actions.component.html
@@ -56,7 +56,7 @@
               *cdkCellDef="let element"
               class="!text-gray-900 !font-medium max-w-[30vw]"
             >
-              {{ element.columnLabel }}
+              {{ element.columnLabel | sharedLocalize }}
             </td>
           </ng-container>
 
@@ -70,7 +70,7 @@
               *cdkCellDef="let element"
               class="!text-gray-900 !font-medium max-w-[30vw]"
             >
-              {{ element.text }}
+              {{ element.text | sharedLocalize }}
             </td>
           </ng-container>
 

--- a/libs/shared/src/lib/components/widgets/grid-settings/custom-row-actions/custom-row-actions.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/custom-row-actions/custom-row-actions.component.ts
@@ -18,6 +18,8 @@ import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.com
 import { ApplicationService } from '../../../../services/application/application.service';
 import { Role } from '../../../../models/user.model';
 import { ActionButton } from '../../grid/action-button.type';
+import { LocalizePipe } from '../../../../pipes/localize/localize.pipe';
+import { resolveLocalizedString } from '../../../../models/localized-string.model';
 import { Dialog } from '@angular/cdk/dialog';
 import { Resource } from '../../../../models/resource.model';
 import { GridSettingsFormFactory } from '../grid-settings.forms';
@@ -41,6 +43,7 @@ import { GridSettingsFormFactory } from '../grid-settings.forms';
     IconModule,
     DragDropModule,
     EmptyModule,
+    LocalizePipe,
   ],
   templateUrl: './custom-row-actions.component.html',
   styleUrls: ['./custom-row-actions.component.scss'],
@@ -198,9 +201,26 @@ export class CustomRowActionsComponent
    */
   public async onDuplicateActionButton(actionButton: ActionButton) {
     const newActionButton = structuredClone(actionButton);
-    newActionButton.text = `${newActionButton.text} (${this.translate.instant(
-      'common.copy'
-    )})`;
+    if (typeof newActionButton.text === 'object' && newActionButton.text) {
+      for (const locale of Object.keys(newActionButton.text)) {
+        console.log('locale', locale);
+        const copySuffix = this.translate.instant('common.copy');
+        const val = (newActionButton.text as Record<string, string>)[locale];
+        if (val)
+          (newActionButton.text as Record<string, string>)[
+            locale
+          ] = `${val} (${copySuffix})`;
+      }
+    } else {
+      const resolvedText =
+        resolveLocalizedString(
+          newActionButton.text,
+          this.translate.currentLang
+        ) ?? '';
+      newActionButton.text = `${resolvedText} (${this.translate.instant(
+        'common.copy'
+      )})`;
+    }
     this.formGroup.controls.customRowActions.push(
       this.formFactory.createCustomRowActionFormGroup(newActionButton)
     );
@@ -244,12 +264,14 @@ export class CustomRowActionsComponent
     let actionButtons: any[];
 
     if (this.searchTerm !== '') {
+      const term = this.searchTerm.toLowerCase();
+      const lang = this.translate.currentLang;
       actionButtons = this.actionButtons.filter(
         (action) =>
-          action.columnLabel
+          resolveLocalizedString(action.columnLabel, lang)
             .toLowerCase()
-            .includes(this.searchTerm.toLowerCase()) ||
-          action.text.toLowerCase().includes(this.searchTerm.toLowerCase())
+            .includes(term) ||
+          resolveLocalizedString(action.text, lang).toLowerCase().includes(term)
       );
     } else {
       actionButtons = this.actionButtons;

--- a/libs/shared/src/lib/components/widgets/grid-settings/edit-custom-row-action-modal/edit-custom-row-action-modal.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/edit-custom-row-action-modal/edit-custom-row-action-modal.component.html
@@ -31,7 +31,9 @@
                   'components.widget.grid.rowAction.fields.columnLabel.text'
                     | translate
                 }}</label>
-                <shared-localized-input formControlName="columnLabel"></shared-localized-input>
+                <shared-localized-input
+                  formControlName="columnLabel"
+                ></shared-localized-input>
               </div>
 
               <!-- Button text -->
@@ -39,7 +41,9 @@
                 <label>{{
                   'models.dashboard.actionButtons.text' | translate
                 }}</label>
-                <shared-localized-input formControlName="buttonText"></shared-localized-input>
+                <shared-localized-input
+                  formControlName="buttonText"
+                ></shared-localized-input>
               </div>
 
               <!-- Use role restriction -->

--- a/libs/shared/src/lib/components/widgets/grid-settings/edit-custom-row-action-modal/edit-custom-row-action-modal.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/edit-custom-row-action-modal/edit-custom-row-action-modal.component.html
@@ -31,7 +31,7 @@
                   'components.widget.grid.rowAction.fields.columnLabel.text'
                     | translate
                 }}</label>
-                <input formControlName="columnLabel" type="string" />
+                <shared-localized-input formControlName="columnLabel"></shared-localized-input>
               </div>
 
               <!-- Button text -->
@@ -39,7 +39,7 @@
                 <label>{{
                   'models.dashboard.actionButtons.text' | translate
                 }}</label>
-                <input formControlName="buttonText" type="string" />
+                <shared-localized-input formControlName="buttonText"></shared-localized-input>
               </div>
 
               <!-- Use role restriction -->
@@ -114,7 +114,7 @@
                   [variant]="form.value.general.variant || 'primary'"
                   (click)="preview()"
                 >
-                  {{ form.value.general.buttonText }}
+                  {{ form.value.general.buttonText | sharedLocalize }}
                 </ui-button>
               </div>
             </div>

--- a/libs/shared/src/lib/components/widgets/grid-settings/edit-custom-row-action-modal/edit-custom-row-action-modal.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/edit-custom-row-action-modal/edit-custom-row-action-modal.component.ts
@@ -19,6 +19,8 @@ import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { EditorModule } from '@tinymce/tinymce-angular';
 import { EditorControlComponent } from '../../../controls/editor-control/editor-control.component';
+import { LocalizedInputComponent } from '../../../controls/localized-input/localized-input.component';
+import { LocalizePipe } from '../../../../pipes/localize/localize.pipe';
 import { QueryBuilderModule } from '../../../query-builder/query-builder.module';
 import { ActionButton } from '../../grid/action-button.type';
 import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
@@ -68,6 +70,8 @@ interface DialogData {
     ToggleModule,
     EditorModule,
     EditorControlComponent,
+    LocalizedInputComponent,
+    LocalizePipe,
     DividerModule,
     TabsModule,
     IconModule,

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
@@ -18,7 +18,7 @@
       <!-- Name -->
       <div uiFormFieldDirective>
         <label>{{ 'common.name' | translate }}</label>
-        <input formControlName="name" type="string" />
+        <shared-localized-input formControlName="name"></shared-localized-input>
       </div>
 
       <ui-alert class="mb-4">

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
@@ -36,6 +36,7 @@ import {
   AlertModule,
 } from '@oort-front/ui';
 import { QueryBuilderModule } from '../../../query-builder/query-builder.module';
+import { LocalizedInputComponent } from '../../../controls/localized-input/localized-input.component';
 
 /** List fo disabled fields */
 const DISABLED_FIELDS = ['id', 'createdAt', 'modifiedAt'];
@@ -67,6 +68,7 @@ const DISABLED_FIELDS = ['id', 'createdAt', 'modifiedAt'];
     SelectMenuModule,
     TabsModule,
     AlertModule,
+    LocalizedInputComponent,
   ],
 })
 export class GridActionSettingsComponent

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.component.ts
@@ -47,6 +47,8 @@ import { TabMainModule } from './tab-main/tab-main.module';
 import { TabGridActionsComponent } from './tab-grid-actions/tab-grid-actions.component';
 import { CustomRowActionsComponent } from './custom-row-actions/custom-row-actions.component';
 import { GridSettingsFormFactory } from './grid-settings.forms';
+import { LocalizedString } from '../../../models/localized-string.model';
+import { localizedRequired } from '../../../utils/validators/localizedRequired.validator';
 
 /**
  * Modal content for the settings of the grid widgets.
@@ -241,7 +243,7 @@ export class GridSettingsComponent
       const row = this.fb.group({
         field: [item.field, Validators.required],
         order: [item.order, Validators.required],
-        label: [item.label, Validators.required],
+        label: [item.label as LocalizedString, localizedRequired],
       });
       (this.widgetFormGroup?.get('sortFields') as any).push(row);
     });

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -68,8 +68,10 @@ export class GridSettingsFormFactory {
     const formGroup = this.fb.group({
       show: [value && value.show ? value.show : false, Validators.required],
       name: [
-        value && value.name ? value.name : DEFAULT_ACTION_NAME,
-        Validators.required,
+        (value && value.name
+          ? value.name
+          : DEFAULT_ACTION_NAME) as LocalizedString,
+        localizedRequired,
       ],
       selectAll: [value && value.selectAll ? value.selectAll : false],
       selectPage: [value && value.selectPage ? value.selectPage : false],
@@ -308,8 +310,11 @@ export class GridSettingsFormFactory {
    */
   public createCustomRowActionFormGroup = (value: ActionButton) => {
     const form = this.fb.group({
-      columnLabel: [get(value, 'columnLabel', ''), Validators.required],
-      text: [get(value, 'text', ''), Validators.required],
+      columnLabel: [
+        get(value, 'columnLabel', '') as LocalizedString,
+        localizedRequired,
+      ],
+      text: [get(value, 'text', '') as LocalizedString, localizedRequired],
       hasRoleRestriction: [
         get(value, 'hasRoleRestriction', false),
         Validators.required,
@@ -403,8 +408,14 @@ export class GridSettingsFormFactory {
   public createCustomRowActionFormGroupForEdition = (value: ActionButton) => {
     const form = this.fb.group({
       general: this.fb.group({
-        columnLabel: [get(value, 'columnLabel', ''), Validators.required],
-        buttonText: [get(value, 'text', ''), Validators.required],
+        columnLabel: [
+          get(value, 'columnLabel', '') as LocalizedString,
+          localizedRequired,
+        ],
+        buttonText: [
+          get(value, 'text', '') as LocalizedString,
+          localizedRequired,
+        ],
         hasRoleRestriction: [
           get(value, 'hasRoleRestriction', false),
           Validators.required,

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-grid-actions/tab-grid-actions.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-grid-actions/tab-grid-actions.component.html
@@ -31,8 +31,8 @@
         <span
           class="max-w-[100px] overflow-hidden text-ellipsis whitespace-nowrap"
           >{{
-            action.value.name.length > 0
-              ? action.value.name
+            ((action.value.name | sharedLocalize) || '').length > 0
+              ? (action.value.name | sharedLocalize)
               : ('components.widget.settings.grid.buttons.defaultName'
                 | translate)
           }}

--- a/libs/shared/src/lib/components/widgets/grid-settings/tab-grid-actions/tab-grid-actions.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/tab-grid-actions/tab-grid-actions.component.ts
@@ -33,6 +33,7 @@ import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { GridActionSettingsComponent } from '../grid-action-settings/grid-action-settings.component';
 import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
+import { LocalizePipe } from '../../../../pipes/localize/localize.pipe';
 
 /**
  * Grid Actions configuration tab.
@@ -54,6 +55,7 @@ import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.com
     ButtonModule,
     AlertModule,
     TooltipModule,
+    LocalizePipe,
   ],
 })
 export class TabGridActionsComponent extends UnsubscribeComponent {

--- a/libs/shared/src/lib/components/widgets/grid/action-button.type.ts
+++ b/libs/shared/src/lib/components/widgets/grid/action-button.type.ts
@@ -1,11 +1,12 @@
 import { Category, Variant } from '@oort-front/ui';
+import { LocalizedString } from '../../../models/localized-string.model';
 
 /**
  * Action button Type
  */
 export type ActionButton = {
-  columnLabel: string;
-  text: string;
+  columnLabel: LocalizedString;
+  text: LocalizedString;
   // Display
   variant: Variant;
   category: Category;

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.html
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.html
@@ -127,10 +127,10 @@
       (selectionChange)="onLayoutChange($event)"
     >
       <ng-template kendoDropDownListItemTemplate let-dataItem>
-        {{ (dataItem.nameTranslations || dataItem.name) | sharedLocalize }}
+        {{ dataItem.nameTranslations || dataItem.name | sharedLocalize }}
       </ng-template>
       <ng-template kendoDropDownListValueTemplate let-dataItem>
-        {{ (dataItem.nameTranslations || dataItem.name) | sharedLocalize }}
+        {{ dataItem.nameTranslations || dataItem.name | sharedLocalize }}
       </ng-template>
     </kendo-dropdownlist>
   </ng-container>

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.html
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.html
@@ -95,7 +95,7 @@
         *ngIf="gridAction.show"
         class="whitespace-nowrap"
       >
-        {{ gridAction.name }}
+        {{ gridAction.name | sharedLocalize }}
       </ui-button>
     </ng-container>
   </div>
@@ -109,7 +109,7 @@
       [placeholder]="'models.widget.sorting.select' | translate"
     >
       <ui-select-option *ngFor="let sort of sortFields" [value]="sort">
-        {{ sort.label }}
+        {{ sort.label | sharedLocalize }}
       </ui-select-option>
     </ui-select-menu>
   </div>
@@ -126,6 +126,12 @@
       [value]="layout"
       (selectionChange)="onLayoutChange($event)"
     >
+      <ng-template kendoDropDownListItemTemplate let-dataItem>
+        {{ (dataItem.nameTranslations || dataItem.name) | sharedLocalize }}
+      </ng-template>
+      <ng-template kendoDropDownListValueTemplate let-dataItem>
+        {{ (dataItem.nameTranslations || dataItem.name) | sharedLocalize }}
+      </ng-template>
     </kendo-dropdownlist>
   </ng-container>
 </ng-template>

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -179,7 +179,6 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
   ngOnInit() {
     this.gridSettings = { ...this.settings };
     delete this.gridSettings.query;
-    let buildSortFields = false;
     if (this.settings.resource) {
       this.useReferenceData = false;
       const layouts = get(this.settings, 'layouts', []);
@@ -224,7 +223,9 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
                 error: true,
               };
             } else {
-              buildSortFields = true;
+              this.widget.settings.sortFields?.forEach((sortField: any) => {
+                this.sortFields.push(sortField);
+              });
             }
             this.gridSettings = {
               ...this.settings,
@@ -255,17 +256,14 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
               };
             }
             this.aggregation = this.aggregations[0] || null;
-            buildSortFields = true;
+            this.widget.settings.sortFields?.forEach((sortField: any) => {
+              this.sortFields.push(sortField);
+            });
           });
         return;
       }
     } else if (this.settings.referenceData) {
-      buildSortFields = true;
       this.useReferenceData = true;
-    }
-
-    if (buildSortFields) {
-      // Build list of available sort fields
       this.widget.settings.sortFields?.forEach((sortField: any) => {
         this.sortFields.push(sortField);
       });

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/edit-layer-modal.component.ts
@@ -33,6 +33,7 @@ import {
 } from 'rxjs';
 import { Aggregation } from '../../../../models/aggregation.model';
 import { Fields, LayerModel } from '../../../../models/layer.model';
+import { resolveLocalizedString } from '../../../../models/localized-string.model';
 import { Layout } from '../../../../models/layout.model';
 import {
   ReferenceData,
@@ -150,7 +151,10 @@ export class EditLayerModalComponent
    */
   private get overlays(): OverlayLayerTree {
     return {
-      label: this.form.get('name')?.value || '',
+      label: resolveLocalizedString(
+        this.form.get('name')?.value,
+        this.translate.currentLang
+      ),
       layer: this.currentLayer,
     };
   }
@@ -225,7 +229,10 @@ export class EditLayerModalComponent
   override ngOnDestroy(): void {
     super.ngOnDestroy();
     const overlays: OverlayLayerTree = {
-      label: this.form.get('name')?.value || '',
+      label: resolveLocalizedString(
+        this.form.get('name')?.value,
+        this.translate.currentLang
+      ),
       layer: this.currentLayer,
     };
     //Once we exit the layer editor, destroy the layer and related controls

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-fields/layer-fields.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-fields/layer-fields.component.html
@@ -1,19 +1,19 @@
 <div class="flex flex-wrap gap-4 flex-col lg:flex-row lg:h-full">
   <!-- Fields form -->
   <div class="flex-1 flex flex-col">
-    <shared-editable-text
+    <shared-editable-localized-text
       *ngFor="let field of fields$ | async"
-      [text]="field.label"
+      [value]="field.label"
       [canEdit]="true"
       (onChange)="saveLabel($event, field)"
     >
       <div class="flex items-center justify-between w-full p-1">
         <div class="!m-0 overflow-hidden text-ellipsis">
-          {{ field.label }}
+          {{ field.label | sharedLocalize }}
         </div>
         <ui-icon icon="edit" class="cursor-pointer" variant="grey"></ui-icon>
       </div>
-    </shared-editable-text>
+    </shared-editable-localized-text>
   </div>
   <!-- Map -->
   <div

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-fields/layer-fields.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-fields/layer-fields.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Fields } from '../../../../../models/layer.model';
+import { LocalizedString } from '../../../../../models/localized-string.model';
 import { DomPortal } from '@angular/cdk/portal';
 
 /**
@@ -25,7 +26,7 @@ export class LayerFieldsComponent {
    * @param event event of the input.
    * @param field field to update.
    */
-  saveLabel(event: string, field: Fields): void {
+  saveLabel(event: LocalizedString | null, field: Fields): void {
     if (event) {
       this.updatedField.emit({ ...field, label: event });
     }

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-fields/layer-fields.module.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-fields/layer-fields.module.ts
@@ -4,13 +4,20 @@ import { LayerFieldsComponent } from './layer-fields.component';
 import { EditableTextModule } from '../../../../editable-text/editable-text.module';
 import { IconModule } from '@oort-front/ui';
 import { PortalModule } from '@angular/cdk/portal';
+import { LocalizePipe } from '../../../../../pipes/localize/localize.pipe';
 
 /**
  * Map layer fields settings module.
  */
 @NgModule({
   declarations: [LayerFieldsComponent],
-  imports: [CommonModule, IconModule, EditableTextModule, PortalModule],
+  imports: [
+    CommonModule,
+    IconModule,
+    EditableTextModule,
+    LocalizePipe,
+    PortalModule,
+  ],
   exports: [LayerFieldsComponent],
 })
 export class LayerFieldsModule {}

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/fields-element/fields-element.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/fields-element/fields-element.component.html
@@ -5,38 +5,17 @@
         'components.widget.settings.map.layers.popup.fieldsElements.title'
           | translate
       }}</label>
-      <shared-editor-control
-        formControlName="title"
-        [editorConfig]="editorConfig"
-      ></shared-editor-control>
-      <ui-icon
-        icon="info"
-        class="cursor-pointer"
-        variant="grey"
-        uiSuffix
-        [uiTooltip]="
-          'components.widget.settings.map.layers.popup.tooltip.text' | translate
-        "
-      ></ui-icon>
+      <shared-localized-input formControlName="title"></shared-localized-input>
     </div>
     <div uiFormFieldDirective>
       <label>{{
         'components.widget.settings.map.layers.popup.fieldsElements.description'
           | translate
       }}</label>
-      <shared-editor-control
+      <shared-localized-input
         formControlName="description"
-        [editorConfig]="editorConfig"
-      ></shared-editor-control>
-      <ui-icon
-        icon="info"
-        class="cursor-pointer"
-        variant="grey"
-        uiSuffix
-        [uiTooltip]="
-          'components.widget.settings.map.layers.popup.tooltip.text' | translate
-        "
-      ></ui-icon>
+        type="textarea"
+      ></shared-localized-input>
     </div>
   </div>
   <ui-divider></ui-divider>

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/fields-element/fields-element.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/fields-element/fields-element.component.ts
@@ -10,21 +10,13 @@ import {
 import { TranslateModule } from '@ngx-translate/core';
 import { Fields } from '../../../../../../models/layer.model';
 import { Observable, takeUntil } from 'rxjs';
-import { EditorControlComponent } from '../../../../../controls/editor-control/editor-control.component';
-import { INLINE_EDITOR_CONFIG } from '../../../../../../const/tinymce.const';
-import { EditorService } from '../../../../../../services/editor/editor.service';
 import { UnsubscribeComponent } from '../../../../../utils/unsubscribe/unsubscribe.component';
 import {
   ListBoxModule,
   ListBoxToolbarConfig,
 } from '@progress/kendo-angular-listbox';
-import {
-  ButtonModule,
-  DividerModule,
-  FormWrapperModule,
-  IconModule,
-  TooltipModule,
-} from '@oort-front/ui';
+import { ButtonModule, DividerModule, FormWrapperModule } from '@oort-front/ui';
+import { LocalizedInputComponent } from '../../../../../controls/public-api';
 /**
  * Popup fields element component.
  */
@@ -39,9 +31,7 @@ import {
     FormWrapperModule,
     DividerModule,
     ButtonModule,
-    EditorControlComponent,
-    IconModule,
-    TooltipModule,
+    LocalizedInputComponent,
     ListBoxModule,
   ],
   templateUrl: './fields-element.component.html',
@@ -55,8 +45,6 @@ export class FieldsElementComponent
   @Input() formGroup!: FormGroup;
   /** Available fields */
   @Input() fields$!: Observable<Fields[]>;
-  /** Tinymce editor configuration */
-  public editorConfig = INLINE_EDITOR_CONFIG;
   /** Available fields as array */
   public availableFields: string[] = [];
   /** Selected fields */
@@ -78,13 +66,6 @@ export class FieldsElementComponent
     // Listen to fields changes
     this.fields$.pipe(takeUntil(this.destroy$)).subscribe((value) => {
       this.availableFields = value.map((field) => field.name);
-      this.editorService.addCalcAndKeysAutoCompleter(
-        this.editorConfig,
-        this.availableFields.map((field) => ({
-          text: `{{${field}}}`,
-          value: `{{${field}}}`,
-        }))
-      );
     });
 
     // Get initial selected fields
@@ -93,15 +74,6 @@ export class FieldsElementComponent
       const index = this.availableFields.indexOf(field);
       if (index > -1) this.availableFields.splice(index, 1);
     });
-  }
-
-  /**
-   * Creates an instance of FieldsElementComponent.
-   *
-   * @param editorService Shared tinymce editor service.
-   */
-  constructor(private editorService: EditorService) {
-    super();
   }
 
   /** Updates the element selected fields form value */

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.html
@@ -7,40 +7,17 @@
           <label>{{
             'components.widget.settings.map.layers.popup.title' | translate
           }}</label>
-          <shared-editor-control
-            formControlName="title"
-            [editorConfig]="editorConfig"
-          ></shared-editor-control>
-          <ui-icon
-            icon="info"
-            class="cursor-pointer"
-            variant="grey"
-            uiSuffix
-            [uiTooltip]="
-              'components.widget.settings.map.layers.popup.tooltip.text'
-                | translate
-            "
-          ></ui-icon>
+          <shared-localized-input formControlName="title"></shared-localized-input>
         </div>
         <div uiFormFieldDirective>
           <label>{{
             'components.widget.settings.map.layers.popup.description'
               | translate
           }}</label>
-          <shared-editor-control
+          <shared-localized-input
             formControlName="description"
-            [editorConfig]="editorConfig"
-          ></shared-editor-control>
-          <ui-icon
-            icon="info"
-            class="cursor-pointer"
-            variant="grey"
-            uiSuffix
-            [uiTooltip]="
-              'components.widget.settings.map.layers.popup.tooltip.text'
-                | translate
-            "
-          ></ui-icon>
+            type="textarea"
+          ></shared-localized-input>
         </div>
       </div>
       <ui-divider class="my-1"></ui-divider>
@@ -79,7 +56,7 @@
                   <h4 class="!m-0">
                     {{ item.value.type }}
                   </h4>
-                  <h6 class="!m-0">{{ item.value.title }}</h6>
+                  <h6 class="!m-0">{{ item.value.title | sharedLocalize }}</h6>
                 </div>
               </div>
               <ui-button

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.html
@@ -7,7 +7,9 @@
           <label>{{
             'components.widget.settings.map.layers.popup.title' | translate
           }}</label>
-          <shared-localized-input formControlName="title"></shared-localized-input>
+          <shared-localized-input
+            formControlName="title"
+          ></shared-localized-input>
         </div>
         <div uiFormFieldDirective>
           <label>{{

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.component.ts
@@ -1,5 +1,5 @@
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { FormArray, FormGroup } from '@angular/forms';
 import {
   PopupElement,
@@ -7,9 +7,7 @@ import {
 } from '../../../../../models/layer.model';
 import { createPopupElementForm } from '../../map-forms';
 import { Fields } from '../../../../../models/layer.model';
-import { Observable, takeUntil } from 'rxjs';
-import { INLINE_EDITOR_CONFIG } from '../../../../../const/tinymce.const';
-import { EditorService } from '../../../../../services/editor/editor.service';
+import { Observable } from 'rxjs';
 import { UnsubscribeComponent } from '../../../../utils/unsubscribe/unsubscribe.component';
 import { DomPortal } from '@angular/cdk/portal';
 
@@ -21,47 +19,17 @@ import { DomPortal } from '@angular/cdk/portal';
   templateUrl: './layer-popup.component.html',
   styleUrls: ['./layer-popup.component.scss'],
 })
-export class LayerPopupComponent
-  extends UnsubscribeComponent
-  implements OnInit
-{
+export class LayerPopupComponent extends UnsubscribeComponent {
   /** Current form group */
   @Input() formGroup!: FormGroup;
   /** Map dom portal */
   @Input() mapPortal?: DomPortal;
   /** Available fields */
   @Input() fields$!: Observable<Fields[]>;
-  /** Keys for editor */
-  public keys: { text: string; value: string }[] = [];
-  /** Editor configuration */
-  public editorConfig = INLINE_EDITOR_CONFIG;
 
   /** @returns popup elements as form array */
   get popupElements(): FormArray {
     return this.formGroup.get('popupElements') as FormArray;
-  }
-
-  /**
-   * Creates an instance of LayerPopupComponent.
-   *
-   * @param editorService Shared tinymce editor service.
-   */
-  constructor(private editorService: EditorService) {
-    super();
-  }
-
-  ngOnInit(): void {
-    // Listen to fields changes
-    this.fields$.pipe(takeUntil(this.destroy$)).subscribe((value) => {
-      this.keys = value.map((field) => ({
-        text: `{{${field.name}}}`,
-        value: `{{${field.name}}}`,
-      }));
-      this.editorService.addCalcAndKeysAutoCompleter(
-        this.editorConfig,
-        this.keys
-      );
-    });
   }
 
   /**

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.module.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/layer-popup.module.ts
@@ -6,7 +6,6 @@ import { TranslateModule } from '@ngx-translate/core';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { FieldsElementComponent } from './fields-element/fields-element.component';
 import { TextElementComponent } from './text-element/text-element.component';
-import { EditorControlComponent } from '../../../../controls/editor-control/editor-control.component';
 import {
   ButtonModule,
   DividerModule,
@@ -17,6 +16,8 @@ import {
   TooltipModule,
 } from '@oort-front/ui';
 import { PortalModule } from '@angular/cdk/portal';
+import { LocalizedInputComponent } from '../../../../controls/public-api';
+import { LocalizePipe } from '../../../../../pipes/localize/localize.pipe';
 
 /**
  * Map layer properties popup module.
@@ -37,7 +38,8 @@ import { PortalModule } from '@angular/cdk/portal';
     IconModule,
     FieldsElementComponent,
     TextElementComponent,
-    EditorControlComponent,
+    LocalizedInputComponent,
+    LocalizePipe,
     TooltipModule,
     PortalModule,
   ],

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.html
@@ -1,8 +1,29 @@
-<ng-container [formGroup]="formGroup">
+<div class="flex flex-col gap-1 w-full">
+  <div class="flex gap-1">
+    <button
+      *ngFor="let locale of locales"
+      type="button"
+      class="px-2 py-0.5 text-xs font-medium uppercase border rounded relative transition-colors"
+      [class.bg-primary-600]="activeLocale === locale"
+      [class.text-white]="activeLocale === locale"
+      [class.border-primary-600]="activeLocale === locale"
+      [class.bg-white]="activeLocale !== locale"
+      [class.text-gray-700]="activeLocale !== locale"
+      [class.border-gray-300]="activeLocale !== locale"
+      (click)="setLocale(locale)"
+    >
+      {{ locale }}
+      <span
+        *ngIf="hasContent(locale) && activeLocale !== locale"
+        class="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-primary-500"
+      ></span>
+    </button>
+  </div>
   <editor
     (onInit)="editorLoading = false"
     [init]="editor"
-    formControlName="text"
+    [ngModel]="values[activeLocale] || ''"
+    (ngModelChange)="onEditorChange($event)"
   ></editor>
-</ng-container>
+</div>
 <ui-spinner *ngIf="editorLoading"></ui-spinner>

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-popup/text-element/text-element.component.ts
@@ -8,6 +8,11 @@ import { Fields } from '../../../../../../models/layer.model';
 import { Observable, takeUntil } from 'rxjs';
 import { UnsubscribeComponent } from '../../../../../utils/unsubscribe/unsubscribe.component';
 import { SpinnerModule } from '@oort-front/ui';
+import {
+  SUPPORTED_LOCALES,
+  SupportedLocale,
+} from '../../../../../controls/localized-input/localized-input.component';
+import { LocalizedString } from '../../../../../../models/localized-string.model';
 
 /**
  * Popup text element component.
@@ -40,6 +45,12 @@ export class TextElementComponent
   public editor: any = POPUP_EDITOR_CONFIG;
   /** Is editor loading */
   public editorLoading = true;
+  /** List of locales rendered as tabs. */
+  public readonly locales = SUPPORTED_LOCALES;
+  /** Locale currently being edited. */
+  public activeLocale: SupportedLocale = 'en';
+  /** Per-locale rich text values. */
+  public values: Partial<Record<SupportedLocale, string>> = {};
 
   /**
    * Popup text element component.
@@ -55,6 +66,9 @@ export class TextElementComponent
   }
 
   ngOnInit(): void {
+    // Initialize the per-locale values from the (possibly legacy plain string)
+    // form control value.
+    this.values = this.toLocaleMap(this.formGroup.get('text')?.value);
     // Listen to fields changes
     this.fields$.pipe(takeUntil(this.destroy$)).subscribe((value) => {
       const keys = value.map((field) => ({
@@ -63,5 +77,64 @@ export class TextElementComponent
       }));
       this.editorService.addCalcAndKeysAutoCompleter(this.editor, keys);
     });
+  }
+
+  /**
+   * Switch the locale currently being edited.
+   *
+   * @param locale Locale to activate.
+   */
+  setLocale(locale: SupportedLocale): void {
+    this.activeLocale = locale;
+  }
+
+  /**
+   * Update the value for the active locale and patch the form control with the
+   * full per-locale map.
+   *
+   * @param value New rich text value for the active locale.
+   */
+  onEditorChange(value: string): void {
+    if (value) {
+      this.values = { ...this.values, [this.activeLocale]: value };
+    } else {
+      const next = { ...this.values };
+      delete next[this.activeLocale];
+      this.values = next;
+    }
+    const control = this.formGroup.get('text');
+    control?.setValue({ ...this.values });
+    control?.markAsDirty();
+  }
+
+  /**
+   * Checks whether a specific locale has a non-empty value.
+   *
+   * @param locale Locale to check.
+   * @returns True when the locale has a non-empty value.
+   */
+  hasContent(locale: SupportedLocale): boolean {
+    return !!this.values[locale];
+  }
+
+  /**
+   * Normalizes a {@link LocalizedString} (plain string or per-locale map) into a
+   * locale map. A plain string is treated as the English entry for backward
+   * compatibility with non-localized values.
+   *
+   * @param value Incoming form value.
+   * @returns Per-locale value map.
+   */
+  private toLocaleMap(
+    value: LocalizedString | null | undefined
+  ): Partial<Record<SupportedLocale, string>> {
+    if (value == null) return {};
+    if (typeof value === 'string') return value ? { en: value } : {};
+    const next: Partial<Record<SupportedLocale, string>> = {};
+    for (const locale of SUPPORTED_LOCALES) {
+      const v = value[locale];
+      if (v) next[locale] = v;
+    }
+    return next;
   }
 }

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-properties/layer-properties.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-properties/layer-properties.component.html
@@ -6,7 +6,7 @@
       <!-- Layer title -->
       <div uiFormFieldDirective>
         <label>{{ 'common.title' | translate }}</label>
-        <input formControlName="name" type="text" />
+        <shared-localized-input formControlName="name"></shared-localized-input>
       </div>
       <!-- Default visibility -->
       <ui-toggle formControlName="visibility">

--- a/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-properties/layer-properties.module.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/edit-layer-modal/layer-properties/layer-properties.module.ts
@@ -12,6 +12,7 @@ import {
   ToggleModule,
 } from '@oort-front/ui';
 import { PortalModule } from '@angular/cdk/portal';
+import { LocalizedInputComponent } from '../../../../controls/public-api';
 
 /**
  * Map layer properties module.
@@ -30,6 +31,7 @@ import { PortalModule } from '@angular/cdk/portal';
     FilterModule,
     ButtonModule,
     PortalModule,
+    LocalizedInputComponent,
   ],
   exports: [LayerPropertiesComponent],
 })

--- a/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
@@ -85,7 +85,10 @@ export const createLayerForm = (value?: LayerModel) => {
     // Layer properties
     id: new FormControl(get(value, 'id', null)),
     type: new FormControl(type, Validators.required),
-    name: new FormControl(get(value, 'name', null), Validators.required),
+    name: new FormControl<LocalizedString>(
+      get(value, 'name', ''),
+      localizedRequired
+    ),
     visibility: new FormControl(
       get(value, 'visibility', true),
       Validators.required
@@ -464,8 +467,10 @@ export const createClassBreakInfoForm = (
  */
 export const createPopupInfoForm = (value: any) =>
   fb.group({
-    title: get(value, 'title', ''),
-    description: get(value, 'description', ''),
+    title: new FormControl<LocalizedString>(get(value, 'title', '')),
+    description: new FormControl<LocalizedString>(
+      get(value, 'description', '')
+    ),
     popupElements: fb.array(
       get(value, 'popupElements', []).map((element: PopupElement) =>
         createPopupElementForm(element)
@@ -496,8 +501,10 @@ export const createPopupElementForm = (value: PopupElement): FormGroup => {
     case 'fields': {
       return fb.group({
         type: 'fields',
-        title: get(value, 'title', ''),
-        description: get(value, 'description', ''),
+        title: new FormControl<LocalizedString>(get(value, 'title', '')),
+        description: new FormControl<LocalizedString>(
+          get(value, 'description', '')
+        ),
         fields: fb.array(get(value, 'fields', []) ?? []),
       });
     }
@@ -512,7 +519,7 @@ export const createPopupElementForm = (value: PopupElement): FormGroup => {
  */
 export const createFieldsInfoForm = (value: Fields): FormGroup =>
   fb.group({
-    label: get(value, 'label', ''),
+    label: new FormControl<LocalizedString>(get(value, 'label', '')),
     name: get(value, 'name', ''),
     type: get(value, 'type', ''),
   });

--- a/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-forms.ts
@@ -494,7 +494,7 @@ export const createPopupElementForm = (value: PopupElement): FormGroup => {
     case 'text': {
       return fb.group({
         type: 'text',
-        text: get(value, 'text', ''),
+        text: new FormControl<LocalizedString>(get(value, 'text', '')),
       });
     }
     default:

--- a/libs/shared/src/lib/components/widgets/map-settings/map-layers/map-layers.component.html
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-layers/map-layers.component.html
@@ -36,7 +36,7 @@
                   <span class="flex items-center gap-1">
                     <ui-icon icon="drag_indicator" class="hover:cursor-move">
                     </ui-icon>
-                    {{ layer.name }}
+                    {{ layer.name | sharedLocalize }}
                   </span>
                 </td>
               </ng-container>

--- a/libs/shared/src/lib/components/widgets/map-settings/map-layers/map-layers.module.ts
+++ b/libs/shared/src/lib/components/widgets/map-settings/map-layers/map-layers.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MapLayersComponent } from './map-layers.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { LocalizePipe } from '../../../../pipes/localize/localize.pipe';
 import {
   ButtonModule,
   DividerModule,
@@ -40,6 +41,7 @@ import { PortalModule } from '@angular/cdk/portal';
     TooltipModule,
     PortalModule,
     AlertModule,
+    LocalizePipe,
   ],
   exports: [MapLayersComponent],
 })

--- a/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card-settings/summary-card-settings.component.ts
@@ -18,6 +18,8 @@ import {
   FormsModule,
   ReactiveFormsModule,
 } from '@angular/forms';
+import { LocalizedString } from '../../../models/localized-string.model';
+import { localizedRequired } from '../../../utils/validators/localizedRequired.validator';
 import { Apollo } from 'apollo-angular';
 import { get } from 'lodash';
 import { Aggregation } from '../../../models/aggregation.model';
@@ -335,7 +337,7 @@ export class SummaryCardSettingsComponent
       const row = this.fb.group({
         field: [item.field, Validators.required],
         order: [item.order, Validators.required],
-        label: [item.label, Validators.required],
+        label: [item.label as LocalizedString, localizedRequired],
       });
       (this.widgetFormGroup?.get('sortFields') as any).push(row);
     });

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -94,7 +94,7 @@
       [placeholder]="'models.widget.sorting.select' | translate"
     >
       <ui-select-option *ngFor="let sort of sortFields" [value]="sort">
-        {{ sort.label }}
+        {{ sort.label | sharedLocalize }}
       </ui-select-option>
     </ui-select-menu>
   </div>

--- a/libs/shared/src/lib/models/layer.model.ts
+++ b/libs/shared/src/lib/models/layer.model.ts
@@ -3,6 +3,7 @@ import { Gradient } from '../components/controls/gradient-picker/gradient-picker
 import { LayerType } from '../components/ui/map/interfaces/layer-settings.type';
 import { HeatMapOptions as HeatMapOptionsWithoutOpacity } from 'leaflet';
 import { AdminIdentifier } from '../services/map/map-polygons.service';
+import { LocalizedString } from './localized-string.model';
 
 /**
  * Layer types for backend
@@ -101,8 +102,8 @@ export interface PopupElementText {
  */
 export interface PopupElementFields {
   type: 'fields';
-  title?: string;
-  description?: string;
+  title?: LocalizedString;
+  description?: LocalizedString;
   fields?: string[];
 }
 
@@ -110,7 +111,7 @@ export interface PopupElementFields {
  * Layer Popup Fields type interface
  */
 export interface Fields {
-  label: string;
+  label: LocalizedString;
   name: string;
   type: string;
   text?: string;
@@ -133,8 +134,8 @@ export interface PopupElement
  * Layer Popup info interface
  */
 export interface PopupInfo {
-  title?: string;
-  description?: string;
+  title?: LocalizedString;
+  description?: LocalizedString;
   popupElements?: PopupElement[];
   fieldsInfo?: Fields[];
 }
@@ -162,7 +163,7 @@ export interface LayerDatasource {
  */
 export interface LayerModel {
   id: string;
-  name: string;
+  name: LocalizedString;
   type?: LayerType;
   sublayers?: string[];
   visibility: boolean;

--- a/libs/shared/src/lib/models/layer.model.ts
+++ b/libs/shared/src/lib/models/layer.model.ts
@@ -94,7 +94,7 @@ export interface LayerDefinition {
  */
 export interface PopupElementText {
   type: 'text';
-  text?: string;
+  text?: LocalizedString;
 }
 
 /**

--- a/libs/shared/src/lib/services/grid-layout/graphql/queries.ts
+++ b/libs/shared/src/lib/services/grid-layout/graphql/queries.ts
@@ -27,6 +27,7 @@ export const GET_GRID_RESOURCE_META = gql`
           node {
             id
             name
+            nameTranslations
             query
             createdAt
             display
@@ -55,6 +56,7 @@ export const GET_GRID_FORM_META = gql`
           node {
             id
             name
+            nameTranslations
             query
             createdAt
             display


### PR DESCRIPTION
# Description

- Add new localize input in the missing fields on grids (layout, action button, sort), summary cards (sort) and maps (all layer inputs).
- Update html and ts in all parts that use those fields so they show the correct translation.
- Fix bug for missing sort option on a grid.

#### On the backend
- Backend: GraphQL input/output types changed GraphQLString → GraphQLJSON for all map layer localized fields; Mongoose schema uses Mixed instead of String
- Backward compatible: existing plain-string layer names/descriptions still resolve correctly

## Useful links

- [AB#134014 translate more fields from widgets](https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories?System.IterationPath=@currentIteration&workitem=134014)
- [AB#134014 Backend PR](https://github.com/ReliefApplications/ems-backend/pull/1243)

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Configure missing locale fields on grids (layout, action button, sort), summary cards (sort) and maps (all layer inputs) and make sure they work as expected -> changing language based on selected language.
- [x] Check than previously single string configured fields still display correctly.

## Screenshots

<img width="413" height="449" alt="Screenshot 2026-06-25 at 14 52 06" src="https://github.com/user-attachments/assets/023b054b-b2e6-4a58-aba8-a64465557204" />
<img width="803" height="490" alt="Screenshot 2026-06-25 at 14 52 19" src="https://github.com/user-attachments/assets/d19f8697-9e91-468b-b09b-4c0dc3fe522d" />

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
