### PR TITLE
AB#109751: Prevent import of incorrect data

### DIFF
--- a/libs/shared/jest.config.ts
+++ b/libs/shared/jest.config.ts
@@ -30,6 +30,7 @@ export default {
   testMatch: [
     '<rootDir>/src/lib/services/auto-translate/*.spec.ts',
     '<rootDir>/src/lib/services/context/*.spec.ts',
+    '<rootDir>/src/lib/services/download/*.spec.ts',
     '<rootDir>/src/lib/services/file/*.spec.ts',
     '<rootDir>/src/lib/services/html-parser/*.spec.ts',
     '<rootDir>/src/lib/services/grid/*.spec.ts',

--- a/libs/shared/src/lib/services/download/download.service.spec.ts
+++ b/libs/shared/src/lib/services/download/download.service.spec.ts
@@ -1,3 +1,4 @@
+import { DOCUMENT } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { DownloadService } from './download.service';
@@ -8,13 +9,54 @@ import {
   TranslateModule,
   TranslateService,
 } from '@ngx-translate/core';
+import { SnackbarService } from '@oort-front/ui';
+import { throwError } from 'rxjs';
+import { RestService } from '../rest/rest.service';
+
+type SnackbarSpinner = {
+  error: boolean;
+  loading: boolean;
+  message: string;
+};
+
+type SnackbarRef = {
+  instance: {
+    nestedComponent: { instance: SnackbarSpinner };
+    triggerSnackBar: jest.Mock;
+  };
+};
 
 describe('DownloadService', () => {
   let service: DownloadService;
+  let restService: { post: jest.Mock };
+  let snackBarRef: SnackbarRef;
 
   beforeEach(() => {
+    const spinner: SnackbarSpinner = {
+      error: false,
+      loading: true,
+      message: '',
+    };
+    snackBarRef = {
+      instance: {
+        nestedComponent: { instance: spinner },
+        triggerSnackBar: jest.fn(),
+      },
+    };
+    restService = { post: jest.fn() };
     TestBed.configureTestingModule({
-      providers: [{ provide: 'environment', useValue: {} }, TranslateService],
+      providers: [
+        { provide: 'environment', useValue: {} },
+        TranslateService,
+        { provide: RestService, useValue: restService },
+        {
+          provide: SnackbarService,
+          useValue: {
+            openComponentSnackBar: jest.fn(() => snackBarRef),
+          },
+        },
+        { provide: DOCUMENT, useValue: document },
+      ],
       imports: [
         HttpClientModule,
         ApolloTestingModule,
@@ -31,5 +73,32 @@ describe('DownloadService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('shows the server validation error for a rejected upload', (done) => {
+    restService.post.mockReturnValue(
+      throwError(() => new Error('Invalid resource reference.'))
+    );
+
+    service
+      .uploadFile(
+        'upload/resource/records/resource-id',
+        new File(['content'], 'records.xlsx')
+      )
+      .subscribe({
+        error: () => {
+          expect(snackBarRef.instance.nestedComponent.instance.message).toBe(
+            'Invalid resource reference.'
+          );
+          expect(snackBarRef.instance.nestedComponent.instance.error).toBe(
+            true
+          );
+          expect(snackBarRef.instance.nestedComponent.instance.loading).toBe(
+            false
+          );
+          expect(snackBarRef.instance.triggerSnackBar).toHaveBeenCalled();
+          done();
+        },
+      });
   });
 });

--- a/libs/shared/src/lib/services/download/download.service.ts
+++ b/libs/shared/src/lib/services/download/download.service.ts
@@ -319,10 +319,15 @@ export class DownloadService {
           snackBarSpinner.instance.loading = false;
           snackBarRef.instance.triggerSnackBar(SNACKBAR_DURATION);
         },
-        error: () => {
-          snackBarSpinner.instance.message = this.translate.instant(
-            'common.notifications.file.upload.error'
-          );
+        error: (error: { error?: unknown; message?: unknown }) => {
+          snackBarSpinner.instance.message =
+            typeof error.error === 'string' && error.error
+              ? error.error
+              : typeof error.message === 'string' && error.message
+              ? error.message
+              : this.translate.instant(
+                  'common.notifications.file.upload.error'
+                );
           snackBarSpinner.instance.loading = false;
           snackBarSpinner.instance.error = true;
           snackBarRef.instance.triggerSnackBar(SNACKBAR_DURATION);


### PR DESCRIPTION
# Description

Prevents malformed values in `resource` question columns from being imported. Previously, invalid resource identifiers could be stored and later cause record-grid queries to fail. The backend now rejects the complete XLSX import with a clear validation response before creating records. The frontend now displays that server response in the upload snackbar instead of the generic upload error.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/109751/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Backend import validation test
  - Upload an XLSX file containing `not-a-resource-id` in a `resource` field column.
  - Verify the API returns HTTP 400.
  - Verify no records are created.

- Frontend upload-notification test
  - Simulate the HTTP interceptor's transformed `Error`.
  - Verify the upload snackbar displays the backend validation message.

- Shared frontend unit-test suite
  - `npx nx run shared:test:ci --runInBand`
  - Result: 24 suites and 342 tests passing.

- Shared frontend lint
  - `npx nx run shared:lint --output-style=static`

- Backend targeted tests and validation
  - `npm run test -- __tests__/unit-tests/routes/upload/upload.routes.spec.ts __tests__/unit-tests/utils/form/transformRecord.spec.ts --runInBand`
  - `npm run build`
  - `npm run check-i18n`

Manual verification:
1. Open `Dashboard > Resources > [resource] > Records`.
2. Upload an XLSX file with an invalid value in a `resource` question column.
3. Verify the snackbar displays the server validation message, for example: `The value for resource field members must be a valid record identifier.`
4. Verify the records grid remains unchanged.

## Screenshots

When trying to upload an invalid id for a Resource field:

<img width="630" height="175" alt="image" src="https://github.com/user-attachments/assets/dc10627a-c0e0-4389-9af0-99a67638e1a7" />

# Checklist:

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules