### PR TITLE
AB#134011 ABC-enable-image-pdf-preview-in-forms

### DIFF
--- a/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
+++ b/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.html
@@ -78,7 +78,35 @@
             <ng-container *ngIf="!recordsDefaultColumns.includes(column)">
               <th uiCellHeader *cdkHeaderCellDef scope="col">{{ column }}</th>
               <td uiCell *cdkCellDef="let element">
-                <div>{{ formatValue(element.data[column]) }}</div>
+                <div
+                  *ngIf="isFileField(column, element)"
+                  class="flex flex-col gap-1 items-start"
+                >
+                  <ng-container
+                    *ngIf="
+                      element.data[column] && element.data[column].length > 0
+                    "
+                  >
+                    <button
+                      *ngFor="let file of element.data[column]"
+                      (click)="$event.stopPropagation(); onOpenFile(file)"
+                      class="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold rounded-full border border-blue-200 bg-blue-50 text-blue-600 hover:bg-blue-100 hover:text-blue-700 transition-colors cursor-pointer"
+                      style="
+                        max-width: 100%;
+                        border-style: solid;
+                        text-align: left;
+                      "
+                    >
+                      <span style="font-size: 14px; line-height: 1">👁</span>
+                      <span class="truncate" style="max-width: 150px">{{
+                        file.name
+                      }}</span>
+                    </button>
+                  </ng-container>
+                </div>
+                <div *ngIf="!isFileField(column, element)">
+                  {{ formatValue(element.data[column]) }}
+                </div>
               </td>
             </ng-container>
             <ng-container *ngIf="column === '_incrementalId'">

--- a/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/resource/records-tab/records-tab.component.ts
@@ -12,6 +12,7 @@ import {
   RestoreRecordMutationResponse,
   getCachedValues,
   updateQueryUniqueValues,
+  FileService,
 } from '@oort-front/shared';
 import { Apollo, QueryRef } from 'apollo-angular';
 import get from 'lodash/get';
@@ -105,13 +106,15 @@ export class RecordsTabComponent
    * @param snackBar Shared snackbar service
    * @param confirmService Shared confirm service
    * @param downloadService Service used to download.
+   * @param fileService File service
    */
   constructor(
     private apollo: Apollo,
     private translate: TranslateService,
     private snackBar: SnackbarService,
     private confirmService: ConfirmService,
-    private downloadService: DownloadService
+    private downloadService: DownloadService,
+    private fileService: FileService
   ) {
     super();
   }
@@ -411,6 +414,59 @@ export class RecordsTabComponent
         .join(', ');
     }
     return value;
+  }
+
+  /**
+   * Get the field schema definition by name
+   *
+   * @param name Field name
+   * @returns Field schema object or undefined
+   */
+  public getFieldByName(name: string): any {
+    return this.resource?.fields?.find((f: any) => f.name === name);
+  }
+
+  /**
+   * Check if the given column corresponds to a file question
+   *
+   * @param columnName Column name
+   * @param element Optional grid row element containing cell data
+   * @returns True if column is a file field
+   */
+  public isFileField(columnName: string, element?: any): boolean {
+    const val = element?.data?.[columnName];
+    if (
+      Array.isArray(val) &&
+      val.length > 0 &&
+      val[0] &&
+      typeof val[0] === 'object' &&
+      'name' in val[0]
+    ) {
+      return true;
+    }
+    const field = this.getFieldByName(columnName);
+    return field?.type === 'JSON' && field?.meta?.type === 'file';
+  }
+
+  /**
+   * Click-to-preview callback for file buttons in the grid
+   *
+   * @param file File object to preview/download
+   */
+  public onOpenFile(file: any): void {
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|webp|bmp|svg)$/i;
+    let resolvedType = file.type;
+    if (IMAGE_EXTENSIONS.test(file.name)) {
+      resolvedType = ext === 'svg' ? 'image/svg+xml' : `image/${ext}`;
+    } else if (file.name.endsWith('.pdf')) {
+      resolvedType = 'application/pdf';
+    }
+    const normalizedFile = {
+      ...file,
+      type: resolvedType,
+    };
+    this.fileService.downloadOrPreview(normalizedFile).subscribe();
   }
 
   /**

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -19,6 +19,7 @@ export * from './lib/services/data-template/data-template.service';
 export * from './lib/services/date-translate/date-translate.service';
 export * from './lib/services/document-management/document-management.service';
 export * from './lib/services/download/download.service';
+export * from './lib/services/file/file.service';
 export * from './lib/services/editor/editor.service';
 export * from './lib/services/form-builder/form-builder.service';
 export * from './lib/services/form/form.service';

--- a/libs/shared/src/lib/services/file/file.service.ts
+++ b/libs/shared/src/lib/services/file/file.service.ts
@@ -211,8 +211,9 @@ export class FileService {
    * @returns file MIME type
    */
   private getFileType(file: File): string {
-    if (file.type) {
-      return file.type;
+    const type = file.type || '';
+    if (type && type !== 'application/octet-stream') {
+      return type;
     }
 
     const extension = this.getFileExtension(file.name);
@@ -220,7 +221,7 @@ export class FileService {
       return PDF_MIME_TYPE;
     }
 
-    return IMAGE_EXTENSIONS.includes(extension) ? `image/${extension}` : '';
+    return IMAGE_EXTENSIONS.includes(extension) ? `image/${extension}` : type;
   }
 
   /**

--- a/libs/shared/src/lib/services/form-builder/form-builder.service.ts
+++ b/libs/shared/src/lib/services/form-builder/form-builder.service.ts
@@ -324,12 +324,24 @@ export class FormBuilderService {
       const xhr = new XMLHttpRequest();
       xhr.open('GET', url);
       xhr.setRequestHeader('Authorization', `Bearer ${token}`);
-      xhr.onloadstart = () => {
-        xhr.responseType = 'blob';
-      };
+      xhr.responseType = 'blob';
       xhr.onload = () => {
-        const file = new File([xhr.response], options.fileValue.name, {
-          type: options.fileValue.type,
+        const name = options.fileValue?.name || 'file';
+        let type =
+          options.fileValue?.type ||
+          xhr.response?.type ||
+          'application/octet-stream';
+        if (type === 'application/octet-stream' && name) {
+          const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|webp|bmp|svg)$/i;
+          if (IMAGE_EXTENSIONS.test(name)) {
+            const ext = name.split('.').pop()?.toLowerCase();
+            type = ext === 'svg' ? 'image/svg+xml' : `image/${ext}`;
+          } else if (/\.pdf$/i.test(name)) {
+            type = 'application/pdf';
+          }
+        }
+        const file = new File([xhr.response], name, {
+          type: type,
         });
         const reader = new FileReader();
         reader.onload = (e) => {

--- a/libs/shared/src/lib/style/survey.scss
+++ b/libs/shared/src/lib/style/survey.scss
@@ -261,6 +261,71 @@
     display: inline;
   }
 
+  // Place the circular preview eye button in the top-left corner of the answered file decorator container
+  .sd-question--answered .sd-file__decorator,
+  .sv-question--answered .sv-file__decorator {
+    &::after {
+      content: '👁';
+      position: absolute;
+      left: 8px;
+      top: 8px;
+      width: 28px;
+      height: 28px;
+      background-color: white;
+      border: 1px solid #e5e7eb;
+      color: var(--primary, #3b82f6); // Primary blue color
+      font-size: 13px;
+      font-weight: bold;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+      transition: all 0.2s ease-in-out;
+      pointer-events: auto !important; // Directly captures preview clicks
+      z-index: 8;
+    }
+
+    &:hover::after {
+      background-color: var(--primary, #3b82f6);
+      color: white;
+      border-color: var(--primary, #3b82f6);
+      transform: scale(1.1);
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
+    }
+  }
+
+  // Explicitly prevent eye pseudo-elements on any nested/internal file preview elements
+  .sd-file__preview::after,
+  .sv-file__preview::after,
+  .sd-file__preview > div::after,
+  .sv-file__preview > div::after,
+  .sd-file__image-wrapper::after,
+  .sv-file__image-wrapper::after,
+  .sd-file__sign::after,
+  .sv-file__sign::after {
+    display: none !important;
+    content: none !important;
+  }
+
+  // Ensure the remove button has proper visual behavior and stays on top of the preview overlay
+  .sd-file__remove-btn,
+  .sv-file__remove-btn,
+  .sd-file__remove-button,
+  .sv-file__remove-button,
+  .sd-file__remove-file-button,
+  .sv-file__remove-file-button {
+    cursor: pointer !important;
+    transition: transform 0.2s ease;
+    z-index: 10 !important;
+    position: relative;
+
+    &:hover {
+      transform: scale(1.1);
+      color: #ef4444 !important; // Red
+    }
+  }
+
   // In form preview
   .file-preview {
     display: flex;

--- a/libs/shared/src/lib/survey/widgets/file-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.ts
@@ -6,9 +6,11 @@ import {
   DocumentManagementService,
 } from '../../services/document-management/document-management.service';
 import { RestService } from '../../services/rest/rest.service';
+import { FileService } from '../../services/file/file.service';
 import { Question, QuestionFile } from '../types';
 import { Injector } from '@angular/core';
 import jsonpath from 'jsonpath';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * Set document properties based on value expressions
@@ -64,6 +66,8 @@ interface FilePreviewDeps {
   documentManagementService: DocumentManagementService;
   restService: RestService;
   environment: any;
+  fileService: FileService;
+  translateService: TranslateService;
 }
 
 /** CSS class of the custom preview wrapper we inject. */
@@ -102,11 +106,13 @@ const ensureFilePreviewStyles = (): void => {
  */
 const getPreviewKind = (name: string, type: string): 'image' | 'pdf' | null => {
   const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|webp|bmp|svg)$/i;
+  const hasGenericType = !type || type === 'application/octet-stream';
   const isImage =
     (typeof type === 'string' && type.startsWith('image/')) ||
-    (!type && IMAGE_EXTENSIONS.test(name));
+    (hasGenericType && IMAGE_EXTENSIONS.test(name));
   if (isImage) return 'image';
-  const isPdf = type === 'application/pdf' || (!type && /\.pdf$/i.test(name));
+  const isPdf =
+    type === 'application/pdf' || (hasGenericType && /\.pdf$/i.test(name));
   return isPdf ? 'pdf' : null;
 };
 
@@ -135,16 +141,50 @@ const removeCustomPreview = (htmlElement: HTMLElement): void => {
  * @param src Blob URL or direct URL of the file to preview
  * @param fileName File name used as alt text / title
  * @param isImage True renders an img; false renders an iframe for PDF
+ * @param downloadLabel Dynamic translated label for the download button
+ * @param onDownload Click callback to download the file
  * @returns The preview wrapper element
  */
 const buildPreviewWrapper = (
   src: string,
   fileName: string,
-  isImage: boolean
+  isImage: boolean,
+  downloadLabel: string,
+  onDownload: () => void
 ): HTMLElement => {
   const wrapper = document.createElement('div');
   wrapper.classList.add(FILE_PREVIEW_CLASS);
+  wrapper.style.display = 'flex';
+  wrapper.style.flexDirection = 'column';
+  wrapper.style.alignItems = 'center';
+  wrapper.style.gap = '8px';
   wrapper.style.marginTop = '8px';
+
+  // Add download button/link
+  const downloadLink = document.createElement('a');
+  downloadLink.href = '#';
+  downloadLink.style.display = 'inline-flex';
+  downloadLink.style.alignItems = 'center';
+  downloadLink.style.gap = '6px';
+  downloadLink.style.fontSize = '14px';
+  downloadLink.style.color = '#3b82f6';
+  downloadLink.style.textDecoration = 'none';
+  downloadLink.style.fontWeight = '500';
+  downloadLink.style.padding = '6px 12px';
+  downloadLink.style.borderRadius = '4px';
+  downloadLink.style.backgroundColor = '#eff6ff';
+  downloadLink.style.border = '1px solid #bfdbfe';
+  downloadLink.innerHTML = `
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="width: 16px; height: 16px;">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path>
+    </svg>
+    ${downloadLabel}
+  `;
+  downloadLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    onDownload();
+  });
+  wrapper.appendChild(downloadLink);
 
   if (isImage) {
     const img = document.createElement('img');
@@ -164,6 +204,45 @@ const buildPreviewWrapper = (
     wrapper.appendChild(iframe);
   }
   return wrapper;
+};
+
+/**
+ * Normalizes a file object from SurveyJS's question value array.
+ * If the file was newly uploaded, it has a shape like `{ file: File, content: string }`.
+ * We extract `name` and `type` from the browser's `File` object.
+ *
+ * @param item File item from question.value
+ * @returns Normalized file object suitable for FileService
+ */
+const normalizeFileItem = (item: any): any => {
+  if (!item) return null;
+  let normalized = item;
+  if (item.file && !item.name) {
+    normalized = {
+      name: item.file.name,
+      type: item.file.type,
+      content: item.content,
+    };
+  }
+  if (
+    normalized &&
+    normalized.name &&
+    (!normalized.type || normalized.type === 'application/octet-stream')
+  ) {
+    const ext = normalized.name.split('.').pop()?.toLowerCase();
+    const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|webp|bmp|svg)$/i;
+    let resolvedType = normalized.type;
+    if (IMAGE_EXTENSIONS.test(normalized.name)) {
+      resolvedType = ext === 'svg' ? 'image/svg+xml' : `image/${ext}`;
+    } else if (normalized.name.endsWith('.pdf')) {
+      resolvedType = 'application/pdf';
+    }
+    normalized = {
+      ...normalized,
+      type: resolvedType,
+    };
+  }
+  return normalized;
 };
 
 /**
@@ -197,7 +276,8 @@ const updateFilePreview = (
   const isDisplayMode = survey?.mode === 'display';
   const value: Array<{ name: string; type: string; content: any }> =
     question.value;
-  const file = Array.isArray(value) && value.length === 1 ? value[0] : null;
+  const rawFile = Array.isArray(value) && value.length === 1 ? value[0] : null;
+  const file = normalizeFileItem(rawFile);
   const kind = file ? getPreviewKind(file.name, file.type) : null;
 
   // Not previewable -> show SurveyJS's default preview again and stop.
@@ -206,15 +286,17 @@ const updateFilePreview = (
     return;
   }
 
-  // In display mode the preview fully replaces the default file list. In edit
-  // mode (updating a record) we keep the default list visible so users can
-  // still remove / download the file, and render the preview below it.
-  if (isDisplayMode) {
-    ensureFilePreviewStyles();
-    htmlElement.classList.add(FILE_PREVIEW_ACTIVE_CLASS);
-  } else {
+  // In edit mode (updating a record), we do not show any custom preview wrapper
+  // below the upload area anymore. We rely on the SurveyJS built-in preview
+  // for images and the click-to-preview modal behavior.
+  if (!isDisplayMode) {
     htmlElement.classList.remove(FILE_PREVIEW_ACTIVE_CLASS);
+    return;
   }
+
+  // In display mode the preview fully replaces the default file list.
+  ensureFilePreviewStyles();
+  htmlElement.classList.add(FILE_PREVIEW_ACTIVE_CLASS);
 
   const { name, content } = file;
   const isImage = kind === 'image';
@@ -228,7 +310,15 @@ const updateFilePreview = (
       return;
     }
     removeCustomPreview(htmlElement);
-    htmlElement.appendChild(buildPreviewWrapper(src, name, isImage));
+    const label =
+      deps.translateService.instant(
+        'components.widget.fileExplorer.actions.download'
+      ) || 'Download File';
+    htmlElement.appendChild(
+      buildPreviewWrapper(src, name, isImage, label, () => {
+        deps.fileService.download(file as any);
+      })
+    );
   };
 
   const fetchAndInject = (token: string, url: string): void => {
@@ -278,10 +368,14 @@ export const init = (
   customWidgetCollectionInstance: CustomWidgetCollection
 ): void => {
   const documentManagementService = injector.get(DocumentManagementService);
+  const fileService = injector.get(FileService);
+  const translateService = injector.get(TranslateService);
   const previewDeps: FilePreviewDeps = {
     documentManagementService,
     restService: injector.get(RestService),
     environment: injector.get('environment'),
+    fileService,
+    translateService,
   };
   const widget = {
     name: 'file-widget',
@@ -303,6 +397,65 @@ export const init = (
       // Keep a live reference to the current element so the value-change
       // handler always targets the latest rendered DOM.
       (question as any).__filePreviewEl = htmlElement;
+
+      // Bind click handler to open custom file preview modal on click
+      if (!(htmlElement as any).__filePreviewClickBound) {
+        (htmlElement as any).__filePreviewClickBound = true;
+
+        htmlElement.addEventListener(
+          'click',
+          (event) => {
+            const target = event.target as HTMLElement;
+
+            // 1. Let native download link clicks bubble
+            const isDownloadClick = !!target.closest(
+              '.sd-file__sign, .sv-file__sign, .sd-file__link, .sv-file__link'
+            );
+            if (isDownloadClick) {
+              return;
+            }
+
+            // 2. Let native remove/delete button clicks bubble
+            const isRemoveClick = !!target.closest('button, [class*="remove"]');
+            if (isRemoveClick) {
+              return;
+            }
+
+            // 3. Resolve the closest file card container
+            const fileCard = target.closest(
+              '.sd-file__decorator, .sv-file__decorator, .sd-file__preview > div, .sv-file__preview > div'
+            ) as HTMLElement;
+            if (!fileCard) {
+              return;
+            }
+
+            // 4. Resolve the file item index (0 for single file, array index for multiple files)
+            let index = 0;
+            const previewContainer = fileCard.closest(
+              '.sd-file__preview, .sv-file__preview'
+            );
+            if (previewContainer) {
+              const fileItem = target.closest(
+                '.sd-file__preview > div, .sv-file__preview > div'
+              );
+              index = fileItem
+                ? Array.from(previewContainer.children).indexOf(fileItem)
+                : -1;
+            }
+
+            // 5. Open the custom preview modal
+            if (index !== -1 && Array.isArray(question.value)) {
+              const file = normalizeFileItem(question.value[index]);
+              if (file) {
+                event.preventDefault();
+                event.stopPropagation();
+                fileService.downloadOrPreview(file).subscribe();
+              }
+            }
+          },
+          true
+        );
+      }
 
       // Render the preview for the current value.
       updateFilePreview(previewDeps, question, htmlElement);


### PR DESCRIPTION
# Description
Implements a unified file preview and download experience within dynamic forms (SurveyJS questions) and the records tab. Previously, file uploads only showed basic list/icon structures. This change introduces:

## Useful links
- **Ticket:** [AB#134011](https://dev.azure.com/reliefapplications/ems/_workitems/edit/134011)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- **Test A (Manual Form Verification):** Uploaded images and PDFs on a survey/form. Confirmed that a single eye icon appears on the top-left of the answered file decorator container, and clicking the container launches the preview modal successfully.

- **Test B (Grid Records Tab):** Navigated to the records tab, verified that attached files in grid cells display appropriately and preview successfully upon clicking.

- **Test C (Build & Lint Checks):** Verified that the production front-office build and the workspace-wide ES/Prettier lint checkers pass without errors.

## Screenshots

[Screencast_20260704_040735.webm](https://github.com/user-attachments/assets/6f42b5e4-f561-40b4-b532-d9d11ef4f27b)
[Screencast_20260704_040658.webm](https://github.com/user-attachments/assets/10fed9db-0060-4e21-851f-de301d70108e)


# Checklist:
- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules