### PR TITLE
AB#82962: The data for map popouts should be loaded on demand, not upfront 

### DIFF
--- a/libs/shared/jest.config.ts
+++ b/libs/shared/jest.config.ts
@@ -33,6 +33,7 @@ export default {
     '<rootDir>/src/lib/services/file/*.spec.ts',
     '<rootDir>/src/lib/services/html-parser/*.spec.ts',
     '<rootDir>/src/lib/services/grid/*.spec.ts',
+    '<rootDir>/src/lib/services/map/map-layers.service.spec.ts',
     '<rootDir>/src/lib/pipes/asset/*.spec.ts',
     '<rootDir>/src/lib/pipes/gradient/*.spec.ts',
     '<rootDir>/src/lib/pipes/readable-history-value/*.spec.ts',

--- a/libs/shared/src/lib/components/ui/map/layer.ts
+++ b/libs/shared/src/lib/components/ui/map/layer.ts
@@ -168,6 +168,8 @@ export class Layer implements LayerModel {
 
   /** Map layer */
   private layer: L.Layer | null = null;
+  /** Latest popup request, used to ignore stale responses from previous clicks. */
+  private popupRequest = 0;
 
   // Global properties for the layer
   /** Layer id */
@@ -411,6 +413,32 @@ export class Layer implements LayerModel {
   }
 
   /**
+   * Load popup properties on demand before opening the popup.
+   *
+   * @param features Selected map features.
+   * @param coordinates Popup coordinates.
+   * @param layerToBind Leaflet layer that owns the popup.
+   */
+  private async openPopup(
+    features: Feature<Geometry>[],
+    coordinates: L.LatLng,
+    layerToBind?: L.Layer
+  ) {
+    const popupRequest = ++this.popupRequest;
+    const popupFeatures = await this.layerService.loadPopupData(features);
+    if (popupRequest !== this.popupRequest) {
+      return;
+    }
+    this.popupService.setPopUp(
+      popupFeatures,
+      coordinates,
+      this.popupInfo,
+      this.metaFields,
+      layerToBind
+    );
+  }
+
+  /**
    * Gets the style for a feature
    * If no style is found, returns the default style
    *
@@ -625,17 +653,14 @@ export class Layer implements LayerModel {
         // In order to destroy all event subscriptions and avoid memory leak
         const setPopupListener = () => {
           const center = centroid(feature);
-          // bind this to the popup service
-          this.popupService.setPopUp(
+          this.openPopup(
             [feature],
             L.latLng({
               lat: center.geometry.coordinates[1],
               lng: center.geometry.coordinates[0],
             }),
-            this.popupInfo,
-            this.metaFields,
             layer
-          );
+          ).catch((error) => console.error(error));
         };
         const listener = this.renderer.listen(layer, 'click', setPopupListener);
         this.listeners.push(listener);
@@ -829,11 +854,8 @@ export class Layer implements LayerModel {
                   } else return false;
                 });
 
-                this.popupService.setPopUp(
-                  matchedPoints,
-                  event,
-                  this.popupInfo,
-                  this.metaFields
+                this.openPopup(matchedPoints, event).catch((error) =>
+                  console.error(error)
                 );
               }
             };
@@ -935,12 +957,8 @@ export class Layer implements LayerModel {
                   const children = event.layer
                     .getAllChildMarkers()
                     .map((child: L.Marker) => child.feature);
-                  this.popupService.setPopUp(
-                    children,
-                    event.latlng,
-                    this.popupInfo,
-                    this.metaFields,
-                    event.layer
+                  this.openPopup(children, event.latlng, event.layer).catch(
+                    (error) => console.error(error)
                   );
                 });
 

--- a/libs/shared/src/lib/services/map/map-layers.service.spec.ts
+++ b/libs/shared/src/lib/services/map/map-layers.service.spec.ts
@@ -1,16 +1,83 @@
 import { TestBed } from '@angular/core/testing';
+import { DOCUMENT } from '@angular/common';
+import { Apollo } from 'apollo-angular';
+import { Feature, Point } from 'geojson';
+import { of } from 'rxjs';
 
+jest.mock('../../components/ui/map/layer', () => ({
+  EMPTY_FEATURE_COLLECTION: { type: 'FeatureCollection', features: [] },
+  Layer: class {},
+}));
+
+import { AggregationService } from '../aggregation/aggregation.service';
+import { ContextService } from '../context/context.service';
+import { ReferenceDataService } from '../reference-data/reference-data.service';
+import { RestService } from '../rest/rest.service';
+import { WidgetService } from '../widget/widget.service';
+import { AggregationBuilderService } from '../aggregation-builder/aggregation-builder.service';
+import { QueryBuilderService } from '../query-builder/query-builder.service';
+import { MapPolygonsService } from './map-polygons.service';
 import { MapLayersService } from './map-layers.service';
 
 describe('MapLayersService', () => {
   let service: MapLayersService;
+  let restService: { apiUrl: string; post: jest.Mock };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    restService = { apiUrl: '/api', post: jest.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        MapLayersService,
+        { provide: Apollo, useValue: {} },
+        { provide: RestService, useValue: restService },
+        { provide: QueryBuilderService, useValue: {} },
+        { provide: AggregationBuilderService, useValue: {} },
+        { provide: ContextService, useValue: {} },
+        { provide: MapPolygonsService, useValue: {} },
+        { provide: WidgetService, useValue: {} },
+        { provide: ReferenceDataService, useValue: {} },
+        { provide: AggregationService, useValue: {} },
+        { provide: DOCUMENT, useValue: document },
+      ],
+    });
     service = TestBed.inject(MapLayersService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('loads complete properties for compact popup features', async () => {
+    const compactFeature: Feature<Point> = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [1, 2] },
+      properties: {
+        __oortPopup: { cacheKey: 'gis:popup:key', featureIndex: 3 },
+      },
+    };
+    const completeFeature: Feature<Point> = {
+      ...compactFeature,
+      properties: { name: 'Popup data' },
+    };
+    restService.post.mockReturnValue(of({ features: [completeFeature] }));
+
+    await expect(service.loadPopupData([compactFeature])).resolves.toEqual([
+      completeFeature,
+    ]);
+    expect(restService.post).toHaveBeenCalledWith('/api/gis/feature/popup', {
+      cacheKey: 'gis:popup:key',
+      featureIndexes: [3],
+    });
+  });
+
+  it('keeps compact features when no popup-cache reference exists', async () => {
+    const feature: Feature<Point> = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [1, 2] },
+      properties: {},
+    };
+
+    await expect(service.loadPopupData([feature])).resolves.toEqual([feature]);
+    expect(restService.post).not.toHaveBeenCalled();
   });
 });

--- a/libs/shared/src/lib/services/map/map-layers.service.ts
+++ b/libs/shared/src/lib/services/map/map-layers.service.ts
@@ -27,6 +27,7 @@ import {
   LayerQueryResponse,
   LayersQueryResponse,
 } from '../../models/layer.model';
+import { LocalizedString } from '../../models/localized-string.model';
 import { RestService } from '../rest/rest.service';
 import { QueryBuilderService } from '../query-builder/query-builder.service';
 import { AggregationBuilderService } from '../aggregation-builder/aggregation-builder.service';
@@ -44,7 +45,7 @@ import getReferenceDataAggregationFields from '../../utils/reference-data/aggreg
 import { authType } from '../../models/api-configuration.model';
 import { ReferenceDataService } from '../reference-data/reference-data.service';
 import { AggregationService } from '../aggregation/aggregation.service';
-import { Feature } from '@turf/helpers';
+import { Feature, Geometry } from 'geojson';
 import filterReferenceData from '../../utils/filter/reference-data-filter.util';
 import { CompositeFilterDescriptor } from '@progress/kendo-data-query';
 
@@ -635,6 +636,9 @@ export class MapLayersService {
     const body = omitBy(
       {
         ...params.layer.datasource,
+        hasPopupData: Boolean(params.layer.popupInfo?.popupElements?.length),
+        popupFields: this.getPopupFields(params.layer),
+        displayFields: this.getDisplayFields(params.layer),
         contextFilters: JSON.stringify(params.contextFilters),
         queryParams: JSON.stringify(
           this.widgetService.replaceReferenceDataQueryParams(
@@ -659,6 +663,127 @@ export class MapLayersService {
         )
     );
   };
+
+  /**
+   * Load complete properties for compact features when their popup is opened.
+   *
+   * @param features Compact map features selected for a popup.
+   * @returns Features with their cached popup properties when available.
+   */
+  public async loadPopupData(
+    features: Feature<Geometry>[]
+  ): Promise<Feature<Geometry>[]> {
+    const popupReferences = features.map((feature) =>
+      this.getPopupReference(feature)
+    );
+    const firstReference = popupReferences[0];
+    if (
+      !firstReference ||
+      popupReferences.some(
+        (reference) => reference?.cacheKey !== firstReference.cacheKey
+      )
+    ) {
+      return features;
+    }
+
+    return lastValueFrom(
+      this.restService
+        .post(`${this.restService.apiUrl}/gis/feature/popup`, {
+          cacheKey: firstReference.cacheKey,
+          featureIndexes: popupReferences.map(
+            (reference) => reference?.featureIndex
+          ),
+        })
+        .pipe(
+          map((response: { features: Feature<Geometry>[] }) =>
+            response.features.length === features.length
+              ? response.features
+              : features
+          ),
+          catchError(() => of(features))
+        )
+    );
+  }
+
+  /**
+   * Get the fields rendered by a map popup.
+   *
+   * @param layer Map layer definition.
+   * @returns Unique popup field paths.
+   */
+  private getPopupFields(layer: LayerModel): string[] {
+    const popupInfo = layer.popupInfo;
+    return Array.from(
+      new Set([
+        ...(popupInfo?.popupElements
+          ?.filter((element) => element.type === 'fields')
+          .flatMap((element) => element.fields || []) || []),
+        ...this.getTemplateFields(popupInfo?.title),
+        ...this.getTemplateFields(popupInfo?.description),
+        ...(popupInfo?.popupElements?.flatMap((element) =>
+          element.type === 'fields'
+            ? [
+                ...this.getTemplateFields(element.title),
+                ...this.getTemplateFields(element.description),
+              ]
+            : this.getTemplateFields(element.text)
+        ) || []),
+      ])
+    );
+  }
+
+  /**
+   * Get field paths referenced by popup template placeholders.
+   *
+   * @param text Localized template text.
+   * @returns Field paths used by the template.
+   */
+  private getTemplateFields(text?: LocalizedString): string[] {
+    const texts = (
+      typeof text === 'string' ? [text] : Object.values(text || {})
+    ).filter((value): value is string => Boolean(value));
+    return texts.flatMap((value) =>
+      (value.match(/{{(.*?)}}/g) || [])
+        .map((placeholder) => placeholder.slice(2, -2).trim())
+        .filter(
+          (placeholder) => placeholder && !placeholder.includes('coordinates')
+        )
+    );
+  }
+
+  /**
+   * Get fields needed before a popup is opened.
+   *
+   * @param layer Map layer definition.
+   * @returns Renderer field paths.
+   */
+  private getDisplayFields(layer: LayerModel): string[] {
+    const rendererField = layer.layerDefinition?.drawingInfo?.renderer?.field1;
+    return [rendererField, layer.datasource?.adminField].filter(
+      (field): field is string => Boolean(field)
+    );
+  }
+
+  /**
+   * Extract an internal popup-cache reference from a compact feature.
+   *
+   * @param feature Map feature.
+   * @returns Popup-cache reference when present.
+   */
+  private getPopupReference(feature: Feature<Geometry>) {
+    const reference = feature.properties?.__oortPopup;
+    if (
+      !reference ||
+      typeof reference !== 'object' ||
+      !('cacheKey' in reference) ||
+      !('featureIndex' in reference) ||
+      typeof reference.cacheKey !== 'string' ||
+      !Number.isInteger(reference.featureIndex)
+    ) {
+      return undefined;
+    }
+    return reference;
+  }
 
   /**
    * Fetches features with aggregation directly from frontend


### PR DESCRIPTION
# Description

Improves map popup performance by loading popup data on demand instead of including it in the initial map-layer response.

The backend now caches the complete generated feature layer in Redis for 15 minutes and returns compact features containing only display data and an internal popup reference. When a user clicks a marker or cluster, the frontend requests only that feature's configured popup fields from the cache. Cache entries are scoped to the authenticated user. The implementation also preserves admin geometry mappings, supports popup template placeholders, and ignores stale popup responses from rapid consecutive clicks.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82962/

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- Backend build and lint
  - Run `npm run build` in `ems-backend`.
  - Run `npx eslint "src/routes/gis/index.ts"` in `ems-backend`.

- Frontend lint and unit tests
  - Run `npx nx run shared:lint --output-style=static` in `ems-frontend`.
  - Run `npx nx run shared:test --configuration=ci --runInBand` in `ems-frontend`.
  - Result: 24 test suites and 343 tests passed.

- Manual Front Office verification
  1. Open `/{applicationId}/dashboard/{dashboardId}` for **Health Emergencies Management Suite – TEST**.
  2. Load the **Dashboard** map and inspect `POST /gis/feature`.
  3. Confirm the initial response includes only compact features and `__oortPopup`, without popup fields.
  4. Click a marker or cluster.
  5. Confirm `POST /gis/feature/popup` is sent.
  6. Confirm the popup displays the fields returned by the popup request.
  7. Confirm the initial GIS layer request is not repeated when opening popups.

## Screenshots

Not applicable. This is a performance and network-payload improvement with no intended visual change.

# Checklist:

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
