### PR TITLE
fix: show actual upload error message instead of a generic one (AB#13…

### DIFF
--- a/libs/shared/jest.config.ts
+++ b/libs/shared/jest.config.ts
@@ -34,6 +34,7 @@ export default {
     '<rootDir>/src/lib/services/html-parser/*.spec.ts',
     '<rootDir>/src/lib/services/grid/*.spec.ts',
     '<rootDir>/src/lib/services/grid-data-formatter/*.spec.ts',
+    '<rootDir>/src/lib/services/download/*.spec.ts',
     '<rootDir>/src/lib/pipes/asset/*.spec.ts',
     '<rootDir>/src/lib/pipes/gradient/*.spec.ts',
     '<rootDir>/src/lib/pipes/readable-history-value/*.spec.ts',

--- a/libs/shared/src/lib/services/download/download.service.spec.ts
+++ b/libs/shared/src/lib/services/download/download.service.spec.ts
@@ -32,4 +32,32 @@ describe('DownloadService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  describe('getUploadErrorMessage', () => {
+    it('returns the backend-provided message when present', () => {
+      const message = (service as any).getUploadErrorMessage(
+        new Error('Row 2: the value "bad" in the _id column is not valid.')
+      );
+      expect(message).toEqual(
+        'Row 2: the value "bad" in the _id column is not valid.'
+      );
+    });
+
+    it('falls back to the generic translated message when there is no error message', () => {
+      const message = (service as any).getUploadErrorMessage({});
+      expect(message).toEqual('common.notifications.file.upload.error');
+    });
+
+    it('falls back to the generic translated message for an empty message', () => {
+      const message = (service as any).getUploadErrorMessage(new Error(''));
+      expect(message).toEqual('common.notifications.file.upload.error');
+    });
+
+    it('falls back to the generic translated message for a coerced object (network-level failure)', () => {
+      const message = (service as any).getUploadErrorMessage(
+        new Error(String(new ProgressEvent('error')))
+      );
+      expect(message).toEqual('common.notifications.file.upload.error');
+    });
+  });
 });

--- a/libs/shared/src/lib/services/download/download.service.ts
+++ b/libs/shared/src/lib/services/download/download.service.ts
@@ -319,16 +319,35 @@ export class DownloadService {
           snackBarSpinner.instance.loading = false;
           snackBarRef.instance.triggerSnackBar(SNACKBAR_DURATION);
         },
-        error: () => {
-          snackBarSpinner.instance.message = this.translate.instant(
-            'common.notifications.file.upload.error'
-          );
+        error: (err) => {
+          snackBarSpinner.instance.message = this.getUploadErrorMessage(err);
           snackBarSpinner.instance.loading = false;
           snackBarSpinner.instance.error = true;
           snackBarRef.instance.triggerSnackBar(SNACKBAR_DURATION);
         },
       })
     );
+  }
+
+  /**
+   * Get the message to display for a failed file upload: the backend's own
+   * translated error text when available (the auth interceptor carries it
+   * through as `error.message`), falling back to a generic message for
+   * network-level failures that carry no usable text (e.g. offline, CORS).
+   *
+   * @param err error thrown by the upload request
+   * @returns message to display to the user
+   */
+  private getUploadErrorMessage(err: any): string {
+    const backendMessage = err?.message;
+    if (
+      typeof backendMessage === 'string' &&
+      backendMessage.trim().length > 0 &&
+      !backendMessage.startsWith('[object ')
+    ) {
+      return backendMessage;
+    }
+    return this.translate.instant('common.notifications.file.upload.error');
   }
 
   /**


### PR DESCRIPTION
# Description

Adds support for uploading records with custom `_id` values via Excel. If the uploaded file's header row contains an `_id` column, each row's value is validated (format, uniqueness in file, not already in DB) before insert. If any row fails, the whole upload is rejected with a translated error. No `_id` column = unchanged behavior.

Also fixes a missing `await` on `Record.insertMany`, and updates the upload error snackbar to show the actual backend message instead of a generic one.

## Useful links

- Ticket: [AB#137745](https://dev.azure.com/WHOHQ/2888b816-2d79-49ef-a86e-561e6cd456a0/_workitems/edit/137745)
- Front-end branch: `[AB#137745](https://dev.azure.com/WHOHQ/2888b816-2d79-49ef-a86e-561e6cd456a0/_workitems/edit/137745)-ABC-Make-excel-upload-easier`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New unit tests for `_id` validation (format, duplicate, existing, empty, no permission)
- [x] New integration tests on the upload route
- [x] Full backend test suite run locally, no regressions
- [x] Manual upload test via the UI (success + rejection cases)

## Screenshots

[Screencast_20260911_021442.webm](https://github.com/user-attachments/assets/812f4f44-a787-4264-9090-4297ddc31e2d)


# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules