### PR TITLE
AB#103685: Long description overflows on forms

### DIFF
--- a/libs/shared/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/shared/src/lib/components/form-builder/form-builder.component.ts
@@ -323,6 +323,13 @@ export class FormBuilderComponent
       this.formChange.emit(this.cleanStructure(survey.text));
     });
 
+    // SurveyJS only rebuilds the description CSS after the question is reloaded.
+    this.surveyCreator.onSurveyPropertyValueChanged.add((_, options) => {
+      if (options.propertyName === 'description') {
+        options.obj.updateElementCss(true);
+      }
+    });
+
     // Always show the per-field "Settings" gear adorner.
     // By default SurveyJS only shows it when the property-grid sidebar is
     // collapsed (flyout mode), which depends on the creator panel width. On


### PR DESCRIPTION
# Description

Long question descriptions overflowed horizontally in the form builder when first entered. SurveyJS did not regenerate a question's description CSS during the initial live property edit. The form builder now refreshes the affected element's CSS when its `description` changes, so the description wraps immediately without requiring a save and reload.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/103685

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manual UI verification:

1. Open Back Office and navigate to **Forms**.
2. Open an editable form in the form builder.
3. Select a question without a description.
4. Enter a long description in the **Description** property.
5. Confirm the description wraps inside the question card immediately, before saving.
6. Save and reopen the field to confirm the rendered description remains correct.

- [x] Manual form-builder verification
- [ ] Automated unit test added

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules