### PR TITLE
AB#77715: Sometimes, the front asks the user to disconnect #77715

### DIFF
--- a/libs/shared/jest.config.ts
+++ b/libs/shared/jest.config.ts
@@ -42,6 +42,7 @@ export default {
     '<rootDir>/src/lib/components/widgets/common/tab-actions/*.spec.ts',
     '<rootDir>/src/lib/components/widgets/common/tab-actions/read-only-fields-modal/*.spec.ts',
     '<rootDir>/src/lib/models/*.spec.ts',
+    '<rootDir>/src/lib/services/auth/*.spec.ts',
     '<rootDir>/src/lib/survey/global-properties/*.spec.ts',
     '<rootDir>/src/lib/utils/*.spec.ts',
     '<rootDir>/src/lib/utils/filter/*.spec.ts',

--- a/libs/shared/src/lib/services/auth/auth.service.spec.ts
+++ b/libs/shared/src/lib/services/auth/auth.service.spec.ts
@@ -1,16 +1,22 @@
 import { HttpClientModule } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import {
   DateTimeProvider,
+  OAuthErrorEvent,
   OAuthLogger,
   OAuthService,
+  OAuthStorage,
+  OAuthSuccessEvent,
   UrlHelperService,
 } from 'angular-oauth2-oidc';
 import { ApolloTestingModule } from 'apollo-angular/testing';
+import { Subject } from 'rxjs';
 import { AppAbility, AuthService } from './auth.service';
 
 describe('AuthService', () => {
   let service: AuthService;
+  let oauthService: OAuthService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -19,16 +25,207 @@ describe('AuthService', () => {
         UrlHelperService,
         OAuthLogger,
         DateTimeProvider,
-        { provide: 'environment', useValue: {} },
+        {
+          provide: 'environment',
+          useValue: {
+            module: 'frontoffice',
+            backOfficeUri: 'http://localhost/',
+            frontOfficeUri: 'http://localhost/',
+          },
+        },
+        {
+          provide: Router,
+          useValue: { navigateByUrl: jest.fn(), navigate: jest.fn() },
+        },
+        { provide: OAuthStorage, useValue: localStorage },
         AppAbility,
       ],
       imports: [HttpClientModule, ApolloTestingModule],
     });
 
     service = TestBed.inject(AuthService);
+    oauthService = TestBed.inject(OAuthService);
+    oauthService.configure({
+      issuer: 'https://login.microsoftonline.com/tenant/v2.0',
+      redirectUri: 'http://localhost/',
+      clientId: 'client',
+      responseType: 'code',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    window.history.replaceState({}, '', '/');
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('initLoginSequence', () => {
+    it('should reuse the existing session when the user is already authenticated', async () => {
+      jest.spyOn(oauthService, 'hasValidAccessToken').mockReturnValue(true);
+      jest.spyOn(oauthService, 'hasValidIdToken').mockReturnValue(true);
+      const loadDiscoverySpy = jest
+        .spyOn(oauthService, 'loadDiscoveryDocument')
+        .mockResolvedValue(new OAuthSuccessEvent('discovery_document_loaded'));
+      const loginFlowSpy = jest
+        .spyOn(oauthService, 'initLoginFlow')
+        .mockImplementation(() => undefined);
+
+      await service.initLoginSequence();
+
+      expect(loadDiscoverySpy).not.toHaveBeenCalled();
+      expect(loginFlowSpy).not.toHaveBeenCalled();
+      let authenticated = false;
+      service.isAuthenticated$.subscribe((value) => (authenticated = value));
+      expect(authenticated).toBe(true);
+      let doneLoading = false;
+      service.isDoneLoading$.subscribe((value) => (doneLoading = value));
+      expect(doneLoading).toBe(true);
+    });
+
+    it('should remove OAuth callback parameters from the URL when reusing an existing session', async () => {
+      window.history.replaceState(
+        {},
+        '',
+        '/?code=abc&state=def&session_state=xyz'
+      );
+      jest.spyOn(oauthService, 'hasValidAccessToken').mockReturnValue(true);
+      jest.spyOn(oauthService, 'hasValidIdToken').mockReturnValue(true);
+
+      await service.initLoginSequence();
+
+      expect(window.location.search).toBe('');
+    });
+
+    it('should refresh the tokens silently when the access token is expired and a refresh token exists', async () => {
+      jest
+        .spyOn(oauthService, 'hasValidAccessToken')
+        .mockReturnValueOnce(false)
+        .mockReturnValue(true);
+      const refreshTokenSpy = jest
+        .spyOn(oauthService, 'refreshToken')
+        .mockResolvedValue({} as never);
+      const loginFlowSpy = jest
+        .spyOn(oauthService, 'initLoginFlow')
+        .mockImplementation(() => undefined);
+      const tryLoginSpy = jest
+        .spyOn(oauthService, 'tryLogin')
+        .mockResolvedValue(false);
+      jest
+        .spyOn(oauthService, 'loadDiscoveryDocument')
+        .mockResolvedValue(new OAuthSuccessEvent('discovery_document_loaded'));
+      localStorage.setItem('refresh_token', 'refresh-token');
+
+      await service.initLoginSequence();
+
+      expect(refreshTokenSpy).toHaveBeenCalled();
+      expect(tryLoginSpy).not.toHaveBeenCalled();
+      expect(loginFlowSpy).not.toHaveBeenCalled();
+    });
+
+    it('should process the OAuth callback instead of refreshing when the URL contains a fresh authorization code', async () => {
+      window.history.replaceState({}, '', '/?code=abc&state=def');
+      jest.spyOn(oauthService, 'hasValidAccessToken').mockReturnValue(false);
+      const refreshTokenSpy = jest
+        .spyOn(oauthService, 'refreshToken')
+        .mockResolvedValue({} as never);
+      const tryLoginSpy = jest
+        .spyOn(oauthService, 'tryLogin')
+        .mockResolvedValue(true);
+      jest
+        .spyOn(oauthService, 'loadDiscoveryDocument')
+        .mockResolvedValue(new OAuthSuccessEvent('discovery_document_loaded'));
+      localStorage.setItem('refresh_token', 'refresh-token');
+
+      await service.initLoginSequence();
+
+      expect(refreshTokenSpy).not.toHaveBeenCalled();
+      expect(tryLoginSpy).toHaveBeenCalled();
+    });
+
+    it('should start a new login flow when no session can be reused', async () => {
+      jest.spyOn(oauthService, 'hasValidAccessToken').mockReturnValue(false);
+      const loginFlowSpy = jest
+        .spyOn(oauthService, 'initLoginFlow')
+        .mockImplementation(() => undefined);
+      jest
+        .spyOn(oauthService, 'loadDiscoveryDocument')
+        .mockResolvedValue(new OAuthSuccessEvent('discovery_document_loaded'));
+
+      await service.initLoginSequence();
+
+      expect(loginFlowSpy).toHaveBeenCalled();
+      let doneLoading = false;
+      service.isDoneLoading$.subscribe((value) => (doneLoading = value));
+      expect(doneLoading).toBe(true);
+    });
+
+    it('should not start a new login flow when the session could be reused after refresh failure', async () => {
+      jest
+        .spyOn(oauthService, 'hasValidAccessToken')
+        .mockReturnValueOnce(false)
+        .mockReturnValue(true);
+      const loginFlowSpy = jest
+        .spyOn(oauthService, 'initLoginFlow')
+        .mockImplementation(() => undefined);
+      jest
+        .spyOn(oauthService, 'loadDiscoveryDocument')
+        .mockResolvedValue(new OAuthSuccessEvent('discovery_document_loaded'));
+      localStorage.setItem('refresh_token', 'refresh-token');
+      jest
+        .spyOn(oauthService, 'refreshToken')
+        .mockRejectedValue(new Error('invalid_grant'));
+
+      await service.initLoginSequence();
+
+      expect(loginFlowSpy).not.toHaveBeenCalled();
+    });
+
+    it('should emit isDoneLoading false when the discovery document cannot be loaded', async () => {
+      jest.spyOn(oauthService, 'hasValidAccessToken').mockReturnValue(false);
+      jest
+        .spyOn(oauthService, 'loadDiscoveryDocument')
+        .mockRejectedValue(new Error('network error'));
+
+      await service.initLoginSequence();
+
+      let doneLoading: boolean | undefined;
+      service.isDoneLoading$.subscribe((value) => (doneLoading = value));
+      expect(doneLoading).toBe(false);
+    });
+  });
+
+  describe('invalid_nonce_in_state event', () => {
+    it('should not restart the login flow when the user is already authenticated', () => {
+      jest.spyOn(oauthService, 'hasValidAccessToken').mockReturnValue(true);
+      const loginFlowSpy = jest
+        .spyOn(oauthService, 'initLoginFlow')
+        .mockImplementation(() => undefined);
+
+      const eventsSubject = (
+        oauthService as unknown as { eventsSubject: Subject<OAuthErrorEvent> }
+      ).eventsSubject;
+      eventsSubject.next(new OAuthErrorEvent('invalid_nonce_in_state', {}));
+
+      expect(loginFlowSpy).not.toHaveBeenCalled();
+    });
+
+    it('should restart the login flow when the user is not authenticated', () => {
+      jest.spyOn(oauthService, 'hasValidAccessToken').mockReturnValue(false);
+      const loginFlowSpy = jest
+        .spyOn(oauthService, 'initLoginFlow')
+        .mockImplementation(() => undefined);
+
+      const eventsSubject = (
+        oauthService as unknown as { eventsSubject: Subject<OAuthErrorEvent> }
+      ).eventsSubject;
+      eventsSubject.next(new OAuthErrorEvent('invalid_nonce_in_state', {}));
+
+      expect(loginFlowSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/libs/shared/src/lib/services/auth/auth.service.ts
+++ b/libs/shared/src/lib/services/auth/auth.service.ts
@@ -7,7 +7,7 @@ import {
   AbilityClass,
   ForcedSubject,
 } from '@casl/ability';
-import { OAuthService } from 'angular-oauth2-oidc';
+import { OAuthEvent, OAuthService } from 'angular-oauth2-oidc';
 import { Apollo } from 'apollo-angular';
 import { get } from 'lodash';
 import {
@@ -158,9 +158,15 @@ export class AuthService {
         }
       });
     this.oauthService.events
-      .pipe(filter((e: any) => e.type === 'invalid_nonce_in_state'))
+      .pipe(filter((e: OAuthEvent) => e.type === 'invalid_nonce_in_state'))
       .subscribe(() => {
-        this.oauthService.initLoginFlow();
+        // A stale callback (e.g. coming from a parallel tab) should not restart
+        // the login flow when the user is already authenticated
+        if (this.oauthService.hasValidAccessToken()) {
+          this.cleanOAuthParamsFromUrl();
+        } else {
+          this.oauthService.initLoginFlow();
+        }
       });
     this.oauthService.setupAutomaticSilentRefresh();
     this.user$.subscribe((user) => this.updateAbility(user));
@@ -218,37 +224,108 @@ export class AuthService {
    * @returns A promise that resolves to void.
    */
   public async initLoginSequence(): Promise<void> {
-    if (!this.oauthService.hasValidAccessToken()) {
-      let environmentUri =
-        this.environment.module === 'backoffice'
-          ? this.environment.backOfficeUri
-          : this.environment.frontOfficeUri;
-      let pathName = '/';
-      // If href starts with environment uri, remove it to get pathname
-      if (location.href.startsWith(environmentUri)) {
-        pathName = location.href.replace(environmentUri, '/');
-      }
-      // else, the href is the environment uri without the trailing '/'
-      // We remove the trailing '/' from the environment uri as we would add it back
-      environmentUri = environmentUri.replace(/\/$/, '');
-      const redirectUri = new URL(pathName, environmentUri);
-      if (redirectUri.pathname !== '/' && redirectUri.pathname !== '/auth/') {
-        localStorage.setItem(
-          'redirectPath',
-          pathName
-          // redirectUri.pathname + redirectUri.search + redirectUri.hash || This would also work but since it does a concat, the other would be faster
-        );
-      }
+    // If the user is already authenticated, reuse the existing session:
+    // the OAuth callback (if any) must not be processed again, as the
+    // authorization code has already been redeemed, and the login flow
+    // must not be restarted.
+    if (
+      this.oauthService.hasValidAccessToken() &&
+      this.oauthService.hasValidIdToken()
+    ) {
+      this.cleanOAuthParamsFromUrl();
+      this.isAuthenticated.next(true);
+      this.isDoneLoading.next(true);
+      return;
     }
-    return this.oauthService
-      .loadDiscoveryDocumentAndLogin()
-      .then(() => {
-        this.isDoneLoading.next(true);
-      })
-      .catch((err) => {
-        console.error(err);
-        this.isDoneLoading.next(false);
-      });
+
+    let environmentUri =
+      this.environment.module === 'backoffice'
+        ? this.environment.backOfficeUri
+        : this.environment.frontOfficeUri;
+    let pathName = '/';
+    // If href starts with environment uri, remove it to get pathname
+    if (location.href.startsWith(environmentUri)) {
+      pathName = location.href.replace(environmentUri, '/');
+    }
+    // else, the href is the environment uri without the trailing '/'
+    // We remove the trailing '/' from the environment uri as we would add it back
+    environmentUri = environmentUri.replace(/\/$/, '');
+    const redirectUri = new URL(pathName, environmentUri);
+    if (redirectUri.pathname !== '/' && redirectUri.pathname !== '/auth/') {
+      localStorage.setItem(
+        'redirectPath',
+        pathName
+        // redirectUri.pathname + redirectUri.search + redirectUri.hash || This would also work but since it does a concat, the other would be faster
+      );
+    }
+
+    try {
+      await this.oauthService.loadDiscoveryDocument();
+      // Try to reuse the existing session before asking the user to log in again:
+      // when the access token has expired but a refresh token is still available,
+      // refresh the tokens silently instead of restarting the whole login flow.
+      if (
+        !this.hasOAuthCallbackParams() &&
+        localStorage.getItem('refresh_token')
+      ) {
+        try {
+          await this.oauthService.refreshToken();
+        } catch (refreshError) {
+          console.error(refreshError);
+        }
+      }
+      // Process the authentication callback if there is one (fresh authorization code)
+      if (!this.oauthService.hasValidAccessToken()) {
+        try {
+          await this.oauthService.tryLogin();
+        } catch (loginError) {
+          console.error(loginError);
+        }
+        // No valid session and no callback to process: start a new login flow
+        if (!this.oauthService.hasValidAccessToken()) {
+          this.oauthService.initLoginFlow();
+        }
+      }
+    } catch (err) {
+      console.error(err);
+      this.isDoneLoading.next(false);
+      return;
+    }
+    // Remove the OAuth callback parameters from the URL, so that the page can
+    // be safely refreshed without trying to redeem the authorization code again
+    this.cleanOAuthParamsFromUrl();
+    this.isAuthenticated.next(this.oauthService.hasValidAccessToken());
+    this.isDoneLoading.next(true);
+  }
+
+  /**
+   * Removes OAuth callback parameters from the current URL,
+   * so that refreshing the page does not try to redeem the authorization code again.
+   */
+  private cleanOAuthParamsFromUrl(): void {
+    const search = window.location.search
+      .replace(/code=[^&]*&?/, '')
+      .replace(/state=[^&]*&?/, '')
+      .replace(/session_state=[^&]*&?/, '')
+      .replace(/error=[^&]*&?/, '')
+      .replace(/error_description=[^&]*&?/, '')
+      .replace(/^\?&/, '?')
+      .replace(/&$/, '')
+      .replace(/^\?$/, '');
+    window.history.replaceState(
+      {},
+      document.title,
+      window.location.pathname + search + window.location.hash
+    );
+  }
+
+  /**
+   * Checks if the current URL contains OAuth callback parameters.
+   *
+   * @returns True if the current URL contains OAuth callback parameters.
+   */
+  private hasOAuthCallbackParams(): boolean {
+    return /[?&](code|state)=/.test(window.location.search);
   }
 
   /**


### PR DESCRIPTION
# Description

In some cases, already-authenticated users were unexpectedly redirected to the Azure AD account picker and asked to disconnect. Additionally, refreshing the application immediately after login could trigger an AADSTS54005 / invalid_grant error because the OAuth authorization code present in the URL was being processed and redeemed more than once.

The shared authentication flow has been updated to reuse existing valid sessions, silently refresh expired tokens when a refresh_token is available, and only restart the full login flow when necessary. OAuth callback parameters are now removed from the URL after authentication to prevent the same code from being processed again on refresh, and the invalid_nonce_in_state handler no longer redirects users who are already authenticated.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/77715/

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tests and linting were successfully completed with no failures or warnings. The authentication test suite includes coverage for reusing existing sessions, cleaning OAuth callback parameters from the URL, silently refreshing expired access tokens, correctly processing new OAuth callbacks, handling refresh and discovery failures, and preventing unnecessary login redirects when the user is already authenticated.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [X] I have made corresponding changes to the documentation ( if required )
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
