### PR TITLE
MedEvac: Common Services user group filtering

### DIFF
--- a/libs/shared/src/lib/components/email/constant.ts
+++ b/libs/shared/src/lib/components/email/constant.ts
@@ -25,6 +25,7 @@ export const commonServiceFields = [
   { key: 'Region', label: 'Region' },
   { key: 'LocationType', label: 'LocationType' },
   { key: 'InternalExternal', label: 'InternalExternal' },
+  { key: 'Groups', label: 'User Groups', namePath: 'GroupName' },
 ];
 
 /** Maximum number of files allowed */

--- a/libs/shared/src/lib/components/email/email.service.ts
+++ b/libs/shared/src/lib/components/email/email.service.ts
@@ -2091,13 +2091,14 @@ export class EmailService {
    */
   processFilters(distributionListCommonQuery: any) {
     distributionListCommonQuery?.filters?.forEach((ele: any) => {
-      let preDefineFields: any = [];
       if (!ele.filters) {
-        preDefineFields = this.commonServiceFields.filter(
-          (x: any) => x.key === ele?.field
+        // Always normalize to key for backend logic
+        const preDefineField = this.commonServiceFields.find(
+          (x: any) => x.key === ele?.field || x.label === ele?.field
         );
-        ele.field =
-          preDefineFields?.length > 0 ? preDefineFields[0]['label'] : ele.field;
+        if (preDefineField) {
+          ele.field = preDefineField.key;
+        }
       } else {
         this.processFilters(ele);
       }

--- a/libs/shared/src/lib/components/filter/filter-row/filter-row.component.html
+++ b/libs/shared/src/lib/components/filter/filter-row/filter-row.component.html
@@ -106,9 +106,12 @@
         <ng-container *ngFor="let field of fields">
           <ui-select-option *ngIf="!field.fields" [value]="field.name">
             {{
-              !isEmailNotification
-                ? field.text || field.name
+              field.isCommonService && field.graphQLFieldName?.label
+                ? field.graphQLFieldName.label
+                : (!isEmailNotification
+                    ? (field.text || field.name)
                 : (this.emailService.replaceUnderscores(field.name) | titlecase)
+                  )
             }}
           </ui-select-option>
 

--- a/libs/shared/src/lib/components/filter/filter-row/filter-row.component.ts
+++ b/libs/shared/src/lib/components/filter/filter-row/filter-row.component.ts
@@ -212,7 +212,7 @@ export class FilterRowComponent
           selectedField?.[0]?.isCommonService &&
           selectedField?.[0]?.editor === 'select'
         ) {
-          await this.getCsData(value, selectedField[0], namePath);
+          await this.loadCommonServiceOptions(selectedField[0], namePath);
         }
         if (this.form?.get('operator')?.value) {
           this.setField(value);
@@ -292,15 +292,6 @@ export class FilterRowComponent
             .filter((x) => x.label === this.form.getRawValue().field)?.[0]?.key
         );
     }
-
-    //Calling the common service function for getting value for Select type of data
-    if (this.field?.isCommonService) {
-      const commonServiceField = commonServiceFields.find(
-        (field) => field.key === this.field?.name
-      );
-      const namePath = commonServiceField?.namePath;
-      this.getCsData(this.field?.name, this.field, namePath);
-    }
   }
 
   /**
@@ -321,7 +312,13 @@ export class FilterRowComponent
       // paint (otherwise the async options arrive after render and only show on hover).
       const field = this.fields.find((x: any) => x.name === initialField);
       if (field?.isCommonService && field?.editor === 'select') {
-        await this.loadCommonServiceOptions(field);
+        const commonServiceField = commonServiceFields.find(
+          (f) => f.key === field.name
+        );
+        await this.loadCommonServiceOptions(
+          field,
+          commonServiceField?.namePath
+        );
       }
       this.setField(initialField);
     }
@@ -594,10 +591,12 @@ export class FilterRowComponent
   /**
    * Loads the Common Services value options for a select field and assigns them
    * onto the field as a fresh array, so the value dropdown reflects them.
+   * Supports an optional nested path for the display value (user-group filtering).
    *
    * @param field selected field object (its name is the reference-data key)
+   * @param path optional nested path to the option value (else uses Name)
    */
-  async loadCommonServiceOptions(field: any): Promise<void> {
+  async loadCommonServiceOptions(field: any, path?: string): Promise<void> {
     const key = field?.name;
     // User-table fields are free-text inputs, not select dropdowns — nothing to load.
     if (!key || this.emailService?.userTableFields?.some((x) => x === key)) {
@@ -607,53 +606,13 @@ export class FilterRowComponent
     try {
       const data = await firstValueFrom(this.cs.restRequest(key));
       field.options = (data?.value ?? []).map((x: any) => ({
-        text: x?.Name,
-        value: x?.Name,
+        text: path ? get(x, path) : x?.Name,
+        value: path ? get(x, path) : x?.Name,
       }));
     } catch (error) {
       console.error(`Error while fetching reference data ${key}:`, error);
     } finally {
       this.loading = false;
-    }
-  }
-
-  /**
-   * Loads Common Services value options onto a select field, supporting an
-   * optional nested path for the display value (used by user-group filtering).
-   *
-   * @param key the reference-data key
-   * @param selectedField field object to assign options onto
-   * @param path optional nested path to the option value (else uses Name)
-   */
-  async getCsData(
-    key: string,
-    selectedField: any,
-    path?: string
-  ): Promise<void> {
-    if (
-      this.emailService?.userTableFields?.filter((x) => x === key).length === 0
-    ) {
-      this.loading = true;
-      await firstValueFrom(this.cs.restRequest(key))
-        .then((data) => {
-          this.loading = false;
-          if (path) {
-            selectedField.options =
-              data?.value.map((x: any) => ({
-                text: get(x, path),
-                value: get(x, path),
-              })) || [];
-          } else {
-            selectedField.options =
-              data?.value.map((x: any) => ({
-                text: x?.Name,
-                value: x?.Name,
-              })) || [];
-          }
-        })
-        .catch((error) => {
-          console.error(`Error while fetching reference data ${key}:`, error);
-        });
     }
   }
 }

--- a/libs/shared/src/lib/components/filter/filter-row/filter-row.component.ts
+++ b/libs/shared/src/lib/components/filter/filter-row/filter-row.component.ts
@@ -19,6 +19,7 @@ import { EmailService } from '../../email/email.service';
 import convertToMinutes from '../../../utils/convert-to-minutes';
 import { CommonServicesService } from '../../../services/common-services/common-services.service';
 import { firstValueFrom } from 'rxjs';
+import { commonServiceFields } from '../../email/constant';
 
 /** Operators that keep attribute comparisons tied to another record field. */
 const ATTRIBUTE_FIELD_OPERATORS = ['eq', 'neq', 'in', 'notin'];
@@ -203,11 +204,15 @@ export class FilterRowComponent
       .subscribe(async (value) => {
         // remove value
         const selectedField = this.fields.filter((x: any) => x.name == value);
+        const commonServiceField = commonServiceFields.find(
+          (field) => field.key === value
+        );
+        const namePath = commonServiceField?.namePath;
         if (
           selectedField?.[0]?.isCommonService &&
           selectedField?.[0]?.editor === 'select'
         ) {
-          await this.loadCommonServiceOptions(selectedField[0]);
+          await this.getCsData(value, selectedField[0], namePath);
         }
         if (this.form?.get('operator')?.value) {
           this.setField(value);
@@ -286,6 +291,15 @@ export class FilterRowComponent
             .map((x) => x.graphQLFieldName)
             .filter((x) => x.label === this.form.getRawValue().field)?.[0]?.key
         );
+    }
+
+    //Calling the common service function for getting value for Select type of data
+    if (this.field?.isCommonService) {
+      const commonServiceField = commonServiceFields.find(
+        (field) => field.key === this.field?.name
+      );
+      const namePath = commonServiceField?.namePath;
+      this.getCsData(this.field?.name, this.field, namePath);
     }
   }
 
@@ -600,6 +614,46 @@ export class FilterRowComponent
       console.error(`Error while fetching reference data ${key}:`, error);
     } finally {
       this.loading = false;
+    }
+  }
+
+  /**
+   * Loads Common Services value options onto a select field, supporting an
+   * optional nested path for the display value (used by user-group filtering).
+   *
+   * @param key the reference-data key
+   * @param selectedField field object to assign options onto
+   * @param path optional nested path to the option value (else uses Name)
+   */
+  async getCsData(
+    key: string,
+    selectedField: any,
+    path?: string
+  ): Promise<void> {
+    if (
+      this.emailService?.userTableFields?.filter((x) => x === key).length === 0
+    ) {
+      this.loading = true;
+      await firstValueFrom(this.cs.restRequest(key))
+        .then((data) => {
+          this.loading = false;
+          if (path) {
+            selectedField.options =
+              data?.value.map((x: any) => ({
+                text: get(x, path),
+                value: get(x, path),
+              })) || [];
+          } else {
+            selectedField.options =
+              data?.value.map((x: any) => ({
+                text: x?.Name,
+                value: x?.Name,
+              })) || [];
+          }
+        })
+        .catch((error) => {
+          console.error(`Error while fetching reference data ${key}:`, error);
+        });
     }
   }
 }


### PR DESCRIPTION
# Description

Extends the Common Services user filter so users can be matched on group membership, not just their scalar attributes.

Also unifies the two Common Services option loaders into a single `loadCommonServiceOptions`, removing `getCsData`.

## Useful links

- [Function PR](https://dev.azure.com/WHOHQ/EMSSAFE/_git/emssafe-emailfunction/pullrequest/26217)
https://github.com/ReliefApplications/ems-backend/pull/1262

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

<img width="972" height="352" alt="image" src="https://github.com/user-attachments/assets/0f945b60-1912-467b-9555-f5df3d702362" />

# Checklist:

( \* == Mandatory )

- [ ] \* I have set myself as assignee of the pull request
- [ ] \* My code follows the style guidelines of this project
- [ ] \* Linting does not generate new warnings
- [ ] \* I have performed a self-review of my own code
- [ ] \* I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [ ] \* I have commented my code, particularly in hard-to-understand areas
- [ ] \* I have put JSDoc comment in all required places
- [ ] \* My changes generate no new warnings
- [ ] \* I have included screenshots describing my changes if relevant
- [ ] \* I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] \* New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
