### PR TITLE
AB#134011 - FIX: Enable image & PDF preview in forms

### DIFF
--- a/libs/shared/jest.config.ts
+++ b/libs/shared/jest.config.ts
@@ -48,6 +48,7 @@ export default {
     '<rootDir>/src/lib/survey/components/resources.spec.ts',
     '<rootDir>/src/lib/survey/components/utils/*.spec.ts',
     '<rootDir>/src/lib/survey/widgets/*.spec.ts',
+    '<rootDir>/src/lib/survey/components/file-download-button/*.spec.ts',
     '<rootDir>/src/lib/utils/*.spec.ts',
     '<rootDir>/src/lib/survey/triggers/*.spec.ts',
   ],

--- a/libs/shared/src/lib/style/survey.scss
+++ b/libs/shared/src/lib/style/survey.scss
@@ -257,7 +257,9 @@
     display: inline;
   }
 
-  // Download action for a single image in read-only form details
+  // Download action for a single image in read-only form details, floating
+  // over the bottom-right corner of the image (the top-right corner is where
+  // SurveyJS places its own choose / clear adorner buttons)
   .file-image-preview {
     .sd-file__image-wrapper {
       position: relative;
@@ -265,23 +267,27 @@
 
     .file-image-preview__download {
       @apply absolute
-        top-2
+        bottom-2
         right-2
         flex
         items-center
         justify-center
         w-9
         h-9
-        rounded-md
-        bg-white
+        rounded-full
+        bg-white/90
         text-gray-700
         shadow-md
-        hover:bg-gray-100
+        transition-colors
+        hover:bg-white
+        hover:text-primary-600
         focus-visible:outline
         focus-visible:outline-2
         focus-visible:outline-offset-2
         focus-visible:outline-primary-600;
       border: 1px solid rgb(209 213 219);
+      // Above the transparent full-size file-name link SurveyJS overlays on
+      // single image previews
       z-index: 1;
 
       svg {

--- a/libs/shared/src/lib/style/survey.scss
+++ b/libs/shared/src/lib/style/survey.scss
@@ -257,47 +257,6 @@
     display: inline;
   }
 
-  // Download action for a single image in read-only form details, floating
-  // over the bottom-right corner of the image (the top-right corner is where
-  // SurveyJS places its own choose / clear adorner buttons)
-  .file-image-preview {
-    .sd-file__image-wrapper {
-      position: relative;
-    }
-
-    .file-image-preview__download {
-      @apply absolute
-        bottom-2
-        right-2
-        flex
-        items-center
-        justify-center
-        w-9
-        h-9
-        rounded-full
-        bg-white/90
-        text-gray-700
-        shadow-md
-        transition-colors
-        hover:bg-white
-        hover:text-primary-600
-        focus-visible:outline
-        focus-visible:outline-2
-        focus-visible:outline-offset-2
-        focus-visible:outline-primary-600;
-      border: 1px solid rgb(209 213 219);
-      // Above the transparent full-size file-name link SurveyJS overlays on
-      // single image previews
-      z-index: 1;
-
-      svg {
-        width: 20px;
-        height: 20px;
-        fill: currentColor;
-      }
-    }
-  }
-
   // Inline PDF preview, rendered inside the upload area of file questions
   .file-pdf-preview {
     .sd-file {

--- a/libs/shared/src/lib/style/survey.scss
+++ b/libs/shared/src/lib/style/survey.scss
@@ -257,6 +257,41 @@
     display: inline;
   }
 
+  // Download action for a single image in read-only form details
+  .file-image-preview {
+    .sd-file__image-wrapper {
+      position: relative;
+    }
+
+    .file-image-preview__download {
+      @apply absolute
+        top-2
+        right-2
+        flex
+        items-center
+        justify-center
+        w-9
+        h-9
+        rounded-md
+        bg-white
+        text-gray-700
+        shadow-md
+        hover:bg-gray-100
+        focus-visible:outline
+        focus-visible:outline-2
+        focus-visible:outline-offset-2
+        focus-visible:outline-primary-600;
+      border: 1px solid rgb(209 213 219);
+      z-index: 1;
+
+      svg {
+        width: 20px;
+        height: 20px;
+        fill: currentColor;
+      }
+    }
+  }
+
   // Inline PDF preview, rendered inside the upload area of file questions
   .file-pdf-preview {
     .sd-file {

--- a/libs/shared/src/lib/survey/components/file-download-button/file-download-button.component.spec.ts
+++ b/libs/shared/src/lib/survey/components/file-download-button/file-download-button.component.spec.ts
@@ -1,0 +1,63 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TranslateModule } from '@ngx-translate/core';
+import { TooltipDirective } from '@oort-front/ui';
+import { FileService } from '../../../services/file/file.service';
+import { FileDownloadButtonComponent } from './file-download-button.component';
+
+describe('FileDownloadButtonComponent', () => {
+  let fixture: ComponentFixture<FileDownloadButtonComponent>;
+  let component: FileDownloadButtonComponent;
+  let fileService: Pick<FileService, 'download'>;
+  const file = {
+    name: 'identity-document.png',
+    type: 'image/png',
+    content: 'stored-file-id',
+  };
+
+  beforeEach(async () => {
+    fileService = { download: jest.fn() };
+    await TestBed.configureTestingModule({
+      imports: [FileDownloadButtonComponent, TranslateModule.forRoot()],
+      providers: [{ provide: FileService, useValue: fileService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FileDownloadButtonComponent);
+    component = fixture.componentInstance;
+    component.file = file;
+    fixture.detectChanges();
+  });
+
+  it('downloads the file when clicked', () => {
+    const button = fixture.nativeElement.querySelector(
+      'button'
+    ) as HTMLButtonElement;
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    button.dispatchEvent(event);
+
+    expect(fileService.download).toHaveBeenCalledWith(file);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('describes the download in a tooltip', () => {
+    const tooltip = fixture.debugElement
+      .query(By.directive(TooltipDirective))
+      .injector.get(TooltipDirective);
+
+    // No translation loader in tests: the key is returned as is
+    expect(tooltip.uiTooltip).toBe('common.downloadObject');
+    expect(tooltip.uiTooltipPosition).toBe('top');
+  });
+
+  it('does nothing when no file is set', () => {
+    component.file = undefined;
+    fixture.detectChanges();
+
+    (
+      fixture.nativeElement.querySelector('button') as HTMLButtonElement
+    ).click();
+
+    expect(fileService.download).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared/src/lib/survey/components/file-download-button/file-download-button.component.ts
+++ b/libs/shared/src/lib/survey/components/file-download-button/file-download-button.component.ts
@@ -1,0 +1,54 @@
+import { Component, HostBinding, inject, Input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { ButtonModule, TooltipModule } from '@oort-front/ui';
+import { File, FileService } from '../../../services/file/file.service';
+
+/**
+ * Download action floating over the image preview of a file question.
+ *
+ * Injected by the file widget inside SurveyJS's image wrapper, which is
+ * already positioned, so the host only needs to anchor itself to the
+ * bottom-right corner of the image (the top-right corner is where SurveyJS
+ * places its own choose / clear buttons).
+ */
+@Component({
+  selector: 'shared-file-download-button',
+  standalone: true,
+  imports: [ButtonModule, TooltipModule, TranslateModule],
+  template: `
+    <ui-button
+      [isIcon]="true"
+      icon="download"
+      category="tertiary"
+      variant="primary"
+      size="small"
+      [uiTooltip]="'common.downloadObject' | translate : { name: file?.name }"
+      uiTooltipPosition="top"
+      (click)="onClick($event)"
+    ></ui-button>
+  `,
+})
+export class FileDownloadButtonComponent {
+  /** File to download */
+  @Input() file?: File;
+  /**
+   * Float over the bottom-right corner of the image, above SurveyJS's
+   * transparent full-size file-name link
+   */
+  @HostBinding('class') hostClass = 'absolute bottom-2 right-2 z-10';
+  /** Shared file service */
+  private fileService = inject(FileService);
+
+  /**
+   * Downloads the file, keeping the click away from SurveyJS's own handlers.
+   *
+   * @param event Click event
+   */
+  onClick(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    if (this.file) {
+      this.fileService.download(this.file);
+    }
+  }
+}

--- a/libs/shared/src/lib/survey/components/file-download-button/public-api.ts
+++ b/libs/shared/src/lib/survey/components/file-download-button/public-api.ts
@@ -1,0 +1,1 @@
+export * from './file-download-button.component';

--- a/libs/shared/src/lib/survey/widgets/file-widget.spec.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.spec.ts
@@ -1,8 +1,8 @@
-import { Injector } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
+import { ComponentRef, Injector } from '@angular/core';
 import { CustomWidgetCollection, SurveyModel } from 'survey-core';
 import { DocumentManagementService } from '../../services/document-management/document-management.service';
-import { FileService } from '../../services/file/file.service';
+import { DomService } from '../../services/dom/dom.service';
+import { FileDownloadButtonComponent } from '../components/file-download-button/public-api';
 import { QuestionFile } from '../types';
 import { init } from './file-widget';
 
@@ -12,20 +12,47 @@ interface FileWidget {
   willUnmount(question: QuestionFile): void;
 }
 
+/** Component reference shape used by the widget. */
+type ButtonRef = Pick<
+  ComponentRef<FileDownloadButtonComponent>,
+  'instance' | 'location' | 'changeDetectorRef'
+>;
+
 describe('file widget', () => {
   let widget: FileWidget;
-  let fileService: Pick<FileService, 'download'>;
+  let domService: Pick<
+    DomService,
+    'appendComponentToBody' | 'removeComponentFromBody'
+  >;
+  const image = {
+    name: 'identity-document.png',
+    type: 'image/png',
+    content: 'stored-file-id',
+  };
 
   beforeEach(() => {
-    fileService = { download: jest.fn() };
-    const documentManagementService = {};
-    const translateService = { instant: jest.fn().mockReturnValue('Download') };
+    domService = {
+      appendComponentToBody: jest.fn(
+        (component: unknown, parent: HTMLElement): ButtonRef => {
+          const nativeElement = document.createElement(
+            'shared-file-download-button'
+          );
+          parent.appendChild(nativeElement);
+          return {
+            instance: {} as FileDownloadButtonComponent,
+            location: { nativeElement },
+            changeDetectorRef: { detectChanges: jest.fn() } as any,
+          };
+        }
+      ) as any,
+      removeComponentFromBody: jest.fn((ref: ButtonRef) =>
+        ref.location.nativeElement.remove()
+      ),
+    };
     const injector = {
       get: (token: unknown): unknown => {
-        if (token === DocumentManagementService)
-          return documentManagementService;
-        if (token === FileService) return fileService;
-        if (token === TranslateService) return translateService;
+        if (token === DocumentManagementService) return {};
+        if (token === DomService) return domService;
         throw new Error('Unexpected injection token');
       },
     } as Injector;
@@ -60,84 +87,78 @@ describe('file widget', () => {
     return element;
   };
 
+  const getButton = (): ButtonRef =>
+    (domService.appendComponentToBody as jest.Mock).mock.results[0].value;
+
   afterEach(() => {
     document.body.innerHTML = '';
   });
 
-  it('downloads a single image from display mode', () => {
-    const file = {
-      name: 'identity-document.png',
-      type: 'image/png',
-      content: 'stored-file-id',
-    };
-    const question = createQuestion('display', [file]);
+  it.each([
+    ['display mode', 'display', image],
+    [
+      'edit mode, for a freshly picked file',
+      'edit',
+      { ...image, content: 'data:image/png;base64,AAAA' },
+    ],
+  ] as const)('injects a download button in %s', (_case, mode, file) => {
+    const question = createQuestion(mode, [file]);
     const element = createElement();
 
     widget.afterRender(question, element);
-    const button = element.querySelector<HTMLButtonElement>(
-      '.file-image-preview__download'
-    );
-    button?.click();
 
-    expect(button?.getAttribute('aria-label')).toBe(
-      'Download: identity-document.png'
+    expect(domService.appendComponentToBody).toHaveBeenCalledWith(
+      FileDownloadButtonComponent,
+      element.querySelector('.sd-file__image-wrapper')
     );
-    expect(fileService.download).toHaveBeenCalledWith(file);
+    expect(getButton().instance.file).toBe(file);
+    expect(getButton().changeDetectorRef.detectChanges).toHaveBeenCalled();
   });
 
-  it('removes the image action when the widget unmounts', () => {
-    const question = createQuestion('display', [
+  it('reuses the button and updates its file on re-render', () => {
+    const question = createQuestion('edit', [image]);
+    const element = createElement();
+    const replacement = { ...image, name: 'other.png' };
+
+    widget.afterRender(question, element);
+    question.value = [replacement];
+    widget.afterRender(question, element);
+
+    expect(domService.appendComponentToBody).toHaveBeenCalledTimes(1);
+    expect(getButton().instance.file).toBe(replacement);
+  });
+
+  it('removes the button when the widget unmounts', () => {
+    const question = createQuestion('display', [image]);
+    const element = createElement();
+
+    widget.afterRender(question, element);
+    widget.willUnmount(question);
+
+    expect(domService.removeComponentFromBody).toHaveBeenCalledWith(
+      getButton()
+    );
+    expect(element.querySelector('shared-file-download-button')).toBeNull();
+    expect(
+      (question.survey as SurveyModel).onValueChanged.remove
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['a PDF', 'display'],
+    ['a PDF in edit mode', 'edit'],
+  ] as const)('does not inject a download button for %s', (_case, mode) => {
+    const question = createQuestion(mode, [
       {
-        name: 'identity-document.png',
-        type: 'image/png',
+        name: 'identity-document.pdf',
+        type: 'application/pdf',
         content: 'stored-file-id',
       },
     ]);
     const element = createElement();
 
     widget.afterRender(question, element);
-    widget.willUnmount(question);
 
-    expect(element.querySelector('.file-image-preview__download')).toBeNull();
-    expect(element.classList.contains('file-image-preview')).toBe(false);
-    expect(
-      (question.survey as SurveyModel).onValueChanged.remove
-    ).toHaveBeenCalledTimes(1);
+    expect(domService.appendComponentToBody).not.toHaveBeenCalled();
   });
-
-  it('downloads a freshly picked image from edit mode', () => {
-    const file = {
-      name: 'identity-document.png',
-      type: 'image/png',
-      content: 'data:image/png;base64,AAAA',
-    };
-    const question = createQuestion('edit', [file]);
-    const element = createElement();
-
-    widget.afterRender(question, element);
-    const button = element.querySelector<HTMLButtonElement>(
-      '.file-image-preview__download'
-    );
-    button?.click();
-
-    expect(button).not.toBeNull();
-    expect(fileService.download).toHaveBeenCalledWith(file);
-  });
-
-  it.each([
-    ['a PDF', 'display', 'application/pdf'],
-    ['a PDF in edit mode', 'edit', 'application/pdf'],
-  ] as const)(
-    'does not add the image download action for %s',
-    (_case, mode, type) => {
-      const question = createQuestion(mode, [
-        { name: 'identity-document', type, content: 'stored-file-id' },
-      ]);
-      const element = createElement();
-
-      widget.afterRender(question, element);
-
-      expect(element.querySelector('.file-image-preview__download')).toBeNull();
-    }
-  );
 });

--- a/libs/shared/src/lib/survey/widgets/file-widget.spec.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.spec.ts
@@ -105,9 +105,28 @@ describe('file widget', () => {
     ).toHaveBeenCalledTimes(1);
   });
 
+  it('downloads a freshly picked image from edit mode', () => {
+    const file = {
+      name: 'identity-document.png',
+      type: 'image/png',
+      content: 'data:image/png;base64,AAAA',
+    };
+    const question = createQuestion('edit', [file]);
+    const element = createElement();
+
+    widget.afterRender(question, element);
+    const button = element.querySelector<HTMLButtonElement>(
+      '.file-image-preview__download'
+    );
+    button?.click();
+
+    expect(button).not.toBeNull();
+    expect(fileService.download).toHaveBeenCalledWith(file);
+  });
+
   it.each([
-    ['edit mode', 'edit', 'image/png'],
     ['a PDF', 'display', 'application/pdf'],
+    ['a PDF in edit mode', 'edit', 'application/pdf'],
   ] as const)(
     'does not add the image download action for %s',
     (_case, mode, type) => {

--- a/libs/shared/src/lib/survey/widgets/file-widget.spec.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.spec.ts
@@ -1,0 +1,124 @@
+import { Injector } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { CustomWidgetCollection, SurveyModel } from 'survey-core';
+import { DocumentManagementService } from '../../services/document-management/document-management.service';
+import { FileService } from '../../services/file/file.service';
+import { QuestionFile } from '../types';
+import { init } from './file-widget';
+
+/** Minimal custom widget contract exercised by this test. */
+interface FileWidget {
+  afterRender(question: QuestionFile, htmlElement: HTMLElement): void;
+  willUnmount(question: QuestionFile): void;
+}
+
+describe('file widget', () => {
+  let widget: FileWidget;
+  let fileService: Pick<FileService, 'download'>;
+
+  beforeEach(() => {
+    fileService = { download: jest.fn() };
+    const documentManagementService = {};
+    const translateService = { instant: jest.fn().mockReturnValue('Download') };
+    const injector = {
+      get: (token: unknown): unknown => {
+        if (token === DocumentManagementService)
+          return documentManagementService;
+        if (token === FileService) return fileService;
+        if (token === TranslateService) return translateService;
+        throw new Error('Unexpected injection token');
+      },
+    } as Injector;
+    const collection = {
+      addCustomWidget: (registeredWidget: FileWidget): void => {
+        widget = registeredWidget;
+      },
+    } as unknown as CustomWidgetCollection;
+
+    init(injector, collection);
+  });
+
+  const createQuestion = (
+    mode: 'display' | 'edit',
+    value: Array<{ name: string; type: string; content: string }>
+  ): QuestionFile =>
+    ({
+      value,
+      survey: {
+        mode,
+        onValueChanged: { add: jest.fn(), remove: jest.fn() },
+        runExpression: jest.fn(),
+      },
+      canPreviewImage: jest.fn().mockReturnValue(true),
+      allowImagesPreview: true,
+    } as unknown as QuestionFile);
+
+  const createElement = (): HTMLElement => {
+    const element = document.createElement('div');
+    element.innerHTML = '<div class="sd-file__image-wrapper"></div>';
+    document.body.appendChild(element);
+    return element;
+  };
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('downloads a single image from display mode', () => {
+    const file = {
+      name: 'identity-document.png',
+      type: 'image/png',
+      content: 'stored-file-id',
+    };
+    const question = createQuestion('display', [file]);
+    const element = createElement();
+
+    widget.afterRender(question, element);
+    const button = element.querySelector<HTMLButtonElement>(
+      '.file-image-preview__download'
+    );
+    button?.click();
+
+    expect(button?.getAttribute('aria-label')).toBe(
+      'Download: identity-document.png'
+    );
+    expect(fileService.download).toHaveBeenCalledWith(file);
+  });
+
+  it('removes the image action when the widget unmounts', () => {
+    const question = createQuestion('display', [
+      {
+        name: 'identity-document.png',
+        type: 'image/png',
+        content: 'stored-file-id',
+      },
+    ]);
+    const element = createElement();
+
+    widget.afterRender(question, element);
+    widget.willUnmount(question);
+
+    expect(element.querySelector('.file-image-preview__download')).toBeNull();
+    expect(element.classList.contains('file-image-preview')).toBe(false);
+    expect(
+      (question.survey as SurveyModel).onValueChanged.remove
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['edit mode', 'edit', 'image/png'],
+    ['a PDF', 'display', 'application/pdf'],
+  ] as const)(
+    'does not add the image download action for %s',
+    (_case, mode, type) => {
+      const question = createQuestion(mode, [
+        { name: 'identity-document', type, content: 'stored-file-id' },
+      ]);
+      const element = createElement();
+
+      widget.afterRender(question, element);
+
+      expect(element.querySelector('.file-image-preview__download')).toBeNull();
+    }
+  );
+});

--- a/libs/shared/src/lib/survey/widgets/file-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.ts
@@ -113,11 +113,12 @@ const removeImageDownloadAction = (htmlElement: HTMLElement): void => {
 };
 
 /**
- * Adds a download action to a single image preview in display mode.
+ * Adds a download action floating over a single image preview.
  *
- * SurveyJS keeps the file-name download link in edit mode, but its read-only
- * image rendering does not expose a download icon. The action delegates to the
- * shared file service so both legacy and document-management files are handled.
+ * SurveyJS renders single images without any visible download control (the
+ * file-name link is transparent and stretched over the image), in both edit
+ * and read-only mode. The action delegates to the shared file service so
+ * freshly picked, legacy and document-management files are all handled.
  *
  * @param question File question instance
  * @param htmlElement The question's rendered root HTML element
@@ -132,13 +133,12 @@ const updateImageDownloadAction = (
 ): void => {
   const value = question.value as File[];
   const file = Array.isArray(value) && value.length === 1 ? value[0] : null;
-  const isDisplayMode = (question.survey as SurveyModel)?.mode === 'display';
   const isImage = file
     ? getPreviewKind(file.name, file.type ?? '') === 'image'
     : false;
   const existing = htmlElement.querySelector(`.${IMAGE_DOWNLOAD_CLASS}`);
 
-  if (!isDisplayMode || !file || !isImage) {
+  if (!file || !isImage) {
     removeImageDownloadAction(htmlElement);
     return;
   }

--- a/libs/shared/src/lib/survey/widgets/file-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.ts
@@ -9,10 +9,11 @@ import {
   DocumentManagementService,
 } from '../../services/document-management/document-management.service';
 import { Question, QuestionFile } from '../types';
-import { Injector } from '@angular/core';
+import { ComponentRef, Injector } from '@angular/core';
 import jsonpath from 'jsonpath';
-import { File, FileService } from '../../services/file/file.service';
-import { TranslateService } from '@ngx-translate/core';
+import { File } from '../../services/file/file.service';
+import { DomService } from '../../services/dom/dom.service';
+import { FileDownloadButtonComponent } from '../components/file-download-button/public-api';
 
 /**
  * Set document properties based on value expressions
@@ -67,15 +68,12 @@ const setDocumentProperties = (
 const PDF_PREVIEW_CLASS = 'file-pdf-preview';
 /** CSS class of the iframe injected inside the upload area for PDFs. */
 const PDF_PREVIEW_FRAME_CLASS = 'file-pdf-preview__frame';
-/** Class toggled on questions with a downloadable image preview. */
-const IMAGE_PREVIEW_CLASS = 'file-image-preview';
-/** CSS class of the download action injected over image previews. */
-const IMAGE_DOWNLOAD_CLASS = 'file-image-preview__download';
 
 /** File question state retained between widget lifecycle hooks. */
 interface FilePreviewQuestion extends QuestionFile {
   __filePreviewElement?: HTMLElement;
   __pdfPreviewObserver?: MutationObserver;
+  __imageDownloadButton?: ComponentRef<FileDownloadButtonComponent>;
   __survey?: SurveyModel;
   __valueChangedHandler?: (
     sender: SurveyModel,
@@ -103,82 +101,76 @@ const getPreviewKind = (name: string, type: string): 'image' | 'pdf' | null => {
 };
 
 /**
- * Removes the image download action from a rendered file question.
+ * Removes the image download action from a file question, destroying the
+ * injected component.
  *
- * @param htmlElement The question's rendered root HTML element
+ * @param question File question instance
+ * @param domService Shared DOM service
  */
-const removeImageDownloadAction = (htmlElement: HTMLElement): void => {
-  htmlElement.classList.remove(IMAGE_PREVIEW_CLASS);
-  htmlElement.querySelector(`.${IMAGE_DOWNLOAD_CLASS}`)?.remove();
+const removeImageDownloadAction = (
+  question: FilePreviewQuestion,
+  domService: DomService
+): void => {
+  if (question.__imageDownloadButton) {
+    domService.removeComponentFromBody(question.__imageDownloadButton);
+    question.__imageDownloadButton = undefined;
+  }
 };
 
 /**
- * Adds a download action floating over a single image preview.
+ * Injects a download action floating over a single image preview.
  *
  * SurveyJS renders single images without any visible download control (the
  * file-name link is transparent and stretched over the image), in both edit
- * and read-only mode. The action delegates to the shared file service so
- * freshly picked, legacy and document-management files are all handled.
+ * and read-only mode. The action is a UI library button injected inside the
+ * image wrapper, kept in sync with the question value.
+ *
+ * Safe to call repeatedly (it is driven by a MutationObserver): the injected
+ * component is reused while SurveyJS keeps the same wrapper, re-created when
+ * the wrapper is re-rendered, and removed once the value is no longer a
+ * single image.
  *
  * @param question File question instance
  * @param htmlElement The question's rendered root HTML element
- * @param fileService Shared file service
- * @param downloadLabel Localized accessible label for the action
+ * @param domService Shared DOM service
  */
 const updateImageDownloadAction = (
-  question: QuestionFile,
+  question: FilePreviewQuestion,
   htmlElement: HTMLElement,
-  fileService: FileService,
-  downloadLabel: string
+  domService: DomService
 ): void => {
   const value = question.value as File[];
   const file = Array.isArray(value) && value.length === 1 ? value[0] : null;
   const isImage = file
     ? getPreviewKind(file.name, file.type ?? '') === 'image'
     : false;
-  const existing = htmlElement.querySelector(`.${IMAGE_DOWNLOAD_CLASS}`);
-
-  if (!file || !isImage) {
-    removeImageDownloadAction(htmlElement);
-    return;
-  }
-
   const wrapper = htmlElement.querySelector(
     '.sd-file__image-wrapper'
   ) as HTMLElement | null;
-  if (!wrapper || existing) return;
 
-  htmlElement.classList.add(IMAGE_PREVIEW_CLASS);
-  const button = document.createElement('button');
-  const accessibleLabel = `${downloadLabel}: ${file.name}`;
-  button.type = 'button';
-  button.classList.add(IMAGE_DOWNLOAD_CLASS);
-  button.title = accessibleLabel;
-  button.setAttribute('aria-label', accessibleLabel);
+  // Preview slot not rendered yet; the observer will call us again once it is.
+  if (!file || !isImage || !wrapper) {
+    removeImageDownloadAction(question, domService);
+    return;
+  }
 
-  const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  icon.setAttribute('viewBox', '0 0 24 24');
-  icon.setAttribute('aria-hidden', 'true');
-  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-  path.setAttribute('d', 'M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z');
-  icon.appendChild(path);
-  button.appendChild(icon);
-  button.addEventListener('click', (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    const currentValue = question.value as File[];
-    const currentFile =
-      Array.isArray(currentValue) && currentValue.length === 1
-        ? currentValue[0]
-        : null;
-    if (
-      currentFile &&
-      getPreviewKind(currentFile.name, currentFile.type ?? '') === 'image'
-    ) {
-      fileService.download(currentFile);
-    }
-  });
-  wrapper.appendChild(button);
+  let button = question.__imageDownloadButton;
+  // SurveyJS re-rendered the preview: the previous button is orphaned
+  if (button && !wrapper.contains(button.location.nativeElement)) {
+    removeImageDownloadAction(question, domService);
+    button = undefined;
+  }
+  if (!button) {
+    button = domService.appendComponentToBody(
+      FileDownloadButtonComponent,
+      wrapper
+    ) as ComponentRef<FileDownloadButtonComponent>;
+    question.__imageDownloadButton = button;
+  }
+  if (button.instance.file !== file) {
+    button.instance.file = file;
+    button.changeDetectorRef.detectChanges();
+  }
 };
 
 /**
@@ -295,8 +287,7 @@ export const init = (
   customWidgetCollectionInstance: CustomWidgetCollection
 ): void => {
   const documentManagementService = injector.get(DocumentManagementService);
-  const fileService = injector.get(FileService);
-  const translateService = injector.get(TranslateService);
+  const domService = injector.get(DomService);
   const widget = {
     name: 'file-widget',
     widgetIsLoaded: (): boolean => true,
@@ -342,22 +333,12 @@ export const init = (
       filePreviewQuestion.__pdfPreviewObserver?.disconnect();
       const observer = new MutationObserver(() => {
         updatePdfPreview(question, htmlElement);
-        updateImageDownloadAction(
-          question,
-          htmlElement,
-          fileService,
-          translateService.instant('common.download')
-        );
+        updateImageDownloadAction(filePreviewQuestion, htmlElement, domService);
       });
       observer.observe(htmlElement, { childList: true, subtree: true });
       filePreviewQuestion.__pdfPreviewObserver = observer;
       updatePdfPreview(question, htmlElement);
-      updateImageDownloadAction(
-        question,
-        htmlElement,
-        fileService,
-        translateService.instant('common.download')
-      );
+      updateImageDownloadAction(filePreviewQuestion, htmlElement, domService);
     },
     willUnmount: (question: QuestionFile): void => {
       const filePreviewQuestion = question as FilePreviewQuestion;
@@ -372,8 +353,8 @@ export const init = (
       }
       if (filePreviewQuestion.__filePreviewElement) {
         removePdfPreview(question, filePreviewQuestion.__filePreviewElement);
-        removeImageDownloadAction(filePreviewQuestion.__filePreviewElement);
       }
+      removeImageDownloadAction(filePreviewQuestion, domService);
       filePreviewQuestion.__pdfPreviewObserver = undefined;
       filePreviewQuestion.__filePreviewElement = undefined;
       filePreviewQuestion.__survey = undefined;

--- a/libs/shared/src/lib/survey/widgets/file-widget.ts
+++ b/libs/shared/src/lib/survey/widgets/file-widget.ts
@@ -1,5 +1,9 @@
 import { isNil } from 'lodash';
-import { CustomWidgetCollection, SurveyModel } from 'survey-core';
+import {
+  CustomWidgetCollection,
+  SurveyModel,
+  ValueChangedEvent,
+} from 'survey-core';
 import {
   CS_DOCUMENTS_PROPERTIES,
   DocumentManagementService,
@@ -7,6 +11,8 @@ import {
 import { Question, QuestionFile } from '../types';
 import { Injector } from '@angular/core';
 import jsonpath from 'jsonpath';
+import { File, FileService } from '../../services/file/file.service';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * Set document properties based on value expressions
@@ -61,6 +67,21 @@ const setDocumentProperties = (
 const PDF_PREVIEW_CLASS = 'file-pdf-preview';
 /** CSS class of the iframe injected inside the upload area for PDFs. */
 const PDF_PREVIEW_FRAME_CLASS = 'file-pdf-preview__frame';
+/** Class toggled on questions with a downloadable image preview. */
+const IMAGE_PREVIEW_CLASS = 'file-image-preview';
+/** CSS class of the download action injected over image previews. */
+const IMAGE_DOWNLOAD_CLASS = 'file-image-preview__download';
+
+/** File question state retained between widget lifecycle hooks. */
+interface FilePreviewQuestion extends QuestionFile {
+  __filePreviewElement?: HTMLElement;
+  __pdfPreviewObserver?: MutationObserver;
+  __survey?: SurveyModel;
+  __valueChangedHandler?: (
+    sender: SurveyModel,
+    options: ValueChangedEvent
+  ) => void;
+}
 
 /**
  * Determines whether a file can be previewed inline and how.
@@ -70,13 +91,94 @@ const PDF_PREVIEW_FRAME_CLASS = 'file-pdf-preview__frame';
  * @returns 'image' | 'pdf' for files we can preview, otherwise null
  */
 const getPreviewKind = (name: string, type: string): 'image' | 'pdf' | null => {
-  const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|webp|bmp|svg)$/i;
+  const IMAGE_EXTENSIONS = /\.(apng|avif|bmp|gif|jpe?g|png|svg|webp)$/i;
+  const hasGenericType = !type || type === 'application/octet-stream';
   const isImage =
     (typeof type === 'string' && type.startsWith('image/')) ||
-    (!type && IMAGE_EXTENSIONS.test(name));
+    (hasGenericType && IMAGE_EXTENSIONS.test(name));
   if (isImage) return 'image';
-  const isPdf = type === 'application/pdf' || (!type && /\.pdf$/i.test(name));
+  const isPdf =
+    type === 'application/pdf' || (hasGenericType && /\.pdf$/i.test(name));
   return isPdf ? 'pdf' : null;
+};
+
+/**
+ * Removes the image download action from a rendered file question.
+ *
+ * @param htmlElement The question's rendered root HTML element
+ */
+const removeImageDownloadAction = (htmlElement: HTMLElement): void => {
+  htmlElement.classList.remove(IMAGE_PREVIEW_CLASS);
+  htmlElement.querySelector(`.${IMAGE_DOWNLOAD_CLASS}`)?.remove();
+};
+
+/**
+ * Adds a download action to a single image preview in display mode.
+ *
+ * SurveyJS keeps the file-name download link in edit mode, but its read-only
+ * image rendering does not expose a download icon. The action delegates to the
+ * shared file service so both legacy and document-management files are handled.
+ *
+ * @param question File question instance
+ * @param htmlElement The question's rendered root HTML element
+ * @param fileService Shared file service
+ * @param downloadLabel Localized accessible label for the action
+ */
+const updateImageDownloadAction = (
+  question: QuestionFile,
+  htmlElement: HTMLElement,
+  fileService: FileService,
+  downloadLabel: string
+): void => {
+  const value = question.value as File[];
+  const file = Array.isArray(value) && value.length === 1 ? value[0] : null;
+  const isDisplayMode = (question.survey as SurveyModel)?.mode === 'display';
+  const isImage = file
+    ? getPreviewKind(file.name, file.type ?? '') === 'image'
+    : false;
+  const existing = htmlElement.querySelector(`.${IMAGE_DOWNLOAD_CLASS}`);
+
+  if (!isDisplayMode || !file || !isImage) {
+    removeImageDownloadAction(htmlElement);
+    return;
+  }
+
+  const wrapper = htmlElement.querySelector(
+    '.sd-file__image-wrapper'
+  ) as HTMLElement | null;
+  if (!wrapper || existing) return;
+
+  htmlElement.classList.add(IMAGE_PREVIEW_CLASS);
+  const button = document.createElement('button');
+  const accessibleLabel = `${downloadLabel}: ${file.name}`;
+  button.type = 'button';
+  button.classList.add(IMAGE_DOWNLOAD_CLASS);
+  button.title = accessibleLabel;
+  button.setAttribute('aria-label', accessibleLabel);
+
+  const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  icon.setAttribute('viewBox', '0 0 24 24');
+  icon.setAttribute('aria-hidden', 'true');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z');
+  icon.appendChild(path);
+  button.appendChild(icon);
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const currentValue = question.value as File[];
+    const currentFile =
+      Array.isArray(currentValue) && currentValue.length === 1
+        ? currentValue[0]
+        : null;
+    if (
+      currentFile &&
+      getPreviewKind(currentFile.name, currentFile.type ?? '') === 'image'
+    ) {
+      fileService.download(currentFile);
+    }
+  });
+  wrapper.appendChild(button);
 };
 
 /**
@@ -193,22 +295,34 @@ export const init = (
   customWidgetCollectionInstance: CustomWidgetCollection
 ): void => {
   const documentManagementService = injector.get(DocumentManagementService);
+  const fileService = injector.get(FileService);
+  const translateService = injector.get(TranslateService);
   const widget = {
     name: 'file-widget',
     widgetIsLoaded: (): boolean => true,
     isFit: (question: Question): boolean => question.getType() === 'file',
     isDefaultRender: true,
     afterRender: (question: QuestionFile, htmlElement: HTMLElement): void => {
+      const filePreviewQuestion = question as FilePreviewQuestion;
+      const survey = question.survey as SurveyModel;
+      filePreviewQuestion.__filePreviewElement = htmlElement;
       // Subscribe to changes, to set all value expressions
-      (question.survey as SurveyModel)?.onValueChanged.add((sender) => {
+      if (
+        filePreviewQuestion.__survey &&
+        filePreviewQuestion.__valueChangedHandler
+      ) {
+        filePreviewQuestion.__survey.onValueChanged.remove(
+          filePreviewQuestion.__valueChangedHandler
+        );
+      }
+      const valueChangedHandler = (sender: SurveyModel): void => {
         setDocumentProperties(documentManagementService, question, sender);
-      });
+      };
+      survey?.onValueChanged.add(valueChangedHandler);
+      filePreviewQuestion.__survey = survey;
+      filePreviewQuestion.__valueChangedHandler = valueChangedHandler;
       // Execute once to set initial values
-      setDocumentProperties(
-        documentManagementService,
-        question,
-        question.survey as SurveyModel
-      );
+      setDocumentProperties(documentManagementService, question, survey);
 
       // Give stored images the same native in-area preview as freshly picked
       // ones: SurveyJS only recognizes images from string contents, but files
@@ -225,13 +339,45 @@ export const init = (
 
       // Render the PDF preview inside the upload area, and keep it in sync
       // with SurveyJS re-renders (value changes, async preview loading).
-      (question as any).__pdfPreviewObserver?.disconnect();
-      const observer = new MutationObserver(() =>
-        updatePdfPreview(question, htmlElement)
-      );
+      filePreviewQuestion.__pdfPreviewObserver?.disconnect();
+      const observer = new MutationObserver(() => {
+        updatePdfPreview(question, htmlElement);
+        updateImageDownloadAction(
+          question,
+          htmlElement,
+          fileService,
+          translateService.instant('common.download')
+        );
+      });
       observer.observe(htmlElement, { childList: true, subtree: true });
-      (question as any).__pdfPreviewObserver = observer;
+      filePreviewQuestion.__pdfPreviewObserver = observer;
       updatePdfPreview(question, htmlElement);
+      updateImageDownloadAction(
+        question,
+        htmlElement,
+        fileService,
+        translateService.instant('common.download')
+      );
+    },
+    willUnmount: (question: QuestionFile): void => {
+      const filePreviewQuestion = question as FilePreviewQuestion;
+      filePreviewQuestion.__pdfPreviewObserver?.disconnect();
+      if (
+        filePreviewQuestion.__survey &&
+        filePreviewQuestion.__valueChangedHandler
+      ) {
+        filePreviewQuestion.__survey.onValueChanged.remove(
+          filePreviewQuestion.__valueChangedHandler
+        );
+      }
+      if (filePreviewQuestion.__filePreviewElement) {
+        removePdfPreview(question, filePreviewQuestion.__filePreviewElement);
+        removeImageDownloadAction(filePreviewQuestion.__filePreviewElement);
+      }
+      filePreviewQuestion.__pdfPreviewObserver = undefined;
+      filePreviewQuestion.__filePreviewElement = undefined;
+      filePreviewQuestion.__survey = undefined;
+      filePreviewQuestion.__valueChangedHandler = undefined;
     },
   };
 


### PR DESCRIPTION
# Description

Fixes [AB#134011](https://dev.azure.com/WHOHQ/2888b816-2d79-49ef-a86e-561e6cd456a0/_workitems/edit/134011) by adding a download button to single-image file previews in form Details mode. Existing PDF, Update mode, and multi-file behavior remains unchanged.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/134011/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Verified that single images can be downloaded from form Details mode
- Verified PDF and Update mode behavior remains unchanged
- Added unit tests for download behavior and widget cleanup
- Ran ESLint and the shared unit test suite successfully

## Screenshots

<img width="2423" height="634" alt="image" src="https://github.com/user-attachments/assets/a9e58af4-c9e7-4ac0-ac0b-271110f39298" />

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
