### PR TITLE
AB#134566: ABC - Allow outdated files in file(s) fields

### DIFF
--- a/apps/front-office/src/app/app.component.spec.ts
+++ b/apps/front-office/src/app/app.component.spec.ts
@@ -34,7 +34,12 @@ describe('AppComponent', () => {
         },
         {
           provide: SwUpdate,
-          useValue: { isEnabled: false, versionUpdates: { subscribe: () => {} } },
+          useValue: {
+            isEnabled: false,
+            versionUpdates: {
+              subscribe: () => undefined,
+            },
+          },
         },
       ],
     }).compileComponents();

--- a/apps/front-office/src/app/app.component.spec.ts
+++ b/apps/front-office/src/app/app.component.spec.ts
@@ -9,6 +9,7 @@ import { environment } from '../environments/environment';
 import { AppComponent } from './app.component';
 import { ApolloTestingModule } from 'apollo-angular/testing';
 import { Ability } from '@casl/ability';
+import { SwUpdate } from '@angular/service-worker';
 
 describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
@@ -30,6 +31,10 @@ describe('AppComponent', () => {
         {
           provide: 'environment',
           useValue: environment,
+        },
+        {
+          provide: SwUpdate,
+          useValue: { isEnabled: false, versionUpdates: { subscribe: () => {} } },
         },
       ],
     }).compileComponents();

--- a/apps/front-office/src/app/application/pages/dashboard/dashboard.component.spec.ts
+++ b/apps/front-office/src/app/application/pages/dashboard/dashboard.component.spec.ts
@@ -13,6 +13,8 @@ import {
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SkeletonModule } from '@oort-front/shared';
 
+import { Ability } from '@casl/ability';
+
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let fixture: ComponentFixture<DashboardComponent>;
@@ -35,6 +37,7 @@ describe('DashboardComponent', () => {
       ],
       declarations: [DashboardComponent],
       providers: [
+        Ability,
         TranslateService,
         {
           provide: 'environment',

--- a/apps/front-office/src/app/application/pages/form/form.component.spec.ts
+++ b/apps/front-office/src/app/application/pages/form/form.component.spec.ts
@@ -11,6 +11,10 @@ import {
   TranslateService,
 } from '@ngx-translate/core';
 
+import { DialogModule } from '@angular/cdk/dialog';
+
+import { Ability } from '@casl/ability';
+
 describe('FormComponent', () => {
   let component: FormComponent;
   let fixture: ComponentFixture<FormComponent>;
@@ -22,6 +26,7 @@ describe('FormComponent', () => {
         HttpClientTestingModule,
         OAuthModule.forRoot(),
         ApolloTestingModule,
+        DialogModule,
         TranslateModule.forRoot({
           loader: {
             provide: TranslateLoader,
@@ -30,7 +35,14 @@ describe('FormComponent', () => {
         }),
       ],
       declarations: [FormComponent],
-      providers: [TranslateService],
+      providers: [
+        Ability,
+        TranslateService,
+        {
+          provide: 'environment',
+          useValue: {},
+        },
+      ],
     }).compileComponents();
   });
 

--- a/apps/front-office/src/app/application/pages/share/share.component.spec.ts
+++ b/apps/front-office/src/app/application/pages/share/share.component.spec.ts
@@ -11,6 +11,11 @@ import {
 } from '@ngx-translate/core';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { OAuthModule } from 'angular-oauth2-oidc';
+
+import { Ability } from '@casl/ability';
+
 describe('ShareComponent', () => {
   let component: ShareComponent;
   let fixture: ComponentFixture<ShareComponent>;
@@ -19,7 +24,12 @@ describe('ShareComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [ShareComponent],
       providers: [
+        Ability,
         TranslateService,
+        {
+          provide: 'environment',
+          useValue: {},
+        },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -28,6 +38,8 @@ describe('ShareComponent', () => {
         },
       ],
       imports: [
+        HttpClientTestingModule,
+        OAuthModule.forRoot(),
         ApolloTestingModule,
         TranslateModule.forRoot({
           loader: {

--- a/apps/front-office/src/app/application/pages/workflow/workflow.component.html
+++ b/apps/front-office/src/app/application/pages/workflow/workflow.component.html
@@ -28,12 +28,12 @@
   class="block"
 >
   <shared-dashboard-export-button
-    *ngIf="$any(routerOutlet?.component)?.dashboard"
+    *ngIf="$any(activeOutletComponent)?.dashboard"
     [title]="
-      $any(routerOutlet?.component)?.dashboard?.nameTranslations ||
-      $any(routerOutlet?.component)?.dashboard?.name
+      $any(activeOutletComponent)?.dashboard?.nameTranslations ||
+      $any(activeOutletComponent)?.dashboard?.name
     "
-    [exporter]="$any(routerOutlet?.component)?.elementRef"
+    [exporter]="$any(activeOutletComponent)?.elementRef"
     class="self-center"
   ></shared-dashboard-export-button>
 </shared-workflow-stepper>

--- a/apps/front-office/src/app/application/pages/workflow/workflow.component.ts
+++ b/apps/front-office/src/app/application/pages/workflow/workflow.component.ts
@@ -31,10 +31,16 @@ import { GET_WORKFLOW_BY_ID } from './graphql/queries';
 export class WorkflowComponent extends UnsubscribeComponent implements OnInit {
   /** Reference to router outlet */
   @ViewChild(RouterOutlet) routerOutlet?: RouterOutlet;
-  /** Get active component safely from router outlet without throwing when unactivated */
+
+  /**
+   * Get active component safely from router outlet without throwing when unactivated
+   *
+   * @returns active router component instance or null
+   */
   get activeOutletComponent(): any {
     return this.routerOutlet?.isActivated ? this.routerOutlet.component : null;
   }
+
   /** Loading state of the page */
   public loading = true;
   /** Current workflow id */

--- a/apps/front-office/src/app/application/pages/workflow/workflow.component.ts
+++ b/apps/front-office/src/app/application/pages/workflow/workflow.component.ts
@@ -31,6 +31,10 @@ import { GET_WORKFLOW_BY_ID } from './graphql/queries';
 export class WorkflowComponent extends UnsubscribeComponent implements OnInit {
   /** Reference to router outlet */
   @ViewChild(RouterOutlet) routerOutlet?: RouterOutlet;
+  /** Get active component safely from router outlet without throwing when unactivated */
+  get activeOutletComponent(): any {
+    return this.routerOutlet?.isActivated ? this.routerOutlet.component : null;
+  }
   /** Loading state of the page */
   public loading = true;
   /** Current workflow id */

--- a/apps/front-office/src/app/auth/pages/login/login.component.spec.ts
+++ b/apps/front-office/src/app/auth/pages/login/login.component.spec.ts
@@ -6,6 +6,8 @@ import { LoginComponent } from './login.component';
 import { Ability } from '@casl/ability';
 import { SpinnerModule } from '@oort-front/ui';
 
+import { TranslateModule } from '@ngx-translate/core';
+
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
@@ -17,6 +19,7 @@ describe('LoginComponent', () => {
         OAuthModule.forRoot(),
         ApolloTestingModule,
         SpinnerModule,
+        TranslateModule.forRoot(),
       ],
       providers: [
         Ability,

--- a/apps/front-office/src/app/redirect/redirect.component.spec.ts
+++ b/apps/front-office/src/app/redirect/redirect.component.spec.ts
@@ -1,5 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { OAuthModule } from 'angular-oauth2-oidc';
+import { TranslateModule } from '@ngx-translate/core';
+import { ApolloTestingModule } from 'apollo-angular/testing';
+import { Ability } from '@casl/ability';
 import { RedirectComponent } from './redirect.component';
 
 describe('RedirectComponent', () => {
@@ -8,7 +14,21 @@ describe('RedirectComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        HttpClientTestingModule,
+        OAuthModule.forRoot(),
+        TranslateModule.forRoot(),
+        ApolloTestingModule,
+      ],
       declarations: [RedirectComponent],
+      providers: [
+        Ability,
+        {
+          provide: 'environment',
+          useValue: {},
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(RedirectComponent);

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -1603,8 +1603,10 @@
       "tooltip": {
         "allowFieldAccessibility": "Allow this role to see the field {{field}}",
         "allowFieldUpdate": "Allow this role to update the field {{field}}",
+        "allowFileDelete": "Allow this role to delete files in field {{field}}",
         "disallowFieldAccessibility": "Disallow this role to see the field {{field}}",
         "disallowFieldUpdate": "Disallow this role to update the field {{field}}",
+        "disallowFileDelete": "Disallow this role to delete files in field {{field}}",
         "grantAddRecordsPermission": "Grant permission to add new records",
         "grantDeleteRecordsPermission": "Grant permission to delete records",
         "grantDownloadRecordsPermission": "Grant permission to download records",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -1606,8 +1606,10 @@
       "tooltip": {
         "allowFieldAccessibility": "Autoriser ce rôle à voir le champ {{field}}",
         "allowFieldUpdate": "Autoriser ce rôle à mettre à jour le champ {{field}}",
+        "allowFileDelete": "Autoriser ce rôle à supprimer des fichiers dans le champ {{field}}",
         "disallowFieldAccessibility": "Interdire ce rôle pour voir le champ {{field}}",
         "disallowFieldUpdate": "Interdire ce rôle pour mettre à jour le champ {{field}}",
+        "disallowFileDelete": "Interdire ce rôle de supprimer des fichiers dans le champ {{field}}",
         "grantAddRecordsPermission": "Permet de créer de nouveaux enregistrements",
         "grantDeleteRecordsPermission": "Permet de supprimer tous les enregistrements",
         "grantDownloadRecordsPermission": "Permet de télécharger les enregistrements",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -1603,8 +1603,10 @@
       "tooltip": {
         "allowFieldAccessibility": "****** {{field}}",
         "allowFieldUpdate": "****** {{field}}",
+        "allowFileDelete": "****** {{field}}",
         "disallowFieldAccessibility": "****** {{field}}",
         "disallowFieldUpdate": "****** {{field}}",
+        "disallowFileDelete": "****** {{field}}",
         "grantAddRecordsPermission": "******",
         "grantDeleteRecordsPermission": "******",
         "grantDownloadRecordsPermission": "******",

--- a/libs/shared/src/i18n/uk.json
+++ b/libs/shared/src/i18n/uk.json
@@ -1603,8 +1603,10 @@
       "tooltip": {
         "allowFieldAccessibility": "Дозволити цій ролі бачити поле {{field}}",
         "allowFieldUpdate": "Дозволити цій ролі оновлювати поле {{field}}",
+        "allowFileDelete": "Дозволити цій ролі видаляти файли в полі {{field}}",
         "disallowFieldAccessibility": "Заборонити цій ролі бачити поле {{field}}",
         "disallowFieldUpdate": "Заборонити цій ролі оновлювати поле {{field}}",
+        "disallowFileDelete": "Заборонити цій ролі видаляти файли в полі {{field}}",
         "grantAddRecordsPermission": "Надати дозвіл на додавання нових записів",
         "grantDeleteRecordsPermission": "Надати дозвіл на видалення записів",
         "grantDownloadRecordsPermission": "Надати дозвіл на завантаження записів",

--- a/libs/shared/src/lib/components/draft-record-list-modal/graphql/queries.ts
+++ b/libs/shared/src/lib/components/draft-record-list-modal/graphql/queries.ts
@@ -16,6 +16,7 @@ export const GET_DRAFT_RECORDS = gql`
         automated
         canSee
         canUpdate
+        canDeleteFiles
       }
     }
   }

--- a/libs/shared/src/lib/components/form-modal/graphql/queries.ts
+++ b/libs/shared/src/lib/components/form-modal/graphql/queries.ts
@@ -20,6 +20,7 @@ export const GET_FORM_BY_ID = gql`
         automated
         canSee
         canUpdate
+        canDeleteFiles
       }
       canUpdate
     }
@@ -55,6 +56,7 @@ export const GET_RECORD_BY_ID = gql`
           automated
           canSee
           canUpdate
+          canDeleteFiles
         }
       }
     }

--- a/libs/shared/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.ts
+++ b/libs/shared/src/lib/components/grid-layout/add-layout-modal/add-layout-modal.component.ts
@@ -152,6 +152,7 @@ export class AddLayoutModalComponent
       disableClose: true,
       data: {
         queryName: this.resource?.queryName || this.form?.queryName,
+        fileFieldNames: this.getFileFieldNames(),
       },
     });
     dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((layout: any) => {
@@ -175,5 +176,16 @@ export class AddLayoutModalComponent
           });
       }
     });
+  }
+
+  /**
+   * Gets file field names available in this layout context.
+   *
+   * @returns File field names
+   */
+  private getFileFieldNames(): string[] {
+    return (this.resource?.fields ?? this.form?.fields ?? [])
+      .filter((field: any) => field.type === 'file')
+      .map((field: any) => field.name);
   }
 }

--- a/libs/shared/src/lib/components/grid-layout/edit-layout-modal/edit-layout-modal.component.html
+++ b/libs/shared/src/lib/components/grid-layout/edit-layout-modal/edit-layout-modal.component.html
@@ -26,6 +26,7 @@
           [queryName]="data.queryName"
           [layoutPreviewData]="layoutPreviewData"
           [showColumnWidth]="true"
+          [fileFieldNames]="data.fileFieldNames || []"
         ></shared-query-builder>
       </div>
     </form>

--- a/libs/shared/src/lib/components/grid-layout/edit-layout-modal/edit-layout-modal.component.ts
+++ b/libs/shared/src/lib/components/grid-layout/edit-layout-modal/edit-layout-modal.component.ts
@@ -27,6 +27,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 interface DialogData {
   layout?: Layout;
   queryName?: string;
+  fileFieldNames?: string[];
 }
 
 /**

--- a/libs/shared/src/lib/components/grid-layout/layout-table/layout-table.component.ts
+++ b/libs/shared/src/lib/components/grid-layout/layout-table/layout-table.component.ts
@@ -149,6 +149,7 @@ export class LayoutTableComponent
       data: {
         layout,
         queryName: this.resource?.queryName,
+        fileFieldNames: this.getFileFieldNames(),
       },
     });
     dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value: any) => {
@@ -189,5 +190,16 @@ export class LayoutTableComponent
     const layouts = [...this.selectedLayouts?.value];
     moveItemInArray(layouts, event.previousIndex, event.currentIndex);
     this.selectedLayouts?.setValue(layouts);
+  }
+
+  /**
+   * Gets file field names available in this layout context.
+   *
+   * @returns File field names
+   */
+  private getFileFieldNames(): string[] {
+    return (this.resource?.fields ?? this.form?.fields ?? [])
+      .filter((field: any) => field.type === 'file')
+      .map((field: any) => field.name);
   }
 }

--- a/libs/shared/src/lib/components/query-builder/query-builder-forms.ts
+++ b/libs/shared/src/lib/components/query-builder/query-builder-forms.ts
@@ -131,6 +131,7 @@ export const addNewField = (field: any, newField?: boolean) => {
         ],
         width: [newField ? null : field.width],
         format: [get(field, 'format', null)],
+        showOutdatedFiles: [get(field, 'showOutdatedFiles', true)],
       });
     }
   }

--- a/libs/shared/src/lib/components/query-builder/query-builder.component.html
+++ b/libs/shared/src/lib/components/query-builder/query-builder.component.html
@@ -153,6 +153,7 @@
             [fields]="availableFields"
             [showLimit]="true"
             [showColumnWidth]="showColumnWidth"
+            [fileFieldNames]="fileFieldNames"
           ></shared-tab-fields>
         </ng-template>
       </ui-tab>

--- a/libs/shared/src/lib/components/query-builder/query-builder.component.ts
+++ b/libs/shared/src/lib/components/query-builder/query-builder.component.ts
@@ -49,6 +49,8 @@ export class QueryBuilderComponent
   @Input() showColumnWidth = false;
   /** Show limit option */
   @Input() showLimit = false;
+  /** Field names that should display file-specific settings. */
+  @Input() fileFieldNames: string[] = [];
   /** Close field event emitter */
   @Output() closeField: EventEmitter<boolean> = new EventEmitter();
   /** Is field boolean control */

--- a/libs/shared/src/lib/components/query-builder/query-builder.module.ts
+++ b/libs/shared/src/lib/components/query-builder/query-builder.module.ts
@@ -36,6 +36,7 @@ import {
   DividerModule,
   IconModule,
   SpinnerModule,
+  ToggleModule,
 } from '@oort-front/ui';
 import { TreeViewModule } from '@progress/kendo-angular-treeview';
 
@@ -88,6 +89,7 @@ import { TreeViewModule } from '@progress/kendo-angular-treeview';
     TreeViewModule,
     SpinnerModule,
     CheckboxModule,
+    ToggleModule,
   ],
   exports: [
     QueryBuilderComponent,

--- a/libs/shared/src/lib/components/query-builder/tab-fields/tab-fields.component.html
+++ b/libs/shared/src/lib/components/query-builder/tab-fields/tab-fields.component.html
@@ -206,6 +206,9 @@
           [uiTooltip]="'components.queryBuilder.fields.format.info' | translate"
         ></ui-icon>
       </div>
+      <ui-toggle *ngIf="isEditedFileField" formControlName="showOutdatedFiles">
+        <ng-container ngProjectAs="label">Show outdated files</ng-container>
+      </ui-toggle>
     </form>
   </ng-container>
   <!-- If not scalar field, display child template -->

--- a/libs/shared/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
+++ b/libs/shared/src/lib/components/query-builder/tab-fields/tab-fields.component.ts
@@ -35,6 +35,8 @@ export class TabFieldsComponent implements OnInit, OnChanges {
   @Input() disabled = false;
   /** All fields */
   @Input() fields: any[] = [];
+  /** Field names that should display file-specific settings. */
+  @Input() fileFieldNames: string[] = [];
   /** Should show limit input */
   @Input() showLimit = false;
   /** Is the column width field displayed */
@@ -210,6 +212,17 @@ export class TabFieldsComponent implements OnInit, OnChanges {
   public onCloseField(): void {
     this.fieldForm = null;
     this.checkfieldsIsValid();
+  }
+
+  /** @returns true when the edited field is a file field. */
+  public get isEditedFileField(): boolean {
+    const fieldName = this.fieldForm?.get('name')?.value;
+    if (this.fileFieldNames.length > 0) {
+      return this.fileFieldNames.includes(fieldName);
+    }
+    return this.fields.some(
+      (field) => field.name === fieldName && field.meta?.type === 'file'
+    );
   }
 
   /**

--- a/libs/shared/src/lib/components/record-modal/graphql/queries.ts
+++ b/libs/shared/src/lib/components/record-modal/graphql/queries.ts
@@ -30,6 +30,7 @@ export const GET_RECORD_BY_ID = gql`
           automated
           canSee
           canUpdate
+          canDeleteFiles
         }
       }
     }
@@ -50,6 +51,7 @@ export const GET_FORM_STRUCTURE = gql`
         automated
         canSee
         canUpdate
+        canDeleteFiles
       }
     }
   }

--- a/libs/shared/src/lib/components/role-summary/role-resources/resource-fields/resource-fields.component.html
+++ b/libs/shared/src/lib/components/role-summary/role-resources/resource-fields/resource-fields.component.html
@@ -68,6 +68,21 @@
               (click)="onEditFieldAccess(index, element, 'canUpdate')"
             >
             </ui-button>
+            <ui-button
+              *ngIf="element.isFileField"
+              [isIcon]="true"
+              [icon]="element.canDeleteFiles ? 'delete' : 'delete_outline'"
+              [variant]="element.canDeleteFiles ? 'primary' : 'grey'"
+              [disabled]="disabled || !element.canSee || !element.canUpdate"
+              [uiTooltip]="
+                (element.canDeleteFiles
+                  ? 'components.role.tooltip.allowFileDelete'
+                  : 'components.role.tooltip.disallowFileDelete'
+                ) | translate : { field: element.name }
+              "
+              (click)="onEditFieldAccess(index, element, 'canDeleteFiles')"
+            >
+            </ui-button>
           </div>
         </td>
       </ng-container>

--- a/libs/shared/src/lib/components/role-summary/role-resources/resource-fields/resource-fields.component.ts
+++ b/libs/shared/src/lib/components/role-summary/role-resources/resource-fields/resource-fields.component.ts
@@ -16,6 +16,8 @@ type ResourceField = {
   name: string;
   canSee: boolean;
   canUpdate: boolean;
+  canDeleteFiles?: boolean;
+  isFileField?: boolean;
 };
 
 /**
@@ -39,7 +41,7 @@ export class ResourceFieldsComponent implements OnInit, OnChanges {
   @Output() onToggle = new EventEmitter<{
     resource: Resource;
     field: ResourceField;
-    permission: 'canSee' | 'canUpdate';
+    permission: 'canSee' | 'canUpdate' | 'canDeleteFiles';
   }>();
 
   /** Filter template id */
@@ -51,8 +53,10 @@ export class ResourceFieldsComponent implements OnInit, OnChanges {
   public displayedColumns: string[] = ['name', 'actions'];
 
   /** Updated field */
-  private updatedField: { index: number; permission: 'canSee' | 'canUpdate' } =
-    { index: -1, permission: 'canSee' };
+  private updatedField: {
+    index: number;
+    permission: 'canSee' | 'canUpdate' | 'canDeleteFiles';
+  } = { index: -1, permission: 'canSee' };
 
   ngOnInit() {
     this.fields = sortBy(this.resource.fields.map(this.hasFieldAccess), 'name');
@@ -66,8 +70,10 @@ export class ResourceFieldsComponent implements OnInit, OnChanges {
       const field = this.fields[this.updatedField.index];
       if (this.updatedField.permission === 'canSee') {
         field.canSee = !field.canSee;
-      } else {
+      } else if (this.updatedField.permission === 'canUpdate') {
         field.canUpdate = !field.canUpdate;
+      } else if (this.updatedField.permission === 'canDeleteFiles') {
+        field.canDeleteFiles = !field.canDeleteFiles;
       }
       this.updatedField.index = -1;
     }
@@ -79,11 +85,20 @@ export class ResourceFieldsComponent implements OnInit, OnChanges {
    * @param field field
    * @returns field with access data
    */
-  private hasFieldAccess = (field: any) => ({
-    name: field.name,
-    canSee: !!field.permissions?.canSee?.includes(this.role.id),
-    canUpdate: !!field.permissions?.canUpdate?.includes(this.role.id),
-  });
+  private hasFieldAccess = (field: any) => {
+    const isFileField = field.type === 'file' || field.meta?.type === 'file';
+    const canDeleteFiles = field.permissions?.canDeleteFiles
+      ? !!field.permissions.canDeleteFiles.includes(this.role.id)
+      : !!field.permissions?.canUpdate?.includes(this.role.id);
+
+    return {
+      name: field.name,
+      canSee: !!field.permissions?.canSee?.includes(this.role.id),
+      canUpdate: !!field.permissions?.canUpdate?.includes(this.role.id),
+      canDeleteFiles,
+      isFileField,
+    };
+  };
 
   /**
    * Filter list of fields by template id
@@ -111,7 +126,7 @@ export class ResourceFieldsComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Emits an event to toggle if field is visible / editable.
+   * Emits an event to toggle if field is visible / editable / delete files allowed.
    *
    * @param index Index of the field to toggle permission for.
    * @param field Field to toggle permission for.
@@ -120,7 +135,7 @@ export class ResourceFieldsComponent implements OnInit, OnChanges {
   public onEditFieldAccess(
     index: number,
     field: ResourceField,
-    permission: 'canSee' | 'canUpdate'
+    permission: 'canSee' | 'canUpdate' | 'canDeleteFiles'
   ) {
     // Save field updated
     this.updatedField = { index, permission };

--- a/libs/shared/src/lib/components/role-summary/role-resources/role-resources.component.ts
+++ b/libs/shared/src/lib/components/role-summary/role-resources/role-resources.component.ts
@@ -397,8 +397,13 @@ export class RoleResourcesComponent
    */
   onEditFieldAccess(
     resource: Resource,
-    field: { name: string; canSee: boolean; canUpdate: boolean },
-    action: 'canSee' | 'canUpdate'
+    field: {
+      name: string;
+      canSee: boolean;
+      canUpdate: boolean;
+      canDeleteFiles?: boolean;
+    },
+    action: 'canSee' | 'canUpdate' | 'canDeleteFiles'
   ): void {
     if (!this.role.id) return;
 

--- a/libs/shared/src/lib/components/role-summary/role-resources/role-resources.component.ts
+++ b/libs/shared/src/lib/components/role-summary/role-resources/role-resources.component.ts
@@ -393,6 +393,7 @@ export class RoleResourcesComponent
    * @param field.name the name of the field to be edited
    * @param field.canSee whether the field can be seen
    * @param field.canUpdate whether the field can be edited
+   * @param field.canDeleteFiles whether the field's persisted files can be deleted outright
    * @param action the permission to be edited
    */
   onEditFieldAccess(

--- a/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
+++ b/libs/shared/src/lib/components/ui/core-grid/grid/grid.component.html
@@ -905,6 +905,12 @@
                 class="w-full !justify-start overflow-hidden text-ellipsis"
               >
                 <span [class]="dataItem.icon[file.name]"></span>
+                <span
+                  *ngIf="file.outdated"
+                  class="k-icon k-i-warning"
+                  style="color: #b45309"
+                  title="Outdated file"
+                ></span>
                 <span class="textbox">{{
                   dataItem.text[field.name][file.name] || file.name
                 }}</span>
@@ -936,6 +942,12 @@
                 >
                   <p style="text-wrap: auto" class="max-w-full">
                     <span [class]="dataItem.icon[file.name]"></span>
+                    <span
+                      *ngIf="file.outdated"
+                      class="k-icon k-i-warning"
+                      style="color: #b45309"
+                      title="Outdated file"
+                    ></span>
                     <span class="textbox">{{
                       dataItem.text[field.name][file.name] || file.name
                     }}</span>

--- a/libs/shared/src/lib/components/ui/map/utils/leaflet-heatmap.js
+++ b/libs/shared/src/lib/components/ui/map/utils/leaflet-heatmap.js
@@ -2,9 +2,11 @@
 
 /** This file has the correct feature to add intensity to the features of the heat array */
 /** Issue taken as source: https://github.com/Leaflet/Leaflet.heat/issues/74 */
-import * as L from 'leaflet';
+import * as LModule from 'leaflet';
 import simpleheat from 'simpleheat';
 import { isNil } from 'lodash';
+
+const L = LModule.default || LModule;
 
 L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
   initialize: function (latlngs, options) {

--- a/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/graphql/queries.ts
@@ -50,6 +50,7 @@ export const GET_GRID_RESOURCE_META = gql`
       id
       name
       queryName
+      fields
       forms {
         id
         name

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.html
@@ -76,6 +76,7 @@
   <ng-container *ngIf="displayMode === 'grid'">
     <div class="min-h-0 flex-1">
       <shared-grid-widget
+        #gridWidget
         class="flex-1 h-full w-full"
         [settings]="gridSettings"
         [widget]="widget"

--- a/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
+++ b/libs/shared/src/lib/components/widgets/summary-card/summary-card.component.ts
@@ -85,7 +85,7 @@ export class SummaryCardComponent
   /** Reference to pdf */
   @ViewChild('pdf') pdf!: any;
   /** Reference to grid component, when grid view is activated */
-  @ViewChild(GridWidgetComponent) gridComponent?: GridWidgetComponent;
+  @ViewChild('gridWidget') gridComponent?: GridWidgetComponent;
   /** Grid settings */
   public gridSettings: any = null;
   /** Current display mode */

--- a/libs/shared/src/lib/models/grid.model.ts
+++ b/libs/shared/src/lib/models/grid.model.ts
@@ -11,6 +11,7 @@ export interface GridField {
   meta: Meta;
   disabled: boolean;
   hidden: boolean;
+  showOutdatedFiles?: boolean;
   width: number;
   order: number;
   canSee: boolean;

--- a/libs/shared/src/lib/models/metadata.model.ts
+++ b/libs/shared/src/lib/models/metadata.model.ts
@@ -13,6 +13,7 @@ export interface Metadata {
   filter?: { defaultOperator?: string; operators: string[] };
   canSee?: boolean;
   canUpdate?: boolean;
+  canDeleteFiles?: boolean;
   multiSelect?: boolean;
   filterable?: boolean;
   options?: { text: LocalizedString; value: any }[];

--- a/libs/shared/src/lib/services/file/file-outdated.utils.ts
+++ b/libs/shared/src/lib/services/file/file-outdated.utils.ts
@@ -1,0 +1,25 @@
+import { File } from './file.service';
+
+/**
+ * Checks whether a file is marked as outdated.
+ *
+ * @param file File value
+ * @returns true when the file is outdated
+ */
+export const isFileOutdated = (file: unknown): boolean =>
+  !!file &&
+  typeof file === 'object' &&
+  (file as Pick<File, 'outdated'>).outdated === true;
+
+/**
+ * Filters files according to the widget/layout display option.
+ *
+ * @param files File values
+ * @param showOutdatedFiles Should outdated files be kept
+ * @returns filtered file values
+ */
+export const filterOutdatedFiles = <T extends Pick<File, 'outdated'>>(
+  files: T[],
+  showOutdatedFiles = true
+): T[] =>
+  showOutdatedFiles ? files : files.filter((file) => !isFileOutdated(file));

--- a/libs/shared/src/lib/services/file/file.service.ts
+++ b/libs/shared/src/lib/services/file/file.service.ts
@@ -36,6 +36,7 @@ export interface File {
   name: string;
   type?: string;
   content?: string | DocumentManagementFileContent;
+  outdated?: boolean;
 }
 
 /**

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -25,6 +25,7 @@ import { EDIT_RECORD } from './graphql/mutations';
 import { DocumentManagementService } from '../document-management/document-management.service';
 import { AutoTranslateService } from '../auto-translate/auto-translate.service';
 import { toSurveyLocale } from '../../utils/languages';
+import { isFileOutdated } from '../file/file-outdated.utils';
 
 /**
  * Shared form builder service.
@@ -132,6 +133,9 @@ export class FormBuilderService {
             question.delete();
           } else {
             question.readOnly = disabled || !editable;
+            if (f.canDeleteFiles !== undefined) {
+              question.setPropertyValue('canDeleteFiles', f.canDeleteFiles);
+            }
           }
         }
       }
@@ -232,7 +236,8 @@ export class FormBuilderService {
     const allowedFileNumber = question.getPropertyValue('allowedFileNumber');
     const allowOutdatedFiles = question.getPropertyValue('allowOutdatedFiles');
     const maximumFiles = allowMultiple ? allowedFileNumber : 1;
-    if (allowOutdatedFiles && files.length > maximumFiles) {
+    const activeFilesCount = files.filter((f) => !isFileOutdated(f)).length;
+    if (allowOutdatedFiles && activeFilesCount > maximumFiles) {
       this.snackBar.openSnackBar(
         this.translate.instant(
           'components.formBuilder.errors.maximumAllowedFiles',
@@ -267,8 +272,10 @@ export class FormBuilderService {
    */
   private onClearFiles(temporaryFilesStorage: any, options: any): void {
     const filesToClear = Array.isArray(options.value) ? options.value : [];
+    const canDeleteFiles = options.question?.getPropertyValue('canDeleteFiles') !== false;
     if (
       options.question?.getPropertyValue('allowOutdatedFiles') &&
+      !canDeleteFiles &&
       filesToClear.length > 0
     ) {
       options.question.value = options.value;

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -230,7 +230,23 @@ export class FormBuilderService {
     let isValid = true;
     const allowMultiple = question.getPropertyValue('allowMultiple');
     const allowedFileNumber = question.getPropertyValue('allowedFileNumber');
-    if (allowMultiple && files.length > allowedFileNumber) {
+    const allowOutdatedFiles = question.getPropertyValue('allowOutdatedFiles');
+    const maximumFiles = allowMultiple ? allowedFileNumber : 1;
+    if (allowOutdatedFiles && files.length > maximumFiles) {
+      this.snackBar.openSnackBar(
+        this.translate.instant(
+          'components.formBuilder.errors.maximumAllowedFiles',
+          { number: maximumFiles }
+        ),
+        { error: true }
+      );
+      isValid = false;
+    }
+    if (
+      !allowOutdatedFiles &&
+      allowMultiple &&
+      files.length > allowedFileNumber
+    ) {
       this.snackBar.openSnackBar(
         this.translate.instant(
           'components.formBuilder.errors.maximumAllowedFiles',
@@ -250,6 +266,15 @@ export class FormBuilderService {
    * @param options Options regarding the files
    */
   private onClearFiles(temporaryFilesStorage: any, options: any): void {
+    const filesToClear = Array.isArray(options.value) ? options.value : [];
+    if (
+      options.question?.getPropertyValue('allowOutdatedFiles') &&
+      filesToClear.length > 0
+    ) {
+      options.question.value = options.value;
+      options.callback('error');
+      return;
+    }
     if (options.question.allowMultiple) {
       // Filtering the temp storage to remove the file based on filename
       if (temporaryFilesStorage[options.name]) {
@@ -279,6 +304,7 @@ export class FormBuilderService {
       ...(temporaryFilesStorage[options.name] ?? []),
     ]);
     if (!isUploadValid) {
+      options.callback('error');
       return;
     }
     if (!isNil(temporaryFilesStorage[options.name])) {
@@ -288,14 +314,15 @@ export class FormBuilderService {
     } else {
       temporaryFilesStorage[options.name] = options.files;
     }
-    let content: any[] = [];
-    options.files.forEach((file: any) => {
+    let content: Array<{
+      file: File;
+      content: string | ArrayBuffer | null;
+    }> = [];
+    options.files.forEach((file: File) => {
       const fileReader = new FileReader();
       fileReader.onload = () => {
         content = content.concat([
           {
-            name: file.name,
-            type: file.type,
             content: fileReader.result,
             file,
           },

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -272,7 +272,8 @@ export class FormBuilderService {
    */
   private onClearFiles(temporaryFilesStorage: any, options: any): void {
     const filesToClear = Array.isArray(options.value) ? options.value : [];
-    const canDeleteFiles = options.question?.getPropertyValue('canDeleteFiles') !== false;
+    const canDeleteFiles =
+      options.question?.getPropertyValue('canDeleteFiles') !== false;
     if (
       options.question?.getPropertyValue('allowOutdatedFiles') &&
       !canDeleteFiles &&

--- a/libs/shared/src/lib/services/form-helper/form-helper.service.ts
+++ b/libs/shared/src/lib/services/form-helper/form-helper.service.ts
@@ -25,6 +25,7 @@ import {
 } from './graphql/mutations';
 import { File, FileService } from '../file/file.service';
 import { getFileIcon, removeFileExtension } from '../file/file.utils';
+import { isFileOutdated } from '../file/file-outdated.utils';
 
 /**
  * Shared survey helper service.
@@ -610,6 +611,9 @@ export class FormHelpersService {
           `<span class="k-icon ${getFileIcon(
             file.name
           )}" style="margin-right: 4px"></span>` +
+          (isFileOutdated(file)
+            ? '<span class="k-icon k-i-warning" style="color: #b45309; margin-right: 4px" title="Outdated file"></span>'
+            : '') +
           `${removeFileExtension(file.name)}</button>`
       )
       .join('');
@@ -635,12 +639,48 @@ export class FormHelpersService {
     if (!htmlQuestion || htmlQuestion.dataset['fileLinksBound'] === 'true') {
       return;
     }
+    this.updateHtmlQuestionOutdatedFiles(
+      survey,
+      options.question,
+      htmlQuestion
+    );
     // Bind the click handler once per rendered element.
     htmlQuestion.dataset['fileLinksBound'] = 'true';
     htmlQuestion.addEventListener('click', (event) =>
       this.onFileClick(event, survey)
     );
   };
+
+  /**
+   * Applies the HTML-question setting that hides outdated file placeholders.
+   *
+   * @param survey Current survey
+   * @param question HTML question
+   * @param htmlQuestion Rendered HTML question element
+   */
+  private updateHtmlQuestionOutdatedFiles(
+    survey: SurveyModel,
+    question: Question,
+    htmlQuestion: HTMLElement
+  ): void {
+    if (question.getPropertyValue('showOutdatedFiles') !== false) {
+      return;
+    }
+    htmlQuestion
+      .querySelectorAll<HTMLButtonElement>('button[type="file"][field][index]')
+      .forEach((button) => {
+        const fieldName = button.getAttribute('field');
+        const index = Number(button.getAttribute('index'));
+        if (!fieldName || Number.isNaN(index)) {
+          return;
+        }
+        const files = this.resolveValue(survey, fieldName);
+        const file = Array.isArray(files) ? files[index] : null;
+        if (this.isFile(file) && isFileOutdated(file)) {
+          button.remove();
+        }
+      });
+  }
 
   /**
    * Handle click event on a rendered HTML question.

--- a/libs/shared/src/lib/services/grid-data-formatter/grid-data-formatter.service.ts
+++ b/libs/shared/src/lib/services/grid-data-formatter/grid-data-formatter.service.ts
@@ -10,6 +10,8 @@ import {
   getUrl,
 } from './grid-data-formatter.helper';
 import { getFileIcon, removeFileExtension } from '../file/file.utils';
+import { File } from '../file/file.service';
+import { filterOutdatedFiles } from '../file/file-outdated.utils';
 
 /**
  * Grid data formatter service
@@ -175,23 +177,26 @@ export class GridDataFormatterService {
             });
           } else {
             // Format files name and icons for each field
-            (get(rowData, field.name) || {}).forEach(
-              (file: { name: string }) => {
-                const text = this.htmlParserService.applyLayoutFormat(
-                  removeFileExtension(file.name),
-                  field
-                );
-                Object.assign(this.textObj.text, {
-                  [field.name]: {
-                    [file.name]: text,
-                  },
-                });
-                const icon = 'k-icon ' + getFileIcon(file.name);
-                Object.assign(this.iconObj.icon, {
-                  [file.name]: icon,
-                });
-              }
+            const files = filterOutdatedFiles(
+              (get(rowData, field.name) || []) as File[],
+              field.showOutdatedFiles !== false
             );
+            rowData[field.name] = files;
+            files.forEach((file) => {
+              const text = this.htmlParserService.applyLayoutFormat(
+                removeFileExtension(file.name),
+                field
+              );
+              Object.assign(this.textObj.text, {
+                [field.name]: {
+                  [file.name]: text,
+                },
+              });
+              const icon = 'k-icon ' + getFileIcon(file.name);
+              Object.assign(this.iconObj.icon, {
+                [file.name]: icon,
+              });
+            });
           }
         }
       });

--- a/libs/shared/src/lib/services/grid/grid.service.ts
+++ b/libs/shared/src/lib/services/grid/grid.service.ts
@@ -155,6 +155,7 @@ export class GridService {
                 meta: metaData,
                 disabled: f.type.endsWith(REFERENCE_DATA_END) ? false : true,
                 hidden: hidden || cachedField?.hidden || false,
+                showOutdatedFiles: f.showOutdatedFiles,
                 width: cachedField?.width || title.length * 7 + 50,
                 fixedWidth: f.width, // width used to overwrite autocalculation
                 order: cachedField?.order,
@@ -212,6 +213,7 @@ export class GridService {
               meta: metaData,
               disabled: f.type.endsWith(REFERENCE_DATA_END) ? false : true,
               hidden: hidden || cachedField?.hidden || false,
+              showOutdatedFiles: f.showOutdatedFiles,
               width: cachedField?.width || title.length * 7 + 50,
               fixedWidth: f.width, // width used to overwrite autocalculation
               order: cachedField?.order,
@@ -249,6 +251,7 @@ export class GridService {
                 get(metaData, 'isCalculated', false) ||
                 this.isFieldDisabled(metaData),
               hidden: hidden || cachedField?.hidden || false,
+              showOutdatedFiles: f.showOutdatedFiles,
               width: cachedField?.width || title.length * 7 + 50,
               fixedWidth: f.width, // width used to overwrite autocalculation
               order: cachedField?.order,

--- a/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser.service.spec.ts
@@ -358,6 +358,31 @@ describe('HtmlParserService', () => {
       expect(result).toContain('k-icon k-i-file-pdf');
       expect(result).toContain('report');
     });
+
+    it('can hide outdated file placeholders', () => {
+      const result = service.parseHtml('<p>{{data.documents}}</p>', {
+        data: {
+          documents: [
+            {
+              name: 'old-report.pdf',
+              type: 'application/pdf',
+              content: 'old-file-id',
+              outdated: true,
+            },
+            {
+              name: 'current-report.pdf',
+              type: 'application/pdf',
+              content: 'current-file-id',
+            },
+          ],
+        },
+        fields: [{ name: 'documents', type: 'file', showOutdatedFiles: false }],
+      });
+
+      expect(result).not.toContain('old-report.pdf');
+      expect(result).toContain('current-report.pdf');
+      expect(result).toContain('index="1"');
+    });
   });
   describe('Parse HTML with context data', () => {
     let replaceRecordFields!: any;

--- a/libs/shared/src/lib/services/html-parser/html-parser.service.ts
+++ b/libs/shared/src/lib/services/html-parser/html-parser.service.ts
@@ -16,6 +16,8 @@ import { REFERENCE_DATA_END } from '../query-builder/query-builder.service';
 import { getFileIcon, removeFileExtension } from '../file/file.utils';
 import { TranslateService } from '@ngx-translate/core';
 import { resolveLocalizedString } from '../../models/localized-string.model';
+import { File } from '../file/file.service';
+import { isFileOutdated } from '../file/file-outdated.utils';
 
 type Shape = 'circle' | 'square';
 
@@ -986,8 +988,12 @@ export class HtmlParserService {
       case 'file':
         convertedValue = '';
         if (isArray(value)) {
-          for (let i = 0; value[i]; ) {
-            const file = value[i];
+          const files = value as File[];
+          for (let i = 0; files[i]; i++) {
+            const file = files[i];
+            if (field.showOutdatedFiles === false && isFileOutdated(file)) {
+              continue;
+            }
             const fileIcon = getFileIcon(file.name);
             const fileName = this.applyLayoutFormat(
               removeFileExtension(file.name),
@@ -998,11 +1004,16 @@ export class HtmlParserService {
                 type="file"
                 class="k-button k-button-flat k-button-flat-base"
                 field="${field.name}"
-                index="${i++}"
+                index="${i}"
                 style="padding: 4px 6px; cursor: pointer; ${style}"
                 title="${file.name}"
               >
                 <span class="k-icon ${fileIcon}" style="margin-right: 4px"></span>
+                ${
+                  isFileOutdated(file)
+                    ? '<span class="k-icon k-i-warning" style="color: #b45309; margin-right: 4px" title="Outdated file"></span>'
+                    : ''
+                }
                 ${fileName}
               </button>
             `

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -175,6 +175,13 @@ export const init = (environment: any): void => {
     default: false,
   });
 
+  serializer.addProperty('file', {
+    name: 'canDeleteFiles:boolean',
+    category: 'general',
+    visible: false,
+    default: true,
+  });
+
   serializer.addProperty('html', {
     name: 'showOutdatedFiles:boolean',
     category: 'general',

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -165,6 +165,26 @@ export const init = (environment: any): void => {
     minValue: 2,
   });
 
+  serializer.addProperty('file', {
+    name: 'allowOutdatedFiles:boolean',
+    category: 'general',
+    visibleIndex: 11,
+    displayName: 'Allow marking files as outdated',
+    description:
+      'When enabled, existing files cannot be removed. Users can mark or unmark them as outdated instead.',
+    default: false,
+  });
+
+  serializer.addProperty('html', {
+    name: 'showOutdatedFiles:boolean',
+    category: 'general',
+    visibleIndex: 20,
+    displayName: 'Show outdated files',
+    description:
+      'When disabled, file placeholders rendered in this HTML question hide files marked as outdated.',
+    default: true,
+  });
+
   // Add set value on complete expression to questions
   serializer.addProperty('question', {
     name: 'setValueOnComplete',

--- a/libs/shared/src/lib/survey/types.ts
+++ b/libs/shared/src/lib/survey/types.ts
@@ -30,6 +30,7 @@ export interface QuestionText extends QuestionTextModel, GlobalProperties {
 /** File question interface */
 export interface QuestionFile extends QuestionFileModel, GlobalProperties {
   allowOutdatedFiles?: boolean;
+  canDeleteFiles?: boolean;
 }
 
 /** Type for comment question */

--- a/libs/shared/src/lib/survey/types.ts
+++ b/libs/shared/src/lib/survey/types.ts
@@ -28,7 +28,9 @@ export interface QuestionText extends QuestionTextModel, GlobalProperties {
 }
 
 /** File question interface */
-export interface QuestionFile extends QuestionFileModel, GlobalProperties {}
+export interface QuestionFile extends QuestionFileModel, GlobalProperties {
+  allowOutdatedFiles?: boolean;
+}
 
 /** Type for comment question */
 export interface QuestionComment

--- a/libs/shared/src/lib/survey/widgets/file-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.ts
@@ -64,8 +64,6 @@ const PDF_PREVIEW_CLASS = 'file-pdf-preview';
 /** CSS class of the iframe injected inside the upload area for PDFs. */
 const PDF_PREVIEW_FRAME_CLASS = 'file-pdf-preview__frame';
 
-/** CSS class of the custom preview wrapper we inject. */
-const FILE_PREVIEW_CLASS = 'file-preview';
 /** Class toggled on the question root to hide SurveyJS's default preview. */
 const FILE_PREVIEW_ACTIVE_CLASS = 'file-preview-active';
 /** Id of the stylesheet that hides the default preview when ours is active. */

--- a/libs/shared/src/lib/survey/widgets/file-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.ts
@@ -64,13 +64,6 @@ const PDF_PREVIEW_CLASS = 'file-pdf-preview';
 /** CSS class of the iframe injected inside the upload area for PDFs. */
 const PDF_PREVIEW_FRAME_CLASS = 'file-pdf-preview__frame';
 
-/** Services needed to resolve and render an inline file preview. */
-interface FilePreviewDeps {
-  documentManagementService: DocumentManagementService;
-  restService: RestService;
-  environment: any;
-}
-
 /** CSS class of the custom preview wrapper we inject. */
 const FILE_PREVIEW_CLASS = 'file-preview';
 /** Class toggled on the question root to hide SurveyJS's default preview. */
@@ -379,7 +372,7 @@ export const init = (
       (question as any).__filePreviewEl = htmlElement;
 
       // Render the preview for the current value.
-      updateFilePreview(previewDeps, question, htmlElement);
+      updatePdfPreview(question, htmlElement);
       updateOutdatedControls(question, htmlElement);
 
       // Re-render the preview whenever this question's value changes. Subscribe
@@ -393,7 +386,7 @@ export const init = (
             if (!el) return;
             // Defer so SurveyJS finishes its own DOM update first.
             setTimeout(() => {
-              updateFilePreview(previewDeps, question, el);
+              updatePdfPreview(question, el);
               updateOutdatedControls(question, el);
             }, 0);
           }

--- a/libs/shared/src/lib/survey/widgets/file-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.ts
@@ -7,6 +7,8 @@ import {
 import { Question, QuestionFile } from '../types';
 import { Injector } from '@angular/core';
 import jsonpath from 'jsonpath';
+import { File as SurveyFile } from '../../services/file/file.service';
+import { isFileOutdated } from '../../services/file/file-outdated.utils';
 
 /**
  * Set document properties based on value expressions
@@ -61,6 +63,59 @@ const setDocumentProperties = (
 const PDF_PREVIEW_CLASS = 'file-pdf-preview';
 /** CSS class of the iframe injected inside the upload area for PDFs. */
 const PDF_PREVIEW_FRAME_CLASS = 'file-pdf-preview__frame';
+
+/** Services needed to resolve and render an inline file preview. */
+interface FilePreviewDeps {
+  documentManagementService: DocumentManagementService;
+  restService: RestService;
+  environment: any;
+}
+
+/** CSS class of the custom preview wrapper we inject. */
+const FILE_PREVIEW_CLASS = 'file-preview';
+/** Class toggled on the question root to hide SurveyJS's default preview. */
+const FILE_PREVIEW_ACTIVE_CLASS = 'file-preview-active';
+/** Id of the stylesheet that hides the default preview when ours is active. */
+const FILE_PREVIEW_STYLE_ID = 'shared-file-preview-style';
+/** CSS class of the outdated controls injected for protected file fields. */
+const FILE_OUTDATED_CONTROLS_CLASS = 'file-outdated-controls';
+/** Class toggled on the question root when file removal should be blocked. */
+const FILE_OUTDATED_MODE_CLASS = 'file-outdated-mode';
+/** Class toggled when the configured file limit has already been reached. */
+const FILE_LIMIT_REACHED_CLASS = 'file-limit-reached';
+
+/**
+ * Injects (once) the stylesheet that hides SurveyJS's default file list while
+ * our custom preview is active. Hiding via a class on the stable question root
+ * (rather than inline styles on the list) survives SurveyJS re-rendering the
+ * list on every value change.
+ */
+const ensureFilePreviewStyles = (): void => {
+  if (document.getElementById(FILE_PREVIEW_STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = FILE_PREVIEW_STYLE_ID;
+  // In display mode our custom preview fully replaces the default file UI, so
+  // hide the whole default file widget container to avoid an empty drop-zone
+  // element showing above the preview. Our preview wrapper is appended as a
+  // sibling of the file widget (on the question root), so it stays visible.
+  style.textContent =
+    `.${FILE_PREVIEW_ACTIVE_CLASS} .sd-file,` +
+    `.${FILE_PREVIEW_ACTIVE_CLASS} .sv-file { display: none !important; }` +
+    `.${FILE_OUTDATED_MODE_CLASS} .sd-file__remove-file-button,` +
+    `.${FILE_OUTDATED_MODE_CLASS} .sv-file__remove-file-button,` +
+    `.${FILE_OUTDATED_MODE_CLASS} .sd-file__clean-btn,` +
+    `.${FILE_OUTDATED_MODE_CLASS} .sv-file__clean-btn { display: none !important; }` +
+    `.${FILE_OUTDATED_MODE_CLASS}.${FILE_LIMIT_REACHED_CLASS} .sd-file__choose-btn,` +
+    `.${FILE_OUTDATED_MODE_CLASS}.${FILE_LIMIT_REACHED_CLASS} .sv-file__choose-btn { display: none !important; }` +
+    `.${FILE_OUTDATED_CONTROLS_CLASS} { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }` +
+    `.${FILE_OUTDATED_CONTROLS_CLASS} .file-outdated-row { align-items: center; display: flex; flex-wrap: wrap; gap: 8px; }` +
+    `.${FILE_OUTDATED_CONTROLS_CLASS} .file-outdated-name { font-weight: 500; }` +
+    `.${FILE_OUTDATED_CONTROLS_CLASS} .file-outdated-status { align-items: center; color: #b45309; display: inline-flex; gap: 4px; }` +
+    `.${FILE_OUTDATED_CONTROLS_CLASS} .file-limit-message { color: #6b7280; font-size: 12px; }` +
+    `.${FILE_OUTDATED_CONTROLS_CLASS} button { align-items: center; border: none; cursor: pointer; display: inline-flex; gap: 4px; justify-content: flex-start; padding: 4px 6px; }` +
+    `.${FILE_OUTDATED_CONTROLS_CLASS} .file-outdated { color: #b45309; }`;
+  document.head.appendChild(style);
+};
 
 /**
  * Determines whether a file can be previewed inline and how.
@@ -183,6 +238,113 @@ const updatePdfPreview = (
 };
 
 /**
+ * Renders controls that let users mark/unmark files as outdated instead of removing them.
+ *
+ * @param question File question instance
+ * @param htmlElement The question's current rendered root HTML element
+ */
+const updateOutdatedControls = (
+  question: QuestionFile,
+  htmlElement: HTMLElement
+): void => {
+  ensureFilePreviewStyles();
+  htmlElement.classList.toggle(
+    FILE_OUTDATED_MODE_CLASS,
+    question.allowOutdatedFiles === true
+  );
+  htmlElement.querySelector(`.${FILE_OUTDATED_CONTROLS_CLASS}`)?.remove();
+  htmlElement.classList.remove(FILE_LIMIT_REACHED_CLASS);
+
+  if (question.allowOutdatedFiles !== true) {
+    return;
+  }
+
+  const files = Array.isArray(question.value)
+    ? (question.value as SurveyFile[])
+    : [];
+  const limit = question.allowMultiple
+    ? Number(question.getPropertyValue('allowedFileNumber'))
+    : 1;
+  const limitReached = files.length >= limit;
+  htmlElement.classList.toggle(FILE_LIMIT_REACHED_CLASS, limitReached);
+  if (files.length === 0) {
+    return;
+  }
+
+  const controls = document.createElement('div');
+  controls.classList.add(FILE_OUTDATED_CONTROLS_CLASS);
+  files.forEach((file, index) => {
+    const outdated = isFileOutdated(file);
+    if (question.isReadOnly && !outdated) {
+      return;
+    }
+
+    const row = document.createElement('div');
+    row.className = 'file-outdated-row';
+
+    if (files.length > 1 || question.isReadOnly) {
+      const name = document.createElement('span');
+      name.className = 'file-outdated-name';
+      name.textContent = file.name;
+      row.appendChild(name);
+    }
+
+    if (outdated) {
+      const status = document.createElement('span');
+      status.className = 'file-outdated-status';
+      const statusIcon = document.createElement('span');
+      statusIcon.className = 'k-icon k-i-warning file-outdated';
+      const statusLabel = document.createElement('span');
+      statusLabel.textContent = 'Outdated';
+      status.appendChild(statusIcon);
+      status.appendChild(statusLabel);
+      row.appendChild(status);
+    }
+
+    if (question.isReadOnly) {
+      controls.appendChild(row);
+      return;
+    }
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'k-button k-button-flat k-button-flat-base';
+    button.title = outdated
+      ? 'Remove outdated status'
+      : 'Mark file as outdated';
+    const icon = document.createElement('span');
+    icon.className = `k-icon ${outdated ? 'k-i-undo' : 'k-i-warning'}`;
+    const label = document.createElement('span');
+    label.textContent = outdated ? 'Restore file' : 'Mark as outdated';
+    button.appendChild(icon);
+    button.appendChild(label);
+    button.addEventListener('click', () => {
+      const nextValue = files.map((currentFile, currentIndex) =>
+        currentIndex === index
+          ? { ...currentFile, outdated: !isFileOutdated(currentFile) }
+          : currentFile
+      );
+      question.value = nextValue;
+      (question.survey as SurveyModel)?.setValue(question.name, nextValue);
+      updateOutdatedControls(question, htmlElement);
+    });
+    row.appendChild(button);
+    controls.appendChild(row);
+  });
+
+  if (!question.isReadOnly && limitReached) {
+    const message = document.createElement('div');
+    message.className = 'file-limit-message';
+    message.textContent =
+      'File limit reached. Existing and outdated files count toward the limit.';
+    controls.appendChild(message);
+  }
+  if (controls.childNodes.length > 0) {
+    htmlElement.appendChild(controls);
+  }
+};
+
+/**
  * Update file widget in order to be able to update properties with value expressions
  *
  * @param injector Parent instance angular injector containing all needed services and directives
@@ -209,6 +371,32 @@ export const init = (
         question,
         question.survey as SurveyModel
       );
+
+      // Keep a live reference to the current element so the value-change
+      // handler always targets the latest rendered DOM.
+      (question as any).__filePreviewEl = htmlElement;
+
+      // Render the preview for the current value.
+      updateFilePreview(previewDeps, question, htmlElement);
+      updateOutdatedControls(question, htmlElement);
+
+      // Re-render the preview whenever this question's value changes. Subscribe
+      // once per question to avoid stacking handlers across re-renders.
+      if (!(question as any).__filePreviewSubscribed) {
+        (question as any).__filePreviewSubscribed = true;
+        (question.survey as SurveyModel)?.onValueChanged.add(
+          (_sender, options: any) => {
+            if (options?.name !== question.name) return;
+            const el = (question as any).__filePreviewEl as HTMLElement;
+            if (!el) return;
+            // Defer so SurveyJS finishes its own DOM update first.
+            setTimeout(() => {
+              updateFilePreview(previewDeps, question, el);
+              updateOutdatedControls(question, el);
+            }, 0);
+          }
+        );
+      }
 
       // Give stored images the same native in-area preview as freshly picked
       // ones: SurveyJS only recognizes images from string contents, but files

--- a/libs/shared/src/lib/survey/widgets/file-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.ts
@@ -248,9 +248,10 @@ const updateOutdatedControls = (
   htmlElement: HTMLElement
 ): void => {
   ensureFilePreviewStyles();
+  const canDeleteFiles = question.canDeleteFiles !== false;
   htmlElement.classList.toggle(
     FILE_OUTDATED_MODE_CLASS,
-    question.allowOutdatedFiles === true
+    question.allowOutdatedFiles === true && !canDeleteFiles
   );
   htmlElement.querySelector(`.${FILE_OUTDATED_CONTROLS_CLASS}`)?.remove();
   htmlElement.classList.remove(FILE_LIMIT_REACHED_CLASS);
@@ -265,7 +266,8 @@ const updateOutdatedControls = (
   const limit = question.allowMultiple
     ? Number(question.getPropertyValue('allowedFileNumber'))
     : 1;
-  const limitReached = files.length >= limit;
+  const activeFilesCount = files.filter((f) => !isFileOutdated(f)).length;
+  const limitReached = activeFilesCount >= limit;
   htmlElement.classList.toggle(FILE_LIMIT_REACHED_CLASS, limitReached);
   if (files.length === 0) {
     return;


### PR DESCRIPTION
# Description

Adds configurable outdated-file handling for file upload fields.

This change allows form builders to enable a field-level option for file upload questions so existing files cannot be removed, but can instead be marked as outdated or restored. The behavior applies to both single-file and multi-file fields. Outdated files remain attached to the record and continue to count toward upload limits.

It also adds display controls for outdated files in HTML questions and grid/layout fields, so each widget/layout can decide whether outdated files should be visible. Outdated files are visually marked with a warning icon wherever they are displayed.

Fixes: [AB#134566](https://dev.azure.com/WHOHQ/2888b816-2d79-49ef-a86e-561e6cd456a0/_workitems/edit/134566) - ABC - Allow outdated files in file(s) fields

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/134566/

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

The following checks were run locally:

- [x] Frontend lint: `npx nx lint shared`
- [x] Frontend tests: `npx nx test shared --runInBand`
- [x] Backend lint: `npm run lint`
- [x] Backend build: `npm run build`

Manual verification performed:

- Enabled `Allow marking files as outdated` on single-file and multi-file upload fields.
- Verified existing files cannot be removed when the option is enabled.
- Verified files can be marked as outdated and restored.
- Verified outdated status persists after saving and reopening a record.
- Verified single-file upload limits are respected.
- Verified multi-file upload limits are respected.
- Verified outdated files are marked with a warning icon in record edit mode, detail mode, HTML questions, and grids.
- Verified `Show outdated files` can hide outdated files in HTML questions.
- Verified `Show outdated files` can hide outdated files in grid layout fields.

## Screenshots

Single and multi-file fields now have the options to mark files as outdated:

<img width="1919" height="665" alt="image" src="https://github.com/user-attachments/assets/c47f5da6-ee83-4b5f-b25d-e5504e142254" />

Adding the mark to any file:

<img width="1245" height="617" alt="image" src="https://github.com/user-attachments/assets/f3561bd6-70be-4c24-abfe-f60589ebd67a" />

<img width="1742" height="1139" alt="image" src="https://github.com/user-attachments/assets/0bf8e2a7-c9fb-4893-ae4a-0b11ac4375cc" />

These fields can be referenced on HTML fields and Grids. Configuration allows for them to show (or not) the outdated files.

<img width="2093" height="818" alt="image" src="https://github.com/user-attachments/assets/ec1dd504-19ad-48eb-be12-43373593eb6b" />

<img width="1172" height="997" alt="image" src="https://github.com/user-attachments/assets/13009982-6744-4e64-bcda-4ee711df9140" />

How outdated files are shown in Grids and HTML fields:

<img width="2117" height="883" alt="image" src="https://github.com/user-attachments/assets/4f03b244-fa5f-462f-a7bf-e375a990949d" />

Outdated files on view mode:

<img width="1936" height="658" alt="image" src="https://github.com/user-attachments/assets/26a9d026-0fed-41c8-81d6-a8d5e61b2d92" />

When the Show Outdated Files toggle is off:

<img width="2494" height="1030" alt="image" src="https://github.com/user-attachments/assets/e29f82fb-5fd2-413b-8d14-16650354003a" />

<img width="1871" height="649" alt="image" src="https://github.com/user-attachments/assets/0a3eae65-8e8e-4034-be0e-0590ed78813c" />

# Checklist:

( * == Mandatory )

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules