### PR TITLE
AB#95542: Allow quick action buttons execution order to be reorganized

### DIFF
--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.html
@@ -25,6 +25,29 @@
         {{ 'components.widget.settings.grid.hint.executionOrder' | translate }}
       </ui-alert>
 
+      <div
+        *ngIf="selectedActions.length > 1"
+        cdkDropList
+        class="mb-4"
+        (cdkDropListDropped)="onActionOrderChange($event)"
+      >
+        <div
+          *ngFor="let action of selectedActions"
+          cdkDrag
+          class="flex items-center rounded border border-gray-200 mb-1 px-1"
+        >
+          <ui-button
+            variant="grey"
+            [isIcon]="true"
+            size="small"
+            cdkDragHandle
+            icon="drag_indicator"
+            [uiTooltip]="'common.tooltip.dragDrop' | translate"
+          ></ui-button>
+          <span>{{ actionLabels[action] | translate }}</span>
+        </div>
+      </div>
+
       <!-- Select all records of query -->
       <ui-checkbox formControlName="selectAll">
         <ng-container ngProjectAs="label">{{

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-action-settings/grid-action-settings.component.ts
@@ -15,6 +15,11 @@ import { ContentType } from '../../../../models/page.model';
 import { WorkflowService } from '../../../../services/workflow/workflow.service';
 import { TemplateTypeEnum } from '../../../../models/template.model';
 import { Dialog } from '@angular/cdk/dialog';
+import {
+  CdkDragDrop,
+  DragDropModule,
+  moveItemInArray,
+} from '@angular/cdk/drag-drop';
 import { createQueryForm } from '../../../query-builder/query-builder-forms';
 import { UnsubscribeComponent } from '../../../utils/unsubscribe/unsubscribe.component';
 import { DistributionModalComponent } from '../../../distribution-lists/components/distribution-modal/distribution-modal.component';
@@ -37,6 +42,10 @@ import {
 } from '@oort-front/ui';
 import { QueryBuilderModule } from '../../../query-builder/query-builder.module';
 import { LocalizedInputComponent } from '../../../controls/localized-input/localized-input.component';
+import {
+  GridActionExecution,
+  GRID_ACTION_EXECUTION_ORDER,
+} from '../grid-settings.forms';
 
 /** List fo disabled fields */
 const DISABLED_FIELDS = ['id', 'createdAt', 'modifiedAt'];
@@ -69,6 +78,7 @@ const DISABLED_FIELDS = ['id', 'createdAt', 'modifiedAt'];
     TabsModule,
     AlertModule,
     LocalizedInputComponent,
+    DragDropModule,
   ],
 })
 export class GridActionSettingsComponent
@@ -107,6 +117,46 @@ export class GridActionSettingsComponent
   @Output() loadChannels = new EventEmitter<void>();
   /** Saves if the channels has been fetched */
   public loadedChannel = false;
+
+  /** Translation keys for actions shown in the execution-order list. */
+  public readonly actionLabels: Record<GridActionExecution, string> = {
+    selectAll:
+      'components.widget.settings.grid.buttons.callback.selectAllRecords',
+    selectPage:
+      'components.widget.settings.grid.buttons.callback.selectAllRecordsActivePage',
+    autoSave: 'components.widget.settings.grid.buttons.callback.save',
+    attachToRecord: 'components.widget.settings.grid.buttons.callback.attach',
+    prefillForm: 'components.widget.settings.grid.buttons.callback.prefill',
+    modifySelectedRows:
+      'components.widget.settings.grid.buttons.callback.modify',
+    notify: 'components.channel.dropdown.select',
+    publish: 'common.publish',
+    sendMail: 'components.widget.settings.grid.buttons.callback.sendMail',
+    goToNextStep:
+      'components.widget.settings.grid.buttons.callback.workflow.next',
+    goToPreviousStep:
+      'components.widget.settings.grid.buttons.callback.workflow.previous',
+    closeWorkflow:
+      'components.widget.settings.grid.buttons.callback.workflow.close',
+  };
+
+  /**
+   * Actions enabled for this button, in their configured execution order.
+   *
+   * @returns enabled actions
+   */
+  get selectedActions(): GridActionExecution[] {
+    return this.actionOrder.filter(
+      (action) => this.formGroup.get(action)?.value
+    );
+  }
+
+  /** @returns persisted execution order, including disabled actions. */
+  get actionOrder(): GridActionExecution[] {
+    return (
+      this.formGroup.get('actionOrder')?.value ?? GRID_ACTION_EXECUTION_ORDER
+    );
+  }
 
   /** @returns The list of fields which are of type scalar and not disabled */
   get scalarFields(): any[] {
@@ -517,5 +567,25 @@ export class GridActionSettingsComponent
       this.loadChannels.emit();
       this.loadedChannel = true;
     }
+  }
+
+  /**
+   * Reorders enabled actions while preserving the relative order of disabled actions.
+   *
+   * @param event drag-and-drop event
+   */
+  public onActionOrderChange(event: CdkDragDrop<GridActionExecution[]>): void {
+    if (event.previousIndex === event.currentIndex) return;
+
+    const selectedActions = [...this.selectedActions];
+    moveItemInArray(selectedActions, event.previousIndex, event.currentIndex);
+
+    const selectedActionSet = new Set(this.selectedActions);
+    const reorderedActions = this.actionOrder.map((action) => {
+      if (!selectedActionSet.has(action)) return action;
+
+      return selectedActions.shift() ?? action;
+    });
+    this.formGroup.get('actionOrder')?.setValue(reorderedActions);
   }
 }

--- a/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
+++ b/libs/shared/src/lib/components/widgets/grid-settings/grid-settings.forms.ts
@@ -23,6 +23,24 @@ import { TranslateService } from '@ngx-translate/core';
 import { ApplicationService } from '../../../services/application/application.service';
 import { Subject, takeUntil } from 'rxjs';
 
+/** Actions that can be run by a grid quick action button. */
+export const GRID_ACTION_EXECUTION_ORDER = [
+  'selectAll',
+  'selectPage',
+  'autoSave',
+  'attachToRecord',
+  'prefillForm',
+  'modifySelectedRows',
+  'notify',
+  'publish',
+  'sendMail',
+  'goToNextStep',
+  'goToPreviousStep',
+  'closeWorkflow',
+] as const;
+
+export type GridActionExecution = (typeof GRID_ACTION_EXECUTION_ORDER)[number];
+
 /** Default action name */
 const DEFAULT_ACTION_NAME = 'Action';
 
@@ -143,6 +161,10 @@ export class GridSettingsFormFactory {
       navigateToPage: [
         value && value.navigateToPage ? value.navigateToPage : false,
       ],
+      actionOrder: [
+        this.getActionOrder(value?.actionOrder),
+        Validators.required,
+      ],
     });
     // Avoid goToNextStep & goToPreviousStep to coexist
     if (formGroup.get('goToNextStep')?.value) {
@@ -162,6 +184,34 @@ export class GridSettingsFormFactory {
     });
     return formGroup;
   };
+
+  /**
+   * Normalizes persisted action ordering, retaining a deterministic position
+   * for actions added after an existing widget was configured.
+   *
+   * @param value persisted action ordering
+   * @returns complete action ordering
+   */
+  private getActionOrder(value: unknown): GridActionExecution[] {
+    const persistedOrder: GridActionExecution[] = [];
+    if (Array.isArray(value)) {
+      for (const action of value) {
+        if (
+          GRID_ACTION_EXECUTION_ORDER.includes(action as GridActionExecution) &&
+          !persistedOrder.includes(action as GridActionExecution)
+        ) {
+          persistedOrder.push(action as GridActionExecution);
+        }
+      }
+    }
+
+    return [
+      ...persistedOrder,
+      ...GRID_ACTION_EXECUTION_ORDER.filter(
+        (action) => !persistedOrder.includes(action)
+      ),
+    ];
+  }
 
   /**
    * Create a grid widget form group.

--- a/libs/shared/src/lib/components/widgets/grid/grid.component.ts
+++ b/libs/shared/src/lib/components/widgets/grid/grid.component.ts
@@ -50,6 +50,9 @@ import { ReferenceDataGridComponent } from '../../ui/reference-data-grid/referen
 import { BaseWidgetComponent } from '../base-widget/base-widget.component';
 import { clone } from 'lodash';
 
+type EmailTemplate = { id: string };
+type EmailDistributionList = { id: string };
+
 /** Component for the grid widget */
 @Component({
   selector: 'shared-grid-widget',
@@ -331,6 +334,66 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
    * @param options action options.
    */
   public async onGridAction(options: any): Promise<void> {
+    const actionKeys = [
+      'selectAll',
+      'selectPage',
+      'autoSave',
+      'attachToRecord',
+      'prefillForm',
+      'modifySelectedRows',
+      'notify',
+      'publish',
+      'sendMail',
+      'goToNextStep',
+      'goToPreviousStep',
+      'closeWorkflow',
+    ];
+    const actionOrder: string[] = Array.isArray(options.actionOrder)
+      ? Array.from(new Set(options.actionOrder)).filter(
+          (action: unknown): action is string =>
+            typeof action === 'string' &&
+            actionKeys.includes(action) &&
+            Boolean(options[action])
+        )
+      : [];
+
+    // Keep the previous fixed execution order for quick actions saved before
+    // action ordering was introduced.
+    if (actionOrder.length === 0) {
+      await this.executeGridAction(options);
+      return;
+    }
+
+    for (const action of actionOrder) {
+      const actionOptions = { ...options };
+      for (const actionKey of actionKeys) {
+        actionOptions[actionKey] = actionKey === action;
+      }
+      const shouldContinue = await this.executeGridAction(actionOptions, false);
+      if (!shouldContinue) return;
+    }
+
+    const hasWorkflowAction = actionOrder.some((action) =>
+      ['goToNextStep', 'goToPreviousStep', 'closeWorkflow'].includes(action)
+    );
+    if (!hasWorkflowAction) {
+      this.grid.selectedRows = [];
+      this.grid.reloadData();
+      this.dashboardService.triggerReloadWidgets();
+    }
+  }
+
+  /**
+   * Executes one quick action step.
+   *
+   * @param options action configuration
+   * @param shouldRefresh whether to refresh the grid after the action
+   * @returns whether the next action should run
+   */
+  private async executeGridAction(
+    options: any,
+    shouldRefresh = true
+  ): Promise<boolean> {
     // Select all the records in the grid
     if (options.selectAll) {
       const query = this.queryBuilder.graphqlQuery(
@@ -368,7 +431,7 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
           }
         );
         // Close the action if error detected during auto save
-        return;
+        return false;
       }
     }
     // Attaches the records to another one.
@@ -383,7 +446,7 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
         // Close the action
         this.grid.reloadData();
         this.dashboardService.triggerReloadWidgets();
-        return;
+        return false;
       }
     }
     // Opens a form with selected records.
@@ -431,7 +494,7 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
         // Close the action
         this.grid.reloadData();
         this.dashboardService.triggerReloadWidgets();
-        return;
+        return false;
       }
     }
     // Auto modify the selected rows
@@ -480,80 +543,65 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
     // Send email using backend mail service.
     if (options.sendMail) {
       const selectedIds = clone(this.grid.selectedRows);
-      this.emailService.getCustomTemplates().subscribe({
-        next: ({ data }) => {
-          const allTemplateData = data.customTemplates.edges.map(
-            (x: any) => x.node
-          );
-          const templates = allTemplateData.filter((template: any) =>
-            options.templates?.includes(template.id)
-          );
-          if (templates.length === 0) {
-            // no template found, skip
-            this.snackBar.openSnackBar(
-              this.translate.instant(
-                'common.notifications.email.errors.noTemplate'
-              ),
-              { error: true }
+      const { data: templateData } = await firstValueFrom(
+        this.emailService.getCustomTemplates()
+      );
+      const templates: EmailTemplate[] = templateData.customTemplates.edges
+        .map((edge: { node: EmailTemplate }) => edge.node)
+        .filter((template: EmailTemplate) =>
+          options.templates?.includes(template.id)
+        );
+      if (templates.length === 0) {
+        this.snackBar.openSnackBar(
+          this.translate.instant(
+            'common.notifications.email.errors.noTemplate'
+          ),
+          { error: true }
+        );
+      } else {
+        const { data: distributionListData } = await firstValueFrom(
+          this.emailService.getEmailDistributionList()
+        );
+        const distributionList: EmailDistributionList | undefined =
+          distributionListData.emailDistributionLists.edges
+            .map((edge: { node: EmailDistributionList }) => edge.node)
+            .find(
+              (list: EmailDistributionList) =>
+                options.distributionList === list.id
             );
-          } else {
-            this.emailService.getEmailDistributionList().subscribe({
-              next: async ({ data }) => {
-                const allDistributionLists =
-                  data.emailDistributionLists.edges.map((x: any) => x.node);
-
-                const distributionList = allDistributionLists.filter(
-                  (dl: any) => options.distributionList === dl.id
-                )[0];
-
-                // Open email template selection
-                const { EmailTemplateModalComponent } = await import(
-                  '../../email-template-modal/email-template-modal.component'
-                );
-                const dialogRef = this.dialog.open(
-                  EmailTemplateModalComponent,
-                  {
-                    data: {
-                      templates,
-                    },
-                  }
-                );
-
-                // Get template from dialog ref
-                const value = await firstValueFrom<any>(
-                  dialogRef.closed.pipe(takeUntil(this.destroy$))
-                );
-                if (value?.template) {
-                  const selectedId = value?.template;
-                  const template = templates.filter(
-                    (x: any) => x.id === selectedId
-                  )[0];
-                  if (template) {
-                    const emailQuery = this.buildEmailQuery(
-                      selectedIds,
-                      options.bodyFields
-                    );
-                    if (emailQuery) {
-                      this.emailService.previewCustomTemplate(
-                        template,
-                        distributionList,
-                        options.navigateToPage &&
-                          this.widget.settings.actions.navigateToPage
-                          ? this.widget.settings.actions.navigateSettings
-                          : undefined,
-                        emailQuery
-                      );
-                      this.status = {
-                        error: false,
-                      };
-                    }
-                  }
-                }
-              },
-            });
+        const { EmailTemplateModalComponent } = await import(
+          '../../email-template-modal/email-template-modal.component'
+        );
+        const dialogRef = this.dialog.open(EmailTemplateModalComponent, {
+          data: { templates },
+        });
+        const value = await firstValueFrom(
+          dialogRef.closed.pipe(takeUntil(this.destroy$))
+        );
+        if (
+          typeof value === 'object' &&
+          value !== null &&
+          'template' in value &&
+          typeof value.template === 'string'
+        ) {
+          const template = templates.find((item) => item.id === value.template);
+          const emailQuery = template
+            ? this.buildEmailQuery(selectedIds, options.bodyFields)
+            : null;
+          if (emailQuery) {
+            this.emailService.previewCustomTemplate(
+              template,
+              distributionList,
+              options.navigateToPage &&
+                this.widget.settings.actions.navigateToPage
+                ? this.widget.settings.actions.navigateSettings
+                : undefined,
+              emailQuery
+            );
+            this.status = { error: false };
           }
-        },
-      });
+        }
+      }
     }
 
     // Workflow only: goes to next step, goes to the previous step, or closes the workflow.
@@ -585,11 +633,12 @@ export class GridWidgetComponent extends BaseWidgetComponent implements OnInit {
             }
           });
       }
-    } else {
+    } else if (shouldRefresh) {
       this.grid.selectedRows = [];
       this.grid.reloadData();
       this.dashboardService.triggerReloadWidgets();
     }
+    return true;
   }
 
   /**


### PR DESCRIPTION
# Description

Quick actions in grid widgets now allow their execution order to be reorganized by drag and drop, matching the UX available in automations.

Before this change, quick actions always executed their enabled steps in a fixed order. Now the grid widget settings let users reorder those steps by drag and drop, the order is persisted as a normalized `actionOrder` list, and quick actions execute their steps sequentially in that order (legacy widgets keep the previous fixed order until saved again). The sequence still stops on abort conditions, and email-template selection is awaited before the next step runs.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/95542/

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `npx nx run shared:lint --skip-nx-cache` — no warnings
- [x] `NODE_OPTIONS="--max-old-space-size=8192" npx nx build back-office --skip-nx-cache` — production build passes (only pre-existing budget warnings)
- [x] Manual: created a widget with a quick action, reordered steps by drag and drop, saved, reopened settings, confirmed the order persists
- [x] Manual: quick action executes steps in the configured order; auto-save failure stops the sequence
- [x] Manual: existing widgets (no `actionOrder`) keep the previous fixed execution order

## Screenshots

<img width="1513" height="1174" alt="image" src="https://github.com/user-attachments/assets/a9bd57a9-8172-49b1-b162-dd407cad521c" />

# Checklist:

( * == Mandatory )

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
