### PR TITLE
AB#95770: UX - Add new form button in resource view #95770

### DIFF
--- a/apps/back-office/src/app/components/add-form-modal/add-form-modal.component.html
+++ b/apps/back-office/src/app/components/add-form-modal/add-form-modal.component.html
@@ -14,6 +14,7 @@
           />
         </div>
         <div
+          *ngIf="!data?.resourceId"
           class="flex flex-col mb-5 gap-1"
           formControlName="newResource"
           uiRadioGroupDirective="newResourceOptions"
@@ -54,7 +55,7 @@
           </ui-radio>
         </div>
         <ng-container *ngIf="!form.value.newResource">
-          <div uiFormFieldDirective>
+          <div uiFormFieldDirective *ngIf="!data?.resourceId">
             <label>{{
               'components.form.create.template.title' | translate
             }}</label>

--- a/apps/back-office/src/app/components/add-form-modal/add-form-modal.component.ts
+++ b/apps/back-office/src/app/components/add-form-modal/add-form-modal.component.ts
@@ -1,5 +1,5 @@
 import { Apollo } from 'apollo-angular';
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit, Optional } from '@angular/core';
 import { Validators, FormBuilder } from '@angular/forms';
 import { GET_RESOURCE_BY_ID } from './graphql/queries';
 import { CommonModule } from '@angular/common';
@@ -16,7 +16,7 @@ import {
   FormWrapperModule,
 } from '@oort-front/ui';
 import { DialogModule } from '@oort-front/ui';
-import { DialogRef } from '@angular/cdk/dialog';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import {
   Form,
   ResourceQueryResponse,
@@ -54,7 +54,7 @@ export class AddFormModalComponent implements OnInit {
   public form = this.fb.group({
     name: ['', Validators.required],
     newResource: this.fb.nonNullable.control(true),
-    resource: [null],
+    resource: [null as string | null],
     inheritsTemplate: this.fb.nonNullable.control(false),
     template: null,
   });
@@ -78,11 +78,15 @@ export class AddFormModalComponent implements OnInit {
    * @param fb Angular form builder
    * @param dialogRef Dialog ref
    * @param apollo Apollo service
+   * @param data Optional resource to associate with the new form
    */
   constructor(
     private fb: FormBuilder,
     public dialogRef: DialogRef<AddFormModalComponent>,
-    private apollo: Apollo
+    private apollo: Apollo,
+    @Optional()
+    @Inject(DIALOG_DATA)
+    public data: { resourceId?: string } | null
   ) {}
 
   /** Load the resources and build the form. */
@@ -127,6 +131,13 @@ export class AddFormModalComponent implements OnInit {
           template: null,
         });
       });
+
+    if (this.data?.resourceId) {
+      this.form.patchValue({
+        newResource: false,
+        resource: this.data.resourceId,
+      });
+    }
   }
 
   /**
@@ -143,8 +154,13 @@ export class AddFormModalComponent implements OnInit {
           id,
         },
       })
-      .subscribe(({ data }) => {
-        this.templates = data.resource.forms || [];
+      .subscribe({
+        next: ({ data }) => {
+          this.templates = data.resource?.forms ?? [];
+        },
+        error: () => {
+          this.templates = [];
+        },
       });
   }
 }

--- a/apps/back-office/src/app/dashboard/pages/resource/forms-tab/forms-tab.component.html
+++ b/apps/back-office/src/app/dashboard/pages/resource/forms-tab/forms-tab.component.html
@@ -1,3 +1,8 @@
+<div class="self-end" *ngIf="resource.canUpdate">
+  <ui-button category="secondary" variant="primary" (click)="onAddForm()">
+    {{ 'models.form.create' | translate }}
+  </ui-button>
+</div>
 <!-- Table container -->
 <div class="overflow-x-hidden shadow-2lg">
   <!-- Table scroll container -->

--- a/apps/back-office/src/app/dashboard/pages/resource/forms-tab/forms-tab.component.spec.ts
+++ b/apps/back-office/src/app/dashboard/pages/resource/forms-tab/forms-tab.component.spec.ts
@@ -8,7 +8,14 @@ import {
   TranslateService,
 } from '@ngx-translate/core';
 import { DialogModule } from '@angular/cdk/dialog';
-import { SkeletonTableModule } from '@oort-front/shared';
+import { Dialog } from '@angular/cdk/dialog';
+import { Resource, SkeletonTableModule } from '@oort-front/shared';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+
+const dialog = {
+  open: jest.fn(() => ({ closed: of(undefined) })),
+};
 
 describe('FormsTabComponent', () => {
   let component: FormsTabComponent;
@@ -28,7 +35,11 @@ describe('FormsTabComponent', () => {
           },
         }),
       ],
-      providers: [TranslateService],
+      providers: [
+        TranslateService,
+        { provide: Dialog, useValue: dialog },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+      ],
     }).compileComponents();
   });
 
@@ -40,5 +51,17 @@ describe('FormsTabComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('opens the form modal scoped to the current resource', async () => {
+    (component as unknown as { resource: Resource }).resource = {
+      id: 'resource-id',
+    } as Resource;
+
+    await component.onAddForm();
+
+    expect(dialog.open).toHaveBeenCalledWith(expect.any(Function), {
+      data: { resourceId: 'resource-id' },
+    });
   });
 });

--- a/apps/back-office/src/app/dashboard/pages/resource/forms-tab/forms-tab.component.ts
+++ b/apps/back-office/src/app/dashboard/pages/resource/forms-tab/forms-tab.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { Apollo } from 'apollo-angular';
 import {
+  AddFormMutationResponse,
   DeleteFormMutationResponse,
   Form,
   Resource,
@@ -10,6 +12,7 @@ import {
 } from '@oort-front/shared';
 import { TranslateService } from '@ngx-translate/core';
 import { DELETE_FORM } from './graphql/mutations';
+import { ADD_FORM } from '../../forms/graphql/mutations';
 import get from 'lodash/get';
 import { GET_RESOURCE_FORMS } from './graphql/queries';
 import { Dialog } from '@angular/cdk/dialog';
@@ -28,7 +31,7 @@ export class FormsTabComponent extends UnsubscribeComponent implements OnInit {
   /**
    * Resource
    */
-  private resource!: Resource;
+  public resource!: Resource;
   /**
    * Forms
    */
@@ -59,15 +62,93 @@ export class FormsTabComponent extends UnsubscribeComponent implements OnInit {
    * @param confirmService Shared confirm service
    * @param translate Angular translate service
    * @param dialog Dialog service
+   * @param router Angular router
    */
   constructor(
     private apollo: Apollo,
     private snackBar: SnackbarService,
     private confirmService: ConfirmService,
     private translate: TranslateService,
-    private dialog: Dialog
+    private dialog: Dialog,
+    private router: Router
   ) {
     super();
+  }
+
+  /**
+   * Opens the form creation modal for the current resource.
+   */
+  async onAddForm(): Promise<void> {
+    try {
+      const { AddFormModalComponent } = await import(
+        '../../../../components/add-form-modal/add-form-modal.component'
+      );
+      const dialogRef = this.dialog.open<
+        { name: string; template: string | null },
+        { resourceId?: string },
+        InstanceType<typeof AddFormModalComponent>
+      >(AddFormModalComponent, {
+        data: { resourceId: this.resource.id },
+      });
+      dialogRef.closed.pipe(takeUntil(this.destroy$)).subscribe((value) => {
+        if (value) {
+          this.apollo
+            .mutate<AddFormMutationResponse>({
+              mutation: ADD_FORM,
+              variables: {
+                name: value.name,
+                resource: this.resource.id,
+                template: value.template,
+              },
+            })
+            .subscribe({
+              next: ({ errors, data }) => {
+                if (errors) {
+                  this.snackBar.openSnackBar(
+                    this.translate.instant(
+                      'common.notifications.objectNotCreated',
+                      {
+                        type: this.translate
+                          .instant('common.form.one')
+                          .toLowerCase(),
+                        error: errors[0].message,
+                      }
+                    ),
+                    { error: true }
+                  );
+                } else if (data) {
+                  this.router.navigate([
+                    '/resources',
+                    this.resource.id,
+                    'forms',
+                    data.addForm.id,
+                    'builder',
+                  ]);
+                  this.snackBar.openSnackBar(
+                    this.translate.instant(
+                      'common.notifications.objectCreated',
+                      {
+                        type: this.translate
+                          .instant('common.form.one')
+                          .toLowerCase(),
+                        value: value.name,
+                      }
+                    )
+                  );
+                }
+              },
+              error: (err) => {
+                this.snackBar.openSnackBar(err.message, { error: true });
+              },
+            });
+        }
+      });
+    } catch (error) {
+      this.snackBar.openSnackBar(
+        error instanceof Error ? error.message : String(error),
+        { error: true }
+      );
+    }
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
# Description

Adds a `Create a Form` action to the Forms tab of an existing resource. The action reuses the existing add-form modal, locks the new form to the current resource, supports optional inheritance from an existing resource form, and opens the created form in its builder.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/95770/

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Focused unit test:
```npx nx test back-office --testPathPattern=forms-tab.component.spec.ts```

## Screenshots

<img width="2179" height="598" alt="image" src="https://github.com/user-attachments/assets/30b26118-188b-4b86-817e-4f9da32af931" />

<img width="1124" height="473" alt="image" src="https://github.com/user-attachments/assets/d7605e8d-9522-489c-81b3-894457ddb3f4" />

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules