### PR TITLE
MedEvac: grid action send separate email

### DIFF
--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -2146,6 +2146,7 @@
               "sendMail": "Send mail",
               "sendSeparateEmail": "Send separate email",
               "separateEmailFields": "Send Separate Email Fields",
+              "separateEmailRecipientRequired": "Select a distribution list or add at least one separate email field containing email values, otherwise the email has no recipients.",
               "separateEmailTokens": "Available body tokens:",
               "workflow": {
                 "close": "Close workflow",

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -2142,6 +2142,9 @@
               "selectAllRecordsActivePage": "Select all records on the active page",
               "selectDisplay": "Select displayed fields",
               "sendMail": "Send mail",
+              "sendSeparateEmail": "Send separate email",
+              "separateEmailFields": "Send Separate Email Fields",
+              "separateEmailTokens": "Available body tokens:",
               "workflow": {
                 "close": "Close workflow",
                 "confirm": "Confirmation message",

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -2146,7 +2146,7 @@
               "sendMail": "Send mail",
               "sendSeparateEmail": "Send separate email",
               "separateEmailFields": "Send Separate Email Fields",
-              "separateEmailRecipientRequired": "Select a distribution list or add at least one separate email field containing email values, otherwise the email has no recipients.",
+              "separateEmailRecipientRequired": "Add at least one separate email field containing email values, or turn off Send Separate Email to use a distribution list, otherwise the email has no recipients.",
               "separateEmailTokens": "Available body tokens:",
               "workflow": {
                 "close": "Close workflow",

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -307,7 +307,7 @@
           "noDistributionList": "Something went wrong during the email sending: no distribution list found",
           "noFields": "DocumentType & InformationConfidentiality is required to proceed!",
           "noRecipient": "At least one recipient is required to proceed!",
-          "noRecipientSse": "At least one recipient is required to proceed! Ensure the Send Separate Email Fields used contain at least one field with valid emails.",
+          "noRecipientSeparateEmail": "At least one recipient is required to proceed! Ensure the Send Separate Email Fields used contain at least one field with valid emails.",
           "noSubject": "Subject is required to proceed!",
           "noTemplate": "Something went wrong during the email sending: no template found",
           "preview": "Preview of email failed"
@@ -2144,10 +2144,7 @@
               "selectAllRecordsActivePage": "Select all records on the active page",
               "selectDisplay": "Select displayed fields",
               "sendMail": "Send mail",
-              "sendSeparateEmail": "Send separate email",
-              "separateEmailFields": "Send Separate Email Fields",
               "separateEmailRecipientRequired": "Add at least one separate email field containing email values, or turn off Send Separate Email to use a distribution list, otherwise the email has no recipients.",
-              "separateEmailTokens": "Available body tokens:",
               "workflow": {
                 "close": "Close workflow",
                 "confirm": "Confirmation message",

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -306,6 +306,8 @@
           "noCustomTitle": "Custom template title is required to proceed!",
           "noDistributionList": "Something went wrong during the email sending: no distribution list found",
           "noFields": "DocumentType & InformationConfidentiality is required to proceed!",
+          "noRecipient": "At least one recipient is required to proceed!",
+          "noRecipientSse": "At least one recipient is required to proceed! Ensure the Send Separate Email Fields used contain at least one field with valid emails.",
           "noSubject": "Subject is required to proceed!",
           "noTemplate": "Something went wrong during the email sending: no template found",
           "preview": "Preview of email failed"

--- a/libs/shared/src/i18n/en.json
+++ b/libs/shared/src/i18n/en.json
@@ -2144,7 +2144,7 @@
               "selectAllRecordsActivePage": "Select all records on the active page",
               "selectDisplay": "Select displayed fields",
               "sendMail": "Send mail",
-              "separateEmailRecipientRequired": "Add at least one separate email field containing email values, or turn off Send Separate Email to use a distribution list, otherwise the email has no recipients.",
+              "separateEmailRecipientRequired": "Add at least one separate email field containing email values, otherwise the separate emails have no recipients. A distribution list can be added as well, but does not replace the per-row field.",
               "workflow": {
                 "close": "Close workflow",
                 "confirm": "Confirmation message",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -2149,7 +2149,7 @@
               "sendMail": "Envoyer le mail",
               "sendSeparateEmail": "Envoyer un e-mail séparé",
               "separateEmailFields": "Champs d'envoi séparé",
-              "separateEmailRecipientRequired": "Sélectionnez une liste de distribution ou ajoutez au moins un champ d'envoi séparé contenant des adresses e-mail, sinon l'e-mail n'a aucun destinataire.",
+              "separateEmailRecipientRequired": "Ajoutez au moins un champ d'envoi séparé contenant des adresses e-mail, ou désactivez l'envoi séparé pour utiliser une liste de distribution, sinon l'e-mail n'a aucun destinataire.",
               "separateEmailTokens": "Tokens disponibles dans le corps :",
               "workflow": {
                 "close": "Fermer le workflow",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -306,6 +306,8 @@
           "noCustomTitle": "Le titre du modèle personnalisé est requis pour continuer!",
           "noDistributionList": "Un problème est survenu lors de l'envoi de l'e-mail: aucune liste de distribution détectée",
           "noFields": "Type de document et informationsLa confidentialité est requise pour continuer !",
+          "noRecipient": "Au moins un destinataire est requis pour continuer !",
+          "noRecipientSse": "Au moins un destinataire est requis pour continuer ! Assurez-vous que les champs utilisés pour l'envoi d'e-mails séparés contiennent au moins un champ avec des adresses e-mail valides.",
           "noSubject": "Le sujet doit continuer!",
           "noTemplate": "Un problème est survenu lors de l'envoi de l'e-mail: aucun template détecté",
           "preview": "Erreur lors de la génération de l'e-mail"

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -2145,6 +2145,9 @@
               "selectAllRecordsActivePage": "Sélectionner tous les enregistrements sur la page active",
               "selectDisplay": "Sélectionner les champs affichés",
               "sendMail": "Envoyer le mail",
+              "sendSeparateEmail": "Envoyer un e-mail séparé",
+              "separateEmailFields": "Champs d'envoi séparé",
+              "separateEmailTokens": "Tokens disponibles dans le corps :",
               "workflow": {
                 "close": "Fermer le workflow",
                 "confirm": "Message de confirmation",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -2147,7 +2147,7 @@
               "selectAllRecordsActivePage": "Sélectionner tous les enregistrements sur la page active",
               "selectDisplay": "Sélectionner les champs affichés",
               "sendMail": "Envoyer le mail",
-              "separateEmailRecipientRequired": "Ajoutez au moins un champ d'envoi séparé contenant des adresses e-mail, ou désactivez l'envoi séparé pour utiliser une liste de distribution, sinon l'e-mail n'a aucun destinataire.",
+              "separateEmailRecipientRequired": "Ajoutez au moins un champ d'envoi séparé contenant des adresses e-mail, sinon les e-mails séparés n'ont aucun destinataire. Une liste de distribution peut également être ajoutée, mais ne remplace pas le champ par ligne.",
               "workflow": {
                 "close": "Fermer le workflow",
                 "confirm": "Message de confirmation",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -2149,6 +2149,7 @@
               "sendMail": "Envoyer le mail",
               "sendSeparateEmail": "Envoyer un e-mail séparé",
               "separateEmailFields": "Champs d'envoi séparé",
+              "separateEmailRecipientRequired": "Sélectionnez une liste de distribution ou ajoutez au moins un champ d'envoi séparé contenant des adresses e-mail, sinon l'e-mail n'a aucun destinataire.",
               "separateEmailTokens": "Tokens disponibles dans le corps :",
               "workflow": {
                 "close": "Fermer le workflow",

--- a/libs/shared/src/i18n/fr.json
+++ b/libs/shared/src/i18n/fr.json
@@ -307,7 +307,7 @@
           "noDistributionList": "Un problème est survenu lors de l'envoi de l'e-mail: aucune liste de distribution détectée",
           "noFields": "Type de document et informationsLa confidentialité est requise pour continuer !",
           "noRecipient": "Au moins un destinataire est requis pour continuer !",
-          "noRecipientSse": "Au moins un destinataire est requis pour continuer ! Assurez-vous que les champs utilisés pour l'envoi d'e-mails séparés contiennent au moins un champ avec des adresses e-mail valides.",
+          "noRecipientSeparateEmail": "Au moins un destinataire est requis pour continuer ! Assurez-vous que les champs utilisés pour l'envoi d'e-mails séparés contiennent au moins un champ avec des adresses e-mail valides.",
           "noSubject": "Le sujet doit continuer!",
           "noTemplate": "Un problème est survenu lors de l'envoi de l'e-mail: aucun template détecté",
           "preview": "Erreur lors de la génération de l'e-mail"
@@ -2147,10 +2147,7 @@
               "selectAllRecordsActivePage": "Sélectionner tous les enregistrements sur la page active",
               "selectDisplay": "Sélectionner les champs affichés",
               "sendMail": "Envoyer le mail",
-              "sendSeparateEmail": "Envoyer un e-mail séparé",
-              "separateEmailFields": "Champs d'envoi séparé",
               "separateEmailRecipientRequired": "Ajoutez au moins un champ d'envoi séparé contenant des adresses e-mail, ou désactivez l'envoi séparé pour utiliser une liste de distribution, sinon l'e-mail n'a aucun destinataire.",
-              "separateEmailTokens": "Tokens disponibles dans le corps :",
               "workflow": {
                 "close": "Fermer le workflow",
                 "confirm": "Message de confirmation",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -307,7 +307,7 @@
           "noDistributionList": "******",
           "noFields": "******",
           "noRecipient": "******",
-          "noRecipientSse": "******",
+          "noRecipientSeparateEmail": "******",
           "noSubject": "******",
           "noTemplate": "******",
           "preview": "******"
@@ -2144,10 +2144,7 @@
               "selectAllRecordsActivePage": "******",
               "selectDisplay": "******",
               "sendMail": "******",
-              "sendSeparateEmail": "******",
-              "separateEmailFields": "******",
               "separateEmailRecipientRequired": "******",
-              "separateEmailTokens": "******",
               "workflow": {
                 "close": "******",
                 "confirm": "******",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -306,6 +306,8 @@
           "noCustomTitle": "******",
           "noDistributionList": "******",
           "noFields": "******",
+          "noRecipient": "******",
+          "noRecipientSse": "******",
           "noSubject": "******",
           "noTemplate": "******",
           "preview": "******"

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -2142,6 +2142,9 @@
               "selectAllRecordsActivePage": "******",
               "selectDisplay": "******",
               "sendMail": "******",
+              "sendSeparateEmail": "******",
+              "separateEmailFields": "******",
+              "separateEmailTokens": "******",
               "workflow": {
                 "close": "******",
                 "confirm": "******",

--- a/libs/shared/src/i18n/test.json
+++ b/libs/shared/src/i18n/test.json
@@ -2146,6 +2146,7 @@
               "sendMail": "******",
               "sendSeparateEmail": "******",
               "separateEmailFields": "******",
+              "separateEmailRecipientRequired": "******",
               "separateEmailTokens": "******",
               "workflow": {
                 "close": "******",

--- a/libs/shared/src/i18n/uk.json
+++ b/libs/shared/src/i18n/uk.json
@@ -306,6 +306,8 @@
           "noCustomTitle": "Назва власного шаблону обов'язкова для продовження!",
           "noDistributionList": "Щось пішло не так під час надсилання листа: не знайдено списку розсилки",
           "noFields": "DocumentType & InformationConfidentiality обов'язкові для продовження!",
+          "noRecipient": "At least one recipient is required to proceed!",
+          "noRecipientSse": "At least one recipient is required to proceed! Ensure the Send Separate Email Fields used contain at least one field with valid emails.",
           "noSubject": "Тема обов'язкова для продовження!",
           "noTemplate": "Щось пішло не так під час надсилання листа: шаблон не знайдено",
           "preview": "Не вдалося завантажити попередній перегляд листа"

--- a/libs/shared/src/i18n/uk.json
+++ b/libs/shared/src/i18n/uk.json
@@ -2147,6 +2147,7 @@
               "sendMail": "Надіслати лист",
               "sendSeparateEmail": "Send separate email",
               "separateEmailFields": "Send Separate Email Fields",
+              "separateEmailRecipientRequired": "Select a distribution list or add at least one separate email field containing email values, otherwise the email has no recipients.",
               "separateEmailTokens": "Available body tokens:",
               "workflow": {
                 "close": "Закрити Робочий процес",

--- a/libs/shared/src/i18n/uk.json
+++ b/libs/shared/src/i18n/uk.json
@@ -307,6 +307,7 @@
           "noDistributionList": "Щось пішло не так під час надсилання листа: не знайдено списку розсилки",
           "noFields": "DocumentType & InformationConfidentiality обов'язкові для продовження!",
           "noRecipient": "At least one recipient is required to proceed!",
+          "noRecipientSeparateEmail": "At least one recipient is required to proceed! Ensure the Send Separate Email Fields used contain at least one field with valid emails.",
           "noRecipientSse": "At least one recipient is required to proceed! Ensure the Send Separate Email Fields used contain at least one field with valid emails.",
           "noSubject": "Тема обов'язкова для продовження!",
           "noTemplate": "Щось пішло не так під час надсилання листа: шаблон не знайдено",

--- a/libs/shared/src/i18n/uk.json
+++ b/libs/shared/src/i18n/uk.json
@@ -2143,6 +2143,9 @@
               "selectAllRecordsActivePage": "Вибрати всі записи на активній сторінці",
               "selectDisplay": "Вибрати відображувані поля",
               "sendMail": "Надіслати лист",
+              "sendSeparateEmail": "Send separate email",
+              "separateEmailFields": "Send Separate Email Fields",
+              "separateEmailTokens": "Available body tokens:",
               "workflow": {
                 "close": "Закрити Робочий процес",
                 "confirm": "Повідомлення про підтвердження",

--- a/libs/shared/src/lib/components/email/email.component.ts
+++ b/libs/shared/src/lib/components/email/email.component.ts
@@ -1132,6 +1132,8 @@ export class EmailComponent extends UnsubscribeComponent implements OnInit {
    * used to create new custom template
    */
   createTemplate(): void {
+    this.emailService.gridActionSendSeparateEmail = false;
+    this.emailService.gridActionDataQuery = null;
     this.emailService.showFileUpload = false;
     this.showTemplateCreationWizard = true;
     if (!this.emailService.isCustomTemplateEdit) {

--- a/libs/shared/src/lib/components/email/email.component.ts
+++ b/libs/shared/src/lib/components/email/email.component.ts
@@ -147,6 +147,7 @@ export class EmailComponent extends UnsubscribeComponent implements OnInit {
   ngOnInit(): void {
     this.emailService.showFileUpload = false;
     this.emailService.isGridAction = false;
+    this.emailService.distributionListSeparate = [];
     this.applicationService.application$.subscribe((res: any) => {
       this.emailService.datasetsForm.get('applicationId')?.setValue(res?.id);
       this.applicationId = res?.id;
@@ -499,6 +500,7 @@ export class EmailComponent extends UnsubscribeComponent implements OnInit {
   ) {
     this.emailService.isDistributionListEdit = false;
     this.emailService.isGridAction = false;
+    this.emailService.distributionListSeparate = [];
     this.emailService.isDistributionListNameDuplicate = false;
     this.emailService.emailListLoading = true;
     this.emailService.enableAllSteps.next(true);
@@ -1406,6 +1408,7 @@ export class EmailComponent extends UnsubscribeComponent implements OnInit {
     this.emailService.setDatasetForm();
     this.emailService.selectedDistributionListName = '';
     this.emailService.isGridAction = false;
+    this.emailService.distributionListSeparate = [];
     this.emailService.isDistributionListNameDuplicate = false;
     this.emailService.emailListLoading = true;
     this.emailService.enableAllSteps.next(true);

--- a/libs/shared/src/lib/components/email/email.service.ts
+++ b/libs/shared/src/lib/components/email/email.service.ts
@@ -243,8 +243,27 @@ export class EmailService {
   public distributionListData: FormGroup | any = [];
   /** Show File Upload */
   public showFileUpload = false;
-  /** Send Separate Dataset Blocks */
-  public sendSeparateBlocks: string[] = [];
+  /** dataQuery for the current grid action (set before child components initialise) */
+  public gridActionDataQuery: any = null;
+  /** Whether SSE is enabled for the current grid action */
+  public gridActionSendSeparateEmail = false;
+
+  /**
+   * Block names marked for individual-email sending. Derived from form state; returns ['Block 1'] in grid-action SSE mode.
+   *
+   * @returns array of block names with SSE enabled
+   */
+  get sendSeparateBlocks(): string[] {
+    if (this.isGridAction) {
+      return this.gridActionSendSeparateEmail ? ['Block 1'] : [];
+    }
+    return (this.datasetsForm?.get('datasets')?.getRawValue() ?? [])
+      .filter(
+        (d: any) =>
+          d.individualEmail && d.query.name && (d.resource || d.reference)
+      )
+      .map((d: any) => d.name);
+  }
 
   /**
    * Generates new dataset group.
@@ -1001,16 +1020,12 @@ export class EmailService {
     if (this.datasetsForm?.get('datasets')?.value?.length > 0) {
       const datasetsValues = this.datasetsForm?.get('datasets')?.getRawValue();
       const datasets: string[] = [];
-      this.sendSeparateBlocks = [];
       datasetsValues.forEach((dataset: any) => {
         if (
           (dataset.query.name && dataset.resource) ||
           (dataset.query.name && dataset.reference)
         ) {
           datasets.push(dataset.name);
-          if (dataset.individualEmail) {
-            this.sendSeparateBlocks.push(dataset.name);
-          }
         }
       });
 
@@ -1033,7 +1048,6 @@ export class EmailService {
       datasets: [],
       fields: [],
     };
-    this.sendSeparateBlocks = [];
   }
 
   /**

--- a/libs/shared/src/lib/components/email/email.service.ts
+++ b/libs/shared/src/lib/components/email/email.service.ts
@@ -245,13 +245,13 @@ export class EmailService {
   public showFileUpload = false;
   /** dataQuery for the current grid action (set before child components initialise) */
   public gridActionDataQuery: any = null;
-  /** Whether SSE is enabled for the current grid action */
+  /** Whether send separate email is enabled for the current grid action */
   public gridActionSendSeparateEmail = false;
-  /** SSE recipients returned by the last preview-distribution-lists call (read-only display) */
+  /** Send-separate-email recipients returned by the last preview-distribution-lists call (read-only display) */
   public distributionListSeparate: any[] = [];
 
-  /** @returns true when the last preview-distribution-lists call returned at least one SSE recipient */
-  get hasSseRecipients(): boolean {
+  /** @returns true when the last preview-distribution-lists call returned at least one send-separate-email recipient */
+  get hasSeparateEmailRecipients(): boolean {
     return (
       this.distributionListSeparate?.some((b: any) => b?.emails?.length > 0) ??
       false
@@ -259,9 +259,9 @@ export class EmailService {
   }
 
   /**
-   * Block names marked for individual-email sending. Derived from form state; returns ['Block 1'] in grid-action SSE mode.
+   * Block names marked for individual-email sending. Derived from form state; returns ['Block 1'] in grid-action send-separate-email mode.
    *
-   * @returns array of block names with SSE enabled
+   * @returns array of block names with send separate email enabled
    */
   get sendSeparateBlocks(): string[] {
     if (this.isGridAction) {

--- a/libs/shared/src/lib/components/email/email.service.ts
+++ b/libs/shared/src/lib/components/email/email.service.ts
@@ -247,8 +247,16 @@ export class EmailService {
   public gridActionDataQuery: any = null;
   /** Whether SSE is enabled for the current grid action */
   public gridActionSendSeparateEmail = false;
-  /** True when the last preview-distribution-lists call returned at least one SSE recipient */
-  public hasSseRecipients = false;
+  /** SSE recipients returned by the last preview-distribution-lists call (read-only display) */
+  public distributionListSeparate: any[] = [];
+
+  /** @returns true when the last preview-distribution-lists call returned at least one SSE recipient */
+  get hasSseRecipients(): boolean {
+    return (
+      this.distributionListSeparate?.some((b: any) => b?.emails?.length > 0) ??
+      false
+    );
+  }
 
   /**
    * Block names marked for individual-email sending. Derived from form state; returns ['Block 1'] in grid-action SSE mode.

--- a/libs/shared/src/lib/components/email/email.service.ts
+++ b/libs/shared/src/lib/components/email/email.service.ts
@@ -247,6 +247,8 @@ export class EmailService {
   public gridActionDataQuery: any = null;
   /** Whether SSE is enabled for the current grid action */
   public gridActionSendSeparateEmail = false;
+  /** True when the last preview-distribution-lists call returned at least one SSE recipient */
+  public hasSseRecipients = false;
 
   /**
    * Block names marked for individual-email sending. Derived from form state; returns ['Block 1'] in grid-action SSE mode.

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.html
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.html
@@ -9,12 +9,12 @@
     <div
       *ngIf="
         isPreviewTemplate &&
-        !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+        !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
       "
       [uiErrorMessage]="
         showRecipientError
-          ? ((emailService.gridActionSendSeparateEmail && !emailService.hasSseRecipients
-              ? 'common.notifications.email.errors.noRecipientSse'
+          ? ((emailService.gridActionSendSeparateEmail && !emailService.hasSeparateEmailRecipients
+              ? 'common.notifications.email.errors.noRecipientSeparateEmail'
               : 'common.notifications.email.errors.noRecipient') | translate)
           : (emailsError | translate)
       "
@@ -29,7 +29,7 @@
         }}<ng-container
           *ngIf="
             !emailService.gridActionSendSeparateEmail ||
-            !emailService.hasSseRecipients
+            !emailService.hasSeparateEmailRecipients
           "
           >*</ng-container
         >
@@ -56,7 +56,7 @@
     <div
       *ngIf="
         isPreviewTemplate &&
-        !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+        !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
       "
       [uiErrorMessage]="emailsError | translate"
       [uiErrorMessageIf]="
@@ -89,7 +89,7 @@
     <div
       *ngIf="
         isPreviewTemplate &&
-        !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+        !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
       "
       [uiErrorMessage]="emailsError | translate"
       [uiErrorMessageIf]="
@@ -120,7 +120,7 @@
     </div>
 
     <!-- Emails from Send Separate Email Preview (read-only) -->
-    <div class="mb-4" *ngIf="isPreviewTemplate && emailService.hasSseRecipients">
+    <div class="mb-4" *ngIf="isPreviewTemplate && emailService.hasSeparateEmailRecipients">
       <h1>
         {{ 'components.select.distribution.sendseparate.list' | translate }}
       </h1>

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.html
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.html
@@ -434,7 +434,7 @@
           uiFormFieldDirective
           [defaultMargin]="false"
           class="w-1/3 px-2"
-          *ngIf="!this.emailService.isGridAction"
+          *ngIf="!this.emailService.isGridAction || blockFieldSelect.length > 0"
         >
           <label
             for="fieldSelect"

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.html
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.html
@@ -110,41 +110,35 @@
       />
     </div>
 
-    <!-- Emails from Send Separate Email Preview -->
-    <div class="mb-4" *ngIf="emailService.hasSseRecipients">
+    <!-- Emails from Send Separate Email Preview (read-only) -->
+    <div class="mb-4" *ngIf="isPreviewTemplate && emailService.hasSseRecipients">
       <label class="block text-sm font-medium leading-6 text-gray-900">
         {{ 'components.select.distribution.sendseparate.list' | translate }}
       </label>
-      <div uiChipList>
-        <ng-container
-          *ngFor="let email of distributionListSeparate[0].emails; let j = index"
+      <ng-container *ngFor="let block of emailService.distributionListSeparate">
+        <div uiChipList>
+          <ng-container *ngFor="let email of block.emails; let j = index">
+            <ui-chip
+              *ngIf="j < 6 || block.isExpanded"
+              variant="primary"
+              class="w-full flex-row flex-wrap justify-between mr-1"
+              >{{ email }}</ui-chip
+            >
+          </ng-container>
+        </div>
+        <ui-button
+          *ngIf="block.emails.length > 6 && !block.isExpanded"
+          class="inline-block mt-2"
+          (click)="block.isExpanded = true"
+          >{{ 'components.email.preview.more' | translate : { length: block.emails.length - 6 } }}</ui-button
         >
-          <ui-chip
-            *ngIf="j < 6 || distributionListSeparate[0].isExpanded"
-            variant="primary"
-            class="w-full flex-row flex-wrap justify-between mr-1"
-            >{{ email }}</ui-chip
-          >
-        </ng-container>
-      </div>
-      <ui-button
-        *ngIf="
-          distributionListSeparate[0].emails.length > 6 &&
-          !distributionListSeparate[0].isExpanded
-        "
-        class="inline-block mt-2"
-        (click)="distributionListSeparate[0].isExpanded = true"
-        >{{
-          'components.email.preview.more'
-            | translate : { length: distributionListSeparate[0].emails.length - 6 }
-        }}</ui-button
-      >
-      <ui-button
-        *ngIf="distributionListSeparate[0].isExpanded"
-        class="inline-block mt-2"
-        (click)="distributionListSeparate[0].isExpanded = false"
-        >{{ 'components.email.preview.less' | translate }}</ui-button
-      >
+        <ui-button
+          *ngIf="block.isExpanded"
+          class="inline-block mt-2"
+          (click)="block.isExpanded = false"
+          >{{ 'components.email.preview.less' | translate }}</ui-button
+        >
+      </ng-container>
     </div>
 
     <!-- Dropdowns and Subject Input -->

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.html
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.html
@@ -479,7 +479,7 @@
           uiFormFieldDirective
           [defaultMargin]="false"
           class="w-1/3 px-2"
-          *ngIf="!this.emailService.isGridAction || blockFieldSelect.length > 0"
+          *ngIf="blockFieldSelect.length > 0"
         >
           <label
             for="fieldSelect"

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.html
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.html
@@ -7,7 +7,10 @@
   <!-- 5th step Layout -->
   <div>
     <div
-      *ngIf="isPreviewTemplate"
+      *ngIf="
+        isPreviewTemplate &&
+        !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+      "
       [uiErrorMessage]="
         showRecipientError
           ? ((emailService.gridActionSendSeparateEmail && !emailService.hasSseRecipients
@@ -51,7 +54,10 @@
     </div>
 
     <div
-      *ngIf="isPreviewTemplate"
+      *ngIf="
+        isPreviewTemplate &&
+        !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+      "
       [uiErrorMessage]="emailsError | translate"
       [uiErrorMessageIf]="
         layoutForm.get('cc')?.errors && layoutForm.get('cc')?.touched
@@ -81,7 +87,10 @@
     </div>
 
     <div
-      *ngIf="isPreviewTemplate"
+      *ngIf="
+        isPreviewTemplate &&
+        !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+      "
       [uiErrorMessage]="emailsError | translate"
       [uiErrorMessageIf]="
         layoutForm.get('bcc')?.errors && layoutForm.get('bcc')?.touched
@@ -112,9 +121,9 @@
 
     <!-- Emails from Send Separate Email Preview (read-only) -->
     <div class="mb-4" *ngIf="isPreviewTemplate && emailService.hasSseRecipients">
-      <label class="block text-sm font-medium leading-6 text-gray-900">
+      <h1>
         {{ 'components.select.distribution.sendseparate.list' | translate }}
-      </label>
+      </h1>
       <ng-container *ngFor="let block of emailService.distributionListSeparate">
         <div uiChipList>
           <ng-container *ngFor="let email of block.emails; let j = index">

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.html
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.html
@@ -7,10 +7,7 @@
   <!-- 5th step Layout -->
   <div>
     <div
-      *ngIf="
-        isPreviewTemplate &&
-        !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
-      "
+      *ngIf="isPreviewTemplate"
       [uiErrorMessage]="
         showRecipientError
           ? ((emailService.gridActionSendSeparateEmail && !emailService.hasSeparateEmailRecipients
@@ -54,10 +51,7 @@
     </div>
 
     <div
-      *ngIf="
-        isPreviewTemplate &&
-        !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
-      "
+      *ngIf="isPreviewTemplate"
       [uiErrorMessage]="emailsError | translate"
       [uiErrorMessageIf]="
         layoutForm.get('cc')?.errors && layoutForm.get('cc')?.touched
@@ -87,10 +81,7 @@
     </div>
 
     <div
-      *ngIf="
-        isPreviewTemplate &&
-        !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
-      "
+      *ngIf="isPreviewTemplate"
       [uiErrorMessage]="emailsError | translate"
       [uiErrorMessageIf]="
         layoutForm.get('bcc')?.errors && layoutForm.get('bcc')?.touched

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.html
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.html
@@ -96,6 +96,43 @@
       />
     </div>
 
+    <!-- Emails from Send Separate Email Preview -->
+    <div class="mb-4" *ngIf="emailService.hasSseRecipients">
+      <label class="block text-sm font-medium leading-6 text-gray-900">
+        {{ 'components.select.distribution.sendseparate.list' | translate }}
+      </label>
+      <div uiChipList>
+        <ng-container
+          *ngFor="let email of distributionListSeparate[0].emails; let j = index"
+        >
+          <ui-chip
+            *ngIf="j < 6 || distributionListSeparate[0].isExpanded"
+            variant="primary"
+            class="w-full flex-row flex-wrap justify-between mr-1"
+            >{{ email }}</ui-chip
+          >
+        </ng-container>
+      </div>
+      <ui-button
+        *ngIf="
+          distributionListSeparate[0].emails.length > 6 &&
+          !distributionListSeparate[0].isExpanded
+        "
+        class="inline-block mt-2"
+        (click)="distributionListSeparate[0].isExpanded = true"
+        >{{
+          'components.email.preview.more'
+            | translate : { length: distributionListSeparate[0].emails.length - 6 }
+        }}</ui-button
+      >
+      <ui-button
+        *ngIf="distributionListSeparate[0].isExpanded"
+        class="inline-block mt-2"
+        (click)="distributionListSeparate[0].isExpanded = false"
+        >{{ 'components.email.preview.less' | translate }}</ui-button
+      >
+    </div>
+
     <!-- Dropdowns and Subject Input -->
     <div class="flex flex-col mb-4 py-5">
       <!-- Subject Input Label -->

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.html
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.html
@@ -8,15 +8,29 @@
   <div>
     <div
       *ngIf="isPreviewTemplate"
-      [uiErrorMessage]="emailsError | translate"
+      [uiErrorMessage]="
+        showRecipientError
+          ? ((emailService.gridActionSendSeparateEmail && !emailService.hasSseRecipients
+              ? 'common.notifications.email.errors.noRecipientSse'
+              : 'common.notifications.email.errors.noRecipient') | translate)
+          : (emailsError | translate)
+      "
       [uiErrorMessageIf]="
-        layoutForm.get('to')?.errors && layoutForm.get('to')?.touched
+        (layoutForm.get('to')?.errors && layoutForm.get('to')?.touched) ||
+        showRecipientError
       "
       uiFormFieldDirective
     >
-      <label class="block text-sm font-medium leading-6 text-gray-900"
-        >{{ 'components.email.distributionList.to' | translate }}*</label
-      >
+      <label class="block text-sm font-medium leading-6 text-gray-900">
+        {{ 'components.email.distributionList.to' | translate
+        }}<ng-container
+          *ngIf="
+            !emailService.gridActionSendSeparateEmail ||
+            !emailService.hasSseRecipients
+          "
+          >*</ng-container
+        >
+      </label>
       <div uiChipList #chipList formControlName="to">
         <ui-chip
           *ngFor="let to of layoutForm.get('to')?.value"

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -100,6 +100,8 @@ export class LayoutComponent
   SEPARATOR_KEYS_CODE = [ENTER, COMMA, TAB, SPACE];
   /** Block field select values */
   blockFieldSelect: string[] = [];
+  /** SSE recipients for read-only preview (not merged into to/cc/bcc) */
+  distributionListSeparate: any[] = [];
 
   /** @returns list of emails */
   get emails(): string[] {
@@ -364,23 +366,18 @@ export class LayoutComponent
     }
 
     if (response?.individualEmailList?.length > 0) {
-      const sseEmails = [
-        ...new Set(
-          response.individualEmailList.flatMap(
-            (block: any) => block.emails ?? []
-          )
-        ),
-      ];
-      this.emailService.emailDistributionList.to = [
-        ...new Set([
-          ...(Array.isArray(this.emailService.emailDistributionList.to)
-            ? this.emailService.emailDistributionList.to
-            : []),
-          ...sseEmails,
-        ]),
-      ];
+      this.distributionListSeparate = response.individualEmailList;
+      this.distributionListSeparate.forEach((block: any) => {
+        // client-side UI flag for showing >6 emails.
+        block.isExpanded = false;
+        block.emails = Array.from(new Set(block.emails));
+      });
+    } else {
+      this.distributionListSeparate = [];
     }
-
+    this.emailService.hasSseRecipients = this.distributionListSeparate.some(
+      (block: any) => block.emails.length > 0
+    );
     this.populateDLForm();
     this.emailService.loading = false;
   }

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -459,8 +459,8 @@ export class LayoutComponent
             // single 'Block 1', already appendFields-flattened in initialiseFieldSelectDropdown
             fields = this.firstBlockFields;
           } else {
-            // Source each SSE block's OWN dataset fields (flattened via appendFields so nested
-            // tokens survive) instead of always using the first block's fields.
+            // Source each send-separate-email block's OWN dataset fields (flattened via
+            // appendFields so nested tokens survive) instead of always using the first block's fields.
             const dataset = (
               this.emailService.datasetsForm?.get('datasets')?.getRawValue() ??
               []
@@ -542,7 +542,7 @@ export class LayoutComponent
       this.emailService.stepperDisable.next({ id: 4, isValid: true });
       // In grid-action mode the recipient validator is the authority for the
       // Next button once the layout is valid; blanket-enabling here would stomp
-      // the SSE/To recipient gate (last-writer-wins on disableNextActionBtn).
+      // the send-separate-email / To recipient gate (last-writer-wins on disableNextActionBtn).
       if (this.emailService.isGridAction) {
         this.validateQuickActionToEmails();
       } else {
@@ -1209,19 +1209,18 @@ export class LayoutComponent
     // check runs last (on load via loadDistributionList, or on a To-field
     // change), so the two writers of disableNextActionBtn agree.
     const layoutInvalid = this.showSubjectValidator || this.showBodyValidator;
+    const toEmpty = (this.layoutForm?.getRawValue()?.to?.length ?? 0) === 0;
     if (
       this.emailService.isGridAction &&
       !this.emailService.gridActionSendSeparateEmail
     ) {
-      const toEmpty = (this.layoutForm?.getRawValue()?.to?.length ?? 0) === 0;
       this.emailService.disableNextActionBtn = toEmpty || layoutInvalid;
       this.showRecipientError = toEmpty;
     } else if (
       this.emailService.isGridAction &&
       this.emailService.gridActionSendSeparateEmail
     ) {
-      const toEmpty = (this.layoutForm?.getRawValue()?.to?.length ?? 0) === 0;
-      const missing = toEmpty && !this.emailService.hasSseRecipients;
+      const missing = toEmpty && !this.emailService.hasSeparateEmailRecipients;
       this.emailService.disableNextActionBtn = missing || layoutInvalid;
       this.showRecipientError = missing;
     }

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -100,8 +100,6 @@ export class LayoutComponent
   SEPARATOR_KEYS_CODE = [ENTER, COMMA, TAB, SPACE];
   /** Block field select values */
   blockFieldSelect: string[] = [];
-  /** SSE recipients for read-only preview (not merged into to/cc/bcc) */
-  distributionListSeparate: any[] = [];
   /** Drives the To-field inline error; set explicitly after API resolves to ensure false→true transition */
   showRecipientError = false;
 
@@ -294,8 +292,7 @@ export class LayoutComponent
    */
   async loadDistributionList() {
     this.emailService.loading = true;
-    this.emailService.hasSseRecipients = false;
-    this.distributionListSeparate = [];
+    this.emailService.distributionListSeparate = [];
     this.showRecipientError = false;
     const query = this.emailService.datasetsForm?.getRawValue();
     query.datasets = this.emailService.datasetsForm
@@ -371,18 +368,14 @@ export class LayoutComponent
     }
 
     if (response?.individualEmailList?.length > 0) {
-      this.distributionListSeparate = response.individualEmailList;
-      this.distributionListSeparate.forEach((block: any) => {
-        // client-side UI flag for showing >6 emails.
-        block.isExpanded = false;
+      this.emailService.distributionListSeparate = response.individualEmailList;
+      this.emailService.distributionListSeparate.forEach((block: any) => {
+        block.isExpanded = false; // client-side UI flag for >6 emails
         block.emails = Array.from(new Set(block.emails));
       });
     } else {
-      this.distributionListSeparate = [];
+      this.emailService.distributionListSeparate = [];
     }
-    this.emailService.hasSseRecipients = this.distributionListSeparate.some(
-      (block: any) => block.emails.length > 0
-    );
     this.populateDLForm();
     this.emailService.loading = false;
   }

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -102,6 +102,8 @@ export class LayoutComponent
   blockFieldSelect: string[] = [];
   /** SSE recipients for read-only preview (not merged into to/cc/bcc) */
   distributionListSeparate: any[] = [];
+  /** Drives the To-field inline error; set explicitly after API resolves to ensure false→true transition */
+  showRecipientError = false;
 
   /** @returns list of emails */
   get emails(): string[] {
@@ -292,6 +294,9 @@ export class LayoutComponent
    */
   async loadDistributionList() {
     this.emailService.loading = true;
+    this.emailService.hasSseRecipients = false;
+    this.distributionListSeparate = [];
+    this.showRecipientError = false;
     const query = this.emailService.datasetsForm?.getRawValue();
     query.datasets = this.emailService.datasetsForm
       ?.get('datasets')
@@ -434,6 +439,7 @@ export class LayoutComponent
           .get('bcc')
           ?.setValue(this.emailService.emailDistributionList.bcc);
       }
+      this.onTxtSubjectChange();
       this.validateQuickActionToEmails();
     }
   }
@@ -1185,8 +1191,17 @@ export class LayoutComponent
       this.emailService.isGridAction &&
       !this.emailService.gridActionSendSeparateEmail
     ) {
-      this.emailService.disableNextActionBtn =
-        this.layoutForm?.getRawValue()?.to?.length === 0 ? true : false;
+      const toEmpty = (this.layoutForm?.getRawValue()?.to?.length ?? 0) === 0;
+      this.emailService.disableNextActionBtn = toEmpty;
+      this.showRecipientError = toEmpty;
+    } else if (
+      this.emailService.isGridAction &&
+      this.emailService.gridActionSendSeparateEmail
+    ) {
+      const toEmpty = (this.layoutForm?.getRawValue()?.to?.length ?? 0) === 0;
+      const missing = toEmpty && !this.emailService.hasSseRecipients;
+      this.emailService.disableNextActionBtn = missing;
+      this.showRecipientError = missing;
     }
   }
 }

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -543,7 +543,10 @@ export class LayoutComponent
       // In grid-action mode the recipient validator is the authority for the
       // Next button once the layout is valid; blanket-enabling here would stomp
       // the send-separate-email / To recipient gate (last-writer-wins on disableNextActionBtn).
-      if (this.emailService.isGridAction) {
+      // Only applies when the To-field UI actually exists (isPreviewTemplate) --
+      // otherwise (e.g. the "create new template" wizard) there's no way to
+      // ever satisfy the recipient check and Next would stay disabled forever.
+      if (this.emailService.isGridAction && this.isPreviewTemplate) {
         this.validateQuickActionToEmails();
       } else {
         this.emailService.disableNextActionBtn = false;

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -432,7 +432,6 @@ export class LayoutComponent
           .get('bcc')
           ?.setValue(this.emailService.emailDistributionList.bcc);
       }
-      this.onTxtSubjectChange();
       this.validateQuickActionToEmails();
     }
   }

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -161,7 +161,6 @@ export class LayoutComponent
   ngOnInit(): void {
     if (this.emailService.isGridAction) {
       this.emailService.resetPreviewData();
-      this.emailService.sendSeparateBlocks = [];
       if (
         !this.emailService.isCustomTemplateEdit &&
         !this.emailService.isNewCustomTemplate
@@ -308,6 +307,23 @@ export class LayoutComponent
         this.emailService.quickEmailDistributionListQuery.cc;
       query.emailDistributionList.bcc =
         this.emailService.quickEmailDistributionListQuery.bcc;
+
+      if (
+        this.emailService.gridActionSendSeparateEmail &&
+        this.emailService.allPreviewData?.[0]?.dataQuery?.queryName
+      ) {
+        if (query.datasets?.length > 0) {
+          const previewData = this.emailService.allPreviewData[0];
+          query.datasets[0].name = 'Block 1';
+          query.datasets[0].individualEmail = true;
+          query.datasets[0].individualEmailFields =
+            previewData.separateEmailFields ?? [];
+          query.datasets[0].query.name = previewData.dataQuery.queryName ?? '';
+          query.datasets[0].query.filter = previewData.dataQuery.filter;
+          query.datasets[0].query.fields = previewData.dataQuery.fields ?? [];
+          query.datasets[0].resource = previewData.dataQuery.resource ?? '';
+        }
+      }
     }
     //Start:- When We are checking from Grid Action grid in that case - Needs to check Resource of DL and Resource of Grid is matching or not
     // if its not matching in that case we are doing Filter as blank , (It should call once its matching the Resource Name)
@@ -346,6 +362,25 @@ export class LayoutComponent
         bcc: this.emailService.emailDistributionList?.bcc || [],
       };
     }
+
+    if (response?.individualEmailList?.length > 0) {
+      const sseEmails = [
+        ...new Set(
+          response.individualEmailList.flatMap(
+            (block: any) => block.emails ?? []
+          )
+        ),
+      ];
+      this.emailService.emailDistributionList.to = [
+        ...new Set([
+          ...(Array.isArray(this.emailService.emailDistributionList.to)
+            ? this.emailService.emailDistributionList.to
+            : []),
+          ...sseEmails,
+        ]),
+      ];
+    }
+
     this.populateDLForm();
     this.emailService.loading = false;
   }
@@ -410,10 +445,14 @@ export class LayoutComponent
    * Block Data for Body
    */
   getBlockData() {
-    if (
+    const hasFieldsInForm =
       this.emailService.datasetsForm.get('datasets')?.value?.[0]?.query?.fields
-        ?.length > 0
-    ) {
+        ?.length > 0;
+    const hasFieldsInGridAction =
+      this.emailService.isGridAction &&
+      this.emailService.gridActionDataQuery?.fields?.length > 0;
+
+    if (hasFieldsInForm || hasFieldsInGridAction) {
       this.blockData =
         this.emailService.previewData?.datasets ??
         this.emailService.getAllPreviewData();
@@ -610,6 +649,18 @@ export class LayoutComponent
    * Initializes the field select dropdown.
    */
   initialiseFieldSelectDropdown(): void {
+    if (
+      this.emailService.isGridAction &&
+      this.emailService.gridActionSendSeparateEmail
+    ) {
+      this.firstBlockFields = (
+        this.emailService.gridActionDataQuery?.fields ?? []
+      )
+        .map((f: any) => f.name)
+        .filter(Boolean);
+      return;
+    }
+
     const firstBlock = this.emailService.getAllPreviewData()[0];
     if (
       firstBlock?.datasetFields?.length > 0 ||
@@ -1133,7 +1184,10 @@ export class LayoutComponent
    * Validate Grid Action To emails
    */
   validateQuickActionToEmails() {
-    if (this.emailService.isGridAction) {
+    if (
+      this.emailService.isGridAction &&
+      !this.emailService.gridActionSendSeparateEmail
+    ) {
       this.emailService.disableNextActionBtn =
         this.layoutForm?.getRawValue()?.to?.length === 0 ? true : false;
     }

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -648,11 +648,12 @@ export class LayoutComponent
       this.emailService.isGridAction &&
       this.emailService.gridActionSendSeparateEmail
     ) {
-      this.firstBlockFields = (
-        this.emailService.gridActionDataQuery?.fields ?? []
-      )
-        .map((f: any) => f.name)
-        .filter(Boolean);
+      const fields: string[] = [];
+      (this.emailService.gridActionDataQuery?.fields ?? []).forEach(
+        (field: any) =>
+          this.emailService.appendFields(field, field.name, fields)
+      );
+      this.firstBlockFields = fields;
       return;
     }
 

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -453,8 +453,26 @@ export class LayoutComponent
         this.emailService.getAllPreviewData();
 
       this.blockFieldSelect = this.emailService.sendSeparateBlocks.flatMap(
-        (block: any) =>
-          this.firstBlockFields.map((field: string) => `${block} - ${field}`)
+        (blockName: string) => {
+          let fields: string[];
+          if (this.emailService.isGridAction) {
+            // single 'Block 1', already appendFields-flattened in initialiseFieldSelectDropdown
+            fields = this.firstBlockFields;
+          } else {
+            // Source each SSE block's OWN dataset fields (flattened via appendFields so nested
+            // tokens survive) instead of always using the first block's fields.
+            const dataset = (
+              this.emailService.datasetsForm?.get('datasets')?.getRawValue() ??
+              []
+            ).find((d: any) => d.name === blockName);
+            const acc: string[] = [];
+            (dataset?.query?.fields ?? []).forEach((f: any) =>
+              this.emailService.appendFields(f, f.name, acc)
+            );
+            fields = acc;
+          }
+          return fields.map((field: string) => `${blockName} - ${field}`);
+        }
       );
     } else {
       this.blockData = [];

--- a/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
+++ b/libs/shared/src/lib/components/email/steps/layout/layout.component.ts
@@ -522,7 +522,14 @@ export class LayoutComponent
     } else {
       this.emailService.disableSaveAndProceed.next(false);
       this.emailService.stepperDisable.next({ id: 4, isValid: true });
-      this.emailService.disableNextActionBtn = false;
+      // In grid-action mode the recipient validator is the authority for the
+      // Next button once the layout is valid; blanket-enabling here would stomp
+      // the SSE/To recipient gate (last-writer-wins on disableNextActionBtn).
+      if (this.emailService.isGridAction) {
+        this.validateQuickActionToEmails();
+      } else {
+        this.emailService.disableNextActionBtn = false;
+      }
     }
   }
 
@@ -1180,12 +1187,16 @@ export class LayoutComponent
    * Validate Grid Action To emails
    */
   validateQuickActionToEmails() {
+    // Layout validity must keep gating Next even when this recipient-aware
+    // check runs last (on load via loadDistributionList, or on a To-field
+    // change), so the two writers of disableNextActionBtn agree.
+    const layoutInvalid = this.showSubjectValidator || this.showBodyValidator;
     if (
       this.emailService.isGridAction &&
       !this.emailService.gridActionSendSeparateEmail
     ) {
       const toEmpty = (this.layoutForm?.getRawValue()?.to?.length ?? 0) === 0;
-      this.emailService.disableNextActionBtn = toEmpty;
+      this.emailService.disableNextActionBtn = toEmpty || layoutInvalid;
       this.showRecipientError = toEmpty;
     } else if (
       this.emailService.isGridAction &&
@@ -1193,7 +1204,7 @@ export class LayoutComponent
     ) {
       const toEmpty = (this.layoutForm?.getRawValue()?.to?.length ?? 0) === 0;
       const missing = toEmpty && !this.emailService.hasSseRecipients;
-      this.emailService.disableNextActionBtn = missing;
+      this.emailService.disableNextActionBtn = missing || layoutInvalid;
       this.showRecipientError = missing;
     }
   }

--- a/libs/shared/src/lib/components/email/steps/preview/preview.component.html
+++ b/libs/shared/src/lib/components/email/steps/preview/preview.component.html
@@ -20,7 +20,8 @@
         class="mb-4"
         *ngIf="
           this.emailService.datasetsForm?.getRawValue()?.emailDistributionList
-            ?.name
+            ?.name &&
+          !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
         "
       >
         <p>
@@ -34,7 +35,11 @@
       <!-- To -->
       <div
         class="mb-4"
-        *ngIf="distributionListTo && distributionListTo.length > 0"
+        *ngIf="
+          distributionListTo &&
+          distributionListTo.length > 0 &&
+          !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+        "
       >
         <h2>{{ 'components.select.distribution.to' | translate }}:</h2>
         <ul class="list-none space-y-1">
@@ -114,7 +119,11 @@
 
       <!-- CC -->
       <div
-        *ngIf="distributionListCc && distributionListCc.length > 0"
+        *ngIf="
+          distributionListCc &&
+          distributionListCc.length > 0 &&
+          !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+        "
         class="mb-4"
       >
         <h2>{{ 'components.select.distribution.cc' | translate }}:</h2>
@@ -153,7 +162,11 @@
 
       <!-- BCC -->
       <div
-        *ngIf="distributionListBcc && distributionListBcc.length > 0"
+        *ngIf="
+          distributionListBcc &&
+          distributionListBcc.length > 0 &&
+          !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+        "
         class="mb-4"
       >
         <h2>{{ 'components.select.distribution.bcc' | translate }}:</h2>
@@ -199,7 +212,7 @@
         *ngFor="let block of distributionListSeparate; let i = index"
       >
         <div class="mb-4">
-          <h3>{{ block.name }}</h3>
+          <h3 *ngIf="!emailService.isGridAction">{{ block.name }}</h3>
           <ul class="list-none space-y-1">
             <div uiChipList>
               <ng-container *ngFor="let email of block.emails; let j = index">

--- a/libs/shared/src/lib/components/email/steps/preview/preview.component.html
+++ b/libs/shared/src/lib/components/email/steps/preview/preview.component.html
@@ -21,7 +21,7 @@
         *ngIf="
           this.emailService.datasetsForm?.getRawValue()?.emailDistributionList
             ?.name &&
-          !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+          !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
         "
       >
         <p>
@@ -38,7 +38,7 @@
         *ngIf="
           distributionListTo &&
           distributionListTo.length > 0 &&
-          !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+          !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
         "
       >
         <h2>{{ 'components.select.distribution.to' | translate }}:</h2>
@@ -122,7 +122,7 @@
         *ngIf="
           distributionListCc &&
           distributionListCc.length > 0 &&
-          !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+          !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
         "
         class="mb-4"
       >
@@ -165,7 +165,7 @@
         *ngIf="
           distributionListBcc &&
           distributionListBcc.length > 0 &&
-          !(emailService.gridActionSendSeparateEmail && emailService.hasSseRecipients)
+          !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
         "
         class="mb-4"
       >

--- a/libs/shared/src/lib/components/email/steps/preview/preview.component.html
+++ b/libs/shared/src/lib/components/email/steps/preview/preview.component.html
@@ -20,8 +20,7 @@
         class="mb-4"
         *ngIf="
           this.emailService.datasetsForm?.getRawValue()?.emailDistributionList
-            ?.name &&
-          !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
+            ?.name
         "
       >
         <p>
@@ -35,11 +34,7 @@
       <!-- To -->
       <div
         class="mb-4"
-        *ngIf="
-          distributionListTo &&
-          distributionListTo.length > 0 &&
-          !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
-        "
+        *ngIf="distributionListTo && distributionListTo.length > 0"
       >
         <h2>{{ 'components.select.distribution.to' | translate }}:</h2>
         <ul class="list-none space-y-1">
@@ -119,11 +114,7 @@
 
       <!-- CC -->
       <div
-        *ngIf="
-          distributionListCc &&
-          distributionListCc.length > 0 &&
-          !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
-        "
+        *ngIf="distributionListCc && distributionListCc.length > 0"
         class="mb-4"
       >
         <h2>{{ 'components.select.distribution.cc' | translate }}:</h2>
@@ -162,11 +153,7 @@
 
       <!-- BCC -->
       <div
-        *ngIf="
-          distributionListBcc &&
-          distributionListBcc.length > 0 &&
-          !(emailService.gridActionSendSeparateEmail && emailService.hasSeparateEmailRecipients)
-        "
+        *ngIf="distributionListBcc && distributionListBcc.length > 0"
         class="mb-4"
       >
         <h2>{{ 'components.select.distribution.bcc' | translate }}:</h2>

--- a/libs/shared/src/lib/components/email/steps/preview/preview.component.ts
+++ b/libs/shared/src/lib/components/email/steps/preview/preview.component.ts
@@ -291,6 +291,11 @@ export class PreviewComponent
             previewData?.dataQuery?.queryName || '';
           this.query.datasets[0].query.fields =
             previewData?.dataQuery?.fields || [];
+          if (previewData?.sendSeparateEmail) {
+            this.query.datasets[0].individualEmail = true;
+            this.query.datasets[0].individualEmailFields =
+              previewData?.separateEmailFields ?? [];
+          }
         }
         if (this.emailService.allPreviewData.length > 0) {
           this.emailService.allPreviewData[0]['emailDistributionList'] =

--- a/libs/shared/src/lib/components/email/steps/preview/preview.component.ts
+++ b/libs/shared/src/lib/components/email/steps/preview/preview.component.ts
@@ -158,6 +158,8 @@ export class PreviewComponent
       this.distributionListTo = this.emailService.emailDistributionList?.to;
       this.distributionListCc = this.emailService.emailDistributionList?.cc;
       this.distributionListBcc = this.emailService.emailDistributionList?.bcc;
+      this.distributionListSeparate =
+        this.emailService.distributionListSeparate ?? [];
     }
 
     this.query = this.emailService.datasetsForm.value;

--- a/libs/shared/src/lib/components/templates/components/preview-template-modal/preview-template-modal.component.ts
+++ b/libs/shared/src/lib/components/templates/components/preview-template-modal/preview-template-modal.component.ts
@@ -74,6 +74,9 @@ export class PreviewTemplateModalComponent implements OnInit {
     private translate: TranslateService,
     private dialogRef: DialogRef
   ) {
+    this.emailService.gridActionDataQuery = this.data.dataQuery;
+    this.emailService.gridActionSendSeparateEmail =
+      this.data.sendSeparateEmail ?? false;
     this.emailService.disableNextActionBtn = false;
     this.emailService.setDatasetForm();
     this.emailService.isGridAction = true;
@@ -89,6 +92,8 @@ export class PreviewTemplateModalComponent implements OnInit {
         navigateToPage: !isNil(this.data.navigateSettings),
         navigateSettings: this.data.navigateSettings,
         dataQuery: this.data.dataQuery,
+        sendSeparateEmail: this.data.sendSeparateEmail ?? false,
+        separateEmailFields: this.data.separateEmailFields ?? [],
       },
     ];
     this.emailService.emailDistributionList = this.data.distributionListInfo;
@@ -247,6 +252,12 @@ export class PreviewTemplateModalComponent implements OnInit {
         payload.emailDistributionList = previewData.emailDistributionList;
         payload.datasets[0].navigateToPage = previewData?.navigateToPage;
         payload.datasets[0].navigateSettings = previewData?.navigateSettings;
+
+        if (this.data.sendSeparateEmail) {
+          payload.datasets[0].individualEmail = true;
+          payload.datasets[0].individualEmailFields =
+            this.data.separateEmailFields ?? [];
+        }
       }
     }
     this.dialogRef.close({ preventDeletion: true });
@@ -273,10 +284,11 @@ export class PreviewTemplateModalComponent implements OnInit {
    * Method called when clicking on Next.
    */
   next() {
-    if (
+    const toMissing =
       !this.emailService.emailDistributionList ||
-      this.emailService.emailDistributionList?.to?.length === 0
-    ) {
+      this.emailService.emailDistributionList?.to?.length === 0;
+
+    if (!this.data.sendSeparateEmail && toMissing) {
       this.snackBar.openSnackBar('To is required to proceed!', {
         error: true,
       });

--- a/libs/shared/src/lib/components/templates/components/preview-template-modal/preview-template-modal.component.ts
+++ b/libs/shared/src/lib/components/templates/components/preview-template-modal/preview-template-modal.component.ts
@@ -288,12 +288,16 @@ export class PreviewTemplateModalComponent implements OnInit {
       !this.emailService.emailDistributionList ||
       this.emailService.emailDistributionList?.to?.length === 0;
 
-    const hasSseRecipients = this.emailService.hasSseRecipients;
+    const hasSeparateEmailRecipients =
+      this.emailService.hasSeparateEmailRecipients;
 
-    if (toMissing && (!this.data.sendSeparateEmail || !hasSseRecipients)) {
+    if (
+      toMissing &&
+      (!this.data.sendSeparateEmail || !hasSeparateEmailRecipients)
+    ) {
       const errorKey =
-        this.data.sendSeparateEmail && !hasSseRecipients
-          ? 'common.notifications.email.errors.noRecipientSse'
+        this.data.sendSeparateEmail && !hasSeparateEmailRecipients
+          ? 'common.notifications.email.errors.noRecipientSeparateEmail'
           : 'common.notifications.email.errors.noRecipient';
       this.snackBar.openSnackBar(this.translate.instant(errorKey), {
         error: true,

--- a/libs/shared/src/lib/components/templates/components/preview-template-modal/preview-template-modal.component.ts
+++ b/libs/shared/src/lib/components/templates/components/preview-template-modal/preview-template-modal.component.ts
@@ -288,8 +288,14 @@ export class PreviewTemplateModalComponent implements OnInit {
       !this.emailService.emailDistributionList ||
       this.emailService.emailDistributionList?.to?.length === 0;
 
-    if (!this.data.sendSeparateEmail && toMissing) {
-      this.snackBar.openSnackBar('To is required to proceed!', {
+    const hasSseRecipients = this.emailService.hasSseRecipients;
+
+    if (toMissing && (!this.data.sendSeparateEmail || !hasSseRecipients)) {
+      const errorKey =
+        this.data.sendSeparateEmail && !hasSseRecipients
+          ? 'common.notifications.email.errors.noRecipientSse'
+          : 'common.notifications.email.errors.noRecipient';
+      this.snackBar.openSnackBar(this.translate.instant(errorKey), {
         error: true,
       });
     } else {

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
@@ -422,6 +422,27 @@
           [showLimit]="true"
           [showColumnWidth]="true"
         ></shared-tab-fields>
+
+        <!-- Send Separate Email -->
+        <ui-checkbox formControlName="sendSeparateEmail">
+          <ng-container ngProjectAs="label">{{
+            'components.widget.settings.grid.buttons.callback.sendSeparateEmail'
+              | translate
+          }}</ng-container>
+        </ui-checkbox>
+        <ng-container *ngIf="formGroup.value.sendSeparateEmail">
+          <h2>{{
+            'components.widget.settings.grid.buttons.callback.separateEmailFields'
+              | translate
+          }}</h2>
+          <shared-tab-fields
+            *ngIf="fields.length > 0"
+            [form]="separateEmailFieldsArray"
+            [fields]="fields"
+            [showLimit]="false"
+            [showColumnWidth]="false"
+          ></shared-tab-fields>
+        </ng-container>
       </div>
 
       <!-- Workflow actions -->

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
@@ -314,6 +314,33 @@
         }}</ng-container>
       </ui-checkbox>
       <div *ngIf="formGroup.value.sendMail" class="sub-parameters">
+        <!-- Export dataset -->
+        <ui-checkbox formControlName="export">
+          <ng-container ngProjectAs="label">{{
+            'components.widget.settings.grid.buttons.callback.export'
+              | translate
+          }}</ng-container>
+        </ui-checkbox>
+
+        <!-- Send Separate Email -->
+        <ui-checkbox formControlName="sendSeparateEmail">
+          <ng-container ngProjectAs="label">{{
+            'components.widget.settings.grid.buttons.callback.sendSeparateEmail'
+              | translate
+          }}</ng-container>
+        </ui-checkbox>
+
+        <!-- Include navigate To Page -->
+        <ui-checkbox
+          formControlName="navigateToPage"
+          *ngIf="widgetFormGroup.value.actions.navigateToPage"
+        >
+          <ng-container ngProjectAs="label">{{
+            'components.widget.settings.grid.buttons.callback.navigateToPage'
+              | translate
+          }}</ng-container>
+        </ui-checkbox>
+
         <!-- Distribution list -->
         <div uiFormFieldDirective *ngIf="!formGroup.value.sendSeparateEmail">
           <label>{{
@@ -395,24 +422,7 @@
           >
           </ui-button>
         </div>
-        <!-- Export dataset -->
-        <ui-checkbox formControlName="export">
-          <ng-container ngProjectAs="label">{{
-            'components.widget.settings.grid.buttons.callback.export'
-              | translate
-          }}</ng-container>
-        </ui-checkbox>
 
-        <!-- Include navigate To Page -->
-        <ui-checkbox
-          formControlName="navigateToPage"
-          *ngIf="widgetFormGroup.value.actions.navigateToPage"
-        >
-          <ng-container ngProjectAs="label">{{
-            'components.widget.settings.grid.buttons.callback.navigateToPage'
-              | translate
-          }}</ng-container>
-        </ui-checkbox>
         <!-- Select fields to see in dataset -->
         <h2>{{ 'components.emailBuilder.fields' | translate }}</h2>
         <shared-tab-fields
@@ -423,13 +433,7 @@
           [showColumnWidth]="true"
         ></shared-tab-fields>
 
-        <!-- Send Separate Email -->
-        <ui-checkbox formControlName="sendSeparateEmail">
-          <ng-container ngProjectAs="label">{{
-            'components.widget.settings.grid.buttons.callback.sendSeparateEmail'
-              | translate
-          }}</ng-container>
-        </ui-checkbox>
+        <!-- Separate email fields -->
         <ng-container *ngIf="formGroup.value.sendSeparateEmail">
           <h2>{{
             'components.widget.settings.grid.buttons.callback.separateEmailFields'

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
@@ -325,8 +325,7 @@
         <!-- Send Separate Email -->
         <ui-checkbox formControlName="sendSeparateEmail">
           <ng-container ngProjectAs="label">{{
-            'components.widget.settings.grid.buttons.callback.sendSeparateEmail'
-              | translate
+            'components.select.distribution.separateEmail' | translate
           }}</ng-container>
         </ui-checkbox>
 
@@ -436,8 +435,7 @@
         <!-- Separate email fields -->
         <ng-container *ngIf="formGroup.value.sendSeparateEmail">
           <h2>{{
-            'components.widget.settings.grid.buttons.callback.separateEmailFields'
-              | translate
+            'components.queryBuilder.sendSeparate.title' | translate
           }}</h2>
           <shared-tab-fields
             *ngIf="fields.length > 0"

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
@@ -341,7 +341,7 @@
         </ui-checkbox>
 
         <!-- Distribution list -->
-        <div uiFormFieldDirective *ngIf="!formGroup.value.sendSeparateEmail">
+        <div uiFormFieldDirective>
           <label>{{
             'components.emailBuilder.distribution' | translate
           }}</label>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
@@ -442,6 +442,16 @@
             [showLimit]="false"
             [showColumnWidth]="false"
           ></shared-tab-fields>
+          <ui-alert
+            *ngIf="formGroup.errors?.missingRecipientSource"
+            variant="danger"
+            class="mt-2"
+          >
+            {{
+              'components.widget.settings.grid.buttons.callback.separateEmailRecipientRequired'
+                | translate
+            }}
+          </ui-alert>
         </ng-container>
       </div>
 

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
@@ -315,7 +315,7 @@
       </ui-checkbox>
       <div *ngIf="formGroup.value.sendMail" class="sub-parameters">
         <!-- Distribution list -->
-        <div uiFormFieldDirective>
+        <div uiFormFieldDirective *ngIf="!formGroup.value.sendSeparateEmail">
           <label>{{
             'components.emailBuilder.distribution' | translate
           }}</label>

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
@@ -380,6 +380,7 @@ export class GridActionSettingsComponent
         if (this.formGroup?.get('sendMail')?.value) {
           if (sendSeparateEmail) {
             this.formGroup?.get('distributionList')?.clearValidators();
+            this.formGroup?.get('distributionList')?.setValue(null);
           } else {
             this.formGroup
               ?.get('distributionList')

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
@@ -256,6 +256,11 @@ export class GridActionSettingsComponent
       .subscribe((value) => {
         if (value) {
           this.formGroup?.get('templates')?.setValidators(Validators.required);
+          if (!this.formGroup?.get('sendSeparateEmail')?.value) {
+            this.formGroup
+              ?.get('distributionList')
+              ?.setValidators(Validators.required);
+          }
         } else {
           this.formGroup?.get('distributionList')?.clearValidators();
           this.formGroup?.get('templates')?.clearValidators();
@@ -361,6 +366,28 @@ export class GridActionSettingsComponent
           this.formGroup?.get('selectAll')?.updateValueAndValidity();
         }
       });
+
+    this.formGroup
+      ?.get('sendSeparateEmail')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((sendSeparateEmail: boolean) => {
+        if (!sendSeparateEmail) {
+          const fields = this.separateEmailFieldsArray;
+          while (fields?.length) {
+            fields.removeAt(0);
+          }
+        }
+        if (this.formGroup?.get('sendMail')?.value) {
+          if (sendSeparateEmail) {
+            this.formGroup?.get('distributionList')?.clearValidators();
+          } else {
+            this.formGroup
+              ?.get('distributionList')
+              ?.setValidators(Validators.required);
+          }
+          this.formGroup?.get('distributionList')?.updateValueAndValidity();
+        }
+      });
   }
 
   /** Set list of resources user can attach a record to */
@@ -395,6 +422,11 @@ export class GridActionSettingsComponent
   /** @returns An array of the modifications on button form */
   get modificationsArray(): UntypedFormArray {
     return this.formGroup?.get('modifications') as UntypedFormArray;
+  }
+
+  /** @returns The separateEmailFields FormArray */
+  get separateEmailFieldsArray(): UntypedFormArray {
+    return this.formGroup?.get('separateEmailFields') as UntypedFormArray;
   }
 
   /**
@@ -481,6 +513,17 @@ export class GridActionSettingsComponent
   public async addEmailTemplate() {
     this.emailService.showFileUpload = false;
     this.emailService.resetAllLayoutData();
+
+    const bodyFieldsRaw: any[] =
+      (this.formGroup.get('bodyFields') as UntypedFormArray)?.getRawValue() ??
+      [];
+    this.emailService.gridActionDataQuery = {
+      fields: bodyFieldsRaw,
+      queryName: '',
+    };
+    this.emailService.gridActionSendSeparateEmail =
+      this.formGroup.get('sendSeparateEmail')?.value ?? false;
+
     const { TemplateModalComponent } = await import(
       '../../../templates/components/template-modal/template-modal.component'
     );
@@ -491,6 +534,8 @@ export class GridActionSettingsComponent
       width: '80%',
     });
     dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value: any) => {
+      this.emailService.gridActionDataQuery = null;
+      this.emailService.gridActionSendSeparateEmail = false;
       if (value) {
         const data = value.result.data.addCustomTemplate;
         this.templates = [data, ...this.templates];

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
@@ -257,10 +257,8 @@ export class GridActionSettingsComponent
         if (value) {
           this.formGroup?.get('templates')?.setValidators(Validators.required);
         } else {
-          this.formGroup?.get('distributionList')?.clearValidators();
           this.formGroup?.get('templates')?.clearValidators();
         }
-        this.formGroup?.get('distributionList')?.updateValueAndValidity();
         this.formGroup?.get('templates')?.updateValueAndValidity();
       });
 
@@ -367,17 +365,11 @@ export class GridActionSettingsComponent
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((sendSeparateEmail: boolean) => {
         if (!sendSeparateEmail) {
+          // Drop per-row recipient fields when separate email is off.
           const fields = this.separateEmailFieldsArray;
           while (fields?.length) {
             fields.removeAt(0);
           }
-        }
-        if (this.formGroup?.get('sendMail')?.value) {
-          if (sendSeparateEmail) {
-            this.formGroup?.get('distributionList')?.clearValidators();
-            this.formGroup?.get('distributionList')?.setValue(null);
-          }
-          this.formGroup?.get('distributionList')?.updateValueAndValidity();
         }
       });
   }

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
@@ -256,11 +256,6 @@ export class GridActionSettingsComponent
       .subscribe((value) => {
         if (value) {
           this.formGroup?.get('templates')?.setValidators(Validators.required);
-          if (!this.formGroup?.get('sendSeparateEmail')?.value) {
-            this.formGroup
-              ?.get('distributionList')
-              ?.setValidators(Validators.required);
-          }
         } else {
           this.formGroup?.get('distributionList')?.clearValidators();
           this.formGroup?.get('templates')?.clearValidators();
@@ -381,10 +376,6 @@ export class GridActionSettingsComponent
           if (sendSeparateEmail) {
             this.formGroup?.get('distributionList')?.clearValidators();
             this.formGroup?.get('distributionList')?.setValue(null);
-          } else {
-            this.formGroup
-              ?.get('distributionList')
-              ?.setValidators(Validators.required);
           }
           this.formGroup?.get('distributionList')?.updateValueAndValidity();
         }

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -152,6 +152,9 @@ export class GridSettingsFormFactory {
         value && value.navigateToPage ? value.navigateToPage : false,
       ],
     });
+    // Require an SSE grid action to have a recipient source (DL or fields)
+    formGroup.addValidators(this.sendSeparateEmailRecipientValidator);
+    formGroup.updateValueAndValidity();
     // Avoid goToNextStep & goToPreviousStep to coexist
     if (formGroup.get('goToNextStep')?.value) {
       formGroup.get('goToPreviousStep')?.setValue(false);
@@ -169,6 +172,32 @@ export class GridSettingsFormFactory {
       }
     });
     return formGroup;
+  };
+
+  /**
+   * Cross-field validator for a grid action form group: a "Send separate email"
+   * action must have at least one recipient source — a distribution list OR
+   * separate-email fields (the per-row recipient extraction fields). Neither
+   * present would mean the email could reach nobody, so it blocks save.
+   *
+   * @param group grid action form group
+   * @returns validation errors
+   */
+  sendSeparateEmailRecipientValidator = (
+    group: AbstractControl
+  ): ValidationErrors | null => {
+    const sendMail = group.get('sendMail')?.value;
+    const sendSeparateEmail = group.get('sendSeparateEmail')?.value;
+    if (!sendMail || !sendSeparateEmail) {
+      return null;
+    }
+    const hasDistributionList = !!group.get('distributionList')?.value;
+    const separateEmailFields = group.get('separateEmailFields') as FormArray;
+    const hasSeparateEmailFields = (separateEmailFields?.length ?? 0) > 0;
+    if (!hasDistributionList && !hasSeparateEmailFields) {
+      return { missingRecipientSource: true };
+    }
+    return null;
   };
 
   /**

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -147,7 +147,7 @@ export class GridSettingsFormFactory {
         value && value.navigateToPage ? value.navigateToPage : false,
       ],
     });
-    // Require an SSE grid action to have a recipient source (DL or fields)
+    // Require a separate-email grid action to have at least one per-row field.
     formGroup.addValidators(this.sendSeparateEmailRecipientValidator);
     formGroup.updateValueAndValidity();
     // Avoid goToNextStep & goToPreviousStep to coexist
@@ -170,11 +170,8 @@ export class GridSettingsFormFactory {
   };
 
   /**
-   * Cross-field validator for a grid action form group: a "Send separate email"
-   * action must have at least one separate-email field (the per-row recipient
-   * extraction source). The distribution list is hidden while SSE is on, so it
-   * is not an alternative; without a field the email reaches nobody, so it
-   * blocks save.
+   * Send-separate-email requires at least one separate-email field (the per-row
+   * recipient source). The distribution list is optional and does not replace it.
    *
    * @param group grid action form group
    * @returns validation errors

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -125,12 +125,7 @@ export class GridSettingsFormFactory {
         value && value.publish ? Validators.required : null,
       ],
       sendMail: [value && value.sendMail ? value.sendMail : false],
-      distributionList: [
-        get(value, 'distributionList', null),
-        value && value.sendMail && !value.sendSeparateEmail
-          ? Validators.required
-          : null,
-      ],
+      distributionList: [get(value, 'distributionList', null)],
       templates: [
         get(value, 'templates', []),
         value && value.sendMail ? Validators.required : null,

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -176,9 +176,10 @@ export class GridSettingsFormFactory {
 
   /**
    * Cross-field validator for a grid action form group: a "Send separate email"
-   * action must have at least one recipient source — a distribution list OR
-   * separate-email fields (the per-row recipient extraction fields). Neither
-   * present would mean the email could reach nobody, so it blocks save.
+   * action must have at least one separate-email field (the per-row recipient
+   * extraction source). The distribution list is hidden while SSE is on, so it
+   * is not an alternative; without a field the email reaches nobody, so it
+   * blocks save.
    *
    * @param group grid action form group
    * @returns validation errors
@@ -191,10 +192,9 @@ export class GridSettingsFormFactory {
     if (!sendMail || !sendSeparateEmail) {
       return null;
     }
-    const hasDistributionList = !!group.get('distributionList')?.value;
     const separateEmailFields = group.get('separateEmailFields') as FormArray;
     const hasSeparateEmailFields = (separateEmailFields?.length ?? 0) > 0;
-    if (!hasDistributionList && !hasSeparateEmailFields) {
+    if (!hasSeparateEmailFields) {
       return { missingRecipientSource: true };
     }
     return null;

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -127,7 +127,9 @@ export class GridSettingsFormFactory {
       sendMail: [value && value.sendMail ? value.sendMail : false],
       distributionList: [
         get(value, 'distributionList', null),
-        value && value.sendMail ? Validators.required : null,
+        value && value.sendMail && !value.sendSeparateEmail
+          ? Validators.required
+          : null,
       ],
       templates: [
         get(value, 'templates', []),
@@ -139,6 +141,12 @@ export class GridSettingsFormFactory {
           ? value.bodyFields.map((x: any) => addNewField(x))
           : [],
         value && value.sendMail ? Validators.required : null
+      ),
+      sendSeparateEmail: [get(value, 'sendSeparateEmail', false)],
+      separateEmailFields: this.fb.array(
+        (get(value, 'separateEmailFields', []) as any[]).map((x: any) =>
+          addNewField(x)
+        )
       ),
       navigateToPage: [
         value && value.navigateToPage ? value.navigateToPage : false,

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -541,7 +541,9 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
                           this.widget.settings.actions.navigateToPage
                           ? this.widget.settings.actions.navigateSettings
                           : undefined,
-                        emailQuery
+                        emailQuery,
+                        options.sendSeparateEmail,
+                        options.separateEmailFields
                       );
                       this.status = {
                         error: false,
@@ -779,6 +781,7 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
       return {
         queryName: this.layout?.query.name || '',
         fields: fields || [],
+        resource: this.settings.resource,
         first: selectedIds.length,
         filter: {
           logic: 'and',

--- a/libs/shared/src/lib/services/email/email.service.ts
+++ b/libs/shared/src/lib/services/email/email.service.ts
@@ -375,12 +375,16 @@ export class EmailService {
    * @param distributionListInfo Distribution list
    * @param navigateSettings Navigate settings, optional
    * @param dataQuery Query email function will use to fetch data
+   * @param sendSeparateEmail Whether to send a separate email per record
+   * @param separateEmailFields Fields used to extract per-record recipient addresses
    */
   async previewCustomTemplate(
     emailContent: any,
     distributionListInfo: any,
     navigateSettings: any,
-    dataQuery?: any
+    dataQuery?: any,
+    sendSeparateEmail?: boolean,
+    separateEmailFields?: any[]
   ) {
     const { PreviewTemplateModalComponent } = await import(
       '../../components/templates/components/preview-template-modal/preview-template-modal.component'
@@ -391,6 +395,8 @@ export class EmailService {
         distributionListInfo,
         navigateSettings,
         dataQuery,
+        sendSeparateEmail,
+        separateEmailFields,
       },
       autoFocus: false,
       disableClose: true,


### PR DESCRIPTION
# Description

Adds send separate-email support to the grid "Send Mail" action, so the grid can be split per row and each row's recipient read from a configured field rather than a distribution list. 

At send time the resolved per-row recipients are shown read-only in the layout step and are never merged into the static To/Cc/Bcc. The Next button's layout and recipient validators were reconciled so a single consistent rule applies: Next is disabled when the layout is invalid or recipients are missing.

## Useful links

- [Function PR](https://dev.azure.com/WHOHQ/EMSSAFE/_git/emssafe-emailfunction/pullrequest/26215)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

### Configuration Steps

<img width="1667" height="278" alt="image" src="https://github.com/user-attachments/assets/084d0c69-8495-4d59-ab6a-2cc32f8c832e" />

<img width="1636" height="551" alt="image" src="https://github.com/user-attachments/assets/7fdc0814-873b-4971-88ad-b5a909e0111b" />

<img width="1625" height="496" alt="image" src="https://github.com/user-attachments/assets/77d59f01-d524-4daf-b957-ea5234841a42" />

### Send Step 1 (allows edits)

<img width="548" height="402" alt="image" src="https://github.com/user-attachments/assets/7b4f1b53-7132-4993-9aab-ff4d7aa07c94" />

### Send Step 2 (final preview before send)

<img width="1218" height="582" alt="image" src="https://github.com/user-attachments/assets/5ebc926f-8e24-461c-af74-793df1d916e4" />



# Checklist:

( \* == Mandatory )

- [ ] \* I have set myself as assignee of the pull request
- [ ] \* My code follows the style guidelines of this project
- [ ] \* Linting does not generate new warnings
- [ ] \* I have performed a self-review of my own code
- [ ] \* I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] \* I have commented my code, particularly in hard-to-understand areas
- [ ] \* I have put JSDoc comment in all required places
- [ ] \* My changes generate no new warnings
- [ ] \* I have included screenshots describing my changes if relevant
- [ ] \* I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] \* New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
