### PR TITLE
AB#137743: Enable Read only fields to not be editable when creating a new record

### DIFF
--- a/libs/shared/src/lib/components/form-builder/form-builder.component.ts
+++ b/libs/shared/src/lib/components/form-builder/form-builder.component.ts
@@ -37,6 +37,7 @@ import { UnsubscribeComponent } from '../utils/unsubscribe/unsubscribe.component
 import { SurveyCustomJSONEditorPlugin } from './custom-json-editor/custom-json-editor.component';
 import { FunctionReferenceModalComponent } from './function-reference-modal/function-reference-modal.component';
 import { AutoTranslateService } from '../../services/auto-translate/auto-translate.service';
+import { SURVEY_PROP_LOCK_READ_ONLY_FIELDS_ON_RECORD_CREATION } from '../../utils/survey-read-only-fields.util';
 
 /**
  * Array containing the different types of questions.
@@ -245,6 +246,28 @@ export class FormBuilderComponent
     this.surveyCreator.onPropertyGridSurveyCreated.add(
       (_: any, options: any) => {
         const grid: SurveyModel = options.survey;
+        grid.onAfterRenderQuestion.add((__, questionOptions) => {
+          if (
+            questionOptions.question.name !==
+            SURVEY_PROP_LOCK_READ_ONLY_FIELDS_ON_RECORD_CREATION
+          ) {
+            return;
+          }
+          // SurveyJS ignores line breaks in boolean property labels by default.
+          questionOptions.htmlElement
+            .querySelectorAll<HTMLElement>('label, label *')
+            .forEach((element) => {
+              element.style.setProperty('white-space', 'pre-line', 'important');
+            });
+          questionOptions.htmlElement
+            .querySelector<HTMLElement>('label')
+            ?.style.setProperty('align-items', 'center');
+          questionOptions.htmlElement
+            .querySelectorAll<HTMLElement>('.sd-question__description')
+            .forEach((element) => {
+              element.style.setProperty('margin-top', '16px');
+            });
+        });
         const toggle = grid.getQuestionByName(
           SURVEY_PROP_CONFIRM_RECORD_UPDATE
         );

--- a/libs/shared/src/lib/components/form-modal/form-modal.component.ts
+++ b/libs/shared/src/lib/components/form-modal/form-modal.component.ts
@@ -52,6 +52,7 @@ import { ADD_RECORD, EDIT_RECORD, EDIT_RECORDS } from './graphql/mutations';
 import { GET_FORM_BY_ID, GET_RECORD_BY_ID } from './graphql/queries';
 import { getSurveyFormActionButtonLabels } from '../../utils/survey-form-action-labels.util';
 import { shouldConfirmRecordUpdate } from '../../utils/survey-confirm-record-update.util';
+import { shouldLockReadOnlyFieldsOnRecordCreation } from '../../utils/survey-read-only-fields.util';
 import { AutoTranslateService } from '../../services/auto-translate/auto-translate.service';
 
 /**
@@ -346,13 +347,18 @@ export class FormModalComponent
         }
         addCustomFunctions(this.authService);
         this.survey.showCompletedPage = false;
+        // Fire once now that the existing record's data is in the survey
+        fireOnRecordEditionTriggers(this.survey);
+      }
+
+      if (
+        this.isUpdate ||
+        shouldLockReadOnlyFieldsOnRecordCreation(this.survey)
+      ) {
         this.form?.fields?.forEach((field) => {
           if (field.readOnly && this.survey.getQuestionByName(field.name))
             this.survey.getQuestionByName(field.name).readOnly = true;
         });
-
-        // Fire once now that the existing record's data is in the survey
-        fireOnRecordEditionTriggers(this.survey);
       }
 
       // Bulk survey.data changes (e.g. multi-edition) do not fire onValueChanged

--- a/libs/shared/src/lib/components/form/form.component.ts
+++ b/libs/shared/src/lib/components/form/form.component.ts
@@ -39,6 +39,7 @@ import { SnackbarService, UILayoutService } from '@oort-front/ui';
 import { isNil } from 'lodash';
 import { getSurveyFormActionButtonLabels } from '../../utils/survey-form-action-labels.util';
 import { AutoTranslateService } from '../../services/auto-translate/auto-translate.service';
+import { shouldLockReadOnlyFieldsOnRecordCreation } from '../../utils/survey-read-only-fields.util';
 
 /**
  * This component is used to display forms
@@ -164,9 +165,11 @@ export class FormComponent
       this.onComplete();
     });
 
-    // Unset readOnly fields if it's the record creation
-    // It's a requirement to let all fields been editable during addition of records
-    if (!isNil(this.record)) {
+    // Read-only fields stay editable during creation unless the form opts in to locking them.
+    if (
+      !isNil(this.record) ||
+      shouldLockReadOnlyFieldsOnRecordCreation(this.survey)
+    ) {
       this.form.fields?.forEach((field) => {
         if (field.readOnly && this.survey.getQuestionByName(field.name))
           this.survey.getQuestionByName(field.name).readOnly = true;

--- a/libs/shared/src/lib/survey/global-properties/others.spec.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.spec.ts
@@ -1,5 +1,6 @@
 import { JsonObjectProperty, Serializer } from 'survey-core';
 import { SURVEY_PROP_MODAL_SAVE_BUTTON_LABEL } from '../../utils/survey-form-action-labels.util';
+import { SURVEY_PROP_LOCK_READ_ONLY_FIELDS_ON_RECORD_CREATION } from '../../utils/survey-read-only-fields.util';
 import { init } from './others';
 
 type SurveyPropertyOwner = {
@@ -44,6 +45,20 @@ describe('survey global navigation properties', () => {
 
     expect(modalSaveButtonProperty).toBeTruthy();
     expect(modalSaveButtonProperty.category).toBe('navigation');
+  });
+
+  it('registers the record creation read-only setting in the data category', () => {
+    const property = Serializer.getProperty(
+      'survey',
+      SURVEY_PROP_LOCK_READ_ONLY_FIELDS_ON_RECORD_CREATION
+    );
+
+    expect(property).toBeTruthy();
+    expect(property.category).toBe('data');
+    expect(property.defaultValue).toBe(false);
+    expect(property.displayName).toBe(
+      'Keep read-only fields locked\nwhen creating a record'
+    );
   });
 
   it('hides modal override properties by default', () => {

--- a/libs/shared/src/lib/survey/global-properties/others.ts
+++ b/libs/shared/src/lib/survey/global-properties/others.ts
@@ -16,6 +16,7 @@ import {
   SURVEY_PROP_CONFIRM_RECORD_UPDATE,
   SURVEY_PROP_CONFIRM_RECORD_UPDATE_IF,
 } from '../../utils/survey-confirm-record-update.util';
+import { SURVEY_PROP_LOCK_READ_ONLY_FIELDS_ON_RECORD_CREATION } from '../../utils/survey-read-only-fields.util';
 import { registerCustomPropertyHelp } from '../localization';
 import { Question } from '../types';
 
@@ -128,6 +129,19 @@ export const init = (environment: any): void => {
     visible: false,
     isSerializable: false,
   });
+
+  // Preserve legacy record creation behavior unless explicitly enabled.
+  serializer.addProperty('survey', {
+    name: `${SURVEY_PROP_LOCK_READ_ONLY_FIELDS_ON_RECORD_CREATION}:boolean`,
+    type: 'boolean',
+    category: 'data',
+    displayName: 'Keep read-only fields locked\nwhen creating a record',
+    default: false,
+  });
+  registerCustomPropertyHelp(
+    SURVEY_PROP_LOCK_READ_ONLY_FIELDS_ON_RECORD_CREATION,
+    'By default, fields marked as read-only can be edited while a new record is being created and only become locked when an existing record is edited. Enable this option to keep them read-only during record creation as well.'
+  );
 
   /** Readonly default accepted types, will use the acceptedTypesValues component */
   serializer.getProperty('file', 'acceptedTypes').readOnly = true;

--- a/libs/shared/src/lib/utils/survey-read-only-fields.util.spec.ts
+++ b/libs/shared/src/lib/utils/survey-read-only-fields.util.spec.ts
@@ -1,0 +1,31 @@
+import { shouldLockReadOnlyFieldsOnRecordCreation } from './survey-read-only-fields.util';
+
+/**
+ * Creates the subset of SurveyJS behavior required by the predicate.
+ *
+ * @param propertyValue Value of the record creation locking setting
+ * @returns Survey-like object exposing the configured property value
+ */
+const createSurvey = (propertyValue?: boolean) => ({
+  getPropertyValue: () => propertyValue,
+});
+
+describe('shouldLockReadOnlyFieldsOnRecordCreation', () => {
+  it('returns false when the option is unset', () => {
+    expect(shouldLockReadOnlyFieldsOnRecordCreation(createSurvey())).toBe(
+      false
+    );
+  });
+
+  it('returns false when the option is disabled', () => {
+    expect(shouldLockReadOnlyFieldsOnRecordCreation(createSurvey(false))).toBe(
+      false
+    );
+  });
+
+  it('returns true when the option is enabled', () => {
+    expect(shouldLockReadOnlyFieldsOnRecordCreation(createSurvey(true))).toBe(
+      true
+    );
+  });
+});

--- a/libs/shared/src/lib/utils/survey-read-only-fields.util.ts
+++ b/libs/shared/src/lib/utils/survey-read-only-fields.util.ts
@@ -1,0 +1,22 @@
+import { SurveyModel } from 'survey-core';
+
+/** Serializer property controlling read-only fields during record creation. */
+export const SURVEY_PROP_LOCK_READ_ONLY_FIELDS_ON_RECORD_CREATION =
+  'lockReadOnlyFieldsOnRecordCreation';
+
+/**
+ * Whether fields marked read-only must remain locked while creating a record.
+ * Missing values preserve the legacy behavior.
+ *
+ * @param survey Active SurveyJS form
+ * @returns True when read-only fields must be locked on record creation
+ */
+export function shouldLockReadOnlyFieldsOnRecordCreation(
+  survey: Pick<SurveyModel, 'getPropertyValue'>
+): boolean {
+  return (
+    survey.getPropertyValue(
+      SURVEY_PROP_LOCK_READ_ONLY_FIELDS_ON_RECORD_CREATION
+    ) === true
+  );
+}


### PR DESCRIPTION
# Description

Added a new option under the form Data settings: Keep read-only fields locked when creating a record.

Read-only fields remain editable when creating a record by default, so existing forms keep their current behavior. When this option is enabled, those fields are locked during both record creation and editing.

The setting is saved in the existing SurveyJS form structure and works in both standard and modal record creation flows. I also adjusted the Form Builder layout so the option label and help text display properly.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/137743/

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- `npx nx lint shared`
- `npx nx test shared --runInBand --testPathPattern='(survey-read-only-fields\.util|global-properties/others)\.spec\.ts'`

Manual verification:

1. Open a form in Back Office Form Builder.
2. Under **Data**, verify the new option and help text layout.
3. Enable the option and create a record with read-only fields.
4. Confirm read-only fields cannot be edited during creation or editing.
5. Disable the option and create a record.
6. Confirm read-only fields are editable during creation and locked during editing.
7. Repeat creation through a modal record flow.

## Screenshots

<img width="662" height="664" alt="image" src="https://github.com/user-attachments/assets/7abab92f-a70a-47e0-b898-e9acad74ad0d" />

<img width="642" height="314" alt="image" src="https://github.com/user-attachments/assets/6759918a-a8ec-40fc-ae93-f16433ba2b49" />

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules